### PR TITLE
stm32h7 basic ethernet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-net"
+version = "0.1.0"
+dependencies = [
+ "cortex-m 0.6.7",
+ "drv-stm32h7-eth",
+ "drv-stm32h7-gpio-api",
+ "drv-stm32h7-rcc-api",
+ "smoltcp",
+ "stm32h7 0.11.0",
+ "userlib",
+]
+
+[[package]]
 name = "task-ping"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,18 @@ name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "atty"
@@ -119,7 +140,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -220,6 +241,19 @@ checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
 
 [[package]]
 name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.2",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643a210c1bdc23d0db511e2a576082f4ff4dcae9d0c37f50b431b8f8439d6d6b"
@@ -257,7 +291,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
 ]
 
 [[package]]
@@ -290,7 +324,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -314,7 +348,7 @@ checksum = "4460596867846f73bddca51f7403b6a29f5315125be10a1640259b4db5b9494c"
 name = "demo"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -331,7 +365,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -356,7 +390,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -444,7 +478,7 @@ dependencies = [
 name = "drv-lpc55-syscon"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "lpc55-pac",
  "num-traits",
  "userlib",
@@ -512,6 +546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-stm32h7-eth"
+version = "0.1.0"
+dependencies = [
+ "cortex-m 0.7.2",
+ "smoltcp",
+ "stm32h7",
+ "userlib",
+]
+
+[[package]]
 name = "drv-stm32h7-gpio"
 version = "0.1.0"
 dependencies = [
@@ -539,7 +583,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "drv-i2c-api",
  "drv-stm32h7-gpio-api",
@@ -557,7 +601,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "drv-i2c-api",
  "drv-stm32h7-gpio-api",
@@ -604,7 +648,7 @@ dependencies = [
 name = "drv-stm32h7-spi-server"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-rcc-api",
  "drv-stm32h7-spi",
@@ -668,7 +712,7 @@ dependencies = [
  "bitvec",
  "digest",
  "ff",
- "generic-array",
+ "generic-array 0.14.4",
  "group",
  "pkcs8",
  "rand_core",
@@ -757,7 +801,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -772,7 +816,7 @@ name = "gemini-bu-rot"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -780,6 +824,24 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -798,7 +860,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -889,7 +951,7 @@ dependencies = [
  "build-util",
  "byteorder",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "serde",
  "ssmarshal",
@@ -942,7 +1004,7 @@ name = "lpc55"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -958,7 +1020,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee47591d506a22d56bc591abb955176b1ad3c22122c2395a69e426ea76e25ab"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "vcell",
 ]
 
@@ -1006,6 +1068,12 @@ checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75de51135344a4f8ed3cfe2720dc27736f7711989703a0b43aadf3753c55577"
 
 [[package]]
 name = "membar"
@@ -1172,7 +1240,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d577d97d1b31268087b6dddf2470e6794ef5eee87d9dca7fcd0481695391a4c"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
 ]
 
 [[package]]
@@ -1181,7 +1249,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
 ]
 
@@ -1477,6 +1545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97173c1ef35b0a09304cb3882eba594761243005847cbbf6124f966e8da6519a"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "managed",
+]
+
+[[package]]
 name = "srec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,13 +1572,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stm32f3"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "081e808e6b2114ced6a83437081ed9816c92017eda7722a7c22f80984fb5476a"
 dependencies = [
  "bare-metal",
- "cortex-m",
+ "cortex-m 0.6.7",
  "cortex-m-rt",
  "vcell",
 ]
@@ -1511,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3d56009c8f32e4f208dbea17df72484154d1040a8969b75d8c73eb7b18fe8f"
 dependencies = [
  "bare-metal",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "vcell",
 ]
@@ -1523,7 +1608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b672c837e0ee8158ecc7fce0f9a948dd0693a9c588338e728d14b73307a0b7d"
 dependencies = [
  "bare-metal",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "vcell",
 ]
@@ -1617,7 +1702,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "task-i2c"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "drv-i2c-api",
  "num-traits",
@@ -1629,7 +1714,7 @@ dependencies = [
 name = "task-idle"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "userlib",
 ]
 
@@ -1638,7 +1723,7 @@ name = "task-jefe"
 version = "0.1.0"
 dependencies = [
  "abi",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "num-traits",
  "ringbuf",
@@ -1650,7 +1735,7 @@ dependencies = [
 name = "task-ping"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "drv-user-leds-api",
  "userlib",
 ]
@@ -1659,7 +1744,7 @@ dependencies = [
 name = "task-pong"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "drv-user-leds-api",
  "userlib",
 ]
@@ -1680,7 +1765,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "drv-i2c-api",
  "drv-stm32h7-gpio-api",
@@ -1698,7 +1783,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "ringbuf",
  "userlib",
@@ -1718,7 +1803,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-semihosting",
  "drv-i2c-api",
  "drv-i2c-devices",
@@ -1741,7 +1826,7 @@ dependencies = [
 name = "test-assist"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "num-traits",
  "test-api",
  "userlib",
@@ -1752,7 +1837,7 @@ dependencies = [
 name = "test-runner"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "num-traits",
  "test-api",
  "userlib",
@@ -1763,7 +1848,7 @@ dependencies = [
 name = "test-suite"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "num-traits",
  "test-api",
  "userlib",
@@ -1776,7 +1861,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -1791,7 +1876,7 @@ name = "tests-lpc55"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -1805,7 +1890,7 @@ dependencies = [
 name = "tests-stm32f4"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",
@@ -1822,7 +1907,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "kern",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,7 @@ dependencies = [
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-rcc-api",
  "smoltcp",
- "stm32h7 0.11.0",
+ "stm32h7",
  "userlib",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "drv/stm32fx-rcc",
     "drv/stm32fx-usart",
 
+    "drv/stm32h7-eth",
     "drv/stm32h7-gpio",
     "drv/stm32h7-gpio-api",
     "drv/stm32h7-rcc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "task-spd",
     "task-spi",
     "task-thermal",
+    "task-net",
 
     "drv/stm32fx-rcc",
     "drv/stm32fx-usart",

--- a/demo-stm32h7/app-h743.toml
+++ b/demo-stm32h7/app-h743.toml
@@ -37,6 +37,15 @@ read = true
 write = true
 execute = false  # let's assume XN until proven otherwise
 
+# Network buffers are placed in sram1, which is directly accessible by the
+# Ethernet MAC.
+[outputs.sram1]
+address = 0x30000000
+size = 0x20000
+read = true
+write = true
+dma = true
+
 [tasks.jefe]
 path = "../task-jefe"
 name = "task-jefe"
@@ -84,6 +93,17 @@ start = true
 [tasks.i2c_driver.interrupts]
 33 = 0b0000_0010        # I2C2 event
 34 = 0b0000_0010        # I2C2 error
+
+[tasks.net]
+path = "../task-net"
+name = "task-net"
+stacksize = 3800
+priority = 2
+requires = {flash = 65536, ram = 4096, sram1 = 32768}
+sections = {eth_bulk = "sram1"}
+uses = ["eth", "eth_dma"]
+start = true
+interrupts = {61 = 0b1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
@@ -161,3 +181,10 @@ size = 1024
 address = 0x58001c00
 size = 1024
 
+[peripherals.eth]
+address = 0x40028000
+size = 0x1000
+
+[peripherals.eth_dma]
+address = 0x40029000
+size = 0x400

--- a/demo-stm32h7/src/main.rs
+++ b/demo-stm32h7/src/main.rs
@@ -90,6 +90,17 @@ unsafe fn system_pre_init() {
         // spin
     }
 
+    // Turn on the internal RAMs.
+    let rcc = &*device::RCC::ptr();
+    rcc.ahb2enr.modify(|_, w| {
+        w.sram1en()
+            .set_bit()
+            .sram2en()
+            .set_bit()
+            .sram3en()
+            .set_bit()
+    });
+
     // Okay, yay, we can use some RAMs now.
 
     // We'll do the rest in system_init.
@@ -183,6 +194,13 @@ fn system_init() {
             .dbgsleep_d1()
             .set_bit()
     });
+
+    // Set up SYSCFG selections so drivers don't have to.
+    p.RCC.apb4enr.modify(|_, w| w.syscfgen().enabled());
+    cortex_m::asm::dmb();
+
+    // Ethernet is on RMII, not MII.
+    p.SYSCFG.pmcr.modify(|_, w| unsafe { w.epis().bits(0b100) });
 
     // Turn on CPU I/D caches to improve performance at the higher clock speeds
     // we're about to enable.

--- a/drv/stm32h7-eth/.cargo/config
+++ b/drv/stm32h7-eth/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/drv/stm32h7-eth/Cargo.toml
+++ b/drv/stm32h7-eth/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "drv-stm32h7-eth"
+version = "0.1.0"
+authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
+edition = "2018"
+
+[features]
+default = []
+with-smoltcp = ["smoltcp"]
+
+[dependencies]
+cortex-m = "0.7"
+userlib = {path = "../../userlib"}
+stm32h7 = {version = "0.13", features = ["stm32h743"]}
+
+[dependencies.smoltcp]
+optional = true
+version = "0.7.1"
+default-features = false
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false
+
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"

--- a/drv/stm32h7-eth/Cargo.toml
+++ b/drv/stm32h7-eth/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [features]
 default = []
 with-smoltcp = ["smoltcp"]
+ipv4 = []
+ipv6 = []
 
 [dependencies]
 cortex-m = "0.7"

--- a/drv/stm32h7-eth/src/lib.rs
+++ b/drv/stm32h7-eth/src/lib.rs
@@ -1,0 +1,429 @@
+//! Hubris driver for the STM32H7 Ethernet MAC and associated stuff.
+//!
+//! This provides a Hubris-dependent driver framework that is agnostic as to
+//! whether it's a separate server, or integrated into another task.
+//!
+//! It might be useful to have a non-OS-dependent driver core at some point, but
+//! we can factor that out after we get this working.
+
+#![no_std]
+
+use core::convert::TryFrom;
+
+use stm32h7::stm32h743 as device;
+
+pub mod ring;
+
+use crate::ring::BUFSZ;
+
+/// Control block for ethernet driver.
+pub struct Ethernet {
+    /// Pointer to the MAC registers.
+    mac: &'static device::ethernet_mac::RegisterBlock,
+    /// Pointer to the MTL registers.
+    _mtl: &'static device::ethernet_mtl::RegisterBlock,
+    /// Pointer to the DMA registers.
+    dma: &'static device::ethernet_dma::RegisterBlock,
+    /// Control of the TX ring.
+    tx_ring: crate::ring::TxRing,
+    /// Control of the RX ring.
+    rx_ring: crate::ring::RxRing,
+}
+
+/// As the name implies, this spins until a predicate becomes true, in a crappy
+/// way.
+///
+/// Some of the Ethernet-related events don't have interrupts, leaving us with
+/// no choice but to repeatedly reload a status register until the condition
+/// becomes true. Doing this naively would starve other tasks of the CPU. So, we
+/// sleep between attempts. This winds up sleeping way-the-heck longer than
+/// required in most cases, but whaddayagonnado.
+fn crappy_spin_until(pred: impl Fn() -> bool) {
+    while !pred() {
+        userlib::hl::sleep_for(1);
+    }
+}
+
+impl Ethernet {
+    /// Initializes the Ethernet controller, prepares the DMA descriptor rings,
+    /// and returns the driver instance.
+    ///
+    /// # Preconditions
+    ///
+    /// - Make sure the Ethernet blocks are out of reset.
+    /// - Make sure the appropriate pins are configured for your board.
+    ///
+    /// We might want to fold these operations into `new` in the future, but for
+    /// now, you need to do them separately.
+    pub fn new(
+        mac: &'static device::ethernet_mac::RegisterBlock,
+        mtl: &'static device::ethernet_mtl::RegisterBlock,
+        dma: &'static device::ethernet_dma::RegisterBlock,
+        tx_ring: crate::ring::TxRing,
+        rx_ring: crate::ring::RxRing,
+    ) -> Self {
+        // The DMA register block contains the soft-reset for the entire system.
+        // We need to do this soft-reset even straight out of chip reset,
+        // because without it, some state is scrambled.
+        dma.dmamr.write(|w| w.swr().set_bit());
+        // The reset process is autonomous and the swr bit is self clearing, but
+        // not instantaneously so. Wait for it to finish. Failing to do this
+        // means we're interacting with the registers during reset and is Bad.
+        crappy_spin_until(|| !dma.dmamr.read().swr().bit());
+
+        // Okay, we have a freshly reset Ethernet controller.
+
+        // Configure the MDIO clock divider. TODO: this divider is currently
+        // hardcoded assuming a ~200MHz AHB frequency.
+        mac.macmdioar.write(|w| unsafe { w.cr().bits(0b0100) });
+        // Program the DMA bus interface parameters. Early versions of the
+        // reference manual contained burst length control bits here, but they
+        // appear to have been defeatured in later editions, so we'll just do
+        // the defaults.
+        dma.dmasbmr.reset();
+
+        // Configure TX burst length to 1, to avoid monopolizing the bus fabric.
+        // TODO this is debatable.
+        dma.dmactx_cr.write(|w| unsafe { w.txpbl().bits(1) });
+
+        // Configure RX burst length to 1, and also set the size of the receive
+        // buffers, which is set centrally rather than on a per-buffer basis.
+        dma.dmacrx_cr.write(|w| unsafe {
+            w.rxpbl().bits(1).rbsz().bits(u16::try_from(BUFSZ).unwrap())
+        });
+
+        // Inform the DMA of the location and length of the TX descriptor ring.
+        // Note that we carefully compute the number of descriptors MINUS ONE,
+        // which is not mentioned in the reference manual -- the reference
+        // manual appears to be wrong.
+        let tx_ring_len = u16::try_from(tx_ring.len())
+            .unwrap()
+            .checked_sub(1)
+            .unwrap();
+        dma.dmactx_dlar.write(|w| unsafe {
+            // The SVD "helpfully" models this field in bits 31:2, so we need to
+            // drop our bottom 2 bits.
+            w.tdesla().bits(tx_ring.base_ptr() as u32 >> 2)
+        });
+        dma.dmactx_rlr
+            .write(|w| unsafe { w.tdrl().bits(tx_ring_len) });
+
+        // Do the same for the RX ring.
+        let rx_ring_len = u16::try_from(rx_ring.len())
+            .unwrap()
+            .checked_sub(1)
+            .unwrap();
+        dma.dmacrx_dlar.write(|w| unsafe {
+            // The SVD "helpfully" models this field in bits 31:2, so we need to
+            // drop our bottom 2 bits.
+            w.rdesla().bits(rx_ring.base_ptr() as u32 >> 2)
+        });
+        dma.dmacrx_rlr
+            .write(|w| unsafe { w.rdrl().bits(rx_ring_len) });
+
+        // Poke both tail pointers so the hardware looks at the descriptors. We
+        // completely initialize the descriptor array, so the tail pointer is
+        // always the end.
+        dma.dmactx_dtpr
+            .write(|w| unsafe { w.tdt().bits(tx_ring.tail_ptr() as u32 >> 2) });
+        dma.dmacrx_dtpr
+            .write(|w| unsafe { w.rdt().bits(rx_ring.tail_ptr() as u32 >> 2) });
+
+        // Central DMA config:
+
+        // We're not appending any additional words to our descriptors.
+        dma.dmaccr.write(|w| unsafe { w.dsl().bits(0) });
+        // We'd like to hear about successful frame reception.
+        dma.dmacier.write(|w| w.nie().set_bit().rie().set_bit());
+        // Start transmit and receive DMA.
+        dma.dmactx_cr.modify(|_, w| w.st().set_bit());
+        dma.dmacrx_cr.modify(|_, w| w.sr().set_bit());
+
+        // Whew!
+
+        // MTL block config:
+        // Configure TX queue mode:
+        // - Use all 2048 bytes of queue RAM
+        // - Transmit Store n' Forward so we can do checksum generation
+        mtl.mtltx_qomr
+            .write(|w| unsafe { w.tqs().bits(0b111).tsf().set_bit() });
+        // Configure RX queue mode:
+        // - Receive Store n' Forward so we can do checksum verification
+        mtl.mtlrx_qomr.write(|w| w.rsf().set_bit());
+
+        // MAC block config:
+        // Enable promiscuous receive. TODO: we will want to set up the filters
+        // later, once we figure out how we assign MAC addresses across the
+        // redundant segments.
+        mac.macpfr.write(|w| w.pr().set_bit());
+        // Force 100mbps full-duplex. TODO: it would be polite to negotiate
+        // this, but the KSZ-series switches we talk to won't negotiate.
+        mac.maccr.write(|w| {
+            w.te()
+                .set_bit()
+                .re()
+                .set_bit()
+                .fes()
+                .set_bit()
+                .dm()
+                .set_bit()
+                .ipc()
+                .set_bit()
+        });
+        // The peripheral seems to want this to be done in a separate write to
+        // MACCR, so:
+        // Enable transmit and receive.
+        mac.maccr.modify(|_, w| w.te().set_bit().re().set_bit());
+
+        Self {
+            mac,
+            _mtl: mtl,
+            dma,
+            tx_ring,
+            rx_ring,
+        }
+    }
+
+    pub fn can_send(&self) -> bool {
+        self.tx_ring.is_next_free()
+    }
+
+    /// Tries to send a packet, if TX buffer space is available.
+    ///
+    /// This will attempt to get a free descriptor/buffer from the TX ring. If
+    /// successful, it will call `fillout` with the address of the buffer, so
+    /// that it can be filled out. `fillout` is expected to overwrite the
+    /// (arbitrary) contents of the packet buffer. This routine will then
+    /// arrange for the hardware to notice an outgoing packet and return
+    /// `Ok(())`.
+    ///
+    /// If the TX ring is full, this will return `Err(fillout)`, giving you the
+    /// function back, since it's a `FnOnce` and maybe you wanted to reuse it.
+    pub fn try_send<R, F: FnOnce(&mut [u8]) -> R>(
+        &self,
+        len: usize,
+        fillout: F,
+    ) -> Result<R, F> {
+        let result = self.tx_ring.try_with_next(len, fillout)?;
+        // We have enqueued a packet! The hardware may be suspended after
+        // discovering no packets to process. Wake it.
+        core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+        self.dma.dmactx_dtpr.write(|w| unsafe {
+            w.tdt().bits(self.tx_ring.tail_ptr() as u32 >> 2)
+        });
+        Ok(result)
+    }
+
+    pub fn can_recv(&self) -> bool {
+        self.rx_ring.is_next_free()
+    }
+
+    /// Tries to receive a packet, if one is present in the RX ring.
+    ///
+    /// This will attempt to get a filled-out descriptor/buffer from the RX
+    /// ring. If successful, it will call `readout` with the packet's slice.
+    /// `readout` can produce a value of some type `R`; after it completes, this
+    /// routine will mark the descriptor as empty and return `Ok(r)`.
+    ///
+    /// If there are no packets waiting in the RX ring, this returns `Err(())`
+    /// and does not call `readout`.
+    pub fn try_recv<R, F: FnOnce(&mut [u8]) -> R>(
+        &self,
+        readout: F,
+    ) -> Result<R, F> {
+        let result = self.rx_ring.try_with_next(readout)?;
+        // We have dequeued a packet! The hardware might not realize there is
+        // room in the RX queue now. Poke it.
+        core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+        self.dma.dmacrx_dtpr.write(|w| unsafe {
+            w.rdt().bits(self.rx_ring.tail_ptr() as u32 >> 2)
+        });
+        Ok(result)
+    }
+
+    /// Pokes at the controller interrupt status registers to handle and clear
+    /// an interrupt condition.
+    ///
+    /// Returns two flags: whether the interrupt condition indicated that
+    /// packets had been successfully transmitted and received, respectively.
+    /// (This is not the _best_ API but we can change it once we figure out how
+    /// it wants to be used.)
+    pub fn on_interrupt(&self) -> (bool, bool) {
+        let (mut packet_transmitted, mut packet_received) = (false, false);
+
+        // Diagnosing an ETH IRQ is kind of involved, because the IRQs are all
+        // muxed. We'll start out at the DMA interrupt summary register.
+        let dmaisr = self.dma.dmaisr.read();
+        if dmaisr.dc0is().bit() {
+            // The DMA unit has an interrupt (on "channel 0" which is the only
+            // channel)
+            let dmacsr = self.dma.dmacsr.read();
+            if dmacsr.ri().bit() {
+                // Received a packet.
+                packet_received = true;
+                // Clear the interrupt. And the summary bit. Yes, we have to
+                // clear the summary bit, it is automatically set but not
+                // cleared.
+                self.dma.dmacsr.write(|w| w.nis().set_bit().ri().set_bit());
+            }
+            if dmacsr.ti().bit() {
+                // Transmitted a packet.
+                packet_transmitted = true;
+                // Clear the interrupt. And the summary bit. Yes, we have to
+                // clear the summary bit, it is automatically set but not
+                // cleared.
+                self.dma.dmacsr.write(|w| w.nis().set_bit().ti().set_bit());
+            }
+        }
+        if dmaisr.macis().bit() {
+            // The MAC has an interrupt. We do not enable any MAC interrupts.
+        }
+        if dmaisr.mtlis().bit() {
+            // The MTL has an interrupt. We do not enable any MTL interrupts.
+        }
+
+        (packet_transmitted, packet_received)
+    }
+
+    /// Kicks off a SMI write of `value` to PHY address `phy`, register number
+    /// `register`. When this function returns, the write has started. It will
+    /// complete asynchronously, so feel free to do other things. Any attempt to
+    /// do other SMI operations will synchronize and block until the SMI unit is
+    /// free.
+    pub fn smi_write(&mut self, phy: u8, register: u8, value: u16) {
+        // Wait until peripheral is free.
+        crappy_spin_until(|| !self.is_smi_busy());
+
+        const WRITE: u8 = 0b01;
+
+        // Load data, then load address + start transaction. The address+start
+        // must be done using modify because the clock config is in the same
+        // register.
+        self.mac.macmdiodr.write(|w| unsafe { w.md().bits(value) });
+        self.mac.macmdioar.modify(|_, w| unsafe {
+            w.pa()
+                .bits(phy)
+                .rda()
+                .bits(register)
+                .goc()
+                .bits(WRITE)
+                .mb()
+                .set_bit()
+        });
+    }
+
+    /// Performs a SMI read from PHY address `phy`, register number `register`,
+    /// and returns the result.
+    ///
+    /// This function blocks until the read is complete, so that it can return
+    /// the result. It will also block until any previously issued write has
+    /// finished.
+    pub fn smi_read(&mut self, phy: u8, register: u8) -> u16 {
+        // Wait until peripheral is free.
+        crappy_spin_until(|| !self.is_smi_busy());
+
+        // Load address + start transaction
+        const READ: u8 = 0b11;
+        self.mac.macmdioar.modify(|_, w| unsafe {
+            w.pa()
+                .bits(phy)
+                .rda()
+                .bits(register)
+                .goc()
+                .bits(READ)
+                .mb()
+                .set_bit()
+        });
+
+        // Wait until it finishes.
+        crappy_spin_until(|| !self.is_smi_busy());
+
+        self.mac.macmdiodr.read().md().bits()
+    }
+
+    fn is_smi_busy(&self) -> bool {
+        self.mac.macmdioar.read().mb().bit()
+    }
+}
+
+#[cfg(feature = "with-smoltcp")]
+pub struct OurRxToken<'a>(&'a Ethernet);
+
+#[cfg(feature = "with-smoltcp")]
+impl<'a> smoltcp::phy::RxToken for OurRxToken<'a> {
+    fn consume<R, F>(
+        self,
+        _timestamp: smoltcp::time::Instant,
+        f: F,
+    ) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
+    {
+        self.0
+            .try_recv(f)
+            .map_err(|_| ())
+            .expect("we checked RX availability earlier")
+    }
+}
+
+#[cfg(feature = "with-smoltcp")]
+pub struct OurTxToken<'a>(&'a Ethernet);
+
+#[cfg(feature = "with-smoltcp")]
+impl<'a> smoltcp::phy::TxToken for OurTxToken<'a> {
+    fn consume<R, F>(
+        self,
+        _timestamp: smoltcp::time::Instant,
+        len: usize,
+        f: F,
+    ) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
+    {
+        self.0
+            .try_send(len, f)
+            // Error value is not debug; discard it
+            .map_err(|_| ())
+            .expect("TX token existed without descriptor available")
+    }
+}
+
+#[cfg(feature = "with-smoltcp")]
+impl<'a> smoltcp::phy::Device<'a> for Ethernet {
+    type RxToken = OurRxToken<'a>;
+    type TxToken = OurTxToken<'a>;
+
+    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+        // Note: smoltcp wants a transmit token every time it receives a packet,
+        // so if the tx queue fills up, we stop being able to receive. I'm ...
+        // not sure why this is desirable, but there we go.
+        //
+        // Note that the can_recv and can_send checks remain valid because the
+        // token mutably borrows the phy.
+        if self.can_recv() && self.can_send() {
+            Some((OurRxToken(self), OurTxToken(self)))
+        } else {
+            None
+        }
+    }
+
+    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+        if self.can_send() {
+            Some(OurTxToken(self))
+        } else {
+            None
+        }
+    }
+
+    fn capabilities(&self) -> smoltcp::phy::DeviceCapabilities {
+        let mut caps = smoltcp::phy::DeviceCapabilities::default();
+        caps.max_transmission_unit = 1514;
+        caps.max_burst_size = Some(1514 * self.tx_ring.len());
+
+        use smoltcp::phy::Checksum;
+        caps.checksum.ipv4 = Checksum::None;
+        caps.checksum.udp = Checksum::None;
+        caps.checksum.icmpv4 = Checksum::None;
+        caps
+    }
+}

--- a/drv/stm32h7-eth/src/lib.rs
+++ b/drv/stm32h7-eth/src/lib.rs
@@ -423,7 +423,14 @@ impl<'a> smoltcp::phy::Device<'a> for Ethernet {
         use smoltcp::phy::Checksum;
         caps.checksum.ipv4 = Checksum::None;
         caps.checksum.udp = Checksum::None;
-        caps.checksum.icmpv4 = Checksum::None;
+        #[cfg(feature = "ipv4")]
+        {
+            caps.checksum.icmpv4 = Checksum::None;
+        }
+        #[cfg(feature = "ipv6")]
+        {
+            caps.checksum.icmpv6 = Checksum::None;
+        }
         caps
     }
 }

--- a/drv/stm32h7-eth/src/ring.rs
+++ b/drv/stm32h7-eth/src/ring.rs
@@ -1,0 +1,392 @@
+//! DMA descriptor rings and data buffers.
+//!
+//! While this module is specific to the DMA descriptor format used by the
+//! Synopsys Ethernet MAC in the STM32H7, it does _not_ depend on the hardware.
+//! This module just moves memory around very carefully.
+//!
+//! Note that the APIs on this module are entirely safe. This is deliberate. The
+//! only unsafe act that a user of this module should expect to perform is
+//! setting up the `static mut` data buffers required to call `new` on the
+//! respective ring types.
+
+use core::cell::{Cell, UnsafeCell};
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// Size of buffer used with the Ethernet DMA. This can be changed but must
+/// remain under 64kiB -- the driver initialization code refers to this constant
+/// when setting up the controller.
+pub const BUFSZ: usize = 1536;
+
+/// Opaque (to you) type alias for an Ethernet packet buffer. To use this module
+/// you need to create a static array of these somehow and provide it to `new`.
+pub struct Buffer(UnsafeCell<[u8; BUFSZ]>);
+
+/// We are careful to use `Buffer` in thread-safe ways and need it to be `Sync`
+/// so that it can be placed in a `static` by our users.
+unsafe impl Sync for Buffer {}
+
+impl Buffer {
+    /// Creates a zero-initialized buffer.
+    pub const fn new() -> Self {
+        Self(UnsafeCell::new([0; BUFSZ]))
+    }
+}
+
+/// Transmit descriptor record.
+///
+/// This is deliberately opaque to viewers outside this module, so that we can
+/// carefully control accesses to its contents.
+#[repr(transparent)]
+pub struct TxDesc {
+    tdes: [AtomicU32; 4],
+}
+
+impl TxDesc {
+    pub const fn new() -> Self {
+        Self {
+            tdes: [
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+            ],
+        }
+    }
+}
+
+/// Control block for a ring of `TxDesc` records and associated `Buffer`s.
+pub struct TxRing {
+    /// The descriptor ring storage.
+    storage: &'static [TxDesc],
+    /// The buffers we're sharing with the hardware.
+    buffers: &'static [Buffer],
+    /// Index of the element within `storage` where we'll try to deposit the
+    /// next transmitted packet. This must be in the range `0..storage.len()` at
+    /// all times.
+    next: Cell<usize>,
+}
+
+impl TxRing {
+    /// Creates a new TX DMA ring out of `storage` and `buffers`.
+    ///
+    /// Note that, because `&'static mut` is not `Copy` and cannot be a reborrow
+    /// (because `'static` is the longest lifetime), you lose access to both
+    /// slices upon calling this. There is no (safe) way to get the pieces back
+    /// out. This is deliberate.
+    ///
+    /// # Panics
+    ///
+    /// If `storage` and `buffers` are not the same length.
+    pub fn new(
+        storage: &'static mut [TxDesc],
+        buffers: &'static mut [Buffer],
+    ) -> Self {
+        assert_eq!(storage.len(), buffers.len());
+        // Drop mutability. We needed the caller to prove exclusive ownership,
+        // but we don't actually need &mut. We assume that both areas of memory
+        // are shared with the DMA controller from this point forward.
+        let (storage, buffers) = (&*storage, &*buffers);
+        // Initialize all TxDesc records to a known state, and in particular,
+        // ensure that they're owned by us (not the hardware).
+        for desc in storage {
+            desc.tdes[3].store(0, Ordering::Release);
+        }
+        Self {
+            storage,
+            buffers,
+            next: Cell::new(0),
+        }
+    }
+
+    /// Returns the base pointer of the `TxDesc` ring. This needs to be loaded
+    /// into the DMA controller so it knows where to look for descriptors.
+    pub fn base_ptr(&self) -> *const TxDesc {
+        self.storage.as_ptr()
+    }
+
+    /// Returns a pointer to the byte just past the end of the `TxDesc` ring.
+    /// This too gets loaded into the DMA controller, so that it knows what
+    /// section of the ring is initialized and can be read. (The answer is "all
+    /// of it.")
+    pub fn tail_ptr(&self) -> *const TxDesc {
+        self.storage.as_ptr_range().end
+    }
+
+    /// Returns the count of entries in the descriptor ring / buffers in the
+    /// pool.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub fn is_next_free(&self) -> bool {
+        let d = &self.storage[self.next.get()];
+        // Check whether the hardware has released this.
+        let tdes3 = d.tdes[3].load(Ordering::Acquire);
+        let own = tdes3 & (1 << 31) != 0;
+        !own
+    }
+
+    /// Attempts to grab the next unused TX buffer in the ring and deposit a
+    /// packet into it.
+    ///
+    /// If the next buffer in the ring is not holding a pending packet, this
+    /// will borrow it and call `body` with its address. `body` returns the
+    /// number of bytes in the packet; this routine will then set up a pending
+    /// transmit descriptor for that prefix of the buffer, and return
+    /// `Some(len)`.
+    ///
+    /// If the next buffer in the ring is pending, that means we have run out of
+    /// TX ring slots. In that case, this will return `None` without invoking
+    /// `body`.
+    ///
+    /// # Panics
+    ///
+    /// If a buffer is available, and we call `body`, and `body` returns a valid
+    /// length larger than `BUFSZ`. Because that's obviously wrong.
+    pub fn try_with_next<R, F: FnOnce(&mut [u8]) -> R>(
+        &self,
+        len: usize,
+        body: F,
+    ) -> Result<R, F> {
+        let d = &self.storage[self.next.get()];
+        // Check whether the hardware has released this.
+        let tdes3 = d.tdes[3].load(Ordering::Acquire);
+        let own = tdes3 & (1 << 31) != 0;
+        if own {
+            Err(body)
+        } else {
+            // Descriptor is free. Since we keep the descriptors paired with
+            // their corresponding buffers, and only lend out the buffers
+            // temporarily (like we're about to do), this means the buffer is
+            // also free.
+            let buffer = self.buffers[self.next.get()].0.get();
+            // Safety: we're dereferencing a raw *mut to get a &mut into the
+            // buffer. We must ensure that the pointer is valid (which we can
+            // tell trivially from the fact that we got it from an UnsafeCell)
+            // and that there is no aliasing. We can say there's no aliasing
+            // because the descriptor is free (above), so we're about to produce
+            // the sole reference to it, which won't outlive this block.
+            let buffer = unsafe { &mut *buffer };
+            let buffer = &mut buffer[..len];
+
+            let result = body(buffer);
+
+            // Program the descriptor to represent the packet. We program
+            // carefully to ensure that the memory accesses happen in the right
+            // order: the entire descriptor must be written before the OWN bit
+            // is set in TDES3 using a RELEASE store.
+            d.tdes[0].store(buffer.as_ptr() as u32, Ordering::Relaxed);
+            d.tdes[1].store(0, Ordering::Relaxed);
+            d.tdes[2].store(len as u32, Ordering::Relaxed);
+            let tdes3 = 1 << 31 // OWN
+                | 1 << 29 // FD
+                | 1 << 28 // LD
+                | 0b11 << 16 // IP checksum
+                | len as u32;
+            d.tdes[3].store(tdes3, Ordering::Release); // <-- release
+
+            self.next.set(if self.next.get() + 1 == self.storage.len() {
+                0
+            } else {
+                self.next.get() + 1
+            });
+
+            Ok(result)
+        }
+    }
+}
+
+/// Receive descriptor record.
+///
+/// This is deliberately opaque to viewers outside this module, so that we can
+/// carefully control accesses to its contents.
+#[repr(transparent)]
+pub struct RxDesc {
+    rdes: [AtomicU32; 4],
+}
+
+impl RxDesc {
+    pub const fn new() -> Self {
+        Self {
+            rdes: [
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+            ],
+        }
+    }
+}
+
+/// Control block for a ring of `RxDesc` records and associated `Buffer`s.
+pub struct RxRing {
+    /// The descriptor ring storage.
+    storage: &'static [RxDesc],
+    /// The buffers we're sharing with the hardware.
+    buffers: &'static [Buffer],
+    /// Index of the element within `storage` where we'll look for the next
+    /// received packet. This must be in the range `0..storage.len()` at all
+    /// times.
+    next: Cell<usize>,
+}
+
+impl RxRing {
+    /// Creates a new RX DMA ring out of `storage` and `buffers`.
+    ///
+    /// Note that, because `&'static mut` is not `Copy` and cannot be a reborrow
+    /// (because `'static` is the longest lifetime), you lose access to both
+    /// slices upon calling this. There is no (safe) way to get the pieces back
+    /// out. This is deliberate.
+    ///
+    /// # Panics
+    ///
+    /// If `storage` and `buffers` are not the same length.
+    pub fn new(
+        storage: &'static mut [RxDesc],
+        buffers: &'static mut [Buffer],
+    ) -> Self {
+        assert_eq!(storage.len(), buffers.len());
+
+        // Give up &mut access to the buffers. We needed the caller to give us
+        // &mut to prove they had, and now we have, exclusive access -- but
+        // we're going to share it.
+        let (storage, buffers) = (&*storage, &*buffers);
+        // Program all descriptors with the matching buffer address and mark
+        // them as available to hardware.
+        for (desc, buf) in storage.iter().zip(buffers) {
+            Self::set_descriptor(desc, buf.0.get());
+        }
+
+        Self {
+            storage,
+            buffers,
+            next: Cell::new(0),
+        }
+    }
+
+    /// Returns the base pointer of the `RxDesc` ring. This needs to be loaded
+    /// into the DMA controller so it knows where to look for descriptors.
+    pub fn base_ptr(&self) -> *const RxDesc {
+        self.storage.as_ptr()
+    }
+
+    /// Returns a pointer to the byte just past the end of the `RxDesc` ring.
+    /// This too gets loaded into the DMA controller, so that it knows what
+    /// section of the ring is initialized and can be read. (The answer is "all
+    /// of it.")
+    pub fn tail_ptr(&self) -> *const RxDesc {
+        self.storage.as_ptr_range().end
+    }
+
+    /// Returns the count of entries in the descriptor ring / buffers in the
+    /// pool.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub fn is_next_free(&self) -> bool {
+        let d = &self.storage[self.next.get()];
+        // Check whether the hardware has released this.
+        let rdes3 = d.rdes[3].load(Ordering::Acquire);
+        let own = rdes3 & (1 << 31) != 0;
+        !own
+    }
+
+    /// Attempts to grab the next filled-out RX buffer in the ring and show it
+    /// to you.
+    ///
+    /// If the next buffer in the ring is holding a pending packet, this will
+    /// borrow it and call `body` with the valid prefix of the buffer, based on
+    /// the received length. Once `body` returns, this routine restores the ring
+    /// entry to empty so that it can be used to receive another packet.
+    ///
+    /// If the next buffer in the ring is empty, that means there are no
+    /// received packets waiting for us.  In that case, this will return `None`
+    /// without invoking `body`.
+    ///
+    /// `body` is allowed to return a value, of some type `R`. If we
+    /// successfully grab a packet and call `body`, we'll return its result.
+    /// This may or may not prove useful.
+    pub fn try_with_next<F: FnOnce(&mut [u8]) -> R, R>(
+        &self,
+        body: F,
+    ) -> Result<R, F> {
+        // body is a FnOnce, so calling it destroys it. In the loop below, the
+        // compiler is not convinced that we call it only once. This adds a
+        // runtime flag to pacify the compiler.
+        let mut body = Some(body);
+        // We loop here so that we can skip over error descriptors and only hand
+        // back real packets.
+        loop {
+            let d = &self.storage[self.next.get()];
+            // Check whether the hardware has released this.
+            let rdes3 = d.rdes[3].load(Ordering::Acquire);
+            let own = rdes3 & (1 << 31) != 0;
+            if own {
+                break Err(body.take().unwrap());
+            } else {
+                // Descriptor is free. Since we keep the descriptors paired with
+                // their corresponding buffers, and only lend out the buffers
+                // temporarily (like we're about to do), this means the buffer is
+                // also free.
+
+                // What sort of descriptor is this?
+                let errors = rdes3 & (1 << 15) != 0;
+                let first_and_last =
+                    rdes3 & ((1 << 28) | (1 << 29)) == ((1 << 28) | (1 << 29));
+
+                let buffer = self.buffers[self.next.get()].0.get();
+
+                let retval = if errors || !first_and_last {
+                    // Skip this
+                    None
+                } else {
+                    // Safety: because the descriptor is free we keep them
+                    // paired, we know the buffer is not aliased, so we're going
+                    // to dereference this raw pointer to produce the only
+                    // reference to its contents. And then discard it at the end
+                    // of this block.
+                    let buffer = unsafe { &mut *buffer };
+
+                    // Work out the valid slice of the packet.
+                    let packet_len = (rdes3 & ((1 << 15) - 1)) as usize;
+
+                    // Pass in the initialized prefix of the packet.
+                    Some((body.take().unwrap())(&mut buffer[..packet_len]))
+                };
+
+                // We need to consume this descriptor whether or not we handed
+                // it off. Rewrite it as an empty rx descriptor:
+                Self::set_descriptor(d, buffer);
+                // At this point the descriptor is no longer free, the buffer is
+                // potentially in use, and we must not access either.
+
+                // Bump index forward.
+                self.next.set(if self.next.get() + 1 == self.storage.len() {
+                    0
+                } else {
+                    self.next.get() + 1
+                });
+
+                // Now break out only if we succeeded.
+                if let Some(result) = retval {
+                    break Ok(result);
+                }
+            }
+        }
+    }
+
+    /// Programs the words in `d` to prepare to receive into `buffer` and sets
+    /// `d` accessible to hardware. The final write to make it accessible is
+    /// performed with Release ordering to get a barrier.
+    fn set_descriptor(d: &RxDesc, buffer: *mut [u8; BUFSZ]) {
+        d.rdes[0].store(buffer as u32, Ordering::Relaxed);
+        d.rdes[1].store(0, Ordering::Relaxed);
+        d.rdes[2].store(0, Ordering::Relaxed);
+        let rdes3 = 1 << 31 // OWN
+            | 1 << 30 // IOC
+            | 1 << 24 // BUF 1 valid
+            ;
+        d.rdes[3].store(rdes3, Ordering::Release); // <-- release
+    }
+}

