### PR TITLE
update getting openocd for Windows

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -64,12 +64,21 @@ You will need:
 If you're on Windows, you can get set up by doing this:
 
 See [here](http://openocd.org/getting-openocd/) for getting the source of `openocd`
-or get unofficial binaries. Alternatively, you can easily install via
+or get unofficial binaries. Alternatively, you can install via
 with [chocolatey](https://chocolatey.org/install):
 
 ```console
 > choco install openocd
 ```
+
+You can easily install `openocd` with [scoop](https://scoop.sh/):
+
+```console
+> scoop bucket add extras
+> scoop install openocd
+```
+NOTE: `openocd` installed via `scoop` has proven problematic for some users. If
+you experience problems, try installing via `choco` or from source (see above).
 
 You'll probably need to install [this
 driver](https://www.st.com/en/development-tools/stsw-link009.html).


### PR DESCRIPTION
As of this writing, the specific release of `openocd` provided by `scoop` does not work to connect to an STM32F4 Discovery. The one in Chocolatey does work. This is strange as they both are listed as version `0.10.0`, however Rick pointed out that `openocd` is notoriously bad at releases and suggested the most reliable path may be to just build from source. 