### PR TITLE
Bump zerocopy version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.3.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib"}
 abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false }
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib"}
 ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 # a target for `cargo xtask check`

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib"}
 ringbuf = {path = "../../lib/ringbuf" }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-onewire = {path = "../onewire"}
 drv-i2c-api = {path = "../i2c-api"}

--- a/drv/lpc55-gpio-api/Cargo.toml
+++ b/drv/lpc55-gpio-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 cfg-if = "0.1.10"
 

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 num-traits = { version = "0.2.12", default-features = false }

--- a/drv/lpc55-iocon-gen/Cargo.toml
+++ b/drv/lpc55-iocon-gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 quote = "1.0.9"
 cfg-if = "0.1.10"
 proc-macro2 = "1.0.9"

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -9,7 +9,7 @@ standalone = []
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 drv-lpc55-spi = {path = "../lpc55-spi"}

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 num-traits = { version = "0.2.12", default-features = false }

--- a/drv/lpc55-syscon-api/Cargo.toml
+++ b/drv/lpc55-syscon-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 # a target for `cargo xtask check`

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 num-traits = { version = "0.2.12", default-features = false }

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}

--- a/drv/onewire-devices/Cargo.toml
+++ b/drv/onewire-devices/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-onewire = {path = "../onewire"}
 

--- a/drv/onewire/Cargo.toml
+++ b/drv/onewire/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 # a target for `cargo xtask check`

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32f3 = { version = "0.13.0", optional = true, default-features = false }
 stm32f4 = { version = "0.13.0", optional = true, default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 [features]

--- a/drv/stm32fx-usart/Cargo.toml
+++ b/drv/stm32fx-usart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32f3 = { version = "0.13.2", features = ["stm32f303"], optional = true }
 stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 [features]

--- a/drv/stm32h7-gpio-api/Cargo.toml
+++ b/drv/stm32h7-gpio-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false }

--- a/drv/stm32h7-i2c/Cargo.toml
+++ b/drv/stm32h7-i2c/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib"}
 ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 stm32h7 = { version = "0.13.0", default-features = false }
 vcell = "0.1.2"
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 userlib = {path = "../../sys/userlib"}
 
 # a target for `cargo xtask check`

--- a/drv/stm32h7-rcc-api/Cargo.toml
+++ b/drv/stm32h7-rcc-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 byteorder = {version = "1.3", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 stm32h7 = { version = "0.13.0", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false}
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 vcell = "0.1.2"
 stm32h7 = { version = "0.13.0", default-features = false }

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api"}
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false}

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 # a target for `cargo xtask check`

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32f3 = { version = "0.13.0", features = ["stm32f303"], optional = true }
 stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
 lpc55-pac = { version = "0.3.0", optional = true }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", optional = true}
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", default-features = false, optional = true}

--- a/lib/hypocalls/Cargo.toml
+++ b/lib/hypocalls/Cargo.toml
@@ -11,7 +11,7 @@ standalone = []
 abi = {path = "../../sys/abi"}
 serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 num-derive = "0.3.0"
 lpc55_romapi = { path = "../../drv/lpc55-romapi" }

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -18,7 +18,7 @@ ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 hmac = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 cfg-if = "0.1.10"
 
 [package.metadata.build]

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default-features = false }
 serde = { version = "1.0.114", default-features = false, features = ["derive"] }

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -10,7 +10,7 @@ klog-itm = []
 
 [dependencies]
 abi = {path = "../abi"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 bitflags = "1.2.1"
 cfg-if = "0.1.10"

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -15,7 +15,7 @@ bstringify = "0.1.2"
 paste = "1"
 serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 #

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -19,7 +19,7 @@ drv-lpc55-gpio-api = {path = "../../drv/lpc55-gpio-api", optional = true}
 drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 serde = { version = "1.0.114", default-features = false }

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -9,7 +9,7 @@ userlib = {path = "../../sys/userlib"}
 hubris-num-tasks = {path = "../../sys/num-tasks"}
 ringbuf = {path = "../../lib/ringbuf" }
 num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -11,7 +11,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 cfg-if = "0.1.10"
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -11,7 +11,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 cfg-if = "0.1.10"
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 drv-onewire = {path = "../../drv/onewire"}

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 hubris-num-tasks = {path = "../../sys/num-tasks"}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 test-api = {path = "../test-api"}
 

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 hubris-num-tasks = {path = "../../sys/num-tasks"}
 test-api = {path = "../test-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
 [features]

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.3.0"
+zerocopy = "0.6.1"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 hubris-num-tasks = {path = "../../sys/num-tasks"}
 num-traits = { version = "0.2.12", default-features = false }


### PR DESCRIPTION
We were on 0.3.0, which was fine, but the new one is much better.

...and is kind of necessary for the Idol work.