### PR TITLE
Skip duplicate workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,20 @@ name: build
 on: [push, pull_request]
 
 jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispath", "schedule"]'
   build:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: dist
     runs-on: '${{ matrix.os }}'
     strategy:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,11 +6,24 @@
 name: auto-format
 on: pull_request
 jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispath", "schedule"]'
   format:
+    needs: skip_duplicate_jobs
     # Check if the PR is not from a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
+      - uses: fkirc/skip-duplicate-actions@master
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -2,11 +2,26 @@ name: standalone
 on: [push, pull_request]
 
 jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispath", "schedule"]'
+
   build:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: standalone build
     runs-on: ubuntu-latest
 
     steps:
+      - uses: fkirc/skip-duplicate-actions@master
       # check out our code
       - uses: actions/checkout@v2
       - name: Update submodule


### PR DESCRIPTION
When a job is set to run on [push, pull_request], a PR from a branch in
the same repo will queue two runs of each job.
fkirc/skip-duplicate-actions looks at the tree hash associated with a
workflow run and will cancel the run if there is an in-progress run at
the same tree hash.