### PR TITLE
Add macro for declaring tasks

### DIFF
--- a/drv/lpc55-gpio/src/main.rs
+++ b/drv/lpc55-gpio/src/main.rs
@@ -49,11 +49,7 @@ enum Op {
     ReadVal = 3,
 }
 
-#[cfg(not(feature = "standalone"))]
-const SYSCON: Task = Task::syscon_driver;
-
-#[cfg(feature = "standalone")]
-const SYSCON: Task = Task::anonymous;
+declare_task!(SYSCON, syscon_driver);
 
 #[repr(u32)]
 enum ResponseCode {

--- a/drv/lpc55-i2c/src/main.rs
+++ b/drv/lpc55-i2c/src/main.rs
@@ -21,13 +21,7 @@ use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const SYSCON: Task = Task::syscon_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const SYSCON: Task = Task::anonymous;
+declare_task!(SYSCON, syscon_driver);
 
 #[derive(FromPrimitive)]
 enum Op {

--- a/drv/lpc55-rng/src/main.rs
+++ b/drv/lpc55-rng/src/main.rs
@@ -29,13 +29,7 @@ use zerocopy::AsBytes;
 
 use lpc55_pac as device;
 
-#[cfg(not(feature = "standalone"))]
-const SYSCON: Task = Task::syscon_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const SYSCON: Task = Task::anonymous;
+declare_task!(SYSCON, syscon_driver);
 
 #[repr(u32)]
 enum ResponseCode {

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -25,13 +25,7 @@ use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const SYSCON: Task = Task::syscon_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const SYSCON: Task = Task::anonymous;
+declare_task!(SYSCON, syscon_driver);
 
 #[repr(u32)]
 enum ResponseCode {

--- a/drv/lpc55-usart/src/main.rs
+++ b/drv/lpc55-usart/src/main.rs
@@ -16,13 +16,7 @@ use lpc55_pac as device;
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[cfg(not(feature = "standalone"))]
-const SYSCON: Task = Task::syscon_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const SYSCON: Task = Task::anonymous;
+declare_task!(SYSCON, syscon_driver);
 
 const OP_WRITE: u32 = 1;
 

--- a/drv/stm32fx-usart/src/main.rs
+++ b/drv/stm32fx-usart/src/main.rs
@@ -18,13 +18,7 @@ use stm32f3::stm32f303 as device;
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
+declare_task!(RCC, rcc_driver);
 
 #[derive(Copy, Clone, Debug, FromPrimitive)]
 enum Operation {

--- a/drv/stm32h7-gpio/src/main.rs
+++ b/drv/stm32h7-gpio/src/main.rs
@@ -137,13 +137,7 @@ impl From<ResponseCode> for u32 {
     }
 }
 
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
+declare_task!(RCC, rcc_driver);
 
 #[export_name = "main"]
 fn main() -> ! {

--- a/drv/stm32h7-i2c-server/src/main.rs
+++ b/drv/stm32h7-i2c-server/src/main.rs
@@ -19,17 +19,8 @@ use fixedmap::*;
 use ringbuf::*;
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const GPIO: Task = Task::gpio_driver;
-
-#[cfg(feature = "standalone")]
-const GPIO: Task = Task::anonymous;
+declare_task!(RCC, rcc_driver);
+declare_task!(GPIO, gpio_driver);
 
 fn lookup_controller<'a>(
     controllers: &'a [I2cController],

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -26,17 +26,8 @@ use drv_stm32h7_gpio_api as gpio_api;
 use drv_stm32h7_rcc_api as rcc_api;
 use drv_stm32h7_spi as spi_core;
 
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-#[cfg(feature = "standalone")]
-const GPIO: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const GPIO: Task = Task::gpio_driver;
+declare_task!(RCC, rcc_driver);
+declare_task!(GPIO, gpio_driver);
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 enum Operation {

--- a/drv/stm32h7-usart/src/main.rs
+++ b/drv/stm32h7-usart/src/main.rs
@@ -16,21 +16,8 @@ use stm32h7::stm32h7b3 as device;
 
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const GPIO: Task = Task::gpio_driver;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const GPIO: Task = Task::anonymous;
+declare_task!(RCC, rcc_driver);
+declare_task!(GPIO, gpio_driver);
 
 #[derive(Copy, Clone, Debug, FromPrimitive)]
 enum Operation {

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -106,13 +106,7 @@ fn main() -> ! {
 
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "stm32f4", feature = "stm32f3"))] {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "standalone")] {
-                const RCC: Task = Task::anonymous;
-            } else {
-                const RCC: Task = Task::rcc_driver;
-            }
-        }
+        declare_task!(RCC, rcc_driver);
     }
 }
 
@@ -245,13 +239,7 @@ fn led_toggle(led: Led) {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "stm32h7")] {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "standalone")] {
-                const GPIO: Task = Task::anonymous;
-            } else {
-                const GPIO: Task = Task::gpio_driver;
-            }
-        }
+        declare_task!(GPIO, gpio_driver);
 
         cfg_if::cfg_if! {
             if #[cfg(target_board = "stm32h7b3i-dk")] {
@@ -393,13 +381,7 @@ fn led_toggle(led: Led) {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "lpc55")] {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "standalone")] {
-                const GPIO: Task = Task::anonymous;
-            } else {
-                const GPIO: Task = Task::gpio_driver;
-            }
-        }
+        declare_task!(GPIO, gpio_driver);
 
         cfg_if::cfg_if! {
             if #[cfg(target_board = "lpcxpresso55s69")] {

--- a/task-i2c/src/main.rs
+++ b/task-i2c/src/main.rs
@@ -38,11 +38,7 @@ use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use drv_i2c_api::*;
 use userlib::*;
 
-#[cfg(feature = "standalone")]
-const I2C: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const I2C: Task = Task::i2c_driver;
+declare_task!(I2C, i2c_driver);
 
 //
 // Okay, don't judge, but these variables constitute an interface with

--- a/task-ping/src/main.rs
+++ b/task-ping/src/main.rs
@@ -4,17 +4,9 @@
 
 use userlib::*;
 
-#[cfg(feature = "standalone")]
-const PEER: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const PEER: Task = Task::pong;
-
-#[cfg(all(feature = "standalone", feature = "uart"))]
-const UART: Task = Task::anonymous;
-
-#[cfg(all(not(feature = "standalone"), feature = "uart"))]
-const UART: Task = Task::usart_driver;
+declare_task!(PEER, pong);
+#[cfg(feature = "uart")]
+declare_task!(UART, usart_driver);
 
 #[inline(never)]
 fn nullread() {

--- a/task-pong/src/main.rs
+++ b/task-pong/src/main.rs
@@ -49,11 +49,7 @@ pub fn main() -> ! {
 }
 
 fn get_user_leds() -> drv_user_leds_api::UserLeds {
-    #[cfg(not(feature = "standalone"))]
-    const USER_LEDS: Task = Task::user_leds;
-
-    #[cfg(feature = "standalone")]
-    const USER_LEDS: Task = Task::anonymous;
+    declare_task!(USER_LEDS, user_leds);
 
     drv_user_leds_api::UserLeds::from(get_task_id(USER_LEDS))
 }

--- a/task-spd/src/main.rs
+++ b/task-spd/src/main.rs
@@ -21,23 +21,9 @@ use drv_stm32h7_rcc_api::{Peripheral, Rcc};
 use ringbuf::*;
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const RCC: Task = Task::rcc_driver;
-
-#[cfg(feature = "standalone")]
-const RCC: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const GPIO: Task = Task::gpio_driver;
-
-#[cfg(feature = "standalone")]
-const GPIO: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const I2C: Task = Task::i2c_driver;
-
-#[cfg(feature = "standalone")]
-const I2C: Task = Task::anonymous;
+declare_task!(RCC, rcc_driver);
+declare_task!(GPIO, gpio_driver);
+declare_task!(I2C, i2c_driver);
 
 fn configure_pin(pin: &I2cPin) {
     let gpio_driver = get_task_id(GPIO);

--- a/task-spi/src/main.rs
+++ b/task-spi/src/main.rs
@@ -4,11 +4,7 @@
 use ringbuf::*;
 use userlib::*;
 
-#[cfg(feature = "standalone")]
-const SPI: Task = Task::anonymous;
-
-#[cfg(not(feature = "standalone"))]
-const SPI: Task = Task::spi_driver;
+declare_task!(SPI, spi_driver);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Payload {

--- a/task-thermal/src/main.rs
+++ b/task-thermal/src/main.rs
@@ -21,11 +21,7 @@ use drv_onewire_devices::ds18b20::*;
 use userlib::units::*;
 use userlib::*;
 
-#[cfg(not(feature = "standalone"))]
-const I2C: Task = Task::i2c_driver;
-
-#[cfg(feature = "standalone")]
-const I2C: Task = Task::anonymous;
+declare_task!(I2C, i2c_driver);
 
 fn convert_fahrenheit(temp: Celsius) -> f32 {
     temp.0 * (9.0 / 5.0) + 32.0

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -849,27 +849,11 @@ fn test_refresh_task_id_off_by_many() {
 ///////////////////////////////////////////////////////////////////////////////
 // Frameworky bits follow
 
-/// Identity of our "assistant task" that we require in the image.
-#[cfg(not(feature = "standalone"))]
-const ASSIST: Task = Task::assist;
-
-/// Our own identity
-#[cfg(not(feature = "standalone"))]
-const SUITE: Task = Task::suite;
-
-#[cfg(not(feature = "standalone"))]
-const RUNNER: Task = Task::runner;
-
-// For standalone mode -- this won't work, but then, neither will a task without
-// a kernel.
-#[cfg(feature = "standalone")]
-const ASSIST: Task = Task::anonymous;
-
-#[cfg(feature = "standalone")]
-const SUITE: Task = Task::anonymous;
-
-#[cfg(feature = "standalone")]
-const RUNNER: Task = Task::anonymous;
+// Identity of our "assistant task" that we require in the image.
+declare_task!(ASSIST, assist);
+// Our own identity
+declare_task!(SUITE, suite);
+declare_task!(RUNNER, runner);
 
 /// Gets the current expected `TaskId` for the assistant.
 fn assist_task_id() -> TaskId {

--- a/userlib/src/hl.rs
+++ b/userlib/src/hl.rs
@@ -578,3 +578,14 @@ pub fn sleep_until(time: u64) {
 pub fn sleep_for(ticks: u64) {
     sleep_until(sys_get_timer().now + ticks)
 }
+
+#[macro_export]
+macro_rules! declare_task {
+    ($var:ident, $task_name:ident) => {
+        #[cfg(not(feature = "standalone"))]
+        const $var: Task = Task::$task_name;
+
+        #[cfg(feature = "standalone")]
+        const $var: Task = Task::anonymous;
+    };
+}


### PR DESCRIPTION
A common idiom right now is to have references to `Task::anonymous`
for compilation purposes when `standalone` is enabled. This has
resulted in a fairly common pattern:

 #[cfg(not(feature = "standalone"))]
 const TASK_NAME: Task = Task::task_driver;

 #[cfg(feature = "standalone")]
 const TASK: Task = Task::anonymous;

Turn this into a macro to cut down on duplication.