### PR TITLE
Enlarge kernel-side generation counter to 32 bits.

### DIFF
--- a/kern/src/task.rs
+++ b/kern/src/task.rs
@@ -46,11 +46,9 @@ pub struct Task {
     state: TaskState,
     /// State for tracking the task's timer.
     timer: TimerState,
-    /// Generation number of this task's current incarnation. This begins at
-    /// zero and gets incremented whenever a task gets rebooted, to try to help
-    /// peers notice that they're talking to a new copy that may have lost
-    /// state.
-    generation: Generation,
+    /// Restart count for this task. We increment this whenever we reinitialize
+    /// the task. The low bits of this become the task's generation number.
+    generation: u32,
 
     /// Static table defining this task's memory regions.
     region_table: &'static [&'static RegionDesc],
@@ -81,7 +79,7 @@ impl Task {
             descriptor,
             region_table,
 
-            generation: Generation::default(),
+            generation: 0,
             notifications: 0,
             save: crate::arch::SavedState::default(),
             timer: crate::task::TimerState::default(),
@@ -277,7 +275,7 @@ impl Task {
     /// system reboot. The task will be left in `Stopped` state. If you would
     /// like to run the task after reinitializing it, you must do so explicitly.
     pub fn reinitialize(&mut self) {
-        self.generation = self.generation.next();
+        self.generation = self.generation.wrapping_add(1);
         self.timer = TimerState::default();
         self.notifications = 0;
         self.state = TaskState::default();
@@ -298,7 +296,8 @@ impl Task {
 
     /// Returns this task's current generation number.
     pub fn generation(&self) -> Generation {
-        self.generation
+        const MASK: u8 = (1u32 << (16 - TaskId::INDEX_BITS) - 1) as u8;
+        Generation::from(self.generation as u8 & MASK)
     }
 
     /// Returns a reference to this task's current state, for inspection.
@@ -751,7 +750,7 @@ pub fn check_task_id_against_table(
     }
 
     // Check for dead task ID.
-    let table_generation = table[id.index()].generation;
+    let table_generation = table[id.index()].generation();
 
     if table_generation != id.generation() {
         let code = abi::dead_response_code(table_generation);
@@ -857,5 +856,5 @@ pub fn force_fault(
 /// Produces a current `TaskId` (i.e. one with the correct generation) for
 /// `tasks[index]`.
 pub fn current_id(tasks: &[Task], index: usize) -> TaskId {
-    TaskId::for_index_and_gen(index, tasks[index].generation)
+    TaskId::for_index_and_gen(index, tasks[index].generation())
 }


### PR DESCRIPTION
In practice, users use this information as a "task restart counter," so
making it wider is better. Only the LSBs serve as the IPC generation
number.

Fixes #208.

Note that there is a corresponding Humility change required or `humility
tasks` won't work.