### PR TITLE
Properly slash paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "clap",
  "goblin",
  "indexmap",
+ "path-slash",
  "serde",
  "serde_json",
  "srec",
@@ -423,6 +424,12 @@ dependencies = [
  "cortex-m",
  "cortex-m-semihosting",
 ]
+
+[[package]]
+name = "path-slash"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf9566c1063a197427135fb518ed42f2be18630fc2401aa267ed2dc95e9c85d"
 
 [[package]]
 name = "plain"

--- a/packager/Cargo.toml
+++ b/packager/Cargo.toml
@@ -13,3 +13,4 @@ indexmap = {version = "1.3", features = ["serde-1"]}
 serde_json = "1.0"
 srec = "0.1"
 goblin = {version = "0.2", features = ["std", "elf32", "endian_fd"]}
+path-slash = "0.1.2"

--- a/packager/src/main.rs
+++ b/packager/src/main.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::ops::Range;
 use std::io::Write;
 
+use path_slash::PathBufExt;
 use serde::Deserialize;
 use structopt::StructOpt;
 use indexmap::IndexMap;
@@ -197,9 +198,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     std::fs::write(args.out.join("combined.srec"), srec_image)?;
 
     let mut gdb_script = std::fs::File::create(args.out.join("script.gdb"))?;
-    writeln!(gdb_script, "add-symbol-file {}", args.out.join("kernel").display())?;
+    writeln!(gdb_script, "add-symbol-file {}", args.out.join("kernel").to_slash().unwrap())?;
     for name in toml.tasks.keys() {
-        writeln!(gdb_script, "add-symbol-file {}", args.out.join(name).display())?;
+        writeln!(gdb_script, "add-symbol-file {}", args.out.join(name).to_slash().unwrap())?;
     }
     drop(gdb_script);
 


### PR DESCRIPTION
gdb's config file requres that we use /, not \, for separating paths.
Windows uses \ for paths, so on Windows, the gdb config generation was
incorrect. This properly changes the slashes for us.

Fixes #27