### PR TITLE
Fix the build on Windows.

### DIFF
--- a/packager/src/main.rs
+++ b/packager/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let toml: Config = toml::from_slice(&cfg)?;
     drop(cfg);
 
-    let mut src_dir = std::fs::canonicalize(&args.cfg)?;
+    let mut src_dir = args.cfg.clone();
     src_dir.pop();
 
     let mut memories = IndexMap::new();
@@ -219,6 +219,14 @@ fn build(
 
     println!("building path {}", path.display());
 
+    // NOTE: current_dir's docs suggest that you should use canonicalize for
+    // portability. However, that's for when you're doing stuff like:
+    //
+    // Command::new("../cargo")
+    //
+    // That is, when you have a relative path to the binary being executed. We
+    // are not including a path in the binary name, so everything is peachy. If
+    // you change this line below, make sure to canonicalize path.
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .arg("--release")
@@ -286,6 +294,14 @@ fn allocate(free: &mut IndexMap<String, Range<u32>>, needs: &IndexMap<String, u3
 fn cargo_output_dir(target: &str, path: &Path) -> Result<PathBuf, Box<dyn Error>> {
     use std::process::Command;
 
+    // NOTE: current_dir's docs suggest that you should use canonicalize for
+    // portability. However, that's for when you're doing stuff like:
+    //
+    // Command::new("../cargo")
+    //
+    // That is, when you have a relative path to the binary being executed. We
+    // are not including a path in the binary name, so everything is peachy. If
+    // you change this line below, make sure to canonicalize path.
     let mut cmd = Command::new("cargo");
     cmd.arg("metadata")
         .arg("--filter-platform")


### PR DESCRIPTION
It turns out that canonicalizing the path causes lots of weird problems.
This is because the app.toml files use relative paths in them, and for
some reason, Cargo fails to build after we turn the paths canonical. By
not doing so, stuff still works.

The reason we were calling canonicalize in the first place is that the
docs suggest doing so. They do because when you have a relative path to
the binary, you get different behavior on different platforms. However,
we are not doing this, so not canonicalizing fixes the issue. I've left
a comment in both places we do this so that if the situation changes, we
catch the bug.