--- a/gemini-bu/src/main.rs
+++ b/gemini-bu/src/main.rs
@@ -73,6 +73,17 @@ unsafe fn system_pre_init() {
         // spin
     }
 
+    // Turn on the internal RAMs.
+    let rcc = &*device::RCC::ptr();
+    rcc.ahb2enr.modify(|_, w| {
+        w.sram1en()
+            .set_bit()
+            .sram2en()
+            .set_bit()
+            .sram3en()
+            .set_bit()
+    });
+
     // Okay, yay, we can use some RAMs now.
 
     // We'll do the rest in system_init.
@@ -122,6 +133,13 @@ fn system_init() {
             .dbgsleep_d1()
             .set_bit()
     });
+
+    // Set up SYSCFG selections so drivers don't have to.
+    p.RCC.apb4enr.modify(|_, w| w.syscfgen().enabled());
+    cortex_m::asm::dmb();
+
+    // Ethernet is on RMII, not MII.
+    p.SYSCFG.pmcr.modify(|_, w| unsafe { w.epis().bits(0b100) });
 
     // Turn on CPU I/D caches to improve performance at the higher clock speeds
     // we're about to enable.

--- a/task-link.x
+++ b/task-link.x
@@ -63,9 +63,7 @@ SECTIONS
     . = ALIGN(4);
   } > RAM
 
