### PR TITLE
Clean up where .addr_table is placed

### DIFF
--- a/task-link.x
+++ b/task-link.x
@@ -30,12 +30,23 @@ SECTIONS
   } > FLASH
 
   /*
+   * Table of entry points for Hubris to get into the bootloader.
+   * table.ld containing the actual bytes is generated at runtime.
+   * Note the ALIGN requirement comes from TrustZone requirements.
+   */
+  .addr_table __erodata : ALIGN(32) {
+    __bootloader_fn_table = .;
+    INCLUDE table.ld
+    __end_flash = .;
+  } > FLASH
+
+  /*
    * Sections in RAM
    *
    * NOTE: the userlib runtime assumes that these sections
    * are 4-byte aligned and padded to 4-byte boundaries.
    */
-  .data : AT(__erodata) ALIGN(4)
+  .data : AT(__end_flash) ALIGN(4)
   {
     . = ALIGN(4);
     __sdata = .;
@@ -47,7 +58,7 @@ SECTIONS
   /* LMA of .data */
   __sidata = LOADADDR(.data);
 
-  .bss : ALIGN(4)
+  .bss (NOLOAD) : ALIGN(4)
   {
     . = ALIGN(4);
     __sbss = .;

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -732,13 +732,6 @@ fn generate_task_linker_script(
         writeln!(linkscr, "}} INSERT BEFORE .got")?;
     }
 
-    writeln!(linkscr, "SECTIONS {{").unwrap();
-    writeln!(linkscr, " .addr_table : ALIGN(32) {{").unwrap();
-    writeln!(linkscr, "    __bootloader_fn_table = .;").unwrap();
-    writeln!(linkscr, " INCLUDE table.ld").unwrap();
-    writeln!(linkscr, " }} > FLASH").unwrap();
-    writeln!(linkscr, "}} INSERT BEFORE .bss").unwrap();
-
     Ok(())
 }
 


### PR DESCRIPTION
Currently .addr_table is placed right before .bss. This may run into
sizing conflicts if .data has any data in it. Fix this by placing
.addr_table in the task-link linker script to make sure everything
always lines up. If there's no data for .addr_table it will just be
silently dropped.

As part of this fixup mark .bss as NOLOAD.