### PR TITLE
Run `cargo upgrade`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
 name = "log"
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "srec"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f5fe3743d9e8135b763161b44830973e95c1562926817862af8e12f7aad82"
+checksum = "17c3a0538ec242e3cd333cdcdc8b720faa2fa0a9d7f444cf1ff63e7d3303adfb"
 
 [[package]]
 name = "ssmarshal"
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "stm32f4"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a3d6c58b14e63926273694e7dd644894513c5e35ce6928c4657ddb62cae976"
+checksum = "11460b4de3a84f072e2cf6e76306c64d27f405a0e83bace0a726f555ddf4bf33"
 dependencies = [
  "bare-metal",
  "cortex-m",

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.3"
+zerocopy = "0.3.0"
 bitflags = "1.2.1"
-byteorder = {version = "1.3.4", default-features = false}
-serde = {version = "1", default-features = false, features = ["derive"]}
+byteorder = { version = "1.3.4", default-features = false }
+serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 
 [lib]
 test = false

--- a/build-util/Cargo.toml
+++ b/build-util/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]
-serde = "1"
-serde_json = "1"
+serde = "1.0.114"
+serde_json = "1.0.56"

--- a/demo-stm32h7/Cargo.toml
+++ b/demo-stm32h7/Cargo.toml
@@ -13,13 +13,13 @@ h743 = ["stm32h7/stm32h743"]
 h7b3 = ["stm32h7/stm32h7b3"]
 
 [dependencies]
-cortex-m = {version = "0.6.0", features = ["inline-asm"]}
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-panic-itm = {version = "0.4.1", optional = true}
-panic-halt = {version = "0.2.0", optional = true}
-panic-semihosting = {version = "0.5.3", optional = true}
-cfg-if = "0.1"
+cortex-m = { version = "0.6.2", features = ["inline-asm"] }
+cortex-m-rt = "0.6.12"
+cortex-m-semihosting = "0.3.5"
+panic-itm = { version = "0.4.1", optional = true }
+panic-halt = { version = "0.2.0", optional = true }
+panic-semihosting = { version = "0.5.3", optional = true }
+cfg-if = "0.1.10"
 
 [dependencies.stm32h7]
 git = "https://github.com/oxidecomputer/stm32-rs-nightlies"

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -5,22 +5,29 @@ readme = "README.md"
 name = "demo"
 version = "0.1.0"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [features]
 default = ["itm"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-panic-itm = {version = "0.4.1", optional = true}
-panic-halt = {version = "0.2.0", optional = true}
-panic-semihosting = {version = "0.5.3", optional = true}
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
+cortex-m-semihosting = "0.3.5"
+panic-itm = { version = "0.4.1", optional = true }
+panic-halt = { version = "0.2.0", optional = true }
+panic-semihosting = { version = "0.5.3", optional = true }
 
 [dependencies.stm32f4]
 features = ["stm32f407", "rt"]
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies.kern]
 path = "../kern"
@@ -34,10 +41,3 @@ build-util = {path = "../build-util"}
 name = "demo"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/drv/lpc55-gpio/Cargo.toml
+++ b/drv/lpc55-gpio/Cargo.toml
@@ -4,12 +4,19 @@ version = "0.1.0"
 authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
-cortex-m-semihosting = "0.3.3"
-num-traits = {version = "0.2", default-features = false}
+cortex-m-semihosting = "0.3.5"
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
@@ -21,10 +28,3 @@ standalone = []
 name = "drv-lpc55-gpio"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -4,13 +4,20 @@ version = "0.1.0"
 authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-cortex-m-semihosting = "0.3.3"
-num-traits = {version = "0.2", default-features = false}
+cortex-m-semihosting = "0.3.5"
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
@@ -22,10 +29,3 @@ standalone = []
 name = "drv-lpc55-i2c"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -9,8 +9,8 @@ userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-cortex-m-semihosting = "0.3.3"
-num-traits = {version = "0.2", default-features = false}
+cortex-m-semihosting = "0.3.5"
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]