-  /* Place the heap right after `.uninit` */
-  . = ALIGN(4);
-  __sheap = .;
+  __sheap = LOADADDR(.uninit) + SIZEOF(.uninit);
 
   /* ## .got */
   /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in

--- a/task-net/Cargo.toml
+++ b/task-net/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "task-net"
+version = "0.1.0"
+authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
+edition = "2018"
+
+[dependencies]
+cortex-m = "0.6.0"
+userlib = {path = "../userlib"}
+drv-stm32h7-eth = {path = "../drv/stm32h7-eth", features = ["with-smoltcp"]}
+drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api"}
+drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api"}
+
+[dependencies.stm32h7]
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
+features = ["stm32h743"]
+
+[dependencies.smoltcp]
+version = "0.7.1"
+default-features = false
+features = [
+    "proto-ipv4",
+    "proto-ipv6",
+    "ethernet",
+    "socket-udp",
+]
+
+[features]
+default = ["standalone"]
+standalone = []
+
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "task-net"
+test = false
+bench = false

--- a/task-net/Cargo.toml
+++ b/task-net/Cargo.toml
@@ -7,13 +7,10 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6.0"
 userlib = {path = "../userlib"}
-drv-stm32h7-eth = {path = "../drv/stm32h7-eth", features = ["with-smoltcp"]}
+drv-stm32h7-eth = {path = "../drv/stm32h7-eth", features = ["with-smoltcp", "ipv6", "ipv4"]}
 drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api"}
 drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api"}
