### PR TITLE
Make features explicit for stm32h7[45b]3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "drv-i2c-api",
  "drv-lpc55-gpio-api",
  "drv-spi-api",
+ "drv-stm32fx-rcc",
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-i2c",
  "drv-stm32h7-rcc-api",

--- a/build-i2c/Cargo.toml
+++ b/build-i2c/Cargo.toml
@@ -13,3 +13,9 @@ cfg-if = "0.1.10"
 multimap = "0.8.3"
 convert_case = "0.4"
 
+[features]
+default = ["standalone"]
+standalone = ["h753"]
+h743 = []
+h753 = []
+h7b3 = []

--- a/build-i2c/src/lib.rs
+++ b/build-i2c/src/lib.rs
@@ -293,11 +293,14 @@ impl ConfigGenerator {
         use drv_stm32h7_rcc_api::Peripheral;
         use drv_i2c_api::Controller;
 
-        #[cfg(feature = "h7b3")]
-        use stm32h7::stm32h7b3 as device;
-
         #[cfg(feature = "h743")]
-        use stm32h7::stm32h743 as device;"##
+        use stm32h7::stm32h743 as device;
+
+        #[cfg(feature = "h753")]
+        use stm32h7::stm32h753 as device;
+
+        #[cfg(feature = "h7b3")]
+        use stm32h7::stm32h7b3 as device;"##
             )?;
         }
 

--- a/demo-stm32h7/Cargo.toml
+++ b/demo-stm32h7/Cargo.toml
@@ -6,12 +6,18 @@ name = "demo-stm32h7"
 version = "0.1.0"
 
 [features]
-default = ["itm", "standalone"]
-standalone = ["h743"]
+default = ["standalone"]
+standalone = ["itm", "h743"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]
 h7b3 = ["stm32h7/stm32h7b3"]
+# Available but unused:
+# h743v = ["stm32h7/stm32h743v"]
+# h747cm4 = ["stm32h7/stm32h747cm4"]
+# h747cm7 = ["stm32h7/stm32h747cm7"]
+# h753v = ["stm32h7/stm32h753v"]
 
 [dependencies]
 cortex-m = { version = "0.7", features = ["inline-asm"] }
@@ -21,7 +27,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../kern"

--- a/demo-stm32h7/app-h743.toml
+++ b/demo-stm32h7/app-h743.toml
@@ -17,7 +17,7 @@ requires = {flash = 32768, ram = 4096}
 # If one does choose to change this to semihosting for purposes of
 # development, be sure to also change it in every task of interest.
 #
-features = ["itm", "h743"]
+features = ["h743", "itm"]
 
 [supervisor]
 notification = 1
@@ -112,7 +112,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi3"]
+features = ["spi3", "h743"]
 uses = ["spi3"]
 start = true
 interrupts = {51 = 1}
