### PR TITLE
Update humility install instructions in README.md

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -98,7 +98,7 @@ You will need:
   [official ARM binaries](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm).
 
 - The Hubris debugger, [Humility](https://github.com/oxidecomputer/humility):
-  - `cargo install --git ssh://git@github.com/oxidecomputer/humility.git`
+  - `cargo install --git ssh://git@github.com/oxidecomputer/humility.git --locked`
 
 ### Windows
 

--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -287,7 +287,7 @@ impl<'a> I2cController<'a> {
             .smbhen().set_bit()         // enable SMBus host mode
             .gcen().clear_bit()         // disable General Call
             .nostretch().clear_bit()    // must enable clock stretching
-            .errie().set_bit()          // emable Error Interrupt
+            .errie().set_bit()          // enable Error Interrupt
             .tcie().set_bit()           // enable Transfer Complete interrupt
             .stopie().clear_bit()       // disable Stop Detection interrupt
             .nackie().set_bit()         // enable NACK interrupt
@@ -701,7 +701,7 @@ impl<'a> I2cController<'a> {
             .gcen().clear_bit()         // disable General Call
             .nostretch().clear_bit()    // enable clock stretching
             .sbc().clear_bit()          // disable byte control 
-            .errie().set_bit()          // emable Error Interrupt
+            .errie().set_bit()          // enable Error Interrupt
             .tcie().set_bit()           // enable Transfer Complete interrupt
             .stopie().set_bit()         // enable Stop Detection interrupt
             .nackie().set_bit()         // enable NACK interrupt


### PR DESCRIPTION
The cargo install command ignores the Cargo.lock by default, we need to
explicitly pass `--locked` to cargo install to avoid changes to git
dependencies breaking hubris install.

See https://github.com/oxidecomputer/humility/issues/57 for details.

Also fixed two typos in comments.