--- a/drv/lpc55-syscon-api/Cargo.toml
+++ b/drv/lpc55-syscon-api/Cargo.toml
@@ -7,20 +7,20 @@ authors = [
 ]
 edition = "2018"
 
-[dependencies]
-userlib = {path = "../../userlib"}
-zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
-
-# This section is here to discourage RLS/rust-analyzer from doing test builds,
-# since test builds don't work for cross compilation.
-[lib]
-test = false
-bench = false
-
 [package.metadata.build]
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
 # target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 target = "thumbv8m.main-none-eabihf"
+
+[dependencies]
+userlib = {path = "../../userlib"}
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -4,12 +4,19 @@ version = "0.1.0"
 authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
-cortex-m = "0.6.0"
-num-traits = {version = "0.2", default-features = false}
+cortex-m = "0.6.2"
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
@@ -21,10 +28,3 @@ standalone = []
 name = "drv-lpc55-syscon"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -4,11 +4,18 @@ version = "0.1.0"
 authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
-cortex-m-semihosting = "0.3.3"
+cortex-m-semihosting = "0.3.5"
 
 [features]
 default = ["standalone"]
@@ -20,10 +27,3 @@ standalone = []
 name = "drv-lpc55-usart"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/stm32f4-rcc/Cargo.toml
+++ b/drv/stm32f4-rcc/Cargo.toml
@@ -4,11 +4,18 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
-stm32f4 = {version = "0.10.0", features = ["stm32f407"]}
+stm32f4 = { version = "0.11.0", features = ["stm32f407"] }
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
@@ -20,10 +27,3 @@ standalone = []
 name = "drv-stm32f4-rcc"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/stm32f4-usart/Cargo.toml
+++ b/drv/stm32f4-usart/Cargo.toml
@@ -4,11 +4,18 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
-stm32f4 = {version = "0.10.0", features = ["stm32f407"]}
+stm32f4 = { version = "0.11.0", features = ["stm32f407"] }
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
@@ -20,10 +27,3 @@ standalone = []
 name = "drv-stm32f4-usart"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/stm32h7-gpio-api/Cargo.toml
+++ b/drv/stm32h7-gpio-api/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
-byteorder = {version = "1.3", default-features = false}
-num-traits = {version = "0.2", default-features = false}
+byteorder = { version = "1.3.4", default-features = false }
+num-traits = { version = "0.2.12", default-features = false }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
-byteorder = {version = "1.3", default-features = false}
-num-traits = {version = "0.2", default-features = false}
+byteorder = { version = "1.3.4", default-features = false }
+num-traits = { version = "0.2.12", default-features = false }
 
 [dependencies.stm32h7]
 git = "https://github.com/oxidecomputer/stm32-rs-nightlies"

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -4,10 +4,17 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf"
+
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 
 [dependencies.stm32h7]
 git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
@@ -23,10 +30,3 @@ standalone = []
 name = "drv-stm32h7-rcc"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf"

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 
 [dependencies.stm32h7]

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>" ]
 edition = "2018"
 
-[dependencies]
-userlib = {path = "../../userlib"}
-zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
-
-# This section is here to discourage RLS/rust-analyzer from doing test builds,
-# since test builds don't work for cross compilation.
-[lib]
-test = false
-bench = false
-
 [package.metadata.build]
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
 # target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 target = "thumbv8m.main-none-eabihf"
+
+[dependencies]
+userlib = {path = "../../userlib"}
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -4,14 +4,21 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [dependencies]
 userlib = {path = "../../userlib"}
-stm32f4 = {version = "0.10.0", features = ["stm32f407"], optional = true}
-lpc55-pac = {version = "0.1.0", optional = true}
+stm32f4 = { version = "0.11.0", features = ["stm32f407"], optional = true }
+lpc55-pac = { version = "0.1.0", optional = true }
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", optional = true}
-cfg-if = "0.1"
+cfg-if = "0.1.10"
 
 [build-dependencies]
 build-util = {path = "../../build-util"}
@@ -28,10 +35,3 @@ lpc55 = ["lpc55-pac"]
 name = "drv-user-leds"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/kern/Cargo.toml
