### PR TITLE
Apply best practices for userlib macros

### DIFF
--- a/userlib/src/hl.rs
+++ b/userlib/src/hl.rs
@@ -578,14 +578,3 @@ pub fn sleep_until(time: u64) {
 pub fn sleep_for(ticks: u64) {
     sleep_until(sys_get_timer().now + ticks)
 }
-
-#[macro_export]
-macro_rules! declare_task {
-    ($var:ident, $task_name:ident) => {
-        #[cfg(not(feature = "standalone"))]
-        const $var: Task = Task::$task_name;
-
-        #[cfg(feature = "standalone")]
-        const $var: Task = Task::anonymous;
-    };
-}

--- a/userlib/src/lib.rs
+++ b/userlib/src/lib.rs
@@ -25,6 +25,9 @@
 #![feature(asm)]
 #![feature(naked_functions)]
 
+#[macro_use]
+mod macros;
+
 pub use abi::*;
 pub use num_derive::{FromPrimitive, ToPrimitive};
 pub use num_traits::{FromPrimitive, ToPrimitive};
@@ -751,51 +754,6 @@ unsafe extern "C" fn sys_get_timer_stub(_out: *mut RawTimerState) {
         sysnum = const Sysnum::GetTimer as u32,
         options(noreturn),
     )
-}
-
-#[cfg(feature = "log-itm")]
-#[macro_export]
-macro_rules! sys_log {
-    ($s:expr) => {
-        unsafe {
-            let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
-            cortex_m::iprintln!(stim, $s);
-        }
-    };
-    ($s:expr, $($tt:tt)*) => {
-        unsafe {
-            let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
-            cortex_m::iprintln!(stim, $s, $($tt)*);
-        }
-    };
-}
-
-#[cfg(feature = "log-semihosting")]
-#[macro_export]
-macro_rules! sys_log {
-    ($s:expr) => {
-        { let _ = cortex_m_semihosting::hprintln!($s); }
-    };
-    ($s:expr, $($tt:tt)*) => {
-        { let _ = cortex_m_semihosting::hprintln!($s, $($tt)*); }
-    };
-}
-
-#[cfg(not(any(feature = "log-semihosting", feature = "log-itm")))]
-#[macro_export]
-macro_rules! sys_log {
-    ($s:expr) => {
-        compile_error!(concat!(
-            "to use sys_log! must enable either ",
-            "'log-semihosting' or 'log-itm' feature"
-        ))
-    };
-    ($s:expr, $($tt:tt)*) => {
-        compile_error!(concat!(
-            "to use sys_log! must enable either ",
-            "'log-semihosting' or 'log-itm' feature"
-        ))
-    };
 }
 
 /// This is the entry point for the kernel. Its job is to set up our memory

--- a/userlib/src/macros.rs
+++ b/userlib/src/macros.rs
@@ -1,0 +1,55 @@
+#[cfg(feature = "log-itm")]
+#[macro_export]
+macro_rules! sys_log {
+    ($s:expr) => {
+        unsafe {
+            let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
+            cortex_m::iprintln!(stim, $s);
+        }
+    };
+    ($s:expr, $($tt:tt)*) => {
+        unsafe {
+            let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
+            cortex_m::iprintln!(stim, $s, $($tt)*);
+        }
+    };
+}
+
+#[cfg(feature = "log-semihosting")]
+#[macro_export]
+macro_rules! sys_log {
+    ($s:expr) => {
+        { let _ = cortex_m_semihosting::hprintln!($s); }
+    };
+    ($s:expr, $($tt:tt)*) => {
+        { let _ = cortex_m_semihosting::hprintln!($s, $($tt)*); }
+    };
+}
+
+#[cfg(not(any(feature = "log-semihosting", feature = "log-itm")))]
+#[macro_export]
+macro_rules! sys_log {
+    ($s:expr) => {
+        compile_error!(concat!(
+            "to use sys_log! must enable either ",
+            "'log-semihosting' or 'log-itm' feature"
+        ))
+    };
+    ($s:expr, $($tt:tt)*) => {
+        compile_error!(concat!(
+            "to use sys_log! must enable either ",
+            "'log-semihosting' or 'log-itm' feature"
+        ))
+    };
+}
+
+#[macro_export]
+macro_rules! declare_task {
+    ($var:ident, $task_name:ident) => {
+        #[cfg(not(feature = "standalone"))]
+        const $var: Task = Task::$task_name;
+
+        #[cfg(feature = "standalone")]
+        const $var: Task = Task::anonymous;
+    };
+}


### PR DESCRIPTION
From https://veykril.github.io/tlborm/decl-macros/minutiae/scoping.html:
* Put macros in a separate module
* #[macro_use] that module at the beginning of the crate root lib

This allows the "crate wide" macros to be used consistently both within
and outside the crate.  Otherwise scoping rules get complicated.