### PR TITLE
Fix spi transfer size on the STM32H7

### DIFF
--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -251,11 +251,11 @@ fn main() -> ! {
                     // reasonable-looking lease(s). This is our commit point.
 
                     // Make sure SPI is on.
-                    spi.enable();
+                    spi.enable(xfer_len as u16);
                     // Load transfer count and start the state machine. At this
                     // point we _have_ to move the specified number of bytes
                     // through (or explicitly cancel, but we don't).
-                    spi.start(xfer_len as u16);
+                    spi.start();
 
                     // As you might expect, we will work from byte 0 to the end
                     // of each buffer. There are two complications:

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -106,12 +106,12 @@ impl Spi {
         self.reg.i2scfgr.write(|w| w.i2smod().clear_bit());
     }
 
-    pub fn enable(&mut self) {
+    pub fn enable(&mut self, tsize: u16) {
+        self.reg.cr2.modify(|_, w| w.tsize().bits(tsize));
         self.reg.cr1.modify(|_, w| w.spe().set_bit());
     }
 
-    pub fn start(&mut self, tsize: u16) {
-        self.reg.cr2.modify(|_, w| w.tsize().bits(tsize));
+    pub fn start(&mut self) {
         self.reg.cr1.modify(|_, w| w.cstart().set_bit());
         // Clear EOT flag
         self.reg.ifcr.write(|w| w.eotc().set_bit());


### PR DESCRIPTION
The manual for the `TSIZE` field in `SPI_CR2` notes
"When these bits are changed by software, the SPI must be disabled".
The driver does not do this precisely. This is observed as hangs
when sending subsequent trasfers of different sizes (e.g. one of
size 2 then one of size 10). Fix this by always setting the
transfer size when enabling block.