### PR TITLE
Remove excessive breakpoints from GDB scripts

### DIFF
--- a/demo-stm32h7/openocd.gdb
+++ b/demo-stm32h7/openocd.gdb
@@ -7,17 +7,7 @@ set print asm-demangle on
 set backtrace limit 32
 
 # detect unhandled exceptions, hard faults and panics
-break DefaultHandler
 break HardFault
-break rust_begin_unwind
-# # run the next few lines so the panic message is printed immediately
-# # the number needs to be adjusted for your panic handler
-# commands $bpnum
-# next 4
-# end
-
-# *try* to stop at the user entry point (it might be gone due to inlining)
-break main
 
 monitor arm semihosting enable
 

--- a/demo/openocd.gdb
+++ b/demo/openocd.gdb
@@ -7,17 +7,7 @@ set print asm-demangle on
 set backtrace limit 32
 
 # detect unhandled exceptions, hard faults and panics
-break DefaultHandler
 break HardFault
-break rust_begin_unwind
-# # run the next few lines so the panic message is printed immediately
-# # the number needs to be adjusted for your panic handler
-# commands $bpnum
-# next 4
-# end
-
-# *try* to stop at the user entry point (it might be gone due to inlining)
-break main
 
 monitor arm semihosting enable
 

--- a/lpc55/openocd.gdb
+++ b/lpc55/openocd.gdb
@@ -7,17 +7,7 @@ set print asm-demangle on
 set backtrace limit 32
 
 # detect unhandled exceptions, hard faults and panics
-break DefaultHandler
 break HardFault
-break rust_begin_unwind
-# # run the next few lines so the panic message is printed immediately
-# # the number needs to be adjusted for your panic handler
-# commands $bpnum
-# next 4
-# end
-
-# *try* to stop at the user entry point (it might be gone due to inlining)
-break main
 
 monitor arm semihosting enable
 


### PR DESCRIPTION
These were leftover from the cargo template we originally used to
bootstrap the project. They've gotten increasingly silly as the system
complexity has grown. Many of the GDB scripts had already been edited to
remove these; this fixes the final three.