### PR TITLE
Add a CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Hubris project status and open source
+
+The Hubris repo (and associated repos) is public because
+
+1. It has always been our intention to make this open-source.
+2. We figured it's best to err on the side of doing this early instead of late.
+
+However, Hubris is not done, or even ready. It's probably not a good fit for
+your use case, because it's not yet a good fit for _our_ use case!
+
+And so, we thought it was important to explain where we're currently at, and
+manage your expectations.
+
+- We are a small company.
+
+- Our current goal is to get our first generation products finished and in
+  customers' hands.
+
+- We're writing Hubris in support of that goal, not as its own thing. Hubris has
+  a total of zero full time engineers -- we're all working on the products, and
+  tool development is a side effect.
+
+- For expediency, we're developing our server firmware and Hubris in the same
+  repo. We will probably split this up later to make it more obvious how to use
+  Hubris from other applications. But, for now, we're primarily focused on
+  getting _our_ firmware ready, because, again, we need to finish our computers.
+
+- These points together mean that we may not have enough bandwidth to review and
+  integrate outside PRs right now. This will change in the future.
+
+You're welcome to send PRs! If we have time, or if the PRs are very small or fix
+bugs, we may even integrate them in the near future. But be aware that we might
+not get to it for a while, by which time it might no longer be relevant.
+
+We've all dealt with those open source projects that feel open in name only, and
+have big patches and history-free source drops appearing from behind the walls
+of some large organization. We don't like that, and we're not going to do that.
+But please bear with us while we're scaling up.
+
+If you want to ask about whether a PR is consistent with our short-term plan
+_before_ you put in the work -- and you should! -- hit us up on the repo
+Discussions tab on GitHub.
+
+Thanks!


### PR DESCRIPTION
This adds a CONTRIBUTING.md that politely explains that we are okay with
having PRs opened, but may not ever accept them. This sets the right
expectations for external contributions to Hubris at this time.

I have authored this commet as @cbiffle and not myself because he
largely wrote this text; I made one or two very inconsequental
grammatical tweaks.