### PR TITLE
docs: Fix invalid reference to "u32.to_le_bytes()"

### DIFF
--- a/doc/ipc.adoc
+++ b/doc/ipc.adoc
@@ -309,7 +309,7 @@ fn read(task: TaskId, fd: u32, buffer: &mut [u8]) -> Result<usize, IoError> {
     let (rc, len) = sys_send(
         task,
         0,
-        &u32.to_le_bytes(),
+        &fd.to_le_bytes(),
         &mut response,
         &[Lease::from(buffer)],
     );


### PR DESCRIPTION
The code sample doesn't make sense, since `to_le_bytes` is a method on instances of `u32`.