@@ -146,7 +146,7 @@ user_leds = "user_leds"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c", "gpio", "qspi"]
+features = ["h743", "stm32h7", "itm", "i2c", "gpio", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
@@ -160,7 +160,7 @@ i2c_driver = "i2c_driver"
 [tasks.hf]
 path = "../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
-features = []
+features = ["h743"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
 stacksize = 2048

--- a/demo-stm32h7/app-h7b3.toml
+++ b/demo-stm32h7/app-h7b3.toml
@@ -17,7 +17,7 @@ requires = {flash = 32768, ram = 4096}
 # If one does choose to change this to semihosting for purposes of
 # development, be sure to also change it in every task of interest.
 #
-features = ["itm", "h7b3"]
+features = ["h7b3", "itm"]
 
 [supervisor]
 notification = 1
@@ -135,7 +135,7 @@ usart_driver = "usart_driver"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c"]
+features = ["h7b3", "stm32h7", "itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 
 [features]
 default = ["standalone"]
+standalone = ["itm", "stm32f4"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
-standalone = ["itm", "stm32f4"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/demo/app-f3.toml
+++ b/demo/app-f3.toml
@@ -47,7 +47,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32fx-rcc"
 name = "drv-stm32fx-rcc"
-features = ["stm32f3"]
+features = ["f3"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]

--- a/demo/app.toml
+++ b/demo/app.toml
@@ -47,7 +47,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32fx-rcc"
 name = "drv-stm32fx-rcc"
-features = ["stm32f4"]
+features = ["f4"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -105,6 +105,7 @@ user_leds = "user_leds"
 path = "../task-hiffy"
 name = "task-hiffy"
 priority = 3
+features = ["stm32f4"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../userlib"}
-stm32h7 = { version = "0.13.0", features = ["stm32h743"] }
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", features = ["h743"]}
-drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
-drv-stm32h7-qspi = {path = "../stm32h7-qspi"}
+stm32h7 = { version = "0.13.0", default-features = false }
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
+drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", default-features = false}
+drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
 cfg-if = "0.1.10"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
@@ -21,7 +21,9 @@ build-util = {path = "../../build-util"}
 
 [features]
 default = ["standalone"]
-standalone = []
+standalone = ["h753"]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743", "drv-stm32h7-qspi/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753", "drv-stm32h7-qspi/h753"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -11,7 +11,14 @@ use userlib::*;
 use drv_stm32h7_gpio_api as gpio_api;
 use drv_stm32h7_qspi::Qspi;
 use drv_stm32h7_rcc_api as rcc_api;
+
+// Note: h7b3 has QUADSPI but has not been used in this project.
+
+#[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
 
 use drv_gimlet_hf_api::{HfError, InternalHfError, Operation};
 

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-spi = {path = "../stm32h7-spi"}
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
+drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false }
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-spi-api = {path = "../spi-api"}
 drv-ice40-spi-program = {path = "../ice40-spi-program"}
@@ -24,7 +24,8 @@ gnarle = {path = "../../gnarle"}
 
 [features]
 default = ["standalone"]
-standalone = []
+standalone = ["h753"]
+h753 = ["drv-stm32h7-spi/h753", "drv-stm32h7-rcc-api/h753"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -6,14 +6,16 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../userlib"}
-stm32f3 = { version = "0.13.0", features = ["stm32f303"], optional = true }
-stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
+stm32f3 = { version = "0.13.0", optional = true, default-features = false }
+stm32f4 = { version = "0.13.0", optional = true, default-features = false }
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 
 [features]
 default = ["standalone"]
-standalone = ["stm32f4"]
+standalone = ["f4"]
+f3 = ["stm32f3/stm32f303"]
+f4 = ["stm32f4/stm32f407"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -9,15 +9,16 @@ userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
-stm32h7 = { version = "0.13.0" }
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false }
+stm32h7 = { version = "0.13.0", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]
-standalone = ["h743"]
-h743 = ["stm32h7/stm32h743"]
-h7b3 = ["stm32h7/stm32h7b3"]
+standalone = ["h753"]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753"]
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-rcc-api/h7b3"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-gpio/src/main.rs
+++ b/drv/stm32h7-gpio/src/main.rs
@@ -82,6 +82,10 @@ use zerocopy::{AsBytes, FromBytes, Unaligned, U16, U32};
 
 #[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
 #[cfg(feature = "h7b3")]
 use stm32h7::stm32h7b3 as device;
 

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -10,7 +10,7 @@ userlib = {path = "../../userlib"}
 ringbuf = {path = "../../ringbuf"}
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
 drv-stm32h7-i2c = {path = "../stm32h7-i2c", default-features = false }
 drv-i2c-api = {path = "../i2c-api"}
 cortex-m-semihosting = "0.3.5"
@@ -26,9 +26,10 @@ cfg-if = "0.1.10"
 
 [features]
 default = ["standalone"]
-standalone = [ "h743" ]
-h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-i2c/h7b3"]
-h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743"]
+standalone = [ "h753" ]
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-i2c/h7b3", "drv-stm32h7-rcc-api/h7b3", "build-i2c/h7b3"]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32h7-rcc-api/h743", "build-i2c/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-i2c/h753", "drv-stm32h7-rcc-api/h753", "build-i2c/h753"]
 itm = [ "userlib/log-itm" ]
 
 # These options allow for external muxes on the Gemini bringup board:

--- a/drv/stm32h7-i2c/Cargo.toml
+++ b/drv/stm32h7-i2c/Cargo.toml
@@ -10,19 +10,20 @@ ringbuf = {path = "../../ringbuf"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
 drv-i2c-api = {path = "../i2c-api"}
 cortex-m-semihosting = "0.3.5"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
 bitfield = "0.13"
-stm32h7 = { version = "0.13.0" }
+stm32h7 = { version = "0.13.0", default-features = false }
 
 [features]
 default = ["standalone"]
-standalone = [ "h743" ]
-h7b3 = ["stm32h7/stm32h7b3"]
-h743 = ["stm32h7/stm32h743"]
+standalone = [ "h753" ]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753"]
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-rcc-api/h7b3"]
 itm = [ "userlib/log-itm" ]
 
 # a target for `cargo xtask check`

--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -8,10 +8,13 @@ use stm32h7::stm32h7b3 as device;
 #[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
 
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
 #[cfg(feature = "h7b3")]
 pub type RegisterBlock = device::i2c3::RegisterBlock;
 
-#[cfg(feature = "h743")]
+#[cfg(any(feature = "h743", feature = "h753"))]
 pub type RegisterBlock = device::i2c1::RegisterBlock;
 
 pub mod ltc4306;
@@ -213,7 +216,7 @@ impl<'a> I2cController<'a> {
                     .scldel().bits(8)
                     .sdadel().bits(0)
                 });
-            } else if #[cfg(feature = "h743")] {
+            } else if #[cfg(any(feature = "h743", feature = "h753"))] {
                 // Here our APB1 peripheral clock is 100MHz, yielding the
                 // following:
                 //
@@ -250,7 +253,7 @@ impl<'a> I2cController<'a> {
             // t_i2cclk this yields 1219.7 (1220); on h7b3, this is 3416.9
             // (3417).
             //
-            if #[cfg(feature = "h743")] {
+            if #[cfg(any(feature = "h743", feature = "h753"))] {
                 i2c.timeoutr.write(|w| { w
                     .timouten().set_bit()           // Enable SCL timeout
                     .timeouta().bits(1220)          // Timeout value

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stm32h7 = { version = "0.13.0", features = ["stm32h743"] }
+stm32h7 = { version = "0.13.0" }
 vcell = "0.1.2"
 zerocopy = "0.3.0"
 userlib = {path = "../../userlib"}
@@ -14,3 +14,9 @@ userlib = {path = "../../userlib"}
 # a target for `cargo xtask check`
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
+
+[features]
+default = ["standalone"]
+standalone = ["h753"]
+h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]

--- a/drv/stm32h7-qspi/src/lib.rs
+++ b/drv/stm32h7-qspi/src/lib.rs
@@ -2,7 +2,14 @@
 
 #![no_std]
 
+// Note that stm32h7b3 has QUADSPI support also.
+
+#[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
 use userlib::{sys_irq_control, sys_recv_closed, TaskId};
 use zerocopy::AsBytes;
 

--- a/drv/stm32h7-rcc-api/Cargo.toml
+++ b/drv/stm32h7-rcc-api/Cargo.toml
@@ -11,7 +11,13 @@ byteorder = {version = "1.3", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 
 [features]
+default = ["standalone"]
+standalone = ["h753"]
 h743 = []
+h747 = []
+h753 = []
+h757 = []
+h7b3 = []
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-rcc-api/src/lib.rs
+++ b/drv/stm32h7-rcc-api/src/lib.rs
@@ -253,7 +253,7 @@ pub enum Peripheral {
 
     #[cfg(feature = "h7b3")]
     OctoSpi1 = ahb3!(14), // B3 only
-    #[cfg(any(feature = "h743", feature = "h747"))]
+    #[cfg(any(feature = "h743", feature = "h747", feature = "h753"))]
     QuadSpi = ahb3!(14), // 43/47 only
 
     Fmc = ahb3!(12),
@@ -280,8 +280,12 @@ pub enum Peripheral {
     Sram1 = ahb2!(29),
     DfsdmDma = ahb2!(11), // B3 only
     Sdmmc2 = ahb2!(9),
+
+    #[cfg(any(feature = "h753"))]
     Rng = ahb2!(6),
+    #[cfg(any(feature = "h753"))]
     Hash = ahb2!(5),
+    #[cfg(any(feature = "h753"))]
     Crypt = ahb2!(4),
 
     #[cfg(feature = "h7b3")]
@@ -292,12 +296,12 @@ pub enum Peripheral {
     SmartRunSram = ahb4!(29), // B3 only
     BackupRam = ahb4!(28),
 
-    #[cfg(any(feature = "h743", feature = "h747"))]
+    #[cfg(any(feature = "h743", feature = "h747", feature = "h753"))]
     Hsem = ahb4!(25), // 43/47: differs from B3
 
     #[cfg(feature = "h7b3")]
     Bdma2 = ahb4!(21),
-    #[cfg(any(feature = "h743", feature = "h747"))]
+    #[cfg(any(feature = "h743", feature = "h747", feature = "h757"))]
     Bdma = ahb4!(21),
 
     GpioK = ahb4!(10),
@@ -353,7 +357,7 @@ pub enum Peripheral {
 
     Hrtim = apb2!(29), // 43/47 only
 
-    #[cfg(any(feature = "h743", feature = "h747"))]
+    #[cfg(any(feature = "h743", feature = "h747", feature = "h757"))]
     Dfsdm1 = apb2!(28), // 43/47 differ from B3
 
     Sai3 = apb2!(24), // 43/47 only

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -13,9 +13,10 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
 default = ["standalone"]
-standalone = [ "h743" ]
-h7b3 = ["stm32h7/stm32h7b3"]
+standalone = [ "h753" ]
 h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]
+h7b3 = ["stm32h7/stm32h7b3"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-rcc/src/main.rs
+++ b/drv/stm32h7-rcc/src/main.rs
@@ -52,6 +52,8 @@
 
 #[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
 #[cfg(feature = "h7b3")]
 use stm32h7::stm32h7b3 as device;
 

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -9,12 +9,12 @@ userlib = {path = "../../userlib"}
 ringbuf = {path = "../../ringbuf"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-spi = {path = "../stm32h7-spi"}
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
-drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
-drv-spi-api = {path = "../spi-api"}
+drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false}
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
+drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", default-features = false}
+drv-spi-api = {path = "../spi-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-stm32h7 = { version = "0.13.0", features = ["stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false }
 cfg-if = "0.1.10"
 
 [build-dependencies]
@@ -22,13 +22,16 @@ build-util = {path = "../../build-util"}
 
 [features]
 default = ["standalone"]
-standalone = []
+standalone = ["h753"]
 spi1 = []
 spi2 = []
 spi3 = []
 spi4 = []
 spi5 = []
 spi6 = []
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-spi/h7b3", "drv-stm32h7-rcc-api/h7b3"]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-spi/h743", "drv-stm32h7-rcc-api/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-spi/h753", "drv-stm32h7-rcc-api/h753"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -9,7 +9,16 @@
 
 use drv_spi_api::*;
 use ringbuf::*;
+
+#[cfg(feature = "h7b3")]
+use stm32h7::stm32h7b3 as device;
+
+#[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
 use userlib::*;
 
 use drv_stm32h7_gpio_api as gpio_api;

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -9,12 +9,15 @@ ringbuf = {path = "../../ringbuf"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 vcell = "0.1.2"
-stm32h7 = { version = "0.13.0", features = ["stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false }
 
 # TODO can probably remove standalone feature for lib crates
 [features]
 default = ["standalone"]
-standalone = []
+standalone = [ "h753" ]
+h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]
+h7b3 = ["stm32h7/stm32h7b3"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -27,7 +27,11 @@
 
 #![no_std]
 
+#[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
 
 pub struct Spi {
     /// Pointer to our register block.

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -9,15 +9,16 @@ userlib = {path = "../../userlib"}
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
-drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api"}
-stm32h7 = { version = "0.13.0" }
+drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}
+stm32h7 = { version = "0.13.0", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]
-default = ["standalone", "h7b3"]
-standalone = []
-h7b3 = ["stm32h7/stm32h7b3"]
-h743 = ["stm32h7/stm32h743"]
+default = ["standalone"]
+standalone = [ "h753" ]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753"]
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-rcc-api/h7b3"]
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/stm32h7-usart/src/main.rs
+++ b/drv/stm32h7-usart/src/main.rs
@@ -11,6 +11,10 @@
 
 #[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
 #[cfg(feature = "h7b3")]
 use stm32h7::stm32h7b3 as device;
 
@@ -56,7 +60,7 @@ fn main() -> ! {
     // concern. Were it literally a static, we could just reference it.
     #[cfg(feature = "h7b3")]
     let usart = unsafe { &*device::USART1::ptr() };
-    #[cfg(feature = "h743")]
+    #[cfg(any(feature = "h743", feature = "h753"))]
     let usart = unsafe { &*device::USART3::ptr() };
 
     // The UART has clock and is out of reset, but isn't actually on until we:
@@ -65,7 +69,7 @@ fn main() -> ! {
     // TODO: this module should _not_ know our clock rate. That's a hack.
     #[cfg(feature = "h7b3")]
     const CLOCK_HZ: u32 = 280_000_000;
-    #[cfg(feature = "h743")]
+    #[cfg(any(feature = "h743", feature = "h753"))]
     const CLOCK_HZ: u32 = 200_000_000;
 
     const BAUDRATE: u32 = 115_200;
@@ -155,7 +159,7 @@ fn turn_on_usart() {
     #[cfg(feature = "h7b3")]
     const PORT: Peripheral = Peripheral::Usart1;
 
-    #[cfg(feature = "h743")]
+    #[cfg(any(feature = "h743", feature = "h753"))]
     const PORT: Peripheral = Peripheral::Usart3;
 
     rcc_driver.enable_clock(PORT);
@@ -171,7 +175,7 @@ fn configure_pins() {
     // TODO these are really board configs, not SoC configs!
     #[cfg(feature = "h7b3")]
     const TX_RX_MASK: PinSet = Port::A.pin(9).and_pin(10);
-    #[cfg(feature = "h743")]
+    #[cfg(any(feature = "h743", feature = "h753"))]
     const TX_RX_MASK: PinSet = Port::D.pin(8).and_pin(9);
 
     gpio_driver

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -12,7 +12,7 @@ lpc55-pac = { version = "0.3.0", optional = true }
 zerocopy = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", optional = true}
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", optional = true}
+drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", default-features = false, optional = true}
 cfg-if = "0.1.10"
 
 [build-dependencies]

--- a/gemini-bu/Cargo.toml
+++ b/gemini-bu/Cargo.toml
@@ -19,7 +19,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt", "stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
 
 [dependencies.kern]
 path = "../kern"

--- a/gemini-bu/app.toml
+++ b/gemini-bu/app.toml
@@ -49,7 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
-features = ["h743"]
+features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -58,7 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
-features = ["h743"]
+features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -70,7 +70,7 @@ rcc_driver = "rcc_driver"
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
 name = "drv-stm32h7-usart"
-features = ["h743"]
+features = ["h753"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
 uses = ["usart3"]
@@ -84,7 +84,7 @@ rcc_driver = "rcc_driver"
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c3", "i2c4"]
@@ -105,7 +105,7 @@ rcc_driver = "rcc_driver"
 [tasks.spd]
 path = "../task-spd"
 name = "task-spd"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384 }
 uses = ["i2c2"]
@@ -134,7 +134,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi2"]
+features = ["h753", "spi2"]
 uses = ["spi2"]
 start = true
 interrupts = {36 = 1}
@@ -149,7 +149,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi4"]
+features = ["h753", "spi4"]
 uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
@@ -207,7 +207,7 @@ i2c_driver = "i2c_driver"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c", "gpio", "spi"]
+features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048

--- a/gemini-bu/src/main.rs
+++ b/gemini-bu/src/main.rs
@@ -18,7 +18,7 @@ use cortex_m_rt::pre_init;
 // gets linked in.
 extern crate stm32h7;
 
-use stm32h7::stm32h743 as device;
+use stm32h7::stm32h753 as device;
 
 use cortex_m_rt::entry;
 use kern::app::App;

--- a/gimlet/Cargo.toml
+++ b/gimlet/Cargo.toml
@@ -19,7 +19,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt", "stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
 
 [dependencies.kern]
 path = "../kern"

--- a/gimlet/app.toml
+++ b/gimlet/app.toml
@@ -49,7 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
-features = ["h743"]
+features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -58,7 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
-features = ["h743"]
+features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi4"]
+features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
@@ -87,7 +87,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi2"]
+features = ["spi2", "h753"]
 uses = ["spi2"]
 start = true
 interrupts = {36 = 1}
@@ -100,7 +100,7 @@ rcc_driver = "rcc_driver"
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
@@ -121,7 +121,7 @@ rcc_driver = "rcc_driver"
 [tasks.spd]
 path = "../task-spd"
 name = "task-spd"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
@@ -139,7 +139,7 @@ i2c_driver = "i2c_driver"
 [tasks.thermal]
 path = "../task-thermal"
 name = "task-thermal"
-features = ["itm"]
+features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
 stacksize = 2048
@@ -151,7 +151,7 @@ i2c_driver = "i2c_driver"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
+features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 start = true
@@ -164,7 +164,7 @@ i2c_driver = "i2c_driver"
 [tasks.gimlet_seq]
 path = "../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
-features = []
+features = ["h753"]
 priority = 3
 requires = {flash = 32768, ram = 1024 }
 stacksize = 1024
@@ -177,7 +177,7 @@ spi_driver = "spi2_driver"
 [tasks.hf]
 path = "../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
-features = []
+features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
 stacksize = 2048

--- a/gimlet/src/main.rs
+++ b/gimlet/src/main.rs
@@ -18,7 +18,7 @@ use cortex_m_rt::pre_init;
 // gets linked in.
 extern crate stm32h7;
 
-use stm32h7::stm32h743 as device;
+use stm32h7::stm32h753 as device;
 
 use cortex_m_rt::entry;
 use kern::app::App;

--- a/gimletlet/Cargo.toml
+++ b/gimletlet/Cargo.toml
@@ -19,7 +19,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt", "stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
 
 [dependencies.kern]
 path = "../kern"

--- a/gimletlet/app.toml
+++ b/gimletlet/app.toml
@@ -49,7 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
-features = ["h743"]
+features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -58,7 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
-features = ["h743"]
+features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -70,7 +70,7 @@ rcc_driver = "rcc_driver"
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
 name = "drv-stm32h7-usart"
-features = ["h743"]
+features = ["h753"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
 uses = ["usart3"]
@@ -84,7 +84,7 @@ rcc_driver = "rcc_driver"
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h743", "itm", "target-enable"]
+features = ["h753", "itm", "target-enable"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]
@@ -103,7 +103,7 @@ rcc_driver = "rcc_driver"
 [tasks.spd]
 path = "../task-spd"
 name = "task-spd"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
 uses = ["i2c2"]
@@ -132,7 +132,7 @@ path = "../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
-features = ["spi4"]
+features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
@@ -166,7 +166,7 @@ user_leds = "user_leds"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
+features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
@@ -180,7 +180,7 @@ i2c_driver = "i2c_driver"
 [tasks.gimlet_seq]
 path = "../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
-features = []
+features = ["h753"]
 priority = 3
 requires = {flash = 32768, ram = 1024 }
 stacksize = 1024
@@ -193,7 +193,7 @@ spi_driver = "spi_driver"
 [tasks.hf]
 path = "../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
-features = []
+features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
 stacksize = 2048

--- a/gimletlet/src/main.rs
+++ b/gimletlet/src/main.rs
@@ -18,7 +18,7 @@ use cortex_m_rt::pre_init;
 // gets linked in.
 extern crate stm32h7;
 
-use stm32h7::stm32h743 as device;
+use stm32h7::stm32h753 as device;
 
 use cortex_m_rt::entry;
 use kern::app::App;

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -18,7 +18,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt", "stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h743"] }
 
 [dependencies.kern]
 path = "../kern"

--- a/sidecar/app.toml
+++ b/sidecar/app.toml
@@ -49,6 +49,7 @@ stacksize = 1536
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
 name = "drv-stm32h7-rcc"
+features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -57,6 +58,7 @@ start = true
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"
+features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -68,7 +70,7 @@ rcc_driver = "rcc_driver"
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h743", "itm"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
@@ -91,7 +93,7 @@ rcc_driver = "rcc_driver"
 [tasks.hiffy]
 path = "../task-hiffy"
 name = "task-hiffy"
-features = ["stm32h7", "itm", "i2c", "gpio"]
+features = ["h753", "stm32h7", "itm", "i2c", "gpio"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 start = true

--- a/task-hiffy/Cargo.toml
+++ b/task-hiffy/Cargo.toml
@@ -12,11 +12,12 @@ userlib = {path = "../userlib", default-features = false}
 ringbuf = {path = "../ringbuf" }
 drv-i2c-api = {path = "../drv/i2c-api"}
 drv-spi-api = {path = "../drv/spi-api"}
-drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api", optional = true}
-drv-stm32h7-i2c = {path = "../drv/stm32h7-i2c" }
-drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api"}
+drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api", default-features = false, optional = true}
+drv-stm32h7-i2c = {path = "../drv/stm32h7-i2c", default-features = false, optional = true }
+drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api", default-features = false, optional = true }
 drv-lpc55-gpio-api = {path = "../drv/lpc55-gpio-api", optional = true}
 drv-gimlet-hf-api = {path = "../drv/gimlet-hf-api", optional = true}
+drv-stm32fx-rcc = {path = "../drv/stm32fx-rcc", default-features = false, optional = true}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 cfg-if = "0.1.10"
@@ -34,7 +35,7 @@ cfg-if = "0.1.10"
 
 [features]
 default = ["standalone"]
-standalone = ["itm", "stm32h7"]
+standalone = ["itm", "stm32h7", "h753"]
 itm = [ "userlib/log-itm" ]
 semihosting = [ "cortex-m-semihosting", "userlib/log-semihosting" ]
 i2c = []
@@ -43,6 +44,11 @@ spi = []
 stm32h7 = ["drv-stm32h7-gpio-api"]
 lpc55 = ["drv-lpc55-gpio-api"]
 qspi = ["drv-gimlet-hf-api"]
+h743 = ["drv-stm32h7-rcc-api/h743", "drv-stm32h7-i2c/h743", "build-i2c/h743"]
+h753 = ["drv-stm32h7-rcc-api/h753", "drv-stm32h7-i2c/h753", "build-i2c/h753"]
+h7b3 = ["drv-stm32h7-rcc-api/h7b3", "drv-stm32h7-i2c/h7b3", "build-i2c/h7b3"]
+stm32f3 = ["drv-stm32fx-rcc/f3"]
+stm32f4 = ["drv-stm32fx-rcc/f4"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task-power/Cargo.toml
+++ b/task-power/Cargo.toml
@@ -28,6 +28,9 @@ default = ["standalone"]
 standalone = ["itm", "drv-i2c-api/standalone" ]
 itm = [ "userlib/log-itm" ]
 semihosting = [ "cortex-m-semihosting", "userlib/log-semihosting" ]
+h743 = ["build-i2c/h743"]
+h753 = ["build-i2c/h753"]
+h7b3 = ["build-i2c/h7b3"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task-spd/Cargo.toml
+++ b/task-spd/Cargo.toml
@@ -9,14 +9,14 @@ userlib = {path = "../userlib"}
 ringbuf = {path = "../ringbuf"}
 spd = {path = "../spd" }
 num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api"}
-drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api"}
-drv-stm32h7-i2c = {path = "../drv/stm32h7-i2c"}
-drv-i2c-api = {path = "../drv/i2c-api"}
+drv-stm32h7-gpio-api = {path = "../drv/stm32h7-gpio-api", default-features = false}
+drv-stm32h7-rcc-api = {path = "../drv/stm32h7-rcc-api", default-features = false}
+drv-stm32h7-i2c = {path = "../drv/stm32h7-i2c", default-features = false}
+drv-i2c-api = {path = "../drv/i2c-api", default-features = false}
 cortex-m-semihosting = "0.3.5"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0" }
+stm32h7 = { version = "0.13.0", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../build-util"}
@@ -25,10 +25,11 @@ anyhow = "1.0.31"
 cfg-if = "0.1.10"
 
 [features]
-default = ["standalone", "h743"]
-standalone = [ "h743", "itm" ]
-h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-i2c/h7b3"]
-h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743"]
+default = ["standalone"]
+standalone = [ "h753", "itm" ]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32h7-rcc-api/h743", "build-i2c/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-i2c/h753", "drv-stm32h7-rcc-api/h753", "build-i2c/h753"]
+h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-i2c/h7b3", "drv-stm32h7-rcc-api/h7b3", "build-i2c/h7b3"]
 itm = [ "userlib/log-itm" ]
 
 # a target for `cargo xtask check`

--- a/task-thermal/Cargo.toml
+++ b/task-thermal/Cargo.toml
@@ -30,6 +30,9 @@ default = ["standalone"]
 standalone = ["itm", "drv-i2c-api/standalone" ]
 itm = [ "userlib/log-itm" ]
 semihosting = [ "cortex-m-semihosting", "userlib/log-semihosting" ]
+h743 = ["build-i2c/h743"]
+h753 = ["build-i2c/h753"]
+h7b3 = ["build-i2c/h7b3"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -7,9 +7,10 @@ version = "0.1.0"
 
 [features]
 default = ["standalone"]
-standalone = ["itm"]
+standalone = ["itm", "h753"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
+h753 = ["stm32h7/stm32h753"]
 
 [dependencies]
 cortex-m = { version = "0.7", features = ["inline-asm"] }
@@ -19,7 +20,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt", "stm32h743"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../kern"

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -6,11 +6,12 @@ name = "tests-stm32h7"
 version = "0.1.0"
 
 [features]
-default = ["itm", "standalone"]
-standalone = ["h743"]
+default = ["standalone"]
+standalone = ["itm", "h743"]
 itm = ["panic-itm", "kern/klog-itm"]
 semihosting = ["panic-semihosting", "kern/klog-semihosting"]
 h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]
 h7b3 = ["stm32h7/stm32h7b3"]
 
 [dependencies]
@@ -21,7 +22,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", features = ["rt"] }
+stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../kern"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -29,6 +29,9 @@ enum Xtask {
         /// Request verbosity from tools we shell out to.
         #[structopt(short)]
         verbose: bool,
+        /// Run `cargo tree --edges features ...` before each invoction of `cargo rustc ...`
+        #[structopt(short, long)]
+        edges: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
     },
@@ -301,15 +304,19 @@ fn main() -> Result<()> {
     let xtask = Xtask::from_args();
 
     match xtask {
-        Xtask::Dist { verbose, cfg } => {
-            dist::package(verbose, &cfg)?;
+        Xtask::Dist {
+            verbose,
+            edges,
+            cfg,
+        } => {
+            dist::package(verbose, edges, &cfg)?;
         }
         Xtask::Flash { verbose, cfg } => {
-            dist::package(verbose, &cfg)?;
+            dist::package(verbose, false, &cfg)?;
             flash::run(verbose, &cfg)?;
         }
         Xtask::Gdb { cfg, gdb_cfg } => {
-            dist::package(false, &cfg)?;
+            dist::package(false, false, &cfg)?;
             gdb::run(&cfg, &gdb_cfg)?;
         }
         Xtask::Humility { cfg, options } => {
@@ -321,7 +328,7 @@ fn main() -> Result<()> {
             verbose,
         } => {
             if !noflash {
-                dist::package(verbose, &cfg)?;
+                dist::package(verbose, false, &cfg)?;
                 flash::run(verbose, &cfg)?;
             }
 


### PR DESCRIPTION
Because stmh743 and stmh753 are so similar, it didn't matter that
the h743 feature and/or feature defaults that used h743 were in use
for the h753 SoC. However, as we start to use the IP of the h753 that
does not exist on the h743, i.e. Rng, Hash, and Crypt, the differences
start to matter.

The changes are tedious which reinforces the argument for better
system configuration tools.

I also added a -e option to xtask 'cargo xtask dist [--edges|-e] ...' that
runs 'cargo tree --edges features' before running 'cargo rustc ...'
This allows more visibility into the task dependencies and what features
are enabled on each. This was helpful in tracking down where the line of
features was broken; a top-level toml may have invoked a feature, but a
mid-level toml would have a dependency on a library that would have used
that feature if it had been passed on. Instead, a default feature or no
feature would be used. Most often, the stm32h7 crate would get compiled
two different ways and then get linked into the same task. The global
for the base of the register blocks would then have two instances which
would conflict.