### PR TITLE
Bump the cortex-m crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,12 +17,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "aligned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
+dependencies = [
+ "generic-array 0.12.3",
+ "generic-array 0.13.2",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -127,9 +147,11 @@ dependencies = [
 
 [[package]]
 name = "cortex-m"
-version = "0.6.2"
-source = "git+https://github.com/oxidecomputer/cortex-m.git?branch=itm-reserved-bits#705812c80f9bb267d3c0162d52dfd43dec9302f3"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be99930c99669a74d986f7fd2162085498b322e6daae8ef63a97cc9ac1dc73c"
 dependencies = [
+ "aligned",
  "bare-metal",
  "bitfield",
  "volatile-register",
@@ -381,6 +403,24 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -736,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stm32f4"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +984,12 @@ checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,6 @@ members = [
 default-members = []
 resolver = "2"
 
-[patch.crates-io]
-#
-# Until https://github.com/rust-embedded/cortex-m/pull/227 is pulled into
-# a cortex-m release, we ned to pull from the Oxide branch with the fix.
-#
-cortex-m = { git = "https://github.com/oxidecomputer/cortex-m.git", branch = "itm-reserved-bits" }
-
 [profile.release]
 codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size on Flash

--- a/demo-stm32h7/Cargo.toml
+++ b/demo-stm32h7/Cargo.toml
@@ -13,7 +13,7 @@ h743 = ["stm32h7/stm32h743"]
 h7b3 = ["stm32h7/stm32h7b3"]
 
 [dependencies]
-cortex-m = { version = "0.6.2", features = ["inline-asm"] }
+cortex-m = { version = "0.6.3", features = ["inline-asm"] }
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.3.5"
 panic-itm = { version = "0.4.1", optional = true }
@@ -37,4 +37,3 @@ build-util = {path = "../build-util"}
 name = "demo-stm32h7"
 test = false
 bench = false
-

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -18,7 +18,7 @@ itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.3.5"
 panic-itm = { version = "0.4.1", optional = true }

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -15,7 +15,7 @@ target = "thumbv8m.main-none-eabihf"
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 lpc55-pac = "0.1.0"
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 num-traits = { version = "0.2.12", default-features = false }
 
 [features]

--- a/kern/Cargo.toml
+++ b/kern/Cargo.toml
@@ -22,7 +22,7 @@ zerocopy = "0.3.0"
 byteorder = { version = "1.3.4", default-features = false }
 bitflags = "1.2.1"
 cfg-if = "0.1.10"
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }

--- a/lpc55/Cargo.toml
+++ b/lpc55/Cargo.toml
@@ -17,7 +17,7 @@ itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.3.5"
 panic-itm = { version = "0.4.1", optional = true }

--- a/task-idle/Cargo.toml
+++ b/task-idle/Cargo.toml
@@ -15,7 +15,7 @@ target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 # suppress default features to avoid including panic message collection, to
 # ensure the idle task remains tiny.
 userlib = {path = "../userlib", default-features = false}
-cortex-m = { version = "0.6.2", features = ["inline-asm"] }
+cortex-m = { version = "0.6.3", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]

--- a/task-jefe/Cargo.toml
+++ b/task-jefe/Cargo.toml
@@ -15,7 +15,7 @@ target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 abi = {path = "../abi"}
 userlib = {path = "../userlib"}
 zerocopy = "0.3.0"
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 
 [features]

--- a/task-ping/Cargo.toml
+++ b/task-ping/Cargo.toml
@@ -14,7 +14,7 @@ target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 userlib = {path = "../userlib"}
 drv-user-leds-api = {path = "../drv/user-leds-api"}
 

--- a/task-pong/Cargo.toml
+++ b/task-pong/Cargo.toml
@@ -14,7 +14,7 @@ target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 userlib = {path = "../userlib"}
 drv-user-leds-api = {path = "../drv/user-leds-api"}
 

--- a/tests-stm32f4/Cargo.toml
+++ b/tests-stm32f4/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../userlib", features = ["log-itm"]}
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 

--- a/tests-stm32f4/stub/Cargo.toml
+++ b/tests-stm32f4/stub/Cargo.toml
@@ -16,7 +16,7 @@ itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.3.5"
 panic-itm = { version = "0.4.1", optional = true }


### PR DESCRIPTION
The patch we needed was upstreamed, so let's use it.