+++ b/kern/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [features]
 default = ["klog-itm"]
 klog-semihosting = ["cortex-m-semihosting"]
@@ -12,13 +19,13 @@ klog-itm = []
 [dependencies]
 abi = {path = "../abi"}
 zerocopy = "0.3.0"
-byteorder = {version = "1.3.4", default-features = false}
+byteorder = { version = "1.3.4", default-features = false }
 bitflags = "1.2.1"
 cfg-if = "0.1.10"
-cortex-m = "0.6.0"
-cortex-m-semihosting = {version = "0.3.3", optional = true}
-serde = {version = "1", default-features = false}
-ssmarshal = {version = "1", default-features = false}
+cortex-m = "0.6.2"
+cortex-m-semihosting = { version = "0.3.5", optional = true }
+serde = { version = "1.0.114", default-features = false }
+ssmarshal = { version = "1.0.0", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../build-util"}
@@ -26,10 +33,3 @@ build-util = {path = "../build-util"}
 [lib]
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/lpc55/Cargo.toml
+++ b/lpc55/Cargo.toml
@@ -5,17 +5,24 @@ readme = "README.md"
 name = "lpc55"
 version = "0.1.0"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv8m.main-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [features]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-panic-itm = {version = "0.4.1", optional = true}
-panic-halt = {version = "0.2.0", optional = true}
-panic-semihosting = {version = "0.5.3", optional = true}
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
+cortex-m-semihosting = "0.3.5"
+panic-itm = { version = "0.4.1", optional = true }
+panic-halt = { version = "0.2.0", optional = true }
+panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.1.0"
 
 [dependencies.kern]
@@ -30,10 +37,3 @@ build-util = {path = "../build-util"}
 name = "lpc55"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv8m.main-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-idle/Cargo.toml
+++ b/task-idle/Cargo.toml
@@ -4,11 +4,18 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [dependencies]
 # suppress default features to avoid including panic message collection, to
 # ensure the idle task remains tiny.
 userlib = {path = "../userlib", default-features = false}
-cortex-m = {version = "0.6", features = ["inline-asm"]}
+cortex-m = { version = "0.6.2", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]
@@ -20,10 +27,3 @@ standalone = []
 name = "task-idle"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-jefe/Cargo.toml
+++ b/task-jefe/Cargo.toml
@@ -4,13 +4,20 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [dependencies]
 abi = {path = "../abi"}
 userlib = {path = "../userlib"}
-stm32f4 = {version = "0.10.0", features = ["stm32f407"]}
+stm32f4 = { version = "0.11.0", features = ["stm32f407"] }
 zerocopy = "0.3.0"
-cortex-m = "0.6.0"
-cortex-m-semihosting = {version = "0.3.3", optional = true}
+cortex-m = "0.6.2"
+cortex-m-semihosting = { version = "0.3.5", optional = true }
 
 [features]
 default = ["standalone"]
@@ -24,10 +31,3 @@ semihosting = [ "cortex-m-semihosting", "userlib/log-semihosting" ]
 name = "task-jefe"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-ping/Cargo.toml
+++ b/task-ping/Cargo.toml
@@ -4,10 +4,17 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.6.0"
+cortex-m = "0.6.2"
 userlib = {path = "../userlib"}
 drv-user-leds-api = {path = "../drv/user-leds-api"}
 
@@ -20,10 +27,3 @@ uart = []
 name = "task-ping"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-pong/Cargo.toml
+++ b/task-pong/Cargo.toml
@@ -4,10 +4,17 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.6.0"
+cortex-m = "0.6.2"
 userlib = {path = "../userlib"}
 drv-user-leds-api = {path = "../drv/user-leds-api"}
 
@@ -19,10 +26,3 @@ standalone = []
 name = "task-pong"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-spam2/Cargo.toml
+++ b/task-spam2/Cargo.toml
@@ -4,11 +4,18 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [dependencies]
 # suppress default features to avoid including panic message collection, to
 # ensure the spam task remains tiny.
 userlib = {path = "../userlib", default-features = false}
-cortex-m-semihosting = "0.3.3"
+cortex-m-semihosting = "0.3.5"
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
 
@@ -23,10 +30,3 @@ standalone = []
 name = "task-spam"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/task-spi/Cargo.toml
+++ b/task-spi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # suppress default features to avoid including panic message collection, to
 # ensure the spi task remains tiny.
 userlib = {path = "../userlib", default-features = false}
-cortex-m-semihosting = "0.3.3"
+cortex-m-semihosting = "0.3.5"
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
 

--- a/task-template/Cargo.toml
+++ b/task-template/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 authors = ["Your Name Here <anonymous@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [dependencies]
 userlib = {path = "../userlib"}
 
@@ -17,10 +24,3 @@ standalone = []
 name = "task-template"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/tests-stm32f4/Cargo.toml
+++ b/tests-stm32f4/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../userlib", features = ["log-itm"]}
-cortex-m = "0.6.0"
+cortex-m = "0.6.2"
 zerocopy = "0.3.0"
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]

--- a/tests-stm32f4/stub/Cargo.toml
+++ b/tests-stm32f4/stub/Cargo.toml
@@ -4,21 +4,28 @@ edition = "2018"
 name = "tests-stm32f4"
 version = "0.1.0"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [features]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-panic-itm = {version = "0.4.1", optional = true}
-panic-halt = {version = "0.2.0", optional = true}
-panic-semihosting = {version = "0.5.3", optional = true}
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
+cortex-m-semihosting = "0.3.5"
+panic-itm = { version = "0.4.1", optional = true }
+panic-halt = { version = "0.2.0", optional = true }
+panic-semihosting = { version = "0.5.3", optional = true }
 
 [dependencies.stm32f4]
 features = ["stm32f407", "rt"]
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies.kern]
 path = "../../kern"
