### PR TITLE
kern: simplify notification mask handling.

### DIFF
--- a/kern/src/startup.rs
+++ b/kern/src/startup.rs
@@ -133,7 +133,6 @@ fn safe_start_kernel(
             descriptor: task_desc,
 
             generation: Generation::default(),
-            notification_mask: 0,
             notifications: 0,
             save: crate::arch::SavedState::default(),
             region_table: &[], // filled in momentarily


### PR DESCRIPTION
Having a `notification_mask` field of `Task` was a leftover from the
days when the mask was a separate piece of state, maintained by its own
syscalls -- before Patrick proposed the simplified atomic receive API.

Because notifications only matter while a task is in receive, we can
just look at where the mask lives as an argument to that syscall. No
need to store it elsewhere; no state that can go out of sync.