### PR TITLE
Increase flash partition size

### DIFF
--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -49,7 +49,7 @@ features = ["itm"]
 path = "../test-suite"
 name = "test-suite"
 priority = 2
-requires = {flash = 32768, ram = 4096}
+requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -37,7 +37,7 @@ features = ["itm"]
 path = "../test-suite"
 name = "test-suite"
 priority = 2
-requires = {flash = 32768, ram = 4096}
+requires = {flash = 65536, ram = 4096}
 start = true
 
 [tasks.assist]

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -37,7 +37,7 @@ features = ["itm"]
 path = "../test-suite"
 name = "test-suite"
 priority = 2
-requires = {flash = 32768, ram = 4096}
+requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -49,7 +49,7 @@ features = ["itm"]
 path = "../test-suite"
 name = "test-suite"
 priority = 2
-requires = {flash = 32768, ram = 4096}
+requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 

--- a/test/tests-stm32h7/app-h7b3.toml
+++ b/test/tests-stm32h7/app-h7b3.toml
@@ -49,7 +49,7 @@ features = ["itm"]
 path = "../test-suite"
 name = "test-suite"
 priority = 2
-requires = {flash = 32768, ram = 4096}
+requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 


### PR DESCRIPTION
My overflow checking change has increased text size -- and in some
cases, made the test suites no longer fit in their partitions.

This has the somewhat dismaying implication that these test suites are
not actually being built in CI.