### PR TITLE
Update README with fdti dependency

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -47,6 +47,9 @@ You will need:
 - [libusb](https://libusb.info/), typically found from your system's package
   manager as `libusb-1.0.0` or similar.
 
+- [libfdti1](https://www.intra2net.com/en/developer/libftdi/), found
+  as `libftdi1-dev` or similar.
+
 - `arm-none-eabi-objcopy` and `arm-none-eabi-gdb`, typically from your system's
   package manager using package names like `arm-none-eabi-binutils` and
   `arm-none-eabi-gdb`.  macOS users might check out


### PR DESCRIPTION
I noticed this was actually necessary when installing Humility (I saw ` /usr/bin/ld: cannot find -lftdi1 ` when executing `cargo install humility` without this dependency).
