### PR TITLE
kern/src/task: fix operator precedence error

### DIFF
--- a/kern/src/task.rs
+++ b/kern/src/task.rs
@@ -296,7 +296,7 @@ impl Task {
 
     /// Returns this task's current generation number.
     pub fn generation(&self) -> Generation {
-        const MASK: u8 = (1u32 << (16 - TaskId::INDEX_BITS) - 1) as u8;
+        const MASK: u8 = ((1u32 << (16 - TaskId::INDEX_BITS)) - 1) as u8;
         Generation::from(self.generation as u8 & MASK)
     }
 


### PR DESCRIPTION
It's...kind of surprising how much of the system tolerated this error,
because it only broke two syscall test cases.