### PR TITLE
Simple task slots

### DIFF
--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -82,7 +82,7 @@ priority = 4
 requires = {flash = 8192, ram = 512}
 stacksize = 512
 start = true
-task-slots = [{peer = "ping"}, "usart_driver"]
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"

--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -62,9 +62,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
 start = true
 interrupts = {38 = 1}
-
-[tasks.usart_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -74,9 +72,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpioe"]
 start = true
-
-[tasks.user_leds.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -86,10 +82,7 @@ priority = 4
 requires = {flash = 8192, ram = 512}
 stacksize = 512
 start = true
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "ping"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -97,9 +90,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -62,9 +62,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
 start = true
 interrupts = {38 = 1}
-
-[tasks.usart_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -74,9 +72,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpiod"]
 start = true
-
-[tasks.user_leds.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -86,10 +82,7 @@ priority = 4
 requires = {flash = 8192, ram = 512}
 stacksize = 512
 start = true
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -97,9 +90,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
@@ -76,10 +74,7 @@ requires = {flash = 8192, ram = 1024}
 uses = ["usart3"]
 start = true
 interrupts = {39 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -89,14 +84,11 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 33 = 0b0000_0010        # I2C2 event
 34 = 0b0000_0010        # I2C2 error
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
 
 #
 # SPI interrupts:
@@ -117,10 +109,7 @@ uses = ["spi3"]
 start = true
 interrupts = {51 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -129,9 +118,7 @@ features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -139,9 +126,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -151,11 +136,7 @@ priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-hf = "hf"
-i2c_driver = "i2c_driver"
+task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
@@ -167,10 +148,7 @@ stacksize = 2048
 start = true
 uses = ["quadspi"]
 interrupts = {92 = 1}
-
-[tasks.hf.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
@@ -76,10 +74,7 @@ requires = {flash = 8192, ram = 1024}
 uses = ["usart3"]
 start = true
 interrupts = {39 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -89,14 +84,11 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 33 = 0b0000_0010        # I2C2 event
 34 = 0b0000_0010        # I2C2 error
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
 
 #
 # SPI interrupts:
@@ -117,10 +109,7 @@ uses = ["spi3"]
 start = true
 interrupts = {51 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -129,9 +118,7 @@ features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -139,9 +126,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -151,11 +136,7 @@ priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-hf = "hf"
-i2c_driver = "i2c_driver"
+task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
@@ -167,10 +148,7 @@ stacksize = 2048
 start = true
 uses = ["quadspi"]
 interrupts = {92 = 1, 80 = 1}
-
-[tasks.hf.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/demo-stm32h7-nucleo/app-h7b3.toml
+++ b/app/demo-stm32h7-nucleo/app-h7b3.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
@@ -76,10 +74,7 @@ requires = {flash = 8192, ram = 1024}
 uses = ["usart1"]
 start = true
 interrupts = {37 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -89,14 +84,11 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -105,9 +97,7 @@ features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -115,9 +105,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -127,10 +115,7 @@ priority = 4
 requires = {flash = 8192, ram = 512}
 stacksize = 512
 start = true
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -139,9 +124,7 @@ features = ["h7b3", "stm32h7", "itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true
-
-[tasks.hiffy.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -91,9 +91,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -102,9 +100,7 @@ features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
@@ -114,10 +110,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm0"]
 start = true
 interrupts = {14 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
@@ -126,9 +119,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
 start = true
-
-[tasks.rng_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
@@ -140,10 +131,7 @@ uses = ["flexcomm3", "flexcomm8"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
-
-[tasks.spi0_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -152,10 +140,7 @@ features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -163,9 +148,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -175,9 +158,7 @@ features = ["lpc55", "gpio", "spi"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
@@ -76,10 +74,7 @@ requires = { flash = 8192, ram = 1024}
 uses = ["usart3"]
 start = true
 interrupts = {39 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -89,6 +84,7 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 31 = 0b0000_0001        # I2C1 event
@@ -98,10 +94,6 @@ start = true
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
 
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
-
 [tasks.spd]
 path = "../../task/spd"
 name = "task-spd"
@@ -110,15 +102,11 @@ priority = 2
 requires = {flash = 16384, ram = 16384 }
 uses = ["i2c2"]
 start = true
+task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.spd.interrupts]
 33 = 0b0000_0010        # I2C2 event
 34 = 0b0000_0010        # I2C2 error
-
-[tasks.spd.task-slots]
-rcc_driver = "rcc_driver"
-gpio_driver = "gpio_driver"
-i2c_driver = "i2c_driver"
 
 #
 # SPI interrupts:
@@ -139,10 +127,7 @@ uses = ["spi2"]
 start = true
 interrupts = {36 = 1}
 stacksize = 1000
-
-[tasks.spi2_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
@@ -154,10 +139,7 @@ uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
 stacksize = 1000
-
-[tasks.spi4_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -166,9 +148,7 @@ features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -176,9 +156,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.thermal]
 path = "../../task/thermal"
@@ -188,9 +166,7 @@ priority = 3
 requires = {flash = 65536, ram = 8192 }
 stacksize = 2048
 start = true
-
-[tasks.thermal.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [tasks.power]
 path = "../../task/power"
@@ -200,9 +176,7 @@ priority = 3
 requires = {flash = 65536, ram = 8192 }
 stacksize = 2048
 start = true
-
-[tasks.power.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -212,10 +186,7 @@ priority = 3
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-i2c_driver = "i2c_driver"
+task-slots = ["gpio_driver", "i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -82,7 +82,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
 start = true
 interrupts = {14 = 1}
-task-slots = ["gpio_driver", "syscon_driver_driver"]
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.spi_driver]
 path = "../../drv/lpc55-spi-server"
@@ -93,7 +93,7 @@ uses = ["iocon", "flexcomm3", "flexcomm8"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
-task-slots = ["gpio_driver", "syscon_driver_driver"]
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -47,9 +47,7 @@ features = ["lpc55", "gpio"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
@@ -74,9 +72,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
@@ -86,10 +82,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
 start = true
 interrupts = {14 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver_driver"]
 
 [tasks.spi_driver]
 path = "../../drv/lpc55-spi-server"
@@ -100,10 +93,7 @@ uses = ["iocon", "flexcomm3", "flexcomm8"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/gimlet/app.toml
+++ b/app/gimlet/app.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
@@ -77,10 +75,7 @@ uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
 stacksize = 1000
-
-[tasks.spi4_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
@@ -92,10 +87,7 @@ uses = ["spi2"]
 start = true
 interrupts = {36 = 1}
 stacksize = 1000
-
-[tasks.spi2_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -105,6 +97,7 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 33 = 0b0000_0010        # I2C2 event
@@ -114,10 +107,6 @@ start = true
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
 
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
-
 [tasks.spd]
 path = "../../task/spd"
 name = "task-spd"
@@ -126,15 +115,11 @@ priority = 2
 requires = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
+task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.spd.interrupts]
 31 = 0b0000_0001        # I2C1 event
 32 = 0b0000_0001        # I2C1 error
-
-[tasks.spd.task-slots]
-rcc_driver = "rcc_driver"
-gpio_driver = "gpio_driver"
-i2c_driver = "i2c_driver"
 
 [tasks.thermal]
 path = "../../task/thermal"
@@ -144,9 +129,7 @@ priority = 3
 requires = {flash = 65536, ram = 8192 }
 stacksize = 2048
 start = true
-
-[tasks.thermal.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -155,11 +138,7 @@ features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-hf = "hf"
-i2c_driver = "i2c_driver"
+task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
@@ -169,10 +148,7 @@ priority = 3
 requires = {flash = 32768, ram = 1024 }
 stacksize = 1024
 start = true
-
-[tasks.gimlet_seq.task-slots]
-gpio_driver = "gpio_driver"
-spi_driver = "spi2_driver"
+task-slots = ["gpio_driver", {spi_driver = "spi2_driver"}]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
@@ -184,10 +160,7 @@ stacksize = 2048
 start = true
 uses = ["quadspi"]
 interrupts = {92 = 1}
-
-[tasks.hf.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
@@ -76,10 +74,7 @@ requires = { flash = 8192, ram = 1024}
 uses = ["usart3"]
 start = true
 interrupts = {39 = 1}
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -89,16 +84,13 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 72 = 0b0000_0100        # I2C3 event
 73 = 0b0000_0100        # I2C3 error
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
 
 [tasks.spd]
 path = "../../task/spd"
@@ -108,15 +100,11 @@ priority = 2
 requires = {flash = 16384, ram = 16384}
 uses = ["i2c2"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver", "i2c_driver"]
 
 [tasks.spd.interrupts]
 33 = 0b0000_0010        # I2C2 event
 34 = 0b0000_0010        # I2C2 error
-
-[tasks.spd.task-slots]
-rcc_driver = "rcc_driver"
-gpio_driver = "gpio_driver"
-i2c_driver = "i2c_driver"
 
 #
 # SPI interrupts:
@@ -137,10 +125,7 @@ uses = ["spi4"]
 start = true
 interrupts = {84 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -149,9 +134,7 @@ features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -159,9 +142,7 @@ name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -171,11 +152,7 @@ priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-hf = "hf"
-i2c_driver = "i2c_driver"
+task-slots = ["hf", "gpio_driver", "i2c_driver", "user_leds"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
@@ -185,10 +162,7 @@ priority = 3
 requires = {flash = 32768, ram = 1024 }
 stacksize = 1024
 start = true
-
-[tasks.gimlet_seq.task-slots]
-gpio_driver = "gpio_driver"
-spi_driver = "spi_driver"
+task-slots = ["gpio_driver", "spi_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
@@ -200,10 +174,7 @@ stacksize = 2048
 start = true
 uses = ["quadspi"]
 interrupts = {92 = 1}
-
-[tasks.hf.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/lpc55xpresso/app-a0.toml
+++ b/app/lpc55xpresso/app-a0.toml
@@ -79,9 +79,7 @@ features = ["lpc55", "gpio"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
@@ -108,9 +106,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
 start = true
 stacksize = 1000
-
-[tasks.gpio_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -120,9 +116,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
@@ -133,10 +127,7 @@ uses = ["flexcomm0"]
 start = true
 interrupts = {14 = 1}
 stacksize = 1000
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/lpc55-i2c"
@@ -146,10 +137,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm4"]
 start = true
 stacksize = 1000
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
@@ -159,9 +147,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
 start = true
 stacksize = 1000
-
-[tasks.rng_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.spi_driver]
 path = "../../drv/lpc55-spi-server"
@@ -172,10 +158,7 @@ uses = ["flexcomm8"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -185,10 +168,7 @@ priority = 4
 requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -197,9 +177,7 @@ priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.spam]
 path = "../../task/spam2"
@@ -207,9 +185,7 @@ name = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000
-
-[tasks.spam.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -78,9 +78,7 @@ features = ["lpc55", "gpio"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
@@ -107,9 +105,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
 start = true
 stacksize = 1000
-
-[tasks.gpio_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -119,9 +115,7 @@ priority = 2
 requires = {flash = 16384, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.user_leds.task-slots]
-gpio_driver = "gpio_driver"
+task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
@@ -132,10 +126,7 @@ uses = ["flexcomm0"]
 start = true
 interrupts = {14 = 1}
 stacksize = 1000
-
-[tasks.usart_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/lpc55-i2c"
@@ -145,10 +136,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm4"]
 start = true
 stacksize = 1000
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
@@ -158,9 +146,7 @@ requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
 start = true
 stacksize = 1000
-
-[tasks.rng_driver.task-slots]
-syscon_driver = "syscon_driver"
+task-slots = ["syscon_driver"]
 
 [tasks.spi_driver]
 path = "../../drv/lpc55-spi-server"
@@ -171,10 +157,7 @@ uses = ["flexcomm8"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
-
-[tasks.spi_driver.task-slots]
-gpio_driver = "gpio_driver"
-syscon_driver = "syscon_driver"
+task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
@@ -184,10 +167,7 @@ priority = 4
 requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.ping.task-slots]
-peer = "pong"
-usart_driver = "usart_driver"
+task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
@@ -196,9 +176,7 @@ priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 1000
-
-[tasks.pong.task-slots]
-user_leds = "user_leds"
+task-slots = ["user_leds"]
 
 [tasks.spam]
 path = "../../task/spam2"
@@ -206,9 +184,7 @@ name = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000
-
-[tasks.spam.task-slots]
-i2c_driver = "i2c_driver"
+task-slots = ["i2c_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -63,9 +63,7 @@ priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
 start = true
-
-[tasks.gpio_driver.task-slots]
-rcc_driver = "rcc_driver"
+task-slots = ["rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
@@ -85,10 +83,7 @@ start = true
 73 = 0b0000_0100        # I2C3 error
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
-
-[tasks.i2c_driver.task-slots]
-gpio_driver = "gpio_driver"
-rcc_driver = "rcc_driver"
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
@@ -97,10 +92,7 @@ features = ["h753", "stm32h7", "itm", "i2c", "gpio"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 start = true
-
-[tasks.hiffy.task-slots]
-gpio_driver = "gpio_driver"
-i2c_driver = "i2c_driver"
+task-slots = ["gpio_driver", "i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -73,6 +73,7 @@ priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
+task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver.interrupts]
 31 = 0b0000_0001        # I2C1 event
@@ -83,7 +84,6 @@ start = true
 73 = 0b0000_0100        # I2C3 error
 95 = 0b0000_1000        # I2C4 event
 96 = 0b0000_1000        # I2C4 error
-task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -264,7 +264,7 @@ where
                 if m.len() != 1 {
                     return Err(serde::de::Error::invalid_length(
                         m.len(),
-                        &"a single value",
+                        &"a single key-value pair",
                     ));
                 }
                 let (k, v) = m.iter().next().unwrap();

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -79,11 +79,7 @@ start = true
 features = ["lpc55"]
 uses = ["stage0", "rom", "syscon", "flash"]
 stacksize = 2048
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -52,11 +52,7 @@ priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-lpc55xpresso/app-a0.toml
+++ b/test/tests-lpc55xpresso/app-a0.toml
@@ -80,11 +80,7 @@ start = true
 features = ["itm", "lpc55"]
 uses = ["stage0", "rom", "syscon", "flash"]
 stacksize = 2048
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -79,11 +79,7 @@ start = true
 features = ["itm", "lpc55"]
 uses = ["stage0", "rom", "syscon", "flash"]
 stacksize = 2048
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -39,11 +39,7 @@ name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -40,11 +40,7 @@ priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -52,11 +52,7 @@ priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-stm32h7/app-h753.toml
+++ b/test/tests-stm32h7/app-h753.toml
@@ -52,11 +52,7 @@ priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"

--- a/test/tests-stm32h7/app-h7b3.toml
+++ b/test/tests-stm32h7/app-h7b3.toml
@@ -52,11 +52,7 @@ priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
-
-[tasks.suite.task-slots]
-assist = "assist"
-suite = "suite"
-runner = "runner"
+task-slots = ["assist", "suite", "runner"]
 
 [tasks.assist]
 path = "../test-assist"


### PR DESCRIPTION
This reduces duplication of task slots in `app.toml` in the common case, but keeps them explicit and preserves the option to do generic slot-to-task mapping.

I don't _think_ this will break Humility, but am not totally sure – @bcantrill, any idea?