### PR TITLE
Rebuild when app.toml changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "filetime"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +915,12 @@ name = "r0"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -1402,6 +1420,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "ctrlc",
+ "filetime",
  "goblin",
  "indexmap",
  "lpc55_support",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,5 +24,7 @@ ctrlc = "3.1.5"
 zip = "=0.5.6"
 abi = { path = "../abi" }
 byteorder = "1.3.4"
+filetime = "0.2.12"
+
 # For NXP signing
 lpc55_support = { path = "../lpc55_support" }


### PR DESCRIPTION
In #87, it was reported that when app.toml changes, the project doesn't
rebuild. This is important, because changes in app.toml can radically
change the final image.

In this commit, we create a timestamp file on succesful builds, and
compare it against the last modified time of the app.toml for a project.
If the app.toml has changed since our last build, we re-build all tasks
and the kernel.

Fixes #87