### PR TITLE
Add support for A0 hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
 name = "lpc55_romapi"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "lpc55-pac",
  "num-derive",
  "num-traits",
@@ -2078,6 +2079,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "stage0"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",

--- a/app/lpc55xpresso/app-a0.toml
+++ b/app/lpc55xpresso/app-a0.toml
@@ -1,0 +1,248 @@
+name = "lpc55xpresso"
+target = "thumbv8m.main-none-eabihf"
+board = "lpcxpresso55s69"
+stacksize = 1024
+secure = true
+
+[kernel]
+path = "."
+name = "lpc55xpresso"
+requires = {flash = 32768, ram = 4096}
+features = ["itm"]
+
+[supervisor]
+notification = 1
+
+[outputs.bootloader_sram]
+address = 0x14000000
+size = 0x8000
+
+[outputs.bootloader_flash]
+address = 0x00000000
+size = 0x8000
+
+[outputs.bootloader_ram]
+address = 0x20000000
+size = 0x4000
+
+# We reserve the last sector (0x8000) for flash testing
+[outputs.flash]
+address = 0x00008000
+size = 0x88000
+read = true
+execute = true
+
+[outputs.ram]
+address = 0x20004000
+size = 0x18000
+read = true
+write = true
+execute = true
+
+[signing.combined]
+method = "ecc"
+priv-key = "../../support/fake_certs/p256-private-key.der"
+
+[signing.bootloader]
+method = "rsa"
+priv-key = "../../support/fake_certs/fake_private_key.pem"
+root-cert = "../../support/fake_certs/fake_certificate.der.crt"
+
+[bootloader]
+path = "../../stage0"
+name = "stage0"
+sections = {"flash_hypo" = "flash"}
+sharedsyms = ["write_to_flash"]
+# Currently we have the first 0x8000 of flash and first 0x4000 of RAM
+# dedicated for the stage0 bootloader and the rest for Hubris. Once we have
+# multiple images this will need to be adjusted
+imagea-flash-start = 0x8000
+imagea-flash-size = 0x88000
+imagea-ram-start = 0x20004000
+imagea-ram-size = 0x18000
+features = ["0A-hardware"]
+
+[tasks.jefe]
+path = "../../task/jefe"
+name = "task-jefe"
+priority = 0
+requires = {flash = 32768, ram = 4096}
+start = true
+features = ["itm"]
+stacksize = 1536
+
+[tasks.hiffy]
+path = "../../task/hiffy"
+name = "task-hiffy"
+priority = 3
+features = ["lpc55", "gpio"]
+requires = {flash = 32768, ram = 16384 }
+stacksize = 2048
+start = true
+
+[tasks.hiffy.task-slots]
+gpio_driver = "gpio_driver"
+
+[tasks.idle]
+path = "../../task/idle"
+name = "task-idle"
+priority = 5
+requires = {flash = 256, ram = 256}
+stacksize = 256
+start = true
+
+[tasks.syscon_driver]
+path = "../../drv/lpc55-syscon"
+name = "drv-lpc55-syscon"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["syscon", "anactrl", "pmc"]
+start = true
+stacksize = 1000
+
+[tasks.gpio_driver]
+path = "../../drv/lpc55-gpio"
+name = "drv-lpc55-gpio"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["gpio", "iocon"]
+start = true
+stacksize = 1000
+
+[tasks.gpio_driver.task-slots]
+syscon_driver = "syscon_driver"
+
+[tasks.user_leds]
+path = "../../drv/user-leds"
+name = "drv-user-leds"
+features = ["lpc55"]
+priority = 2
+requires = {flash = 16384, ram = 1024}
+start = true
+stacksize = 1000
+
+[tasks.user_leds.task-slots]
+gpio_driver = "gpio_driver"
+
+[tasks.usart_driver]
+path = "../../drv/lpc55-usart"
+name = "drv-lpc55-usart"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["flexcomm0"]
+start = true
+interrupts = {14 = 1}
+stacksize = 1000
+
+[tasks.usart_driver.task-slots]
+gpio_driver = "gpio_driver"
+syscon_driver = "syscon_driver"
+
+[tasks.i2c_driver]
+path = "../../drv/lpc55-i2c"
+name = "drv-lpc55-i2c"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["flexcomm4"]
+start = true
+stacksize = 1000
+
+[tasks.i2c_driver.task-slots]
+gpio_driver = "gpio_driver"
+syscon_driver = "syscon_driver"
+
+[tasks.rng_driver]
+path = "../../drv/lpc55-rng"
+name = "drv-lpc55-rng"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["rng", "pmc"]
+start = true
+stacksize = 1000
+
+[tasks.rng_driver.task-slots]
+syscon_driver = "syscon_driver"
+
+[tasks.spi_driver]
+path = "../../drv/lpc55-spi-server"
+name = "drv-lpc55-spi-server"
+priority = 2
+requires = {flash = 16384, ram = 1024}
+uses = ["flexcomm8"]
+start = true
+interrupts = {59 = 1}
+stacksize = 1000
+
+[tasks.spi_driver.task-slots]
+gpio_driver = "gpio_driver"
+syscon_driver = "syscon_driver"
+
+[tasks.ping]
+path = "../../task/ping"
+name = "task-ping"
+features = ["uart"]
+priority = 4
+requires = {flash = 8192, ram = 1024}
+start = true
+stacksize = 1000
+
+[tasks.ping.task-slots]
+peer = "pong"
+usart_driver = "usart_driver"
+
+[tasks.pong]
+path = "../../task/pong"
+name = "task-pong"
+priority = 3
+requires = {flash = 8192, ram = 1024}
+start = true
+stacksize = 1000
+
+[tasks.pong.task-slots]
+user_leds = "user_leds"
+
+[tasks.spam]
+path = "../../task/spam2"
+name = "task-spam"
+priority = 3
+requires = {flash = 8192, ram = 1024}
+stacksize = 1000
+
+[tasks.spam.task-slots]
+i2c_driver = "i2c_driver"
+
+[peripherals.syscon]
+address = 0x40000000
+size = 4096
+
+[peripherals.anactrl]
+address = 0x40013000
+size = 4096
+
+[peripherals.gpio]
+address = 0x4008c000
+size = 9348
+
+[peripherals.iocon]
+address = 0x40001000
+size = 4096
+
+[peripherals.flexcomm0]
+address = 0x40086000
+size = 4096
+
+[peripherals.flexcomm4]
+address = 0x4008A000
+size = 4096
+
+[peripherals.pmc]
+address = 0x40020000
+size = 4096
+
+[peripherals.flexcomm8]
+address = 0x4009F000
+size = 4096
+
+[peripherals.rng]
+address = 0x4003A000
+size = 4096

