### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ jobs:
             deps: sudo apt-get install binutils-arm-none-eabi libudev-dev
           - os: windows-latest
             deps: |
-              Invoke-WebRequest -Uri https://github.com/steveklabnik/arm-none-eabi-objcopy/releases/download/9-2020-q2-update/arm-none-eabi-objcopy.exe -OutFile "D:\a\hubris\arm-none-eabi-objcopy.exe"
-              echo "D:\a\hubris\" >> $env:GITHUB_PATH
-              echo "VCPKG_ROOT=$Env:VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
+              Invoke-WebRequest -Uri https://github.com/steveklabnik/arm-none-eabi-objcopy/releases/download/9-2020-q2-update/arm-none-eabi-objcopy.exe -OutFile "$Env:RUNNER_TEMP\arm-none-eabi-objcopy.exe"
+              echo $Env:RUNNER_TEMP >> $Env:GITHUB_PATH
+              echo "VCPKG_ROOT=$Env:VCPKG_INSTALLATION_ROOT" >> $Env:GITHUB_ENV
               vcpkg install openssl:x64-windows
     env:
       VCPKGRS_DYNAMIC: 1


### PR DESCRIPTION
There's some weird reason where scoop isn't installing the right thing. So, let's fix that.

To do so, we are:

1. going to download just objcopy
2. gonna use vcpkg to get openssl

This completely removes scoop and all its shenanigans; vcpkg is already
installed in the CI environment.
