### PR TITLE
kern: fix DMA mem atts for ARMv7M

### DIFF
--- a/kern/src/arch/arm_m.rs
+++ b/kern/src/arch/arm_m.rs
@@ -366,10 +366,9 @@ pub fn apply_memory_protection(task: &task::Task) {
         } else if ratts.contains(app::RegionAttributes::DMA) {
             // Conservative settings for normal memory assuming that DMA might
             // be a problem:
-            // - Outer and inner write-through.
-            // - Read allocate, no write allocate.
+            // - Outer and inner non-cacheable.
             // - Shared.
-            (0b000, 0b110)
+            (0b001, 0b100)
         } else {
             // Aggressive settings for normal memory assume that it is used only
             // by this processor:


### PR DESCRIPTION
I had mistakenly set DMA-marked memory as write-through, which is great
for publishing data _to_ devices only, but means we can read stale data
when we look for data _from_ devices. In the general case we need it to
be noncacheable, until we get cache maintenance ops.