### PR TITLE
Add feature flag for PLLs on LPC55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
 name = "gemini-bu-rot"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
@@ -920,6 +921,7 @@ dependencies = [
 name = "lpc55"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
@@ -1754,6 +1756,7 @@ dependencies = [
 name = "tests-lpc55"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",

--- a/gemini-bu-rot/Cargo.toml
+++ b/gemini-bu-rot/Cargo.toml
@@ -10,6 +10,7 @@ default = ["standalone"]
 standalone = ["itm"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
+plls = []
 
 [dependencies]
 cortex-m = "0.7"
@@ -19,6 +20,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.3.0"
+cfg-if = "0.1.10"
 
 [dependencies.kern]
 path = "../kern"

--- a/gemini-bu-rot/src/main.rs
+++ b/gemini-bu-rot/src/main.rs
@@ -22,6 +22,7 @@ extern "C" {
     static __eheap: u8;
 }
 
+#[cfg(feature = "plls")]
 fn setup_clocks() {
     // From the manual:
     //
@@ -188,9 +189,15 @@ fn setup_clocks() {
 
 #[entry]
 fn main() -> ! {
-    setup_clocks();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "plls")] {
+            setup_clocks();
 
-    const CYCLES_PER_MS: u32 = 150_000;
+            const CYCLES_PER_MS: u32 = 150_000;
+        } else {
+            const CYCLES_PER_MS: u32 = 96_000;
+        }
+    }
 
     unsafe {
         //

--- a/lpc55/Cargo.toml
+++ b/lpc55/Cargo.toml
@@ -10,6 +10,7 @@ default = ["standalone"]
 standalone = ["itm"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
+plls = []
 
 [dependencies]
 cortex-m = "0.7"
@@ -19,6 +20,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.3.0"
+cfg-if = "0.1.10"
 
 [dependencies.kern]
 path = "../kern"

--- a/lpc55/src/main.rs
+++ b/lpc55/src/main.rs
@@ -22,6 +22,7 @@ extern "C" {
     static __eheap: u8;
 }
 
+#[cfg(feature = "plls")]
 fn setup_clocks() {
     // From the manual:
     //
@@ -188,9 +189,15 @@ fn setup_clocks() {
 
 #[entry]
 fn main() -> ! {
-    setup_clocks();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "plls")] {
+            setup_clocks();
 
-    const CYCLES_PER_MS: u32 = 150_000;
+            const CYCLES_PER_MS: u32 = 150_000;
+        } else {
+            const CYCLES_PER_MS: u32 = 96_000;
+        }
+    }
 
     unsafe {
         //

--- a/test/tests-lpc55/Cargo.toml
+++ b/test/tests-lpc55/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 default = ["itm"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
+plls = []
 
 [dependencies]
 cortex-m = "0.7"
@@ -18,6 +19,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.3.0"
+cfg-if = "0.1.10"
 
 [dependencies.kern]
 path = "../../kern"


### PR DESCRIPTION
The LPC55 can nominally run at 150mhz with PLLs. According to the
documentation, the maximum speed for flash programming is 100mhz.
For now, add a compile time feature flag for building with PLLs.
When PLLs are not enabled run at the default of 96mhz.