### PR TITLE
turn on backtraces in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
 
       # invoke our build
       - uses: actions-rs/cargo@v1
+        env:
+          RUST_BACKTRACE: 1
         with:
           command: xtask
           args: dist ${{ matrix.app_toml}}


### PR DESCRIPTION
It can be useful to see the backtrace when CI fails.