### PR TITLE
doc: suggest ARM tools from brew cask on macOS

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -52,9 +52,9 @@ You will need:
 
 - `arm-none-eabi-objcopy` and `arm-none-eabi-gdb`, typically from your system's
   package manager using package names like `arm-none-eabi-binutils` and
-  `arm-none-eabi-gdb`.  macOS users might check out
-  [homebrew-arm](https://github.com/osx-cross/homebrew-arm), a Homebrew repo
-  with formulae that install the official ARM binaries.
+  `arm-none-eabi-gdb`.  macOS users can run
+  `brew install --cask gcc-arm-embedded` to install the
+  [official ARM binaries](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm).
 
 - The Hubris debugger, [Humility](https://github.com/oxidecomputer/humility):
   - `cargo install --git ssh://git@github.com/oxidecomputer/humility.git`


### PR DESCRIPTION
This seems slightly more official than the third-party taps.