-
-[dependencies.stm32h7]
-git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
-features = ["stm32h743"]
+stm32h7 = {version = "0.13", features = ["stm32h743"]}
 
 [dependencies.smoltcp]
 version = "0.7.1"

--- a/task-net/src/main.rs
+++ b/task-net/src/main.rs
@@ -1,0 +1,299 @@
+#![no_std]
+#![no_main]
+
+use core::mem::MaybeUninit;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use userlib::{Generation, Task, TaskId};
+
+use drv_stm32h7_eth as eth;
+use drv_stm32h7_rcc_api::Rcc;
+use stm32h7::stm32h743 as device;
+
+#[cfg(not(feature = "standalone"))]
+const RCC: Task = Task::rcc_driver;
+#[cfg(feature = "standalone")]
+const RCC: Task = Task::anonymous;
+
+#[cfg(not(feature = "standalone"))]
+const GPIO: Task = Task::gpio_driver;
+#[cfg(feature = "standalone")]
+const GPIO: Task = Task::anonymous;
+
+const TX_RING_SZ: usize = 4;
+
+fn claim_tx_statics() -> (
+    &'static mut [eth::ring::TxDesc; TX_RING_SZ],
+    &'static mut [eth::ring::Buffer; TX_RING_SZ],
+) {
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::SeqCst) {
+        panic!()
+    }
+
+    let descs = {
+        #[link_section = ".eth_bulk"]
+        static mut TX_DESC: MaybeUninit<[eth::ring::TxDesc; TX_RING_SZ]> =
+            MaybeUninit::uninit();
+        // Safety: unsafe because referencing a static mut; we have ensured that
+        // this only happens once by the structure of this function.
+        let descs = unsafe { &mut TX_DESC };
+        // Safety: unsafe because we're casting and then dereferencing a raw
+        // pointer; we're transmuting from MaybeUninit<[]> to [MaybeUninit<>]
+        // which is ok.
+        let descs: &'static mut [MaybeUninit<eth::ring::TxDesc>; TX_RING_SZ] =
+            unsafe { &mut *(descs as *mut _ as *mut _) };
+        for uninit_desc in descs.iter_mut() {
+            *uninit_desc = MaybeUninit::new(eth::ring::TxDesc::new());
+        }
+        // Safety: unsafe because we're casting away the MaybeUninit and
+        // dereferencing the result. We've fully initialized it just now, so
+        // we're good.
+        unsafe { &mut *(descs as *mut _ as *mut _) }
+    };
+    let bufs = {
+        #[link_section = ".eth_bulk"]
+        static mut TX_BUF: MaybeUninit<[eth::ring::Buffer; TX_RING_SZ]> =
+            MaybeUninit::uninit();
+        // Safety: unsafe because referencing a static mut; we have ensured that
+        // this only happens once by the structure of this function.
+        let bufs = unsafe { &mut TX_BUF };
+        // Safety: unsafe because we're casting and then dereferencing a raw
+        // pointer; we're transmuting from MaybeUninit<[]> to [MaybeUninit<>]
+        // which is ok.
+        let bufs: &'static mut [MaybeUninit<eth::ring::Buffer>; TX_RING_SZ] =
+            unsafe { &mut *(bufs as *mut _ as *mut _) };
+        for uninit_buf in bufs.iter_mut() {
+            *uninit_buf = MaybeUninit::new(eth::ring::Buffer::new());
+        }
+        // Safety: unsafe because we're casting away the MaybeUninit and
+        // dereferencing the result. We've fully initialized it just now, so
+        // we're good.
+        unsafe { &mut *(bufs as *mut _ as *mut _) }
+    };
+
+    (descs, bufs)
+}
+
+const RX_RING_SZ: usize = 4;
+
+fn claim_rx_statics() -> (
+    &'static mut [eth::ring::RxDesc; RX_RING_SZ],
+    &'static mut [eth::ring::Buffer; RX_RING_SZ],
+) {
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::SeqCst) {
+        panic!()
+    }
+
+    let descs = {
+        #[link_section = ".eth_bulk"]
+        static mut RX_DESC: MaybeUninit<[eth::ring::RxDesc; RX_RING_SZ]> =
+            MaybeUninit::uninit();
+        // Safety: unsafe because referencing a static mut; we have ensured that
+        // this only happens once by the structure of this function.
+        let descs = unsafe { &mut RX_DESC };
+        // Safety: unsafe because we're casting and then dereferencing a raw
+        // pointer; we're transmuting from MaybeUninit<[]> to [MaybeUninit<>]
+        // which is ok.
+        let descs: &'static mut [MaybeUninit<eth::ring::RxDesc>; RX_RING_SZ] =
+            unsafe { &mut *(descs as *mut _ as *mut _) };
+        for uninit_desc in descs.iter_mut() {
+            *uninit_desc = MaybeUninit::new(eth::ring::RxDesc::new());
+        }
+        // Safety: unsafe because we're casting away the MaybeUninit and
+        // dereferencing the result. We've fully initialized it just now, so
+        // we're good.
+        unsafe { &mut *(descs as *mut _ as *mut _) }
+    };
+    let bufs = {
+        #[link_section = ".eth_bulk"]
+        static mut RX_BUF: MaybeUninit<[eth::ring::Buffer; RX_RING_SZ]> =
+            MaybeUninit::uninit();
+        // Safety: unsafe because referencing a static mut; we have ensured that
+        // this only happens once by the structure of this function.
+        let bufs = unsafe { &mut RX_BUF };
+        // Safety: unsafe because we're casting and then dereferencing a raw
+        // pointer; we're transmuting from MaybeUninit<[]> to [MaybeUninit<>]
+        // which is ok.
+        let bufs: &'static mut [MaybeUninit<eth::ring::Buffer>; RX_RING_SZ] =
+            unsafe { &mut *(bufs as *mut _ as *mut _) };
+        for uninit_buf in bufs.iter_mut() {
+            *uninit_buf = MaybeUninit::new(eth::ring::Buffer::new());
+        }
+        // Safety: unsafe because we're casting away the MaybeUninit and
+        // dereferencing the result. We've fully initialized it just now, so
+        // we're good.
+        unsafe { &mut *(bufs as *mut _ as *mut _) }
+    };
+
+    (descs, bufs)
+}
+
+#[export_name = "main"]
+fn main() -> ! {
+    let rcc = TaskId::for_index_and_gen(RCC as usize, Generation::default());
+    let rcc = Rcc::from(rcc);
+    rcc.enable_clock(drv_stm32h7_rcc_api::Peripheral::Eth1Rx);
+    rcc.enable_clock(drv_stm32h7_rcc_api::Peripheral::Eth1Tx);
+    rcc.enable_clock(drv_stm32h7_rcc_api::Peripheral::Eth1Mac);
+
+    rcc.enter_reset(drv_stm32h7_rcc_api::Peripheral::Eth1Mac);
+    rcc.leave_reset(drv_stm32h7_rcc_api::Peripheral::Eth1Mac);
+
+    configure_ethernet_pins();
+
+    let (tx_storage, tx_buffers) = claim_tx_statics();
+    let tx_ring = eth::ring::TxRing::new(tx_storage, tx_buffers);
+    let (rx_storage, rx_buffers) = claim_rx_statics();
+    let rx_ring = eth::ring::RxRing::new(rx_storage, rx_buffers);
+
+    let eth = eth::Ethernet::new(
+        unsafe { &*device::ETHERNET_MAC::ptr() },
+        unsafe { &*device::ETHERNET_MTL::ptr() },
+        unsafe { &*device::ETHERNET_DMA::ptr() },
+        tx_ring,
+        rx_ring,
+    );
+
+    use smoltcp::iface::Neighbor;
+    use smoltcp::socket::SocketSet;
+    use smoltcp::wire::IpAddress;
+
+    static FAKE_MAC: &[u8] = &[0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C];
+    static FAKE_IP: &[u8] = &[169, 254, 31, 12];
+
+    let mac = smoltcp::wire::EthernetAddress::from_bytes(FAKE_MAC);
+    let ip_addr = smoltcp::wire::Ipv4Address::from_bytes(FAKE_IP);
+    let ip_cidr = smoltcp::wire::Ipv4Cidr::new(ip_addr, 16);
+    let ip_cidr = smoltcp::wire::IpCidr::from(ip_cidr);
+    let mut ip_addrs = [ip_cidr];
+    let mut neighbor_cache_storage: [Option<(IpAddress, Neighbor)>; 16] =
+        [None; 16];
+    let neighbor_cache =
+        smoltcp::iface::NeighborCache::new(&mut neighbor_cache_storage[..]);
+
+    let mut eth = smoltcp::iface::EthernetInterfaceBuilder::new(eth)
+        .ethernet_addr(mac)
+        .ip_addrs(&mut ip_addrs[..])
+        .neighbor_cache(neighbor_cache)
+        .finalize();
+    let mut socket_set = [None, None];
+    let mut socket_set = SocketSet::new(&mut socket_set[..]);
+
+    let mii_basic_control = eth.device_mut().smi_read(0x01, 0x00);
+    let mii_basic_control = mii_basic_control
+        | 1 << 12 // AN enable
+        | 1 << 9 // restart autoneg
+        ;
+    eth.device_mut().smi_write(0x01, 0x00, mii_basic_control);
+
+    // Wait for link-up
+    while eth.device_mut().smi_read(0x01, 0x01) & (1 << 2) == 0 {
+        userlib::hl::sleep_for(1);
+    }
+
+    const ETH_IRQ: u32 = 1;
+    userlib::sys_irq_control(ETH_IRQ, true);
+
+    loop {
+        let poll_result = eth.poll(
+            &mut socket_set,
+            smoltcp::time::Instant::from_millis(
+                userlib::sys_get_timer().now as i64,
+            ),
+        );
+
+        let no_block = match poll_result {
+            Err(_) => {
+                // TODO counters would be good
+                true
+            }
+            Ok(activity) => activity,
+        };
+
+        if !no_block {
+            userlib::hl::recv(
+                &mut [],
+                ETH_IRQ,
+                &mut eth,
+                |eth, notification| {
+                    if notification & ETH_IRQ != 0 {
+                        eth.device_mut().on_interrupt();
+                        userlib::sys_irq_control(ETH_IRQ, true);
+                    }
+                },
+                |_, _: u32, _| {
+                    // We weren't expecting messages.
+                    Ok::<_, u32>(())
+                },
+            );
+        }
+    }
+}
+
+fn configure_ethernet_pins() {
+    // TODO this mapping is hard-coded for the STM32H7 Nucleo board!
+    //
+    // This board's mapping:
+    //
+    // RMII REF CLK     PA1
+    // MDIO             PA2
+    // RMII RX DV       PA7
+    //
+    // MDC              PC1
+    // RMII RXD0        PC4
+    // RMII RXD1        PC5
+    //
+    // RMII TX EN       PG11
+    // RMII TXD1        PB13 <-- port B
+    // RMII TXD0        PG13
+    use drv_stm32h7_gpio_api::*;
+
+    let gpio = Gpio::from(TaskId::for_index_and_gen(
+        GPIO as usize,
+        Generation::default(),
+    ));
+    let eth_af = Alternate::AF11;
+
+    gpio.configure(
+        Port::A,
+        (1 << 1) | (1 << 2) | (1 << 7),
+        Mode::Alternate,
+        OutputType::PushPull,
+        Speed::VeryHigh,
+        Pull::None,
+        eth_af,
+    )
+    .unwrap();
+    gpio.configure(
+        Port::B,
+        (1 << 13),
+        Mode::Alternate,
+        OutputType::PushPull,
+        Speed::VeryHigh,
+        Pull::None,
+        eth_af,
+    )
+    .unwrap();
+    gpio.configure(
+        Port::C,
+        (1 << 1) | (1 << 4) | (1 << 5),
+        Mode::Alternate,
+        OutputType::PushPull,
+        Speed::VeryHigh,
+        Pull::None,
+        eth_af,
+    )
+    .unwrap();
+    gpio.configure(
+        Port::G,
+        (1 << 11) | (1 << 12) | (1 << 13),
+        Mode::Alternate,
+        OutputType::PushPull,
+        Speed::VeryHigh,
+        Pull::None,
+        eth_af,
+    )
+    .unwrap();
+}

