### PR TITLE
stm32h7-spi: initial prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-stm32h7-spi"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "stm32h7",
+ "vcell",
+ "zerocopy",
+]
+
+[[package]]
+name = "drv-stm32h7-spi-server"
+version = "0.1.0"
+dependencies = [
+ "cortex-m 0.6.7",
+ "drv-stm32h7-gpio-api",
+ "drv-stm32h7-rcc-api",
+ "drv-stm32h7-spi",
+ "num-traits",
+ "stm32h7",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-stm32h7-usart"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ members = [
     "drv/stm32h7-gpio-api",
     "drv/stm32h7-rcc",
     "drv/stm32h7-rcc-api",
+    "drv/stm32h7-spi",
+    "drv/stm32h7-spi-server",
     "drv/stm32h7-usart",
 
     "drv/lpc55-syscon",

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "drv-stm32h7-spi-server"
+version = "0.1.0"
+authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../userlib"}
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+drv-stm32h7-spi = {path = "../stm32h7-spi"}
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
+drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
+cortex-m = "0.6.3"
+
+[dependencies.stm32h7]
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
+features = ["stm32h743"]
+
+[features]
+default = ["standalone"]
+standalone = []
+
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-stm32h7-spi-server"
+test = false
+bench = false

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -1,0 +1,334 @@
+//! Server task for the STM32H7 SPI peripheral.
+//!
+//! Currently this hardcodes the clock rate and doesn't manage chip select.
+//!
+//! # IPC Protocol
+//!
+//! ## Exchange (1)
+//!
+//! Transmits data on MOSI and simultaneously receives data on MISO.
+//!
+//! Transmitted data is read from a byte buffer passed as borrow 0. This borrow
+//! must be readable.
+//!
+//! Received data is either written into borrow 0 (overwriting transmitted
+//! data), or can be written into a separate buffer by passing it as borrow 1.
+//! Whichever borrow is used for received data must be writable, and if it's
+//! separate from the transmit buffer, the two buffers must be the same length.
+
+#![no_std]
+#![no_main]
+
+use stm32h7::stm32h743 as device;
+use userlib::*;
+
+use drv_stm32h7_gpio_api as gpio_api;
+use drv_stm32h7_rcc_api as rcc_api;
+use drv_stm32h7_spi as spi_core;
+
+#[cfg(feature = "standalone")]
+const RCC: Task = Task::anonymous;
+
+#[cfg(not(feature = "standalone"))]
+const RCC: Task = Task::rcc_driver;
+
+#[cfg(feature = "standalone")]
+const GPIO: Task = Task::anonymous;
+
+#[cfg(not(feature = "standalone"))]
+const GPIO: Task = Task::gpio_driver;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
+enum Operation {
+    Read = 0b01,
+    Write = 0b10,
+    Exchange = 0b11,
+}
+
+impl Operation {
+    pub fn is_read(self) -> bool {
+        self as u32 & 1 != 0
+    }
+
+    pub fn is_write(self) -> bool {
+        self as u32 & 0b10 != 0
+    }
+}
+
+#[repr(u32)]
+enum ResponseCode {
+    BadArg = 2,
+}
+
+// TODO: it is super unfortunate to have to write this by hand, but deriving
+// ToPrimitive makes us check at runtime whether the value fits
+impl From<ResponseCode> for u32 {
+    fn from(rc: ResponseCode) -> Self {
+        rc as u32
+    }
+}
+
+const IRQ_MASK: u32 = 1;
+
+#[export_name = "main"]
+fn main() -> ! {
+    let rcc_driver = rcc_api::Rcc::from(TaskId::for_index_and_gen(
+        RCC as usize,
+        Generation::default(),
+    ));
+
+    // TODO this is hardcoded to SPI2 for now.
+
+    rcc_driver.enable_clock(rcc_api::Peripheral::Spi2);
+    rcc_driver.leave_reset(rcc_api::Peripheral::Spi2);
+
+    // Manufacture a pointer to SPI2 because the stm32h7 crate won't help us
+    // Safety: we're dereferencing a pointer to a guaranteed-valid address of
+    // registers.
+    let registers = unsafe { &*device::SPI2::ptr() };
+
+    let mut spi = spi_core::Spi::from(registers);
+
+    spi.initialize(
+        device::spi1::cfg1::MBR_A::DIV256,
+        8,
+        device::spi1::cfg2::COMM_A::FULLDUPLEX,
+        device::spi1::cfg2::LSBFRST_A::LSBFIRST,
+        device::spi1::cfg2::CPHA_A::FIRSTEDGE,
+        device::spi1::cfg2::CPOL_A::IDLELOW,
+        device::spi1::cfg2::SSOM_A::NOTASSERTED,
+    );
+
+    let gpio_driver = gpio_api::Gpio::from(TaskId::for_index_and_gen(
+        GPIO as usize,
+        Generation::default(),
+    ));
+    // Mux SPI2 onto the data pins but _not_ CS for now
+    gpio_driver
+        .configure(
+            gpio_api::Port::I,
+            (1 << 1) | (1 << 2) | (1 << 3),
+            gpio_api::Mode::Alternate,
+            gpio_api::OutputType::PushPull,
+            gpio_api::Speed::High,
+            gpio_api::Pull::None,
+            gpio_api::Alternate::AF5,
+        )
+        .unwrap();
+
+    loop {
+        hl::recv_without_notification(
+            // Our only operations use zero-length messages, so we can use a
+            // zero-length buffer here.
+            &mut [],
+            |op, msg| match op {
+                // Yes, this case matches all the enum values right now. This is
+                // insurance if we were to add a fourth!
+                Operation::Exchange | Operation::Read | Operation::Write => {
+                    // We can take varying numbers of leases, so we'll do lease
+                    // verification ourselves just below.
+                    let lease_count = msg.lease_count();
+                    let ((), caller) =
+                        msg.fixed().ok_or(ResponseCode::BadArg)?;
+
+                    // Inspect the message and generate two `Option<Borrow>`s
+                    // and a transfer length. Note: the two borrows may refer to
+                    // the same buffer! See the `1` case below for details.
+                    let (data_src, data_dst, xfer_len) = match lease_count {
+                        1 => {
+                            // Caller has provided a single lease, which must
+                            // have different attributes depending on what
+                            // operation they've requested.
+                            let borrow = caller.borrow(0);
+                            let info =
+                                borrow.info().ok_or(ResponseCode::BadArg)?;
+
+                            // Note that the attributes _we_ require are the
+                            // inverse of the sense of the SPI operation, e.g.
+                            // to read from SPI we must be able to _write_ the
+                            // lease, and vice versa.
+                            let required_attributes = match op {
+                                Operation::Read => LeaseAttributes::WRITE,
+                                Operation::Write => LeaseAttributes::READ,
+                                Operation::Exchange => {
+                                    LeaseAttributes::WRITE
+                                        | LeaseAttributes::READ
+                                }
+                            };
+
+                            if !info.attributes.contains(required_attributes) {
+                                return Err(ResponseCode::BadArg);
+                            }
+
+                            let read_borrow = if op.is_read() {
+                                Some(borrow.clone())
+                            } else {
+                                None
+                            };
+                            let write_borrow =
+                                if op.is_write() { Some(borrow) } else { None };
+
+                            (read_borrow, write_borrow, info.len)
+                        }
+                        2 if op == Operation::Exchange => {
+                            // Caller has provided two leases, the first as a
+                            // data source and the second as a data sink. This
+                            // is only legal if we are both transmitting and
+                            // receiving. The buffers are currently required to
+                            // be the same length for simplicity, though this
+                            // restriction is not inherent and could be lifted
+                            // with some effort.
+                            let src_borrow = caller.borrow(0);
+                            let src_info = src_borrow
+                                .info()
+                                .ok_or(ResponseCode::BadArg)?;
+
+                            if !src_info
+                                .attributes
+                                .contains(LeaseAttributes::READ)
+                            {
+                                return Err(ResponseCode::BadArg);
+                            }
+
+                            let dst_borrow = caller.borrow(1);
+                            let dst_info = dst_borrow
+                                .info()
+                                .ok_or(ResponseCode::BadArg)?;
+
+                            if !dst_info
+                                .attributes
+                                .contains(LeaseAttributes::WRITE)
+                            {
+                                return Err(ResponseCode::BadArg);
+                            }
+
+                            if dst_info.len != src_info.len {
+                                return Err(ResponseCode::BadArg);
+                            }
+
+                            (Some(src_borrow), Some(dst_borrow), src_info.len)
+                        }
+                        _ => return Err(ResponseCode::BadArg),
+                    };
+
+                    // That routine should have returned at least one borrow.
+                    // Here's an assert that takes fewer text bytes than assert.
+                    if data_src.is_none() && data_dst.is_none() {
+                        panic!()
+                    }
+
+                    // Due to driver limitations we will only move up to 64kiB
+                    // per transaction. It would be worth lifting this
+                    // limitation, maybe. Doing so would require managing data
+                    // in 64kiB chunks (because the peripheral is 16-bit) and
+                    // using the "reload" facility on the peripheral.
+                    //
+                    // Zero-byte SPI transactions don't make sense and we'll
+                    // decline them.
+                    if xfer_len == 0 || xfer_len >= 0x1_0000 {
+                        return Err(ResponseCode::BadArg);
+                    }
+
+                    // We have a reasonable-looking request containing (a)
+                    // reasonable-looking lease(s). This is our commit point.
+
+                    // Make sure SPI is on.
+                    spi.enable();
+                    // Load transfer count and start the state machine. At this
+                    // point we _have_ to move the specified number of bytes
+                    // through (or explicitly cancel, but we don't).
+                    spi.start(xfer_len as u16);
+
+                    // As you might expect, we will work from byte 0 to the end
+                    // of each buffer. There are two complications:
+                    //
+                    // 1. Transmit and receive can be at different positions --
+                    //    transmit will tend to lead receive, because the SPI
+                    //    unit contains FIFOs.
+                    //
+                    // 2. We're only keeping track of position in the buffers
+                    //    we're using: both tx and rx are `Option<(Borrow,
+                    //    usize)>`.
+
+                    // Tack a position field onto whichever borrows actually
+                    // exist.
+                    let mut tx = data_src.map(|borrow| (borrow, 0));
+                    let mut rx = data_dst.map(|borrow| (borrow, 0));
+
+                    // Enable interrupt on the conditions we're interested in.
+                    spi.enable_transfer_interrupts();
+
+                    // While work remains, we'll attempt to move up to one byte
+                    // in each direction, sleeping if we can do neither.
+                    while tx.is_some() || rx.is_some() {
+                        // Entering RECV to check for interrupts is not free, so
+                        // we only do it if we've filled the TX FIFO and emptied
+                        // the RX and repeating this loop would just burn power
+                        // and CPU. If there is any potential value to repeating
+                        // the loop immediately, we'll set this flag.
+                        let mut made_progress = false;
+
+                        if let Some((tx_data, tx_pos)) = &mut tx {
+                            if spi.can_tx_frame() {
+                                // Transfer byte from caller to TX FIFO.
+                                let byte: u8 = tx_data
+                                    .read_at(*tx_pos)
+                                    .ok_or(ResponseCode::BadArg)?;
+                                spi.send8(byte);
+                                *tx_pos += 1;
+
+                                // If we have _just_ finished...
+                                if *tx_pos == xfer_len {
+                                    // We will finish transmitting well before
+                                    // we're done receiving, so stop getting
+                                    // interrupt notifications for transmit
+                                    // space available during that time.
+                                    spi.disable_can_tx_interrupt();
+                                    tx = None;
+                                }
+
+                                made_progress = true;
+                            }
+                        }
+
+                        if let Some((rx_data, rx_pos)) = &mut rx {
+                            if spi.can_rx_byte() {
+                                // Transfer byte from RX FIFO to caller.
+                                let r = spi.recv8();
+                                rx_data
+                                    .write_at(*rx_pos, r)
+                                    .ok_or(ResponseCode::BadArg)?;
+                                *rx_pos += 1;
+
+                                if *rx_pos == xfer_len {
+                                    rx = None;
+                                }
+
+                                made_progress = true;
+                            }
+                        }
+
+                        if !made_progress {
+                            // Allow the controller interrupt to post to our
+                            // notification set.
+                            sys_irq_control(IRQ_MASK, true);
+                            // Wait for our notification set to get, well, set.
+                            sys_recv_closed(&mut [], IRQ_MASK, TaskId::KERNEL)
+                                .expect("kernel died?");
+                        }
+                    }
+
+                    // Wrap up the transfer and restore things to a reasonable
+                    // state.
+                    spi.end();
+
+                    // As we're done with the borrows, we can now resume the
+                    // caller.
+                    caller.reply(());
+
+                    Ok(())
+                }
+            },
+        );
+    }
+}

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "drv-stm32h7-spi"
+version = "0.1.0"
+authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
+edition = "2018"
+
+[dependencies]
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+vcell = "0.1.2"
+
+[dependencies.stm32h7]
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
+features = ["stm32h743"]
+
+# TODO can probably remove standalone feature for lib crates
+[features]
+default = ["standalone"]
+standalone = []
+
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -1,0 +1,249 @@
+//! A driver for the STM32H7 SPI, in host mode.
+//!
+//! This is the core logic, separated from the IPC server. The peripheral also
+//! supports I2S, which we haven't bothered implementing because we don't have a
+//! need for it.
+//!
+//! # Clocking
+//!
+//! The SPI block has no fewer than three clock domains.
+//!
+//! 1. `pclk` contains most of the control logic and operates at the APB
+//!    frequency.
+//!
+//! 2. `ker_ck` contains the clock generator and is driven as a "kernel clock"
+//!    from the RCC -- there is a separate mux there to choose its source.
+//!
+//! 3. The "serial interface domain" (no catchy abbreviation provided) is
+//!    clocked at the external SCK rate. This is derived from `ker_ck` in host
+//!    role.
+//!
+//! In host role, the SPI needs to have at least `ker_ck` running to do useful
+//! work.
+//!
+//! # Automagic CRC generation
+//!
+//! We do not currently support the hardware's automatic CRC features.
+
+#![no_std]
+
+use stm32h7::stm32h743 as device;
+
+pub struct Spi {
+    /// Pointer to our register block.
+    ///
+    /// This is not a `SPIx` type from the `stm32h7` crate because then we're
+    /// generic for no good reason and type parameters multiply. Ew.
+    ///
+    /// Pay no heed to the 1 in `spi1` -- that's what the common module is
+    /// called.
+    reg: &'static device::spi1::RegisterBlock,
+}
+
+impl From<&'static device::spi1::RegisterBlock> for Spi {
+    fn from(reg: &'static device::spi1::RegisterBlock) -> Self {
+        Self { reg }
+    }
+}
+
+impl Spi {
+    pub fn initialize(
+        &mut self,
+        mbr: device::spi1::cfg1::MBR_A,
+        bits_per_frame: u8,
+        comm: device::spi1::cfg2::COMM_A,
+        lsbfrst: device::spi1::cfg2::LSBFRST_A,
+        cpha: device::spi1::cfg2::CPHA_A,
+        cpol: device::spi1::cfg2::CPOL_A,
+        ssom: device::spi1::cfg2::SSOM_A,
+    ) {
+        // Expected preconditions:
+        // - GPIOs configured to proper AF etc - we cannot do this, because we
+        // cannot presume to have either direct GPIO access _or_ IPC access.
+        // - Clock on, reset off - again, we can't do this directly.
+
+        assert!(bits_per_frame >= 4 && bits_per_frame <= 32);
+
+        // Write CFG1/CFG2 to configure
+        self.reg
+            .cfg1
+            .write(|w| w.mbr().variant(mbr).dsize().bits(bits_per_frame - 1));
+
+        // TODO: C driver has some bits about twiddling SSI state to avoid MODF.
+        // I've hardcoded what I believe is the equivalent result here.
+
+        self.reg.cfg2.write(|w| {
+            w.master()
+                .set_bit()
+                // If you want to enable SS output, this bit needs to be set; if you
+                // don't, it appears harmless, so we set it unconditionally.
+                .ssm()
+                .set_bit()
+                // SS output enabled; but not necessarily routed to a pin (caller
+                // determines that)
+                .ssoe()
+                .enabled()
+                // Don't glitch pins when being reconfigured.
+                .afcntr()
+                .controlled()
+                // This is currently a host-only driver.
+                .master()
+                .set_bit()
+                .comm()
+                .variant(comm)
+                .lsbfrst()
+                .variant(lsbfrst)
+                .cpha()
+                .variant(cpha)
+                .cpol()
+                .variant(cpol)
+                .ssom()
+                .variant(ssom)
+        });
+
+        self.reg.cr1.write(|w| w.ssi().set_bit());
+
+        self.reg.i2scfgr.write(|w| w.i2smod().clear_bit());
+    }
+
+    pub fn enable(&mut self) {
+        self.reg.cr1.modify(|_, w| w.spe().set_bit());
+    }
+
+    pub fn start(&mut self, tsize: u16) {
+        self.reg.cr2.modify(|_, w| w.tsize().bits(tsize));
+        self.reg.cr1.modify(|_, w| w.cstart().set_bit());
+        // Clear EOT flag
+        self.reg.ifcr.write(|w| w.eotc().set_bit());
+    }
+
+    pub fn can_rx_word(&self) -> bool {
+        self.reg.sr.read().rxwne().bit()
+    }
+
+    pub fn can_rx_byte(&self) -> bool {
+        let sr = self.reg.sr.read();
+        sr.rxwne().bit() || sr.rxplvl().bits() != 0
+    }
+
+    pub fn can_tx_frame(&self) -> bool {
+        let sr = self.reg.sr.read();
+        sr.txp().bit()
+    }
+
+    pub fn send32(&mut self, bytes: u32) {
+        self.reg.txdr.write(|w| w.txdr().bits(bytes));
+    }
+
+    pub fn end_of_transmission(&self) -> bool {
+        self.reg.sr.read().eot().bit()
+    }
+
+    /// Stuffs one byte of data into the SPI TX FIFO.
+    ///
+    /// Preconditions:
+    ///
+    /// - There must be room for a byte in the TX FIFO (call `can_tx_frame` to
+    ///   check, or call this in response to a TXP interrupt).
+    pub fn send8(&mut self, byte: u8) {
+        // The TXDR register can be accessed as a byte, halfword, or word. This
+        // determines how many bytes are pushed in. stm32h7/svd2rust don't
+        // understand this, and so we have to get a pointer to the byte portion
+        // of the register manually and dereference it.
+
+        // Because svd2rust didn't see this one coming, we cannot get a direct
+        // reference to the VolatileCell within the wrapped Reg type of txdr,
+        // nor will the Reg type agree to give us a pointer to its contents like
+        // VolatileCell will, presumably to save us from ourselves. And thus we
+        // must exploit the fact that VolatileCell is the only (non-zero-sized)
+        // member of Reg, and in fact _must_ be for Reg to work correctly when
+        // used to overlay registers in memory.
+
+        // Safety: "Downcast" txdr to a pointer to its sole member, whose type
+        // we know because of our unholy source-code-reading powers.
+        let txdr: &vcell::VolatileCell<u32> =
+            unsafe { core::mem::transmute(&self.reg.txdr) };
+        // vcell is more pleasant and will happily give us the pointer we want.
+        let txdr: *mut u32 = txdr.as_ptr();
+        // As we are a little-endian machine it is sufficient to change the type
+        // of the pointer to byte.
+        let txdr8 = txdr as *mut u8;
+
+        // Safety: we are dereferencing a pointer given to us by VolatileCell
+        // (and thus UnsafeCell) using the same volatile access it would use.
+        unsafe {
+            txdr8.write_volatile(byte);
+        }
+    }
+
+    pub fn recv32(&mut self) -> u32 {
+        self.reg.rxdr.read().rxdr().bits()
+    }
+
+    /// Pulls one byte of data from the SPI RX FIFO.
+    ///
+    /// Preconditions:
+    ///
+    /// - There must be at least one byte of data in the FIFO (check using
+    ///   `has_rx_byte` or call this in response to an RXP interrupt).
+    ///
+    /// - Frame size must be set to 8 bits or smaller. (Behavior if you write a
+    ///   partial frame to the FIFO is not immediately clear from the
+    ///   datasheet.)
+    pub fn recv8(&mut self) -> u8 {
+        // The RXDR register can be accessed as a byte, halfword, or word. This
+        // determines how many bytes are pushed in. stm32h7/svd2rust don't
+        // understand this, and so we have to get a pointer to the byte portion
+        // of the register manually and dereference it.
+
+        // See send8 for further rationale / ranting.
+
+        // Safety: "Downcast" rxdr to a pointer to its sole member, whose type
+        // we know because of our unholy source-code-reading powers.
+        let rxdr: &vcell::VolatileCell<u32> =
+            unsafe { core::mem::transmute(&self.reg.rxdr) };
+        // vcell is more pleasant and will happily give us the pointer we want.
+        let rxdr: *mut u32 = rxdr.as_ptr();
+        // As we are a little-endian machine it is sufficient to change the type
+        // of the pointer to byte.
+        let rxdr8 = rxdr as *mut u8;
+
+        // Safety: we are dereferencing a pointer given to us by VolatileCell
+        // (and thus UnsafeCell) using the same volatile access it would use.
+        unsafe { rxdr8.read_volatile() }
+    }
+
+    pub fn end(&mut self) {
+        // Clear flags that tend to get set during transactions.
+        self.reg
+            .ifcr
+            .write(|w| w.txtfc().set_bit().eotc().set_bit());
+        // Disable the transfer state machine.
+        self.reg.cr1.modify(|_, w| w.spe().clear_bit());
+        // Turn off interrupt enables.
+        self.reg.ier.reset();
+
+        // This is where we'd report errors (TODO). For now, just clear the
+        // error flags, as they're sticky.
+        self.reg.ifcr.write(|w| {
+            w.ovrc()
+                .set_bit()
+                .udrc()
+                .set_bit()
+                .modfc()
+                .set_bit()
+                .tifrec()
+                .set_bit()
+        });
+    }
+
+    pub fn enable_transfer_interrupts(&mut self) {
+        self.reg
+            .ier
+            .write(|w| w.txpie().set_bit().rxpie().set_bit());
+    }
+
+    pub fn disable_can_tx_interrupt(&mut self) {
+        self.reg.ier.modify(|_, w| w.txpie().clear_bit());
+    }
+}

