### PR TITLE
Fix openocd init scripts on STM32H7.

### DIFF
--- a/demo-stm32h7/openocd.cfg
+++ b/demo-stm32h7/openocd.cfg
@@ -15,7 +15,6 @@ source [find target/stm32h7x_dual_bank.cfg]
 # implementation.
 #
 $_CHIPNAME.cpu0 configure -event examine-end {
-	echo "Info : executing patched examine-end for $_CHIPNAME.cpu0"
 	# Enable D3 and D1 DBG clocks
 	# DBGMCU_CR |= D3DBGCKEN | D1DBGCKEN
 	stm32h7x_dbgmcu_mmw 0x004 0x00600000 0

--- a/gemini-bu/openocd.cfg
+++ b/gemini-bu/openocd.cfg
@@ -18,7 +18,6 @@ source [find target/stm32h7x_dual_bank.cfg]
 # implementation.
 #
 $_CHIPNAME.cpu0 configure -event examine-end {
-	echo "Info : executing patched examine-end for $_CHIPNAME.cpu0"
 	# Enable D3 and D1 DBG clocks
 	# DBGMCU_CR |= D3DBGCKEN | D1DBGCKEN
 	stm32h7x_dbgmcu_mmw 0x004 0x00600000 0

--- a/gimletlet/openocd.cfg
+++ b/gimletlet/openocd.cfg
@@ -20,7 +20,6 @@ source [find target/stm32h7x_dual_bank.cfg]
 # implementation.
 #
 $_CHIPNAME.cpu0 configure -event examine-end {
-	echo "Info : executing patched examine-end for $_CHIPNAME.cpu0"
 	# Enable D3 and D1 DBG clocks
 	# DBGMCU_CR |= D3DBGCKEN | D1DBGCKEN
 	stm32h7x_dbgmcu_mmw 0x004 0x00600000 0


### PR DESCRIPTION
These were printing a misleading failure on success. However, there was
a real failure happening under the hood, it just didn't tend to affect
people. The problem appears to have been from _an echo statement_ so
I've removed it.