### PR TITLE
xtask/dist: fix cmdline for 2+ features

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -212,9 +212,7 @@ fn build(
         .arg(name);
     if !features.is_empty() {
         cmd.arg("--features");
-        for feature in features {
-            cmd.arg(feature);
-        }
+        cmd.arg(features.join(","));
     }
 
     cmd.current_dir(path);


### PR DESCRIPTION
Yeah, turns out this has been wrong _forever._