### PR TITLE
STM32H7 OpenOCD config breaks SWO/SWV

### DIFF
--- a/demo-stm32h7/openocd.cfg
+++ b/demo-stm32h7/openocd.cfg
@@ -10,16 +10,32 @@ source [find target/stm32h7x_dual_bank.cfg]
 # The documentation is clear that these must be preserved at their reset
 # value (namely: zero) -- and setting them causes SWO to not function at all.
 # Making what feels like the reasonable assumption that this bug will never
-# actually be fixed by OpenOCD, we undo that damage here by zeroing out the
-# reserved bits, preserving the values that the configuration was trying to
-# set. Note that we can't actually do any of this without first calling "init"
-# to force us into the run stage (and therefore allow for memory reading and
-# writing).
+# actually be fixed by OpenOCD, we instead workaround it by overriding the
+# event in which the damage is done, replacing it with the correct
+# implementation.
 #
-init
+$_CHIPNAME.cpu0 configure -event examine-end {
+	echo "Info : executing patched examine-end for $_CHIPNAME.cpu0"
+	# Enable D3 and D1 DBG clocks
+	# DBGMCU_CR |= D3DBGCKEN | D1DBGCKEN
+	stm32h7x_dbgmcu_mmw 0x004 0x00600000 0
 
-#
-# Now undo the damage done by clearing the five (?!) bits set.
-#
-echo "Info : Fixing DBGMCU CR to restore SWO"
-stm32h7x_dbgmcu_mmw 0x004 0 0x000001B8
+	# Enable debug during low power modes (uses more power)
+	# DBGMCU_CR |= DBG_STANDBY | DBG_STOP | DBG_SLEEP
+	#
+	# Note that we do this ONLY for D1; setting this for D3 (a.k.a.
+	# SmartRun, a.k.a. SRD) and/or the reserved bits that may have once
+	# corresponded to D2 is what causes SWO to malfunction.  As an added
+	# precaution, we also take the step of explicitly clearing these bits,
+	# should a broken OpenOCD have already set them.
+	stm32h7x_dbgmcu_mmw 0x004 0x00000007 0x000001B8
+
+	# Stop watchdog counters during halt
+	# DBGMCU_APB3FZ1 |= WWDG1
+	stm32h7x_dbgmcu_mmw 0x034 0x00000040 0
+	# DBGMCU_APB1LFZ1 |= WWDG2
+	stm32h7x_dbgmcu_mmw 0x03C 0x00000800 0
+	# DBGMCU_APB4FZ1 |= WDGLSD1 | WDGLSD2
+	stm32h7x_dbgmcu_mmw 0x054 0x000C0000 0
+}
+


### PR DESCRIPTION
There exists a bug in OpenOCD's stm32h7x.cfg file whereby it will set reserved bits in the STM32H7 DBGMCU CR:

   https://sourceforge.net/p/openocd/tickets/266/

The documentation is clear that these must be preserved at their reset value (namely: zero) -- and setting them causes SWO to not function at all.  Making what feels like the reasonable assumption that this bug will never actually be fixed by OpenOCD, we undo that damage here by zeroing out the reserved bits, preserving the values that the configuration was trying to set.