--- a/app/lpc55xpresso/wipecmpa.gdb
+++ b/app/lpc55xpresso/wipecmpa.gdb
@@ -1,0 +1,82 @@
+# Erase the CMPA area of 0A hardware
+#
+# The CMPA region of the LPC55 contains settings for secure boot.
+# On 1B hardware, you can still use the built in ISP commands to erase
+# memory and unset secure mode unless you have locked down a board (set the
+# hash when programming or set the seal flag in the API).
+#
+# On 0A hardware these command do not seem to be available when any secure mode
+# is set up. You can still access ISP mode and SWD but the regular read/write
+# commands are restricted. Because we have access to SWD, it is still possible
+# to unset secure mode by calling these functions manually. This is the
+# rough equivalent to
+#
+# flash_config_t f;
+#
+# memzero(&f, sizeof(f));
+# memzero(0x20004000, 0x1000);
+#
+# flash_init(&f);
+# ffr_init(&f);
+# ffr_cust_factory_page_write(&f, 0x20004000, 0);
+#
+# This is buggy because we're supposed to set the CPU frequency but there's
+# no way to know that from the program. As long as the PLLs aren't running
+# this should work well enough but it is recommended to run
+#
+# monitor read32 0x9e400 512
+#
+# afterwards to verify that the CMPA region has been completely erased. If
+# it has not, running it again usually works.
+#
+# Q: Isn't this dangerous/buggy/hacky
+# A: Absolutely. Ideally you would not use 0A hardware with secure booting
+#    but this is designed to be here in the unfortunate even you need to work
+#    on secure 0A hardware.
+
+target extended-remote :3333
+
+monitor halt
+
+# Clear the space we'll be using for flash_config
+monitor fill 0x20000000 0x1000 0x0
+
+# set our stack to something that won't collide
+
+set $sp = 0x20040000
+
+# arg 0 = our flash_config
+set $r0 = 0x20000000
+
+# address of flash_init
+set $pc = 0x1300409c
+# end of flash_init
+break *0x13004138
+
+continue
+
+# arg 0 = our flash_config
+set $r0 = 0x20000000
+
+# address of ffr_init
+set $pc = 0x13004914
+# end of ffr_init
+break *0x13004930
+continue
+
+# Now clear our "CMPA" region
+monitor fill 0x20004000 0x1000 0x0
+
+# arg 0 = our flash_config
+set $r0 = 0x20000000
+# arg 1 = our CMPA region
+set $r1 = 0x20004000
+# arg 2 = seal (this must be 0!)
+set $r2 = 0x0
+
+# address of CMPA write function
+set $pc = 0x13004c22
+# end of CMPA write function
+break *0x13004ca0
+continue
+