--- a/gemini-bu/app.toml
+++ b/gemini-bu/app.toml
@@ -71,6 +71,15 @@ uses = ["usart3"]
 start = true
 interrupts = {39 = 1}
 
+[tasks.spi2_driver]
+path = "../drv/stm32h7-spi-server"
+name = "drv-stm32h7-spi-server"
+priority = 2
+requires = {flash = 8192, ram = 1024}
+uses = ["spi2"]
+start = true
+interrupts = {36 = 1}
+
 [tasks.user_leds]
 path = "../drv/user-leds"
 name = "drv-user-leds"
@@ -109,6 +118,10 @@ size = 0x0800
 [peripherals.gpios3]
 address = 0x58022800
 size = 0x0400
+
+[peripherals.spi2]
+address = 0x40003800
+size = 1024
 
 [peripherals.usart3]
 address = 0x40004800

--- a/gemini-bu/src/main.rs
+++ b/gemini-bu/src/main.rs
@@ -169,12 +169,8 @@ fn system_init() {
         // at its normal (wide) output range. We will also want its P-output,
         // which is the output that's tied to the system clock.
         //
-        // We don't currently use the Q and R outputs, and we could switch
-        // them off to save power -- but they can function as kernel clocks
-        // for many of our peripherals, and thus might be useful.
-        //
-        // (Note that the R clock winds up being the source for the trace
-        // unit, so saying we don't use it is a little facetious.)
+        // The Q tap goes to a bunch of peripheral kernel clocks. The R clock
+        // goes to the trace unit.
         p.RCC.pllcfgr.modify(|_, w| {
             w.pll1vcosel()
                 .wide_vco()
@@ -199,8 +195,8 @@ fn system_init() {
         // The P value is the divisor from VCO frequency to system
         // frequency, so it needs to be 2 to get a 400MHz P-output.
         //
-        // We set the Q and R outputs to the same frequency, because the
-        // right choice isn't obvious yet.
+        // We set the R output to the same frequency because it's what Humility
+        // currently expects, and drop the Q output for kernel clock use.
         p.RCC.pll1divr.modify(|_, w| unsafe {
             w.divn1()
                 .bits(100 - 1)
@@ -208,7 +204,7 @@ fn system_init() {
                 .div2()
                 // Q and R fields aren't modeled correctly in the API, so:
                 .divq1()
-                .bits(1)
+                .bits(4 - 1)
                 .divr1()
                 .bits(1)
         });

--- a/task-spi/src/main.rs
+++ b/task-spi/src/main.rs
@@ -17,13 +17,13 @@ fn main() -> ! {
     let spi = TaskId::for_index_and_gen(SPI as usize, Generation::default());
     hprintln!("Waiting to receive SPI data").ok();
     loop {
-        let mut recv: [u8; 5] = [0; 5];
-        let a: &mut [u8] = &mut recv;
-        let (code, _) = sys_send(spi, 2, &[], &mut [], &[Lease::from(a)]);
+        let mut buf: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let (code, _) =
+            sys_send(spi, 2, &[], &mut [], &[Lease::from(&mut buf[..])]);
         if code != 0 {
             hprintln!("Got error code {}", code).ok();
         } else {
-            hprintln!("Got buffer {:x?}", recv).ok();
+            hprintln!("Got buffer {:x?}", buf).ok();
         }
     }
 }

--- a/userlib/src/hl.rs
+++ b/userlib/src/hl.rs
@@ -192,6 +192,10 @@ impl<'a> Message<'a> {
             self.fixed()
         }
     }
+
+    pub fn lease_count(&self) -> usize {
+        self.lease_count
+    }
 }
 
 /// A typed handle to a task, used to send a single reply of type `R`.
@@ -256,6 +260,7 @@ impl<R> Caller<R> {
 /// The borrow handle borrows the `Caller` to keep you from accidentally holding
 /// the borrow after you reply to the caller (causing it to revoke the lease).
 /// This is an error-robustness thing and not a safety thing.
+#[derive(Clone)]
 pub struct Borrow<'caller> {
     id: TaskId,
     index: usize,


### PR DESCRIPTION
This illustrates the server vs. library split I'm proposing for drivers.

The `stm32h7-spi` crate provides common operations on the SPI peripheral, like checking FIFO levels, enqueueing bytes, etc., but without assuming a concurrency or interrupt model. This means it can't block or use IPC. In exchange, this crate should be usable both in a Hubris driver/server, _and_ in something like a bootloader that isn't using the kernel.

The `stm32h7-spi-server` crate implements an IPC server task _on top of_ the core driver crate.