### PR TITLE
doc/ipc: Explain that borrows are accessed separately by the receiver

### DIFF
--- a/doc/ipc.adoc
+++ b/doc/ipc.adoc
@@ -360,7 +360,8 @@ explained in the section <<notifications>>.)
 caller sent an over-long message that has been truncated, and you likely want to
 return an error.
 <5> Number of bytes the caller reserved for receiving your reply.
-<6> Number of leases the caller sent you.
+<6> Number of leases the caller sent you. The actual borrows are accessed
+    with separate system calls — see section <<sys_borrow_read>>.
 
 [source,rust]
 ----

--- a/doc/syscalls.adoc
+++ b/doc/syscalls.adoc
@@ -375,6 +375,7 @@ you `RECV`).
 The time unit for deadlines is not currently specified -- it's currently an
 abstract "kernel ticks" unit. This will be fixed.
 
+[#sys_borrow_read]
 === `BORROW_READ` (4)
 
 Copies data from memory borrowed from a caller (a "borrow").


### PR DESCRIPTION
I got confused about the fact that RecvMessage doesn't contain any way
to actually tell the receiver about the loaned memory. I believe this
additional cross-reference should greatly help with understanding this
section.