### PR TITLE
Switch stm32-rs h7 dep to fork.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "stm32h7"
 version = "0.11.0"
-source = "git+https://github.com/stm32-rs/stm32-rs-nightlies#3a98a595ed9126ed7e9515c575fb753b60cb9391"
+source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies#0258085314efe2dca393f51cbe4362b37337ffdd"
 dependencies = [
  "bare-metal",
  "cortex-m",

--- a/demo-stm32h7/Cargo.toml
+++ b/demo-stm32h7/Cargo.toml
@@ -19,7 +19,7 @@ panic-halt = {version = "0.2.0", optional = true}
 panic-semihosting = {version = "0.5.3", optional = true}
 
 [dependencies.stm32h7]
-git = "https://github.com/stm32-rs/stm32-rs-nightlies"
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
 features = ["stm32h7b3", "rt"]
 
 [dependencies.kern]

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -10,7 +10,7 @@ zerocopy = "0.3.0"
 num-traits = {version = "0.2", default-features = false}
 
 [dependencies.stm32h7]
-git = "https://github.com/stm32-rs/stm32-rs-nightlies"
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
 features = ["stm32h7b3"]
 
 [features]

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -12,7 +12,7 @@ zerocopy = "0.3.0"
 num-traits = {version = "0.2", default-features = false}
 
 [dependencies.stm32h7]
-git = "https://github.com/stm32-rs/stm32-rs-nightlies"
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
 features = ["stm32h7b3"]
 optional = true
 


### PR DESCRIPTION
The actual upstream repo we were tracking GCs its commits, including the
one we had locked. This fork won't do that.

See https://github.com/stm32-rs/stm32-rs/issues/397