### PR TITLE
Infer package list from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
+dependencies = [
+ "semver 0.11.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff65715a17cba8979903db6294baef56c5d39e05c8b054cffa31e69e61f24c68"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +948,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -963,7 +983,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -971,6 +1001,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1291,6 +1330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1446,7 @@ dependencies = [
  "abi",
  "anyhow",
  "byteorder",
+ "cargo_metadata",
  "ctrlc",
  "goblin",
  "indexmap",

--- a/demo-stm32h7/Cargo.toml
+++ b/demo-stm32h7/Cargo.toml
@@ -33,6 +33,10 @@ default-features = false
 [build-dependencies]
 build-util = {path = "../build-util"}
 
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
+
 # this lets you use `cargo fix`!
 [[bin]]
 name = "demo-stm32h7"

--- a/task-oh-no/Cargo.toml
+++ b/task-oh-no/Cargo.toml
@@ -4,12 +4,9 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve.klabnik@oxide.computer>"]
 edition = "2018"
 
+# a target for `cargo xtask check`
 [package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+target = "thumbv7em-none-eabihf"
 
 [dependencies]
 userlib = {path = "../userlib"}

--- a/task-oh-no/src/main.rs
+++ b/task-oh-no/src/main.rs
@@ -6,7 +6,7 @@ use userlib::*;
 use zerocopy::AsBytes;
 
 #[cfg(feature = "standalone")]
-const OHNO2: Task = SELF;
+const OHNO2: Task = Task::anonymous;
 
 #[cfg(not(feature = "standalone"))]
 const OHNO2: Task = Task::oh_no2;

--- a/task-oh-no2/Cargo.toml
+++ b/task-oh-no2/Cargo.toml
@@ -4,12 +4,9 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve.klabnik@oxide.computer>"]
 edition = "2018"
 
+# a target for `cargo xtask check`
 [package.metadata.build]
-# Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+target = "thumbv7em-none-eabihf"
 
 [dependencies]
 userlib = {path = "../userlib"}

--- a/tests-stm32f4/Cargo.toml
+++ b/tests-stm32f4/Cargo.toml
@@ -15,6 +15,10 @@ default = ["standalone"]
 standalone = []
 itm = ["userlib/log-itm"]
 
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/tests-stm32f4/src/bin/runner.rs
+++ b/tests-stm32f4/src/bin/runner.rs
@@ -324,6 +324,7 @@ fn find_and_report_fault() -> bool {
                     sys_log!("Task #{} Bad Syscall Usage {:?}", i, e)
                 }
                 FaultInfo::Panic => sys_log!("Task #{} Panic!", i),
+                _ => {}
             };
             if i == TEST_TASK {
                 tester_faulted = true;

--- a/tests-stm32f4/src/bin/testsuite.rs
+++ b/tests-stm32f4/src/bin/testsuite.rs
@@ -436,7 +436,7 @@ const ASSIST: Task = Task::assist;
 // For standalone mode -- this won't work, but then, neither will a task without
 // a kernel.
 #[cfg(feature = "standalone")]
-const ASSIST: Task = SELF;
+const ASSIST: Task = Task::anonymous;
 
 /// Tracks the current generation of the assistant task as we restart it.
 static ASSIST_GEN: AtomicU8 = AtomicU8::new(0);

--- a/tests-stm32f4/stub/Cargo.toml
+++ b/tests-stm32f4/stub/Cargo.toml
@@ -5,6 +5,7 @@ name = "tests-stm32f4"
 version = "0.1.0"
 
 [features]
+default = ["itm"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 
@@ -23,6 +24,10 @@ version = "0.11.0"
 [dependencies.kern]
 path = "../../kern"
 default-features = false
+
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/tests-stm32f4/stub/src/main.rs
+++ b/tests-stm32f4/stub/src/main.rs
@@ -27,6 +27,9 @@ extern "C" {
 
 #[entry]
 fn main() -> ! {
+    // Default boot speed, until we bother raising it:
+    const CYCLES_PER_MS: u32 = 16_000;
+
     unsafe {
         let heap_size =
             (&__eheap as *const _ as usize) - (&__sheap as *const _ as usize);
@@ -34,6 +37,7 @@ fn main() -> ! {
             &hubris_app_table,
             (&mut __sheap) as *mut _,
             heap_size,
+            CYCLES_PER_MS,
         )
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.3.15"
 anyhow = "1.0.32"
+cargo_metadata = "0.12.0"
 
 # for dist
 serde = { version = "1.0.114", features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -156,42 +156,37 @@ fn main() -> Result<()> {
             if !all {
                 check::run(package, target)?;
             } else {
-                let packages = [
-                    "abi",
-                    "drv-lpc55-gpio",
-                    "drv-lpc55-i2c",
-                    "drv-lpc55-rng",
-                    "drv-lpc55-spi",
-                    "drv-lpc55-syscon-api",
-                    "drv-lpc55-syscon",
-                    "drv-lpc55-usart",
-                    "drv-stm32f4-rcc",
-                    "drv-stm32f4-usart",
-                    "drv-stm32h7-gpio-api",
-                    "drv-stm32h7-gpio",
-                    "drv-stm32h7-rcc",
-                    "drv-stm32h7-usart",
-                    "drv-user-leds-api",
-                    "drv-user-leds",
-                    "kern",
-                    "task-idle",
-                    "task-jefe",
-                    "task-ping",
-                    "task-pong",
-                    "task-spam",
-                    "task-spi",
-                    "task-template",
-                    "userlib",
-                    "demo",
-                    "demo-stm32h7",
-                    "lpc55",
-                ];
+                use cargo_metadata::MetadataCommand;
 
-                for package in &packages {
-                    check::run(
-                        Some(package.to_string()),
-                        Some("thumbv7em-none-eabihf".to_string()),
-                    )?;
+                let metadata = MetadataCommand::new()
+                    .manifest_path("./Cargo.toml")
+                    .exec()
+                    .unwrap();
+
+                #[derive(Debug, Deserialize)]
+                struct CustomMetadata {
+                    build: Option<BuildMetadata>,
+                }
+
+                #[derive(Debug, Deserialize)]
+                struct BuildMetadata {
+                    target: Option<String>,
+                }
+
+                for id in &metadata.workspace_members {
+                    let package = metadata
+                        .packages
+                        .iter()
+                        .find(|p| &p.id == id)
+                        .unwrap()
+                        .clone();
+
+                    let m: Option<CustomMetadata> =
+                        serde_json::from_value(package.metadata)?;
+
+                    let target = (|| m?.build?.target)();
+
+                    check::run(Some(package.name), target)?;
                 }
             }
         }


### PR DESCRIPTION
The initial implementation here had a hand-crafted list of packages. It
is error-prone to do this.

And as you can see, it was. There were a few packages that weren't able
to be properly checked. This commit uses cargo-metadata to properly get
the list of all packages, and fixes up the build for the ones that
weren't quite building.