--- a/task-net/src/main.rs
+++ b/task-net/src/main.rs
@@ -158,16 +158,24 @@ fn main() -> ! {
 
     use smoltcp::iface::Neighbor;
     use smoltcp::socket::SocketSet;
-    use smoltcp::wire::IpAddress;
+    use smoltcp::wire::{IpAddress, Ipv6Address};
 
     static FAKE_MAC: &[u8] = &[0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C];
-    static FAKE_IP: &[u8] = &[169, 254, 31, 12];
+
+    let ipv6_addr =
+        Ipv6Address::new(0xfe80, 0, 0, 0, 0x0004, 0x06ff, 0xfe08, 0x0a0c);
 
     let mac = smoltcp::wire::EthernetAddress::from_bytes(FAKE_MAC);
-    let ip_addr = smoltcp::wire::Ipv4Address::from_bytes(FAKE_IP);
-    let ip_cidr = smoltcp::wire::Ipv4Cidr::new(ip_addr, 16);
-    let ip_cidr = smoltcp::wire::IpCidr::from(ip_cidr);
-    let mut ip_addrs = [ip_cidr];
+    let ipv6_net = smoltcp::wire::IpCidr::from(smoltcp::wire::Ipv6Cidr::new(
+        ipv6_addr, 64,
+    ));
+
+    let ipv4_addr = smoltcp::wire::Ipv4Address::from_bytes(&[169, 254, 31, 12]);
+    let ipv4_net = smoltcp::wire::IpCidr::from(smoltcp::wire::Ipv4Cidr::new(
+        ipv4_addr, 16,
+    ));
+
+    let mut ip_addrs = [ipv6_net, ipv4_net];
     let mut neighbor_cache_storage: [Option<(IpAddress, Neighbor)>; 16] =
         [None; 16];
     let neighbor_cache =
@@ -268,7 +276,7 @@ fn configure_ethernet_pins() {
     .unwrap();
     gpio.configure(
         Port::B,
-        (1 << 13),
+        1 << 13,
         Mode::Alternate,
         OutputType::PushPull,
         Speed::VeryHigh,

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -401,7 +401,7 @@ fn generate_task_linker_script(
             writeln!(linkscr, "    *(.{} .{}.*);", section, section)?;
             writeln!(linkscr, "  }} > {}", memory.to_ascii_uppercase())?;
         }
-        writeln!(linkscr, "}} INSERT BEFORE .got")?;
+        writeln!(linkscr, "}} INSERT AFTER .uninit")?;
     }
 
     Ok(())


### PR DESCRIPTION
With this change, the demo image on the STM32H7 Nucleo board can respond to ARP and ICMPv4 echos. ...and basically nothing else. This marks the first use of DMA in Hubris, so, woo.