### PR TITLE
hiffy: remove errant drv-stm32fx-rcc dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,6 @@ dependencies = [
  "drv-i2c-api",
  "drv-lpc55-gpio-api",
  "drv-spi-api",
- "drv-stm32fx-rcc",
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-i2c",
  "drv-stm32h7-rcc-api",
@@ -2356,16 +2355,6 @@ dependencies = [
  "drv-i2c-api",
  "drv-i2c-devices",
  "ringbuf",
- "userlib",
- "zerocopy",
-]
-
-[[package]]
-name = "task-spam"
-version = "0.1.0"
-dependencies = [
- "cortex-m-semihosting",
- "lpc55-pac",
  "userlib",
  "zerocopy",
 ]

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -96,7 +96,6 @@ task-slots = ["user_leds"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 3
-features = ["stm32f4"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -17,7 +17,6 @@ drv-stm32h7-i2c = {path = "../../drv/stm32h7-i2c", default-features = false, opt
 drv-stm32h7-rcc-api = {path = "../../drv/stm32h7-rcc-api", default-features = false, optional = true }
 drv-lpc55-gpio-api = {path = "../../drv/lpc55-gpio-api", optional = true}
 drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
-drv-stm32fx-rcc = {path = "../../drv/stm32fx-rcc", default-features = false, optional = true}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
 zerocopy = "0.3.0"
@@ -46,8 +45,6 @@ qspi = ["drv-gimlet-hf-api"]
 h743 = ["drv-stm32h7-rcc-api/h743", "drv-stm32h7-i2c/h743", "build-i2c/h743"]
 h753 = ["drv-stm32h7-rcc-api/h753", "drv-stm32h7-i2c/h753", "build-i2c/h753"]
 h7b3 = ["drv-stm32h7-rcc-api/h7b3", "drv-stm32h7-i2c/h7b3", "build-i2c/h7b3"]
-stm32f3 = ["drv-stm32fx-rcc/f3"]
-stm32f4 = ["drv-stm32fx-rcc/f4"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.


### PR DESCRIPTION
That's a binary, not a library, so it's not useful as a dependency. This
was producing a warning.