### PR TITLE
xtask: Use metadata.build.target when checking individual packages.

### DIFF
--- a/build/xtask/src/check.rs
+++ b/build/xtask/src/check.rs
@@ -7,9 +7,7 @@ fn get_custom_target(pkg_name: &str) -> Option<String> {
     use cargo_metadata::MetadataCommand;
     use serde::Deserialize;
 
-    let metadata = MetadataCommand::new()
-        .exec()
-        .unwrap();
+    let metadata = MetadataCommand::new().exec().unwrap();
 
     let package = metadata
         .packages


### PR DESCRIPTION
The docs for xtask state that if --target is not provided then the value
from package.metadata.build.target will be used. This is true when
checking --all packages but not individual packages. This patch
implements this behavior when xtask check is:
- executed from the workspace root with the '-p' option
- executed from a project directory with no params
In both of these cases cargo metadata json is now parsed to extract the
project.metadata.build.target value. If found the target is then added
to the final check command invocation. Otherwise the 'cargo check'
default target (the host architecture) is used.