### PR TITLE
Handle control-c properly in gdb xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cc"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +157,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113ef0ecffee2b62b58f9380f4469099b30e9f9cbee2804771b4203ba1762cfa"
 dependencies = [
  "cortex-m",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -460,6 +476,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -922,6 +951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "volatile-register"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1001,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "xtask"
 version = "1.0.0"
 dependencies = [
+ "ctrlc",
  "goblin",
  "indexmap",
  "path-slash",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,3 +17,4 @@ srec = "0.1"
 goblin = {version = "0.2", features = ["std", "elf32", "endian_fd"]}
 serde_json = "1.0"
 path-slash = "0.1.2"
+ctrlc = "3.1.4"

--- a/xtask/src/gdb.rs
+++ b/xtask/src/gdb.rs
@@ -5,6 +5,8 @@ use std::process::Command;
 use crate::Config;
 
 pub fn run(cfg: &Path, gdb_cfg: &Path) -> Result<(), Box<dyn Error>> {
+    ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
+
     let cfg_contents = std::fs::read(&cfg)?;
     let toml: Config = toml::from_slice(&cfg_contents)?;
 


### PR DESCRIPTION
~~Previously, if control-c were hit while in the gdb xtask, it would kill~~
~~the xtask, but leave the gdb process running. With this change, we~~
~~set up a control-c handler, and make sure to clean up after ourselves.~~

~~I don't know if we want to sleep at all in this busy-loop...~~