### PR TITLE
Disable outlining

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -495,7 +495,8 @@ fn build(
             "-C link-arg=-Tlink.x \
         -L {} \
         -C link-arg=-z -C link-arg=common-page-size=0x20 \
-        -C link-arg=-z -C link-arg=max-page-size=0x20",
+        -C link-arg=-z -C link-arg=max-page-size=0x20 \
+        -C llvm-args=--enable-machine-outliner=never",
             canonical_cargo_out_dir.display()
         ),
     );


### PR DESCRIPTION
The last toolchain bump exposed some issue with outlining, turn
it off for now

See https://github.com/rust-lang/rust/issues/85351