### PR TITLE
Remove the authors field

### DIFF
--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "demo-stm32f4-discovery"

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "demo-stm32h7-nucleo"

--- a/app/gemini-bu-rot/Cargo.toml
+++ b/app/gemini-bu-rot/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Rick Altherr <rick@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "gemini-bu-rot"

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "gemini-bu"

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Rick Altherr <rick@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "gimlet-rot"

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "gimlet"

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "gimletlet"

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "lpc55xpresso"

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "build-i2c"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/build/util/Cargo.toml
+++ b/build/util/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "build-util"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "xtask"
 version = "1.0.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>", "Steve Klabnik <steve.klabnik@oxide.computer>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-i2c-api"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-i2c-devices"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-gpio-api/Cargo.toml
+++ b/drv/lpc55-gpio-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-gpio-api"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-gpio/Cargo.toml
+++ b/drv/lpc55-gpio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-gpio"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-i2c"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-rng"
 version = "0.1.0"
-authors = ["Steve Klabnik <steve.klabnik@oxide.computer>",]
 edition = "2018"
 
 [features]

--- a/drv/lpc55-romapi/Cargo.toml
+++ b/drv/lpc55-romapi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "lpc55_romapi"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [features]

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-spi-server"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-spi"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-syscon-api/Cargo.toml
+++ b/drv/lpc55-syscon-api/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "drv-lpc55-syscon-api"
 version = "0.1.0"
-authors = [
-  "Laura Abbott <laura@oxide.computer>",
-  "Cliff L. Biffle <cliff@oxide.computer>",
-]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-syscon"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-lpc55-usart"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/onewire-devices/Cargo.toml
+++ b/drv/onewire-devices/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-onewire-devices"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/onewire/Cargo.toml
+++ b/drv/onewire/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-onewire"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-spi-api"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32fx-rcc"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32fx-usart/Cargo.toml
+++ b/drv/stm32fx-usart/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32fx-usart"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-gpio-api/Cargo.toml
+++ b/drv/stm32h7-gpio-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-gpio-api"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>" ]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-gpio"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-i2c-server"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-i2c/Cargo.toml
+++ b/drv/stm32h7-i2c/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-i2c"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-rcc-api/Cargo.toml
+++ b/drv/stm32h7-rcc-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-rcc-api"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>" ]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-rcc"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-spi-server"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-spi"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-stm32h7-usart"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-user-leds-api"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>" ]
 edition = "2018"
 
 [dependencies]

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drv-user-leds"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/lib/fixedmap/Cargo.toml
+++ b/lib/fixedmap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "fixedmap"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [lib]

--- a/lib/hypocalls/Cargo.toml
+++ b/lib/hypocalls/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hypocalls"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [features]

--- a/lib/ringbuf/Cargo.toml
+++ b/lib/ringbuf/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ringbuf"
 version = "0.2.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [features]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "stage0"
 version = "0.1.0"
-authors = ["Laura Abbott <laura@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "abi"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kern"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [features]

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "userlib"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [features]

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-hiffy"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [package.metadata.build]

--- a/task/idle/Cargo.toml
+++ b/task/idle/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-idle"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-jefe"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/task/ping/Cargo.toml
+++ b/task/ping/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-ping"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/task/pong/Cargo.toml
+++ b/task/pong/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-pong"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-power"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [package.metadata.build]

--- a/task/spam2/Cargo.toml
+++ b/task/spam2/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-spam"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-spd"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/task/template/Cargo.toml
+++ b/task/template/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-template"
 version = "0.1.0"
-authors = ["Your Name Here <anonymous@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "task-thermal"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [package.metadata.build]

--- a/test/test-api/Cargo.toml
+++ b/test/test-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-api"
 version = "0.1.0"
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-assist"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-runner"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-suite"
 version = "0.1.0"
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 
 [dependencies]

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "tests-gemini-bu-rot"

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "tests-gemini-bu"

--- a/test/tests-lpc55/Cargo.toml
+++ b/test/tests-lpc55/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "tests-lpc55"

--- a/test/tests-stm32fx/Cargo.toml
+++ b/test/tests-stm32fx/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "tests-stm32f4"

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2018"
 readme = "README.md"
 name = "tests-stm32h7"


### PR DESCRIPTION
The author's field is now optional per
https://github.com/rust-lang/rust/issues/83227

For sake of clarity, remove it across Hubris