### PR TITLE
Add MPL 2.0 license and check for it

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,46 @@
+# adapted from:
+#
+# * base code: https://peterevans.dev/posts/github-actions-how-to-automate-code-formatting-in-pull-requests/
+# * fix push auth: https://github.com/ad-m/github-push-action
+# * checkout PR head commit https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+name: license-check
+on: pull_request
+jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispath", "schedule"]'
+  format:
+    needs: skip_duplicate_jobs
+    # Check if the PR is not from a fork
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fkirc/skip-duplicate-actions@master
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Update submodule
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.SSH_KEY_FOR_SUBMODULE}}
+          SSH_PUBKEY_FOR_SUBMODULE: ${{secrets.SSH_PUBKEY_FOR_SUBMODULE}}
+        run: |
+            mkdir $HOME/.ssh && ssh-keyscan github.com >> $HOME/.ssh/known_hosts && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && echo "$SSH_PUBKEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa.pub && chmod 600 $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa.pub && git submodule update --init --recursive
+        shell: bash
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install binutils-arm-none-eabi libudev-dev
+
+      - name: Show Rust toolchain
+        run: rustup show
+
+      - name: Run cargo xtask license-check
+        run: cargo xtask license-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2601,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2617,6 +2646,7 @@ dependencies = [
  "srec",
  "structopt",
  "toml",
+ "walkdir",
  "zip",
 ]
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/app/demo-stm32f4-discovery/src/main.rs
+++ b/app/demo-stm32f4-discovery/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/demo-stm32h7-nucleo/build.rs
+++ b/app/demo-stm32h7-nucleo/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/app/demo-stm32h7-nucleo/src/main.rs
+++ b/app/demo-stm32h7-nucleo/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/gemini-bu-rot/src/main.rs
+++ b/app/gemini-bu-rot/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/gemini-bu/build.rs
+++ b/app/gemini-bu/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/app/gemini-bu/src/main.rs
+++ b/app/gemini-bu/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/gimlet-rot/src/main.rs
+++ b/app/gimlet-rot/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/gimlet/build.rs
+++ b/app/gimlet/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/app/gimlet/src/main.rs
+++ b/app/gimlet/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/gimletlet/build.rs
+++ b/app/gimletlet/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/app/gimletlet/src/main.rs
+++ b/app/gimletlet/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/lpc55xpresso/src/main.rs
+++ b/app/lpc55xpresso/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/app/sidecar/build.rs
+++ b/app/sidecar/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/app/sidecar/src/main.rs
+++ b/app/sidecar/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::{bail, Result};
 use convert_case::{Case, Casing};
 use indexmap::IndexMap;

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use std::env;

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -26,6 +26,7 @@ abi = { path = "../../sys/abi" }
 byteorder = "1.3.4"
 filetime = "0.2.12"
 scroll = "0.10"
+walkdir = "2.0.0"
 
 # For NXP signing
 lpc55_support = { path = "../../support/lpc55" }

--- a/build/xtask/src/check.rs
+++ b/build/xtask/src/check.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::env;
 use std::process::Command;
 

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::env;
 use std::process::Command;
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs::{self, File};