@@ -32,10 +39,3 @@ build-util = {path = "../../build-util"}
 name = "tests-stm32f4"
 test = false
 bench = false
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/userlib/Cargo.toml
+++ b/userlib/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
+[package.metadata.build]
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
 [features]
 default = ["panic-messages"]
 panic-messages = []
@@ -12,12 +19,12 @@ log-semihosting = []
 
 [dependencies]
 abi = {path = "../abi"}
-r0 = "1.0"
-serde = {version = "1", default-features = false}
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.3"
-num-traits = {version = "0.2", default-features = false}
-num-derive = "0.3"
+r0 = "1.0.0"
+serde = { version = "1.0.114", default-features = false }
+ssmarshal = { version = "1.0.0", default-features = false }
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+num-derive = "0.3.0"
 
 [lib]
 test = false
@@ -25,10 +32,3 @@ bench = false
 
 [build-dependencies]
 build-util = {path = "../build-util"}
-
-[package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3"
+structopt = "0.3.15"
 
 # for package
-serde = {version = "1.0", features = ["derive"]}
-toml = "0.5"
-indexmap = {version = "1.3", features = ["serde-1"]}
-srec = "0.1"
-goblin = {version = "0.2", features = ["std", "elf32", "endian_fd"]}
-serde_json = "1.0"
-path-slash = "0.1.2"
-ctrlc = "3.1.4"
+serde = { version = "1.0.114", features = ["derive"] }
+toml = "0.5.6"
+indexmap = { version = "1.4.0", features = ["serde-1"] }
+srec = "0.2.0"
+goblin = { version = "0.2.3", features = ["std", "elf32", "endian_fd"] }
+serde_json = "1.0.56"
+path-slash = "0.1.3"
+ctrlc = "3.1.5"
 zip = "0.5.6"


### PR DESCRIPTION
This has done the following:

- Normalized a bunch of our Cargo.toml files (hopefully avoiding this
  kind of diff in the future)

- Recorded the particular minor versions we're using in the toml files
  (which ensures that we don't accidentally regress and lose things
  we're relying on).

- Actually upgraded three crates: libc, srec, and stm32f4. The first two
  are used only in the build tools.