### PR TITLE
userlib: internal wrapper for ensuring volatile access of TaskSlot inner

### DIFF
--- a/userlib/src/task_slot.rs
+++ b/userlib/src/task_slot.rs
@@ -1,4 +1,49 @@
+use self::volatile_const::VolatileConst;
 use abi::{Generation, TaskId};
+
+mod volatile_const {
+    /// Wraps a T which is expected to be constant at runtime but may change
+    /// after compilation.
+    ///
+    /// A static or const T is considered immutable by the compiler so it may
+    /// constant-fold the value (as known at compile-time).  If the T is
+    /// expected to be modified between compilation and runtime, it does not
+    /// meet the compiler's definition of immutable but the compiler doesn't
+    /// know that without some help.  https://crates.io/crates/vcell seems like
+    /// an available solution but it also provides inner mutability via
+    /// UnsafeCell which causes the compiler to move it from .rodata linker
+    /// section to .data and thus consuming slightly more RAM than necessary.
+    /// Instead, VolatileConst provides only a copying getter which keeps the
+    /// variable in .rodata and more accurately reflects that this value is
+    /// expected to be immutable at runtime.
+    #[repr(transparent)]
+    pub struct VolatileConst<T> {
+        value: T,
+    }
+
+    impl<T> VolatileConst<T> {
+        /// Creates a new `VolatileConst` containing the given value
+        pub const fn new(value: T) -> Self {
+            Self { value }
+        }
+
+        /// Returns a copy of the contained value
+        #[inline(always)]
+        pub fn get(&self) -> T
+        where
+            T: Copy,
+        {
+            unsafe { core::ptr::read_volatile(&self.value) }
+        }
+
+        /// Returns a raw pointer to the underlying data in the cell
+        ///
+        /// Directly reading through this pointer at runtime is an error.
+        pub const fn as_ptr(&self) -> *const T {
+            &self.value
+        }
+    }
+}
 
 /// Placeholder for post-compilation linking of tasks.
 ///
@@ -10,13 +55,13 @@ use abi::{Generation, TaskId};
 /// task's identifying information by a post-compile process.  These
 /// placeholders can then be converted into TaskId at runtime.
 #[repr(C)]
-pub struct TaskSlot(u16);
+pub struct TaskSlot(VolatileConst<u16>);
 
 impl TaskSlot {
     /// A TaskSlot that has not been resolved by a later processing step.
     ///
     /// Calling get_task_id() on an unbound TaskSlot will panic.
-    pub const UNBOUND: Self = Self(TaskId::UNBOUND.0);
+    pub const UNBOUND: Self = Self(VolatileConst::new(TaskId::UNBOUND.0));
 
     pub fn get_task_id(&self) -> TaskId {
         let task_index = self.get_task_index();
@@ -31,20 +76,7 @@ impl TaskSlot {
     }
 
     pub fn get_task_index(&self) -> u16 {
-        // In the expected use case of a static TaskSlot instance, such an
-        // instance is considered immutable by the compiler.  The compiler may
-        // choose to exploit that immutability to constant-fold the value of
-        // self.0 (as known at compile-time).  Since the intent of TaskSlot is
-        // to modify the value of self.0 after compilation, it does not meet the
-        // compiler's definition of immutable but the compiler doesn't know that
-        // without some help.  This is similar to interior mutability a la
-        // UnsafeCell but slightly different as a TaskSlot instance _is_
-        // immutable at runtime and there is only ever one reference to self.0.
-        // Instead, we need to force the compiler to load self.0 from RAM as it
-        // couldn't know what the value is at compile time.  This is effectively
-        // the same as a volatile read where the value in storage may be changed
-        // outside the compiler and runtime.
-        unsafe { core::ptr::read_volatile(&self.0) }
+        self.0.get()
     }
 }
 
@@ -76,7 +108,16 @@ impl<const N: usize> TaskSlotTableEntry<N> {
         task_slot: &'static TaskSlot,
     ) -> Self {
         Self {
-            taskidx_address: &task_slot.0,
+            // Directly reading through the pointer returned by
+            // VolatileConst::as_ptr() is always an error.  In this case,
+            // for_task_slot() is only intended to be used by task_slot!() which
+            // places the TaskSlotTableEntry in a .task_slot_table linker
+            // section that is treated similar to debug information in that no
+            // virtual addresses are allocated to the contents and the section
+            // is not loaded into the process space.  As such, instances of
+            // TaskSlotTableEntry will never exist at runtime and thus the
+            // pointer will never be read through at runtime.
+            taskidx_address: task_slot.0.as_ptr(),
             slot_name_len: slot_name.len(),
             slot_name: *slot_name,
         }


### PR DESCRIPTION
Big, bold warnings in comments wasn't enough for a non-volatile access to slip in.  `vcell` crate seems perfect for this but it provides inner mutability which pushes the static from .rodata to .data.