### PR TITLE
Fill TX FIFO as much as possible

### DIFF
--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -378,7 +378,7 @@ fn main() -> ! {
                         let mut made_progress = false;
 
                         if let Some((tx_data, tx_pos)) = &mut tx {
-                            if spi.can_tx_frame() {
+                            while spi.can_tx_frame() {
                                 // If our position is less than our tx len,
                                 // transfer a byte from caller to TX FIFO --
                                 // otherwise put a dummy byte on the wire
@@ -393,6 +393,7 @@ fn main() -> ! {
                                 ringbuf_entry!(Trace::Tx(*tx_pos, byte));
                                 spi.send8(byte);
                                 *tx_pos += 1;
+                                made_progress = true;
 
                                 // If we have _just_ finished...
                                 if *tx_pos == xfer_len.0 {
@@ -402,9 +403,8 @@ fn main() -> ! {
                                     // space available during that time.
                                     spi.disable_can_tx_interrupt();
                                     tx = None;
+                                    break;
                                 }
-
-                                made_progress = true;
                             }
                         }
 


### PR DESCRIPTION
Otherwise, SPI lags when doing read-write transfers through `humility spi`

Before this fix, invoking `humility spi -p2 -r -w 0x80,0,0,0,0x81,0x81,0x81,0x81 -n8`:

<img width="826" alt="write_read" src="https://user-images.githubusercontent.com/745333/142485713-c2227d91-cd55-4956-bfc8-c358bd6a55cf.png">

Afterwards:
<img width="558" alt="Screen Shot 2021-11-18 at 2 42 53 PM" src="https://user-images.githubusercontent.com/745333/142485813-fe6e41f7-9bc8-4f42-87b6-98bab3561577.png">


