### PR TITLE
README: Remove PR submission instructions handling private repo quirks.

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -55,11 +55,8 @@ probably also works on Illumos and Mac; if anyone would like to step up to
 maintain support and a continuous build for those architectures, we'd love the
 help.
 
-To submit changes for review, push them to a new branch in this repo (_not_ a
-separate GitHub fork) and submit a pull request to merge that branch into
-master.  (Pull requests from separate GitHub forks do not currently work.
-First, the pre-integration checks do not get run automatically in forks, so
-you'd have to enable Actions in your fork.
+To submit changes for review push them to a branch in a fork and submit a pull
+request to merge that branch into master.
 
 ## Prereqs
 


### PR DESCRIPTION
Now that the Hubris repo is public PRs should come from forks.

Fixes issue identified here: https://github.com/oxidecomputer/hubris/pull/324#issuecomment-991720140