### PR TITLE
HIFFY_DATA missing on non-Gemini H7 boards

### DIFF
--- a/demo-stm32h7/app-h743.toml
+++ b/demo-stm32h7/app-h743.toml
@@ -123,7 +123,7 @@ start = true
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["itm", "i2c"]
+features = ["stm32h7", "itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048

--- a/demo-stm32h7/app-h7b3.toml
+++ b/demo-stm32h7/app-h7b3.toml
@@ -112,7 +112,7 @@ start = true
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["itm", "i2c"]
+features = ["stm32h7", "itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true

--- a/gimlet/app.toml
+++ b/gimlet/app.toml
@@ -82,7 +82,7 @@ start = true
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["itm", "i2c", "gpio"]
+features = ["stm32h7", "itm", "i2c", "gpio"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true

--- a/gimletlet/app.toml
+++ b/gimletlet/app.toml
@@ -127,7 +127,7 @@ start = true
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["itm", "i2c", "gpio"]
+features = ["stm32h7", "itm", "i2c", "gpio"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048


### PR DESCRIPTION
This addresses issue #201.