### PR TITLE
Batch of fixes for ioactive issues

### DIFF
--- a/kern/src/arch/arm_m.rs
+++ b/kern/src/arch/arm_m.rs
@@ -356,12 +356,13 @@ pub fn reinitialize(task: &mut task::Task) {
         }
     }
 
+    let descriptor = task.descriptor();
     let frame = &mut task.try_write(&mut frame_uslice).unwrap()[0];
 
     // Conservatively/defensively zero the entire frame.
     *frame = ExtendedExceptionFrame::default();
     // Now fill in the bits we actually care about.
-    frame.base.pc = task.descriptor().entry_point | 1; // for thumb
+    frame.base.pc = descriptor.entry_point | 1; // for thumb
     frame.base.xpsr = INITIAL_PSR;
     frame.base.lr = 0xFFFF_FFFF; // trap on return from main
     frame.fpscr = INITIAL_FPSCR;

--- a/kern/src/kipc.rs
+++ b/kern/src/kipc.rs
@@ -45,7 +45,7 @@ where
 }
 
 fn serialize_response<T>(
-    task: &Task,
+    task: &mut Task,
     mut buf: USlice<u8>,
     val: &T,
 ) -> Result<usize, UserError>
@@ -76,11 +76,11 @@ fn read_task_status(
             UsageError::TaskOutOfRange,
         )));
     }
-    let response_len = serialize_response(
-        &tasks[caller],
-        response,
-        tasks[index as usize].state(),
-    )?;
+    // cache other state before taking out a mutable borrow on tasks
+    let other_state = *tasks[index as usize].state();
+
+    let response_len =
+        serialize_response(&mut tasks[caller], response, &other_state)?;
     tasks[caller]
         .save_mut()
         .set_send_response_and_length(0, response_len);

--- a/kern/src/task.rs
+++ b/kern/src/task.rs
@@ -104,7 +104,7 @@ impl Task {
     /// that the task `self` can access it for read. This is used to access task
     /// memory from the kernel in validated form.
     pub fn try_read<'a, T>(
-        &self,
+        &'a self,
         slice: &'a USlice<T>,
     ) -> Result<&'a [T], FaultInfo>
     where
@@ -139,7 +139,7 @@ impl Task {
     /// that the task `self` can access it for write. This is used to access task
     /// memory from the kernel in validated form.
     pub fn try_write<'a, T>(
-        &self,
+        &'a mut self,
         slice: &'a mut USlice<T>,
     ) -> Result<&'a mut [T], FaultInfo>
     where
@@ -287,7 +287,7 @@ impl Task {
 
     /// Returns a reference to the `TaskDesc` that was used to initially create
     /// this task.
-    pub fn descriptor(&self) -> &TaskDesc {
+    pub fn descriptor(&self) -> &'static TaskDesc {
         self.descriptor
     }
 

--- a/kern/src/umem.rs
+++ b/kern/src/umem.rs
@@ -239,24 +239,28 @@ impl<'a> From<&'a ULease> for USlice<u8> {
     }
 }
 
-/// Copies bytes from task `from` in region `from_slice` into task `to` at
-/// region `to_slice`, checking memory access before doing so.
+/// Copies bytes from `tasks[from_index]` in region `from_slice` into
+/// `tasks[to_index]` at region `to_slice`, checking memory access before doing
+/// so.
 ///
 /// The actual number of bytes copied will be `min(from_slice.length,
 /// to_slice.length)`, and will be returned.
 ///
-/// If `from_slice` or `to_slice` refers to memory the task can't read or write
-/// (respectively), no bytes are copied, and this returns an `InteractFault`
-/// indicating which task(s) messed this up.
+/// If `from_slice` or `to_slice` refers to memory that the respective task
+/// can't read or write (respectively), no bytes are copied, and this returns an
+/// `InteractFault` indicating which task(s) messed this up.
 ///
 /// This operation will not accept device memory as readable or writable.
 pub fn safe_copy(
-    from: &Task,
+    tasks: &mut [Task],
+    from_index: usize,
     from_slice: USlice<u8>,
-    to: &Task,
+    to_index: usize,
     mut to_slice: USlice<u8>,
 ) -> Result<usize, InteractFault> {
     let copy_len = from_slice.len().min(to_slice.len());
+
+    let (from, to) = index2_distinct(tasks, from_index, to_index);
 
     let src = from.try_read(&from_slice);
     // We're going to blame any aliasing on the recipient, who shouldn't have
@@ -282,5 +286,23 @@ pub fn safe_copy(
             src: src.err(),
             dst: dst.err(),
         }),
+    }
+}
+
+/// Utility routine for getting `&mut` to _two_ elements of a slice, at indexes
+/// `i` and `j`. `i` and `j` must be distinct, or this will panic.
+fn index2_distinct<T>(
+    elements: &mut [T],
+    i: usize,
+    j: usize,
+) -> (&mut T, &mut T) {
+    if i < j {
+        let (prefix, suffix) = elements.split_at_mut(i + 1);
+        (&mut prefix[i], &mut suffix[j - (i + 1)])
+    } else if j < i {
+        let (prefix, suffix) = elements.split_at_mut(j + 1);
+        (&mut suffix[i - (j + 1)], &mut prefix[j])
+    } else {
+        panic!()
     }
 }


### PR DESCRIPTION
This sequence of commits fixes #169 and #170, and partially fixes #168 and #171, by rearranging how the kernel represents and performs accesses to task memory.

I wrote these commits in August and forgot about them, whoops.

Fixing the rest of #171 is more involved and will be a followup.