### PR TITLE
GitHub Workflows: apt update before (pinned) apt install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             target: thumbv8m.main-none-eabihf
 
           - os: ubuntu-latest
-            deps: sudo apt-get install binutils-arm-none-eabi=2.27-9ubuntu1+9 libudev-dev=237-3ubuntu10.44
+            deps: sudo apt-get update && sudo apt-get install binutils-arm-none-eabi=2.27-9ubuntu1+9 libudev-dev=237-3ubuntu10.44
           - os: windows-latest
             deps: |
               Invoke-WebRequest -Uri https://github.com/steveklabnik/arm-none-eabi-objcopy/releases/download/9-2020-q2-update/arm-none-eabi-objcopy.exe -OutFile "$Env:RUNNER_TEMP\arm-none-eabi-objcopy.exe"

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -63,7 +63,7 @@ jobs:
           key: build-standalone-${{ steps.rust-toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       # install dependencies
-      - run: sudo apt-get install binutils-arm-none-eabi=2.27-9ubuntu1+9 libudev-dev=237-3ubuntu10.44
+      - run: sudo apt-get update && sudo apt-get install binutils-arm-none-eabi=2.27-9ubuntu1+9 libudev-dev=237-3ubuntu10.44
 
       # check that everything builds
       - name: Check standalone build


### PR DESCRIPTION
Without this PR, seeing some spurious GitHub workflow errors, e.g.: https://github.com/oxidecomputer/hubris/pull/128/checks?check_run_id=1736229151