### PR TITLE
Default to installing thumbv{7em,8m}-none-eabihf targets

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-12-29
+[toolchain]
+channel = "nightly-2020-12-29"
+targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf"]


### PR DESCRIPTION
Rustup 1.23 allows rust-toolchain to be TOML which can additionally
specify which targets and components to install. If you get an error
about invalid channel name "[toolchain}", update rustup by running
`rustup self update`.