--- a/build/xtask/src/elf.rs
+++ b/build/xtask/src/elf.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 pub fn get_endianness(elf: &goblin::elf::Elf) -> scroll::Endian {
     if elf.little_endian {
         scroll::Endian::Little

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use path_slash::PathBufExt;
 use std::env;
 use std::path::{Path, PathBuf};

--- a/build/xtask/src/gdb.rs
+++ b/build/xtask/src/gdb.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/build/xtask/src/humility.rs
+++ b/build/xtask/src/humility.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/build/xtask/src/license.rs
+++ b/build/xtask/src/license.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::{env, fs::File};
+
+use anyhow::Result;
+use walkdir::{DirEntry, WalkDir};
+
+const LICENSE_HEADER: &str =
+    "// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+";
+
+/// alternative header with //s as bookends
+const LICENSE_HEADER_ALT: &str = "//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+";
+
+pub fn check() -> Result<bool> {
+    // assume only the best about our codebase
+    let mut fail = false;
+
+    // this gets the manifest of the xtask, so we need to go up two levels to
+    // actually get the root directory
+    let mut root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    root.push("..");
+    root.push("..");
+
+    let walker = WalkDir::new(&root).into_iter();
+
+    // don't bother walking the target directory
+    let walker = walker.filter_entry(|entry| !is_target_dir(entry));
+
+    for entry in walker {
+        let entry = entry?;
+
+        // we are only checking for Rust files for now
+        if !is_rust_file(&entry) {
+            continue;
+        }
+
+        let check_header = |header: &str| -> Result<bool> {
+            let f = File::open(entry.path())?;
+            let reader = BufReader::with_capacity(header.len(), f);
+            for (text, header) in reader.lines().zip(header.lines()) {
+                let text = text?;
+
+                if text != header {
+                    return Ok(false);
+                }
+            }
+
+            Ok(true)
+        };
+
+        // !check_header(LICENSE_HEADER)? && !check_header(LICENSE_HEADER_ALT)?;
+
+        if !check_header(LICENSE_HEADER)? {
+            if !check_header(LICENSE_HEADER_ALT)? {
+                fail = true;
+                let path = entry.path().strip_prefix(&root)?;
+                println!("{}: missing header", path.display());
+            }
+        }
+    }
+
+    Ok(fail)
+}
+
+fn is_rust_file(entry: &DirEntry) -> bool {
+    entry.path().extension().map(|e| e == "rs").unwrap_or(false)
+}
+
+fn is_target_dir(entry: &DirEntry) -> bool {
+    entry.file_type().is_dir() && (entry.file_name() == "target")
+}

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -14,6 +18,7 @@ mod elf;
 mod flash;
 mod gdb;
 mod humility;
+mod license;
 mod task_slot;
 mod test;
 
@@ -112,6 +117,9 @@ enum Xtask {
         /// Path to task executable
         task_bin: PathBuf,
     },
+
+    /// Check that all .rs files have the MPL header
+    LicenseCheck,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -352,6 +360,11 @@ fn main() -> Result<()> {
         }
         Xtask::TaskSlots { task_bin } => {
             task_slot::dump_task_slot_table(&task_bin)?;
+        }
+        Xtask::LicenseCheck => {
+            if !license::check()? {
+                std::process::exit(1);
+            }
         }
     }
 

--- a/build/xtask/src/task_slot.rs
+++ b/build/xtask/src/task_slot.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::elf;
 use anyhow::{bail, Result};
 use scroll::Pread;

--- a/build/xtask/src/test.rs
+++ b/build/xtask/src/test.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! API crate for the Gimlet Host Flash server.
 
 #![no_std]

--- a/drv/gimlet-hf-server/build.rs
+++ b/drv/gimlet-hf-server/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Gimlet host flash server.
 //!
 //! This server is responsible for managing access to the host flash; it embeds

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::{env, fs, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Server for managing the Gimlet sequencing process.
 //!
 //!

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the I2C server
 //!
 //! This API allows for access to I2C devices.  The actual I2C bus

--- a/drv/i2c-devices/src/adm1272.rs
+++ b/drv/i2c-devices/src/adm1272.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the ADM1272 hot-swap controller
 
 use drv_i2c_api::*;

--- a/drv/i2c-devices/src/adt7420.rs
+++ b/drv/i2c-devices/src/adt7420.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the ADT7420 temperature sensor
 
 use crate::TempSensor;

--- a/drv/i2c-devices/src/ds2482.rs
+++ b/drv/i2c-devices/src/ds2482.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the DS2482-100 1-wire initiator
 
 use bitfield::bitfield;

--- a/drv/i2c-devices/src/isl68224.rs
+++ b/drv/i2c-devices/src/isl68224.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use drv_i2c_api::*;
 use pmbus::commands::isl68224::*;
 use pmbus::*;

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! I2C device drivers
 //!
 //! This crate contains (generally) all I2C device drivers, including:

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the MAX31790 fan controller
 
 use bitfield::bitfield;

--- a/drv/i2c-devices/src/max6634.rs
+++ b/drv/i2c-devices/src/max6634.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the MAX6634 temperature sensor
 
 use crate::TempSensor;

--- a/drv/i2c-devices/src/mcp9808.rs
+++ b/drv/i2c-devices/src/mcp9808.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the MCP9808 temperature sensor
 
 use crate::TempSensor;

--- a/drv/i2c-devices/src/pct2075.rs
+++ b/drv/i2c-devices/src/pct2075.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the PCT2075 temperature sensor
 
 use crate::TempSensor;

--- a/drv/i2c-devices/src/raa229618.rs
+++ b/drv/i2c-devices/src/raa229618.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use drv_i2c_api::*;
 use pmbus::commands::raa229618::*;
 use pmbus::*;

--- a/drv/i2c-devices/src/tmp116.rs
+++ b/drv/i2c-devices/src/tmp116.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the TMP116 temperature sensor
 
 use crate::TempSensor;

--- a/drv/i2c-devices/src/tps546b24a.rs
+++ b/drv/i2c-devices/src/tps546b24a.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the TPS546B24A buck converter
 
 use drv_i2c_api::*;

--- a/drv/ice40-spi-program/src/lib.rs
+++ b/drv/ice40-spi-program/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Code for programming an iCE40 FPGA using separate GPIO and SPI servers.
 //!
 //! **Note:** this code makes an environmental assumption that you are not using

--- a/drv/lpc55-gpio-api/build.rs
+++ b/drv/lpc55-gpio-api/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/lpc55-gpio-api/src/lib.rs
+++ b/drv/lpc55-gpio-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 
 use core::cell::Cell;

--- a/drv/lpc55-gpio/src/main.rs
+++ b/drv/lpc55-gpio/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the LPC55S6x GPIO
 //!
 //! GPIO is covered by two separate hardware blocks: GPIO which handles the

--- a/drv/lpc55-i2c/src/main.rs
+++ b/drv/lpc55-i2c/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the LPC55 i2c chip.
 //!
 //! TODO This currently blocks and should really become interrupt driven

--- a/drv/lpc55-iocon-gen/build.rs
+++ b/drv/lpc55-iocon-gen/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/lpc55-iocon-gen/src/lib.rs
+++ b/drv/lpc55-iocon-gen/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 /// proc macro to generate iocon function for LPC55
 extern crate proc_macro;
 use proc_macro::TokenStream;

--- a/drv/lpc55-rng/src/main.rs
+++ b/drv/lpc55-rng/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Random Number Generation
 //!
 //! This task will produce random u32 values for you, if you ask nicely.

--- a/drv/lpc55-romapi/src/lib.rs
+++ b/drv/lpc55-romapi/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![feature(asm)]
 #![feature(naked_functions)]
 #![no_std]

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the LPC55 HighSpeed SPI interface.
 //!
 //! Mostly for demonstration purposes, write is verified read is not

--- a/drv/lpc55-spi/src/lib.rs
+++ b/drv/lpc55-spi/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 
 use lpc55_pac as device;

--- a/drv/lpc55-syscon-api/src/lib.rs
+++ b/drv/lpc55-syscon-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the LPC55S6x SYSCON block
 //!
 //! This driver is responsible for clocks (peripherals and PLLs), systick

--- a/drv/lpc55-syscon/src/main.rs
+++ b/drv/lpc55-syscon/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the LPC55S6x SYSCON block
 //!
 //! This driver is responsible for clocks (peripherals and PLLs), systick

--- a/drv/lpc55-usart/src/main.rs
+++ b/drv/lpc55-usart/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the LPC55 U(S)ART.
 //!
 //! This driver is currently configured to run at 9600. We could potentially

--- a/drv/onewire-devices/src/ds18b20.rs
+++ b/drv/onewire-devices/src/ds18b20.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the DS18B20 Programmable Resolution 1-Wire Digital Thermometer
 //!
 //! This is a basic driver for converting and reading the temperature on

--- a/drv/onewire-devices/src/lib.rs
+++ b/drv/onewire-devices/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! 1-wire device drivers
 //!
 //! This crate contains all 1-wire device drivers -- which is currently a

--- a/drv/onewire/src/lib.rs
+++ b/drv/onewire/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! 1-wire APIs
 //!
 //! This crate has functions and structures specific to the 1-wire interface,

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the SPI server
 
 #![no_std]

--- a/drv/stm32fx-rcc/src/main.rs
+++ b/drv/stm32fx-rcc/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32F3/4 Reset and Clock Controller (RCC).
 //!
 //! This driver puts the system into a reasonable initial state, and then fields

--- a/drv/stm32fx-usart/src/main.rs
+++ b/drv/stm32fx-usart/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32F4 U(S)ART.
 //!
 //! # IPC protocol

--- a/drv/stm32h7-gpio-api/src/lib.rs
+++ b/drv/stm32h7-gpio-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the STM32H7 GPIO server.
 
 #![no_std]

--- a/drv/stm32h7-gpio/src/main.rs
+++ b/drv/stm32h7-gpio/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! STM32H7 GPIO Server.
 //!
 //! # IPC protocol

--- a/drv/stm32h7-i2c-server/build.rs
+++ b/drv/stm32h7-i2c-server/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 

--- a/drv/stm32h7-i2c-server/src/main.rs
+++ b/drv/stm32h7-i2c-server/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32H7 I2C interface
 
 #![no_std]

--- a/drv/stm32h7-i2c-target-server/build.rs
+++ b/drv/stm32h7-i2c-target-server/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32H7 I2C interface
 
 #![no_std]

--- a/drv/stm32h7-i2c/src/ltc4306.rs
+++ b/drv/stm32h7-i2c/src/ltc4306.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the LTC4306 I2C mux
 
 use crate::*;

--- a/drv/stm32h7-i2c/src/max7358.rs
+++ b/drv/stm32h7-i2c/src/max7358.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the MAX7358 I2C mux
 
 use crate::*;

--- a/drv/stm32h7-i2c/src/pca9548.rs
+++ b/drv/stm32h7-i2c/src/pca9548.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Driver for the PCA9548 I2C mux
 
 use crate::*;

--- a/drv/stm32h7-qspi/src/lib.rs
+++ b/drv/stm32h7-qspi/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! STM32H7 QSPI low-level driver crate.
 
 #![no_std]

--- a/drv/stm32h7-rcc-api/src/lib.rs
+++ b/drv/stm32h7-rcc-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the STM32H7 RCC server.
 
 #![no_std]

--- a/drv/stm32h7-rcc/src/main.rs
+++ b/drv/stm32h7-rcc/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32H7 Reset and Clock Controller (RCC).
 //!
 //! This driver puts the system into a reasonable initial state, and then fields

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Server task for the STM32H7 SPI peripheral.
 //!
 //! Currently this hardcodes the clock rate.

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32H7 SPI, in host mode.
 //!
 //! This is the core logic, separated from the IPC server. The peripheral also

--- a/drv/stm32h7-usart/src/main.rs
+++ b/drv/stm32h7-usart/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for the STM32H7 U(S)ART.
 //!
 //! # IPC protocol

--- a/drv/user-leds-api/src/lib.rs
+++ b/drv/user-leds-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Client API for the User LEDs driver.
 
 #![no_std]

--- a/drv/user-leds/build.rs
+++ b/drv/user-leds/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A driver for some basic dev board User LEDs.
 //!
 //! We assume that there are two user LEDs available, numbered 0 and 1. The

--- a/lib/fixedmap/src/lib.rs
+++ b/lib/fixedmap/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Fixed map
 //!
 //! This contains a very simple implementation of a fixed-sized map, with

--- a/lib/gnarle/src/lib.rs
+++ b/lib/gnarle/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! A very simple Run-Length Encoding (RLE) compression method.
 //!
 //! This is mostly intended for compressing data with sections of very low

--- a/lib/hypocalls/build.rs
+++ b/lib/hypocalls/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::env;
 use std::fs::File;
 use std::io::Write;

--- a/lib/hypocalls/src/lib.rs
+++ b/lib/hypocalls/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![feature(asm)]
 #![feature(naked_functions)]

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Ring buffer for debugging Hubris tasks and drivers
 //!
 //! This contains an implementation for a static ring buffer designed to be used

--- a/stage0/src/hypo.rs
+++ b/stage0/src/hypo.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Hypovisor calls
 
 use lpc55_romapi::FlashStatus;

--- a/stage0/src/image_header.rs
+++ b/stage0/src/image_header.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 extern "C" {
     static IMAGEA: ImageHeader;
 }

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![feature(cmse_nonsecure_entry)]
 #![feature(asm)]
 #![feature(naked_functions)]

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Kernel ABI definitions, shared between kernel and applications.
 
 #![no_std]

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::env;
 use std::fs::File;
 use std::io::Write;

--- a/sys/kern/src/app.rs
+++ b/sys/kern/src/app.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Application description and startup.
 //!
 //! An "application" here is the entire collection of tasks and configuration

--- a/sys/kern/src/arch.rs
+++ b/sys/kern/src/arch.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Architecture-specific support.
 //!
 //! In practice, this works by

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Architecture support for ARMv{7,8}-M.
 //!
 //! Mostly ARMv7-M at the moment.

--- a/sys/kern/src/err.rs
+++ b/sys/kern/src/err.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Common error-handling support.
 //!
 //! This module is designed around the idea that kernel code spends too much

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Implementation of IPC operations on the virtual kernel task.
 
 use abi::{FaultInfo, SchedState, TaskState, UsageError};

--- a/sys/kern/src/lib.rs
+++ b/sys/kern/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Hubris kernel.
 //!
 //! This is the application-independent portion of the operating system, and the

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Kernel startup.
 
 use crate::app;

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Architecture-independent syscall implementation.
 //!
 //! This builds on architecture-specific parts defined in the `arch::*` modules.

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Implementation of tasks.
 
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/sys/kern/src/time.rs
+++ b/sys/kern/src/time.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Implementation of kernel time.
 
 /// In-kernel timestamp representation.

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Support for safely interacting with untrusted/unprivileged/user memory.
 
 use core::marker::PhantomData;

--- a/sys/userlib/build.rs
+++ b/sys/userlib/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::env;
 use std::fs::File;
 use std::io::Write;

--- a/sys/userlib/src/hl.rs
+++ b/sys/userlib/src/hl.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! High-level user interface.
 //!
 //! This is intended to provide a more ergonomic interface than the raw

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Operations implemented by IPC with the kernel task.
 
 use zerocopy::AsBytes;

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! User application support library for Hubris.
 //!
 //! This contains syscall stubs and types, and re-exports the contents of the

--- a/sys/userlib/src/macros.rs
+++ b/sys/userlib/src/macros.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 pub use bstringify;
 pub use paste;
 

--- a/sys/userlib/src/task_slot.rs
+++ b/sys/userlib/src/task_slot.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use self::volatile_const::VolatileConst;
 use abi::{Generation, TaskId};
 

--- a/sys/userlib/src/units.rs
+++ b/sys/userlib/src/units.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //!
 //! Tuple structs for units that are useful in the real world
 //!

--- a/sys/userlib/src/util.rs
+++ b/sys/userlib/src/util.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/task/hiffy/build.rs
+++ b/task/hiffy/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use hif::{Failure, Fault};
 
 cfg_if::cfg_if! {

--- a/task/hiffy/src/generic.rs
+++ b/task/hiffy/src/generic.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use hif::Function;
 
 pub enum Functions {

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #[cfg(feature = "spi")]
 use crate::common::{spi_read, spi_write};
 use byteorder::ByteOrder;

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! HIF interpreter
 //!
 //! HIF is the Hubris/Humility Interchange Format, a simple stack-based

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #[cfg(feature = "spi")]
 use crate::common::{spi_read, spi_write};
 use hif::*;

--- a/task/idle/src/main.rs
+++ b/task/idle/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/task/jefe/src/external.rs
+++ b/task/jefe/src/external.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! External interface for Jefe
 //!
 //! It can be very handy to have Jefe be externally influenced by a debugger.

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Implementation of the system supervisor.
 //!
 //! The supervisor is responsible for:

--- a/task/ping/src/main.rs
+++ b/task/ping/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 #![feature(asm)]

--- a/task/pong/src/main.rs
+++ b/task/pong/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/task/power/build.rs
+++ b/task/power/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Power monitoring
 //!
 //! This is a primordial power monitoring task.

--- a/task/spam2/src/main.rs
+++ b/task/spam2/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/task/spd/build.rs
+++ b/task/spd/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 

--- a/task/spd/src/ltc4306.rs
+++ b/task/spd/src/ltc4306.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //
 // Virtual LTC4306 implementation.  The part is pretty simple, but this
 // virtualiation is even simpler:  we do not support enabling any combination

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! SPD proxy task
 //!
 //! This task acts as a proxy for the Serial Presence Detect (SPD) found in

--- a/task/template/src/main.rs
+++ b/task/template/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 #![no_main]
 

--- a/task/thermal/build.rs
+++ b/task/thermal/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Thermal loop
 //!
 //! This is a primordial thermal loop, which will ultimately reading temperature

--- a/test/test-api/src/lib.rs
+++ b/test/test-api/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_std]
 
 use userlib::*;

--- a/test/test-assist/src/main.rs
+++ b/test/test-assist/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! "Assistant" task for testing interprocess interactions.
 
 #![no_std]

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Generic test suite runner task.
 //!
 //! # Architecture

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Test suite.
 //!
 //! This task is driven by the `runner` to run test cases (defined below).

--- a/test/tests-stm32h7/build.rs
+++ b/test/tests-stm32h7/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 fn main() {
     build_util::expose_target_board();
 }


### PR DESCRIPTION
This adds the required MPL 2.0 header to all Rust files, and adds an
xtask, license-check, that will make sure all Rust files in the
repository have it.

This will fail currently because the submodules do not have the licenses yet. I will send in those PRs next, but we can at least see it fail once!