### PR TITLE
Reduce overbuilding of stm32h7 crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if 0.1.10",
+ "cortex-m",
  "drv-gimlet-hf-api",
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-qspi",
@@ -673,6 +674,7 @@ name = "drv-stm32h7-gpio"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "cortex-m",
  "drv-stm32h7-rcc-api",
  "num-traits",
  "stm32h7",
@@ -741,6 +743,7 @@ dependencies = [
 name = "drv-stm32h7-rcc"
 version = "0.1.0"
 dependencies = [
+ "cortex-m",
  "num-traits",
  "stm32h7",
  "userlib",
@@ -790,6 +793,7 @@ dependencies = [
 name = "drv-stm32h7-usart"
 version = "0.1.0"
 dependencies = [
+ "cortex-m",
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-rcc-api",
  "num-traits",

--- a/demo-stm32h7/app-h743.toml
+++ b/demo-stm32h7/app-h743.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]

--- a/demo-stm32h7/app-h7b3.toml
+++ b/demo-stm32h7/app-h7b3.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h7b3"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h7b3"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -14,6 +14,7 @@ drv-stm32h7-qspi = {path = "../stm32h7-qspi"}
 cfg-if = "0.1.10"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [build-dependencies]
 build-util = {path = "../../build-util"}

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -14,7 +14,7 @@ drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-spi-api = {path = "../spi-api"}
 drv-ice40-spi-program = {path = "../ice40-spi-program"}
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
 
 [build-dependencies]

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -10,11 +10,14 @@ zerocopy = "0.3.0"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
-stm32h7 = { version = "0.13.0", features = ["stm32h7b3"] }
+stm32h7 = { version = "0.13.0" }
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]
-standalone = []
+standalone = ["h743"]
+h743 = ["stm32h7/stm32h743"]
+h7b3 = ["stm32h7/stm32h7b3"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-gpio/src/main.rs
+++ b/drv/stm32h7-gpio/src/main.rs
@@ -77,9 +77,13 @@
 
 use byteorder::LittleEndian;
 use drv_stm32h7_rcc_api::{Peripheral, Rcc};
-use stm32h7::stm32h7b3 as device;
 use userlib::*;
 use zerocopy::{AsBytes, FromBytes, Unaligned, U16, U32};
+
+#[cfg(feature = "h743")]
+use stm32h7::stm32h743 as device;
+#[cfg(feature = "h7b3")]
+use stm32h7::stm32h7b3 as device;
 
 #[derive(FromPrimitive)]
 enum Op {

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -18,9 +18,9 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
 stm32h7 = { version = "0.13.0" }
 
-
 [build-dependencies]
 build-util = {path = "../../build-util"}
+
 [features]
 default = ["standalone"]
 standalone = [ "h743" ]

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -8,11 +8,14 @@ edition = "2018"
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
-stm32h7 = { version = "0.13.0", features = ["stm32h7b3"] }
+stm32h7 = { version = "0.13.0" }
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]
-standalone = []
+standalone = [ "h743" ]
+h7b3 = ["stm32h7/stm32h7b3"]
+h743 = ["stm32h7/stm32h743"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-rcc/src/main.rs
+++ b/drv/stm32h7-rcc/src/main.rs
@@ -50,7 +50,11 @@
 #![no_std]
 #![no_main]
 
+#[cfg(feature = "h743")]
+use stm32h7::stm32h743 as device;
+#[cfg(feature = "h7b3")]
 use stm32h7::stm32h7b3 as device;
+
 use userlib::*;
 use zerocopy::AsBytes;
 

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -13,7 +13,7 @@ drv-stm32h7-spi = {path = "../stm32h7-spi"}
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-spi-api = {path = "../spi-api"}
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 stm32h7 = { version = "0.13.0", features = ["stm32h743"] }
 cfg-if = "0.1.10"
 

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -11,6 +11,7 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
 stm32h7 = { version = "0.13.0" }
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
 default = ["standalone", "h7b3"]

--- a/gemini-bu/app.toml
+++ b/gemini-bu/app.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]

--- a/gimlet/app.toml
+++ b/gimlet/app.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]

--- a/gimletlet/app.toml
+++ b/gimletlet/app.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]

--- a/task-hiffy/Cargo.toml
+++ b/task-hiffy/Cargo.toml
@@ -15,7 +15,7 @@ drv-spi-api = {path = "../drv/spi-api"}
 drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api", optional = true}
 drv-lpc55-gpio-api = {path = "../drv/lpc55-gpio-api", optional = true}
 drv-gimlet-hf-api = {path = "../drv/gimlet-hf-api", optional = true}
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 cfg-if = "0.1.10"
 zerocopy = "0.3.0"
@@ -29,7 +29,7 @@ build-util = {path = "../build-util"}
 
 [features]
 default = ["standalone"]
-standalone = ["itm", "drv-stm32h7-gpio-api", "stm32h7"]
+standalone = ["itm", "stm32h7"]
 itm = [ "userlib/log-itm" ]
 semihosting = [ "cortex-m-semihosting", "userlib/log-semihosting" ]
 i2c = []

--- a/task-jefe/Cargo.toml
+++ b/task-jefe/Cargo.toml
@@ -10,7 +10,7 @@ userlib = {path = "../userlib" }
 ringbuf = {path = "../ringbuf" }
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.3.0"
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 
 [features]

--- a/task-spd/Cargo.toml
+++ b/task-spd/Cargo.toml
@@ -16,7 +16,7 @@ drv-i2c-api = {path = "../drv/i2c-api"}
 cortex-m-semihosting = "0.3.5"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt"] }
+stm32h7 = { version = "0.13.0" }
 
 [build-dependencies]
 build-util = {path = "../build-util"}


### PR DESCRIPTION
I noticed that building gimletlet firmware from clean got bottlenecked
_several times_ on the stm32h7 crate. An ideal build would build stm32h7
at most twice: once without the rt feature for use in tasks, and once
with for use in the kernel. We were building it more like five, six
times.

There turned out to be several reasons for this.

1. Some drivers were accidentally hardcoded to h7b3. For an h743 build,
   this meant we had to build at least twice.

2. At least one driver was asking for the rt feature, which doesn't make
   sense in a task. That's another axis of difference.

3. Some drivers were requesting cortex-m with the inline-asm feature,
   some were not. Because stm32h7 depends on cortex-m, this is a third
   axis of difference: stm32h7 must be rebuilt when cortex-m's features
   change.

I have reduced this by

- Ensuring that all drivers are configured for h743 where necessary.
- Removing unnecessary feature differences.
- _Adding dependencies_ on cortex-m directly so that tasks can specify
  its features.

These changes reduce a clean gimletlet build by 50% on my laptop.