--- a/drv/lpc55-romapi/Cargo.toml
+++ b/drv/lpc55-romapi/Cargo.toml
@@ -8,11 +8,13 @@ default = ["panic-messages"]
 panic-messages = []
 log-itm = []
 log-semihosting = []
+0A-hardware = []
 
 [dependencies]
 lpc55-pac = "0.3.0"
 num-derive = "0.3.3"
 num-traits = { version = "0.2", default-features = false }
+cfg-if = "0.1.10"
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/lpc55-romapi/src/lib.rs
+++ b/drv/lpc55-romapi/src/lib.rs
@@ -157,6 +157,8 @@ struct Version1DriverInterface {
         whichProperty: u32,
         value: &mut u32,
     ) -> u32,
+    // Why yes these two structures differ by several reserved words!
+    #[cfg(not(feature = "0A-hardware"))]
     reserved: [u32; 3],
     /// ffr_init: Initialize the FFR structure (needs to run before other
     /// functions)
@@ -520,10 +522,22 @@ pub unsafe fn flash_erase(addr: u32, len: u32) -> Result<(), FlashStatus> {
         .version1_flash_driver
         .ffr_init)(&mut f))?;
 
-    handle_flash_status((bootloader_tree()
-        .flash_driver
-        .version1_flash_driver
-        .flash_erase)(&mut f, addr, len, ERASE_KEY))
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "0A-hardware")] {
+                // NXP table is incorrect
+                let func = core::mem::transmute::<
+                    usize,
+                    fn(&mut FlashConfig, u32, u32, u32) -> u32,>(0x1300413b);
+                handle_flash_status(func(&mut f, addr, len, ERASE_KEY))
+
+        } else  {
+            handle_flash_status((bootloader_tree()
+                .flash_driver
+                .version1_flash_driver
+                .flash_erase)(&mut f, addr, len, ERASE_KEY))
+        }
+
+    }
 }
 
 pub unsafe fn flash_write(
@@ -550,10 +564,23 @@ pub unsafe fn flash_write(
 
     // XXX so much more validation needed
 
-    handle_flash_status((bootloader_tree()
-        .flash_driver
-        .version1_flash_driver
-        .flash_program)(&mut f, addr, buffer, len))
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "0A-hardware")] {
+
+                // NXP's function table is incorrect
+                let func = core::mem::transmute::<
+                    usize,
+                    fn(&mut FlashConfig, u32, *mut u32, u32) -> u32,
+                >(0x1300419d);
+                handle_flash_status(func(&mut f, addr, buffer, len))
+
+        } else {
+            handle_flash_status((bootloader_tree()
+                .flash_driver
+                .version1_flash_driver
+                .flash_program)(&mut f, addr, buffer, len))
+        }
+    }
 }
 
 /*

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -3,6 +3,10 @@ name = "stage0"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+default = []
+0A-hardware = ["lpc55_romapi/0A-hardware"]
+
 [dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.6.12"
@@ -16,6 +20,7 @@ p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecds
 hmac = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }
 zerocopy = "0.3.0"
+cfg-if = "0.1.10"
 
 [package.metadata.build]
 target = "thumbv8m.main-none-eabihf"

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -43,8 +43,23 @@ pub unsafe extern "C" fn SecureFault() {
     loop {}
 }
 
+// These correspond to REV_ID in the SYSCON_DIEID field
+#[cfg(feature = "0A-hardware")]
+const ROM_VER: u32 = 0;
+
+#[cfg(not(feature = "0A-hardware"))]
+const ROM_VER: u32 = 1;
+
 #[entry]
 fn main() -> ! {
+    // This is the SYSCON_DIEID register on LPC55 which contains the ROM
+    // version. Make sure our configuration matches!
+    let val = unsafe { core::ptr::read_volatile(0x50000ffc as *const u32) };
+
+    if val & 1 != ROM_VER {
+        loop {}
+    }
+
     let imagea = image_header::get_image_a().unwrap();
 
     let entry_pt = imagea.get_pc();

--- a/test/tests-lpc55xpresso/app-a0.toml
+++ b/test/tests-lpc55xpresso/app-a0.toml
@@ -1,0 +1,121 @@
+name = "tests-lpc55xpresso"
+target = "thumbv8m.main-none-eabihf"
+board = "lpcxpresso55s69"
+stacksize = 2048
+
+[kernel]
+path = "../../app/lpc55xpresso"
+name = "lpc55xpresso"
+requires = {flash = 32768, ram = 4096}
+features = ["itm"]
+
+[supervisor]
+notification = 1
+
+[outputs.bootloader_sram]
+address = 0x14000000
+size = 0x8000
+
+[outputs.bootloader_flash]
+address = 0x00000000
+size = 0x8000
+
+[outputs.bootloader_ram]
+address = 0x20000000
+size = 0x4000
+
+# We reserve the last sector (0x8000) for flash testing
+[outputs.flash]
+address = 0x00008000
+size = 0x88000
+read = true
+execute = true
+
+[outputs.ram]
+address = 0x20004000
+size = 0x18000
+read = true
+write = true
+execute = false
+
+[signing.combined]
+method = "ecc"
+priv-key = "../../support/fake_certs/p256-private-key.der"
+
+[signing.bootloader]
+method = "rsa"
+priv-key = "../../support/fake_certs/fake_private_key.pem"
+root-cert = "../../support/fake_certs/fake_certificate.der.crt"
+
+
+[bootloader]
+path = "../../stage0"
+name = "stage0"
+sections = {"flash_hypo" = "flash"}
+sharedsyms = ["write_to_flash"]
+# Currently we have the first 0x8000 of flash and first 0x4000 of RAM
+# dedicated for the stage0 bootloader and the rest for Hubris. Once we have
+# multiple images this will need to be adjusted
+imagea-flash-start = 0x8000
+imagea-flash-size = 0x88000
+imagea-ram-start = 0x20004000
+imagea-ram-size = 0x18000
+features = ["0A-hardware"]
+
+[tasks.runner]
+path = "../test-runner"
+name = "test-runner"
+priority = 0
+requires = {flash = 16384, ram = 4096}
+start = true
+features = ["itm"]
+uses = ["stage0"]
+
+[tasks.suite]
+path = "../test-suite"
+name = "test-suite"
+priority = 2
+requires = {flash = 65536, ram = 4096}
+start = true
+features = ["itm", "lpc55"]
+uses = ["stage0", "rom", "syscon", "flash"]
+stacksize = 2048
+
+[tasks.suite.task-slots]
+assist = "assist"
+suite = "suite"
+runner = "runner"
+
+[tasks.assist]
+path = "../test-assist"
+name = "test-assist"
+priority = 1
+requires = {flash = 16384, ram = 4096}
+start = true
+features = ["itm"]
+uses = ["stage0"]
+
+[tasks.idle]
+path = "../../task/idle"
+name = "task-idle"
+priority = 3
+requires = {flash = 256, ram = 256}
+stacksize = 256
+start = true
+
+# Hmmm put this in a better region?
+[extratext.stage0]
+address = 0x0
+size = 0x8000
+
+[extratext.rom]
+address = 0x13000000
+size = 0x20000
+
+[peripherals.syscon]
+address = 0x50000000
+size = 0x1000
+
+[peripherals.flash]
+address = 0x50034000
+size = 0x1000


### PR DESCRIPTION
The ROM API was intentionally written to only support lpc55
hardware rev 1B. It's still useful to be able to do basic verification
on 0A hardware. Add appropriate support iin the ROM API.