### PR TITLE
Replace rustfmt::skip with alternate construction

### DIFF
--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -400,14 +400,14 @@ impl<'a> I2cController<'a> {
         self.wait_until_notbusy()?;
 
         if wlen > 0 {
-            #[rustfmt::skip]
-            i2c.cr2.modify(|_, w| { w
-                .nbytes().bits(wlen as u8)
-                .autoend().clear_bit()
-                .add10().clear_bit()
-                .sadd().bits((addr << 1).into())
-                .rd_wrn().clear_bit()
-                .start().set_bit()
+            i2c.cr2.modify(|_, w| {
+                w.nbytes().bits(wlen as u8);
+                w.autoend().clear_bit();
+                w.add10().clear_bit();
+                w.sadd().bits((addr << 1).into());
+                w.rd_wrn().clear_bit();
+                w.start().set_bit();
+                w
             });
 
             let mut pos = 0;
@@ -487,25 +487,25 @@ impl<'a> I2cController<'a> {
             // read).
             //
             if let ReadLength::Fixed(rlen) = rlen {
-                #[rustfmt::skip]
-                i2c.cr2.modify(|_, w| { w
-                    .nbytes().bits(rlen as u8)
-                    .autoend().clear_bit()
-                    .add10().clear_bit()
-                    .sadd().bits((addr << 1).into())
-                    .rd_wrn().set_bit()
-                    .start().set_bit()
+                i2c.cr2.modify(|_, w| {
+                    w.nbytes().bits(rlen as u8);
+                    w.autoend().clear_bit();
+                    w.add10().clear_bit();
+                    w.sadd().bits((addr << 1).into());
+                    w.rd_wrn().set_bit();
+                    w.start().set_bit();
+                    w
                 });
             } else {
-                #[rustfmt::skip]
-                i2c.cr2.modify(|_, w| { w
-                    .nbytes().bits(1)
-                    .autoend().clear_bit()
-                    .reload().set_bit()
-                    .add10().clear_bit()
-                    .sadd().bits((addr << 1).into())
-                    .rd_wrn().set_bit()
-                    .start().set_bit()
+                i2c.cr2.modify(|_, w| {
+                    w.nbytes().bits(1);
+                    w.autoend().clear_bit();
+                    w.reload().set_bit();
+                    w.add10().clear_bit();
+                    w.sadd().bits((addr << 1).into());
+                    w.rd_wrn().set_bit();
+                    w.start().set_bit();
+                    w
                 });
             }
 
@@ -549,10 +549,10 @@ impl<'a> I2cController<'a> {
                 let byte: u8 = i2c.rxdr.read().rxdata().bits();
 
                 if rlen == ReadLength::Variable {
-                    #[rustfmt::skip]
-                    i2c.cr2.modify(|_, w| { w
-                        .nbytes().bits(byte)
-                        .reload().clear_bit()
+                    i2c.cr2.modify(|_, w| {
+                        w.nbytes().bits(byte);
+                        w.reload().clear_bit();
+                        w
                     });
 
                     rlen = ReadLength::Fixed(byte.into());
@@ -628,14 +628,14 @@ impl<'a> I2cController<'a> {
 
             ringbuf_entry!(Trace::Konami(*op));
 
-            #[rustfmt::skip]
-            i2c.cr2.modify(|_, w| { w
-                .nbytes().bits(0u8)
-                .autoend().clear_bit()
-                .add10().clear_bit()
-                .sadd().bits((addr << 1).into())
-                .rd_wrn().bit(opval)
-                .start().set_bit()
+            i2c.cr2.modify(|_, w| {
+                w.nbytes().bits(0u8);
+                w.autoend().clear_bit();
+                w.add10().clear_bit();
+                w.sadd().bits((addr << 1).into());
+                w.rd_wrn().bit(opval);
+                w.start().set_bit();
+                w
             });
 
             // All done; now block until our transfer is complete -- or until

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -80,24 +80,23 @@ impl Spi {
         // TODO: C driver has some bits about twiddling SSI state to avoid MODF.
         // I've hardcoded what I believe is the equivalent result here.
 
-        #[rustfmt::skip]
         self.reg.cfg2.write(|w| {
+            // This bit determines if software manages SS (SSM = 1) or
+            // hardware (SSM = 0). Let hardware set SS appropriately.
+            w.ssm().clear_bit();
+            // SS output enabled; but not necessarily routed to a pin
+            // (caller determines that)
+            w.ssoe().enabled();
+            // Don't glitch pins when being reconfigured.
+            w.afcntr().controlled();
+            // This is currently a host-only driver.
+            w.master().set_bit();
+            w.comm().variant(comm);
+            w.lsbfrst().variant(lsbfrst);
+            w.cpha().variant(cpha);
+            w.cpol().variant(cpol);
+            w.ssom().variant(ssom);
             w
-                // This bit determines if software manages SS (SSM = 1) or
-                // hardware (SSM = 0). Let hardware set SS appropriately.
-                .ssm().clear_bit()
-                // SS output enabled; but not necessarily routed to a pin
-                // (caller determines that)
-                .ssoe().enabled()
-                // Don't glitch pins when being reconfigured.
-                .afcntr().controlled()
-                // This is currently a host-only driver.
-                .master().set_bit()
-                .comm().variant(comm)
-                .lsbfrst().variant(lsbfrst)
-                .cpha().variant(cpha)
-                .cpol().variant(cpol)
-                .ssom().variant(ssom)
         });
 
         self.reg.cr1.write(|w| w.ssi().set_bit());


### PR DESCRIPTION
This builder construction allows rustfmt to consider each of the individual expressions instead of forcing it to consider them all at once. There are a couple of instances within `drv/stm32h7-i2c/src/lib.rs` that were not changed since the existing inline-comment style would have been mangled.

I went back and forth on the few instances that I left out. I tried moving the comments to their own line, a style that is used elsewhere in the code base, but it made the block look verbose. I'm not familiar enough with the overall coding style to make a recommendation, but I'd be happy to include additional changes in this pull request if it's desired. Here is the diff for reference:

<details>

```diff
diff --git a/drv/stm32h7-i2c/src/lib.rs b/drv/stm32h7-i2c/src/lib.rs
index f0055e9..3517d77 100644
--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -282,17 +282,26 @@ impl<'a> I2cController<'a> {
         self.configure_timing(i2c);
         self.configure_timeouts(i2c);
 
-        #[rustfmt::skip]
-        i2c.cr1.modify(|_, w| { w
-            .smbhen().set_bit()         // enable SMBus host mode
-            .gcen().clear_bit()         // disable General Call
-            .nostretch().clear_bit()    // must enable clock stretching
-            .errie().set_bit()          // emable Error Interrupt
-            .tcie().set_bit()           // enable Transfer Complete interrupt
-            .stopie().clear_bit()       // disable Stop Detection interrupt
-            .nackie().set_bit()         // enable NACK interrupt
-            .rxie().set_bit()           // enable RX interrupt
-            .txie().set_bit()           // enable TX interrupt
+        i2c.cr1.modify(|_, w| {
+            // enable SMBus host mode
+            w.smbhen().set_bit();
+            // disable General Call
+            w.gcen().clear_bit();
+            // must enable clock stretching
+            w.nostretch().clear_bit();
+            // emable Error Interrupt
+            w.errie().set_bit();
+            // enable Transfer Complete interrupt
+            w.tcie().set_bit();
+            // disable Stop Detection interrupt
+            w.stopie().clear_bit();
+            // enable NACK interrupt
+            w.nackie().set_bit();
+            // enable RX interrupt
+            w.rxie().set_bit();
+            // enable TX interrupt
+            w.txie().set_bit();
+            w
         });
 
         i2c.cr1.modify(|_, w| w.pe().set_bit());
@@ -685,29 +694,41 @@ impl<'a> I2cController<'a> {
 
         self.configure_timing(i2c);
 
-        #[rustfmt::skip]
-        i2c.oar1.modify(|_, w| { w
-            .oa1en().clear_bit()                    // own-address disable 
+        i2c.oar1.modify(|_, w| {
+            // own-address disable
+            w.oa1en().clear_bit()
         });
 
-        #[rustfmt::skip]
-        i2c.oar2.modify(|_, w| { w
-            .oa2en().set_bit()                  // own-address-2 enable
-            .oa2msk().bits(0b111)                // mask 7 == match all
+        i2c.oar2.modify(|_, w| {
+            // own-address-2 enable
+            w.oa2en().set_bit();
+            // mask 7 == match all
+            w.oa2msk().bits(0b111);
+            w
         });
 
-        #[rustfmt::skip]
-        i2c.cr1.modify(|_, w| { w
-            .gcen().clear_bit()         // disable General Call
-            .nostretch().clear_bit()    // enable clock stretching
-            .sbc().clear_bit()          // disable byte control 
-            .errie().set_bit()          // emable Error Interrupt
-            .tcie().set_bit()           // enable Transfer Complete interrupt
-            .stopie().set_bit()         // enable Stop Detection interrupt
-            .nackie().set_bit()         // enable NACK interrupt
-            .addrie().set_bit()         // enable Address interrupt
-            .rxie().set_bit()           // enable RX interrupt
-            .txie().set_bit()           // enable TX interrupt
+        i2c.cr1.modify(|_, w| {
+            // disable General Call
+            w.gcen().clear_bit();
+            // enable clock stretching
+            w.nostretch().clear_bit();
+            // disable byte control
+            w.sbc().clear_bit();
+            // emable Error Interrupt
+            w.errie().set_bit();
+            // enable Transfer Complete interrupt
+            w.tcie().set_bit();
+            // enable Stop Detection interrupt
+            w.stopie().set_bit();
+            // enable NACK interrupt
+            w.nackie().set_bit();
+            // enable Address interrupt
+            w.addrie().set_bit();
+            // enable RX interrupt
+            w.rxie().set_bit();
+            // enable TX interrupt
+            w.txie().set_bit();
+            w
         });
 
         i2c.cr1.modify(|_, w| w.pe().set_bit());
```
</details>