### PR TITLE
ARM-M: fix interrupt priority configuration.

### DIFF
--- a/kern/src/arch/arm_m.rs
+++ b/kern/src/arch/arm_m.rs
@@ -589,8 +589,9 @@ pub fn start_first_task(tick_divisor: u32, task: &task::Task) -> ! {
         // (presumably due to an oversight) not present in the cortex_m API, so
         // let's fake it.
         let ictr = (0xe000_e004 as *const u32).read_volatile();
-        // This gives interrupt count in blocks of 32.
-        let irq_block_count = ictr as usize & 0xF;
+        // This gives interrupt count in blocks of 32, minus 1, so there are
+        // always at least 32 interrupts.
+        let irq_block_count = (ictr as usize & 0xF) + 1;
         let irq_count = irq_block_count * 32;
         // Blindly poke all the interrupts to 0xFF.
         for i in 0..irq_count {


### PR DESCRIPTION
Due to an off-by-one error, the kernel was not disabling preemption by
the last 32 implemented interrupts in a given SoC. If you are not
_using_ any of the last 32 implemented interrupts, you won't notice this
-- but once you start, you will find subtle race conditions caused by
the non-preemptible kernel becoming mysteriously preemptible, as Laura
can attest.

The core problem is that the INTLINESNUM field in ICTR is _not_ the
number of interrupt line control registers, but rather the number of
_the highest implemented,_ meaning it is N-1.

This commit fixes this by adding a 1.