### PR TITLE
Update AsciiDoc code blocks to use syntax highlighting

### DIFF
--- a/doc/drivers.adoc
+++ b/doc/drivers.adoc
@@ -60,8 +60,7 @@ fn main() {
 
 	B.clk.write(|w| w.clock.very_fast());
 
-	B.cfg.modify(|_, w| w.foo.disable().
-				enabled.set());
+	B.cfg.modify(|_, w| w.foo.disable().enabled.set());
 
 	let mask = 1;
 	// Data we need during operation. None indicates no operation

--- a/doc/drivers.adoc
+++ b/doc/drivers.adoc
@@ -52,7 +52,8 @@ manually. To make life easier, these calls are wrapped via calls in the
 size validation. A typical server will look like
 
 
-```
+[source, rust]
+---------------------------------------------------------------------
 fn main() {
 	turn_on_hardware_clocks();
 	let B = get_hardware_block();
@@ -135,7 +136,7 @@ fn main() {
 	}
 
 }
-```
+---------------------------------------------------------------------
 
 = Driver API crates
 
@@ -145,8 +146,8 @@ especially helpful for drivers which may rely on magic numbers for
 setting hardware. If a driver is name `drv-abc123-foo` the API crate
 is typically named `drv-abc123-foo-api`. An example API might look like:
 
-```
-
+[source, rust]
+---------------------------------------------------------------------
 enum Op {
 	Write,
 	Read,
@@ -179,4 +180,4 @@ impl Data {
 		hl::send(self.0, &WriteData(peripheral, entry));
 	}
 }
-```
+---------------------------------------------------------------------

--- a/doc/syscalls.adoc
+++ b/doc/syscalls.adoc
@@ -103,7 +103,8 @@ The error-free path:
 Each lease is 12 bytes in size and must be 4-byte aligned. A lease is equivalent
 to the following Rust struct:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 #[repr(C)]
 struct Lease {
     attributes: u32,
@@ -113,7 +114,7 @@ struct Lease {
 
 const ATT_READ: u32 = 1 << 0;
 const ATT_WRITE: u32 = 1 << 1;
-....
+---------------------------------------------------------------------
 
 - `attributes` can specify that a lease can be read from, written to, or both.
   Any use of undefined attribute bits will cause a fault.

--- a/doc/tr1.adoc
+++ b/doc/tr1.adoc
@@ -291,7 +291,8 @@ Here are some highlights.
 As with most operating systems, tasks can be in a number of states: stopped,
 runnable, blocked, etc. A common way to express this might be:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 struct Task {
     state: State,
     // other stuff omitted
@@ -302,14 +303,15 @@ enum State {
     Runnable,
     Blocked,
 }
-....
+---------------------------------------------------------------------
 
 A fault event causes a task to no longer be schedulable, until the fault is
 resolved or the task is restarted. A fault cannot *replace* the task's state,
 because we want to remember it -- for debugging, at the least. And so we might
 be tempted to do this:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 struct Task {
     state: State,
     fault: Option<Fault>,
@@ -326,19 +328,20 @@ enum Fault {
     MemoryAccess(Address),
     OtherReasons,
 }
-....
+---------------------------------------------------------------------
 
 But this makes it really easy to schedule a faulted task _by accident,_ in a way
 that's hard to spot with local reasoning. Specifically:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 for task in tasks {
     if task.state == State::Runnable {
         schedule(task);
         break;
     }
 }
-....
+---------------------------------------------------------------------
 
 Looks correct! Is not correct. (The same issue could happen when replying to a
 blocked task, setting it runnable without noticing a fault.)
@@ -349,7 +352,8 @@ but are _not_: a fault makes the other state temporarily irrelevant.
 We can express this at the type level to make this class of mistake much less
 likely:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 struct Task {
     state: HealthState,
     // other stuff omitted
@@ -373,7 +377,7 @@ enum Fault {
     MemoryAccess(Address),
     OtherReasons,
 }
-....
+---------------------------------------------------------------------
 
 That is, while the original `State` is preserved when a fault is taken, it's
 moved inside the `HealthState::Faulted` variant where it's structurally distinct
@@ -382,14 +386,15 @@ from `Healthy`.
 Our scheduler loop above no longer compiles, because `task.state` is not a
 `State`. Instead, we write the code like this:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 for task in tasks {
     if task.state == HealthState::Healthy(State::Runnable) {
         schedule(task);
         break;
     }
 }
-....
+---------------------------------------------------------------------
 
 Any faulted state fails that equality test without further thought.
 
@@ -412,14 +417,15 @@ the next scheduling round without checking.
 
 Hubris currently addresses this with the `NextTask` enum, which looks like this:
 
-....
+[source, rust]
+---------------------------------------------------------------------
 #[must_use]
 enum NextTask {
     Same,
     Specific(usize),
     Other,
 }
-....
+---------------------------------------------------------------------
 
 An operation returns `NextTask` if it *may* affect scheduling. `Same` indicates
 that no context switch is required; `Specific(x)` indicates that a switch to a
@@ -440,7 +446,8 @@ When two `NextTask` values meet, they can be combined; this provides better
 composition of operations than a simple "switch needed" flag. Combining two
 `NextTask` values works as follows (expressed as a Rust `match`):
 
-....
+[source, rust]
+---------------------------------------------------------------------
 match (self, other) {
     // If both agree, our job is easy.
     (x, y) if x == y => x,
@@ -454,7 +461,7 @@ match (self, other) {
     // All we have left is...
     (Same, Same) => Same,
 }
-....
+---------------------------------------------------------------------
 
 (That's copied verbatim from the kernel source.)
 


### PR DESCRIPTION
This should be viewable under "rich diff" on GitHub.

(thanks for the great docs, btw!)