### PR TITLE
Output the missing peripheral name and referencing task instead of panicing.

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -709,8 +709,16 @@ fn make_descriptors(
         // For peripherals referenced by the task, we don't need to allocate
         // _new_ regions, since we did them all in advance. Just record the
         // entries for the TaskDesc.
-        for (j, name) in task.uses.iter().enumerate() {
-            task_regions[allocs.len() + j] = peripheral_index[name] as u8;
+        for (j, peripheral_name) in task.uses.iter().enumerate() {
+            if let Some(&peripheral) = peripheral_index.get(&peripheral_name) {
+                task_regions[allocs.len() + j] = peripheral as u8;
+            } else {
+                bail!(
+                    "Could not find peripheral `{}` referenced by task `{}`.",
+                    peripheral_name,
+                    name
+                );
+            }
         }
 
         let mut flags = abi::TaskFlags::empty();


### PR DESCRIPTION
Got confused by this error initially as all it tells you is that it panic-ed while building:
```
thread 'main' panicked at 'IndexMap: key not found', xtask/src/dist.rs:713:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Updated it with a lot more helpful error message so one doesn't need to go digging into the source to figure out what failed:
```
Error: Could not find peripheral `gpiod` referenced by task `user_leds`.
```