### PR TITLE
Beginnings of IDL conversion using Idol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,8 @@ dependencies = [
  "cfg-if 0.1.10",
  "drv-lpc55-gpio-api",
  "drv-stm32h7-gpio-api",
+ "idol",
+ "idol-runtime",
  "lpc55-pac",
  "num-traits",
  "stm32f3",
@@ -903,6 +905,8 @@ dependencies = [
 name = "drv-user-leds-api"
 version = "0.1.0"
 dependencies = [
+ "abi",
+ "idol",
  "num-traits",
  "userlib",
  "zerocopy",
@@ -1226,6 +1230,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idol"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#ec1047cce1c35dad72162b102e9a8193f0f4572d"
+dependencies = [
+ "indexmap",
+ "quote",
+ "ron 0.7.0",
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "idol-runtime"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#ec1047cce1c35dad72162b102e9a8193f0f4572d"
+dependencies = [
+ "userlib",
+ "zerocopy",
+]
 
 [[package]]
 name = "indexmap"
@@ -1682,7 +1707,7 @@ dependencies = [
  "libm",
  "num-derive",
  "num-traits",
- "ron",
+ "ron 0.6.6",
  "serde",
  "serde_with",
 ]
@@ -1875,6 +1900,17 @@ name = "ron"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,7 @@ name = "drv-stm32h7-gpio-api"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "idol",
  "num-traits",
  "userlib",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ name = "drv-gimlet-hf-api"
 version = "0.1.0"
 dependencies = [
  "abi",
+ "idol",
  "num-traits",
  "userlib",
  "zerocopy",
@@ -544,9 +545,12 @@ dependencies = [
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-qspi",
  "drv-stm32h7-rcc-api",
+ "idol",
+ "idol-runtime",
  "num-traits",
  "stm32h7",
  "userlib",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,8 @@ name = "drv-stm32h7-rcc"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
+ "idol",
+ "idol-runtime",
  "num-traits",
  "stm32h7",
  "userlib",
@@ -836,6 +838,7 @@ name = "drv-stm32h7-rcc-api"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "idol",
  "num-traits",
  "userlib",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,8 +725,10 @@ name = "drv-spi-api"
 version = "0.1.0"
 dependencies = [
  "abi",
+ "idol",
  "num-traits",
  "userlib",
+ "zerocopy",
 ]
 
 [[package]]
@@ -866,6 +868,8 @@ dependencies = [
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-rcc-api",
  "drv-stm32h7-spi",
+ "idol",
+ "idol-runtime",
  "num-traits",
  "ringbuf",
  "stm32h7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,9 @@ opt-level = "z" # smaller optimizations
 
 [profile.dev]
 opt-level = 1 # no optimizations was just too painful in terms of flash size
+
+[patch."https://github.com/oxidecomputer/hubris".userlib]
+path = "sys/userlib"
+
+[patch."https://github.com/oxidecomputer/hubris".abi]
+path = "sys/abi"

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -18,3 +18,5 @@ target = "thumbv7em-none-eabihf"
 [features]
 standalone = []
 
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/gimlet-hf-api/build.rs
+++ b/drv/gimlet-hf-api/build.rs
@@ -3,13 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_target_board();
-
-    idol::server::build_server_support(
+    idol::client::build_client_stub(
         "../../idl/gimlet-hf.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
+        "client_stub.rs",
     )?;
-
     Ok(())
 }

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -6,19 +6,7 @@
 
 #![no_std]
 
-use core::cell::Cell;
 use userlib::*;
-use zerocopy::AsBytes;
-
-#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
-pub enum Operation {
-    ReadId = 1,
-    ReadStatus = 2,
-    BulkErase = 3,
-    PageProgram = 4,
-    Read = 5,
-    SectorErase = 6,
-}
 
 /// Errors that can be produced from the host flash server API.
 ///
@@ -30,135 +18,23 @@ pub enum HfError {
     ServerRestarted = 2,
 }
 
+impl From<HfError> for u16 {
+    fn from(rc: HfError) -> Self {
+        rc as u16
+    }
+}
+
 impl From<HfError> for u32 {
     fn from(rc: HfError) -> Self {
         rc as u32
     }
 }
 
-/// Errors that can be produced from the host flash server itself. This is a
-/// supserset of `HfError` including cases that should not be capable of
-/// occurring if the client is correct.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum InternalHfError {
-    Recoverable(HfError),
-    BadMessage,
-    MissingLease,
-    BadLease,
-}
-
-impl From<InternalHfError> for u32 {
-    fn from(rc: InternalHfError) -> Self {
-        match rc {
-            InternalHfError::Recoverable(e) => u32::from(e),
-            // These need to be larger than anything in HfError.
-            InternalHfError::BadMessage => 0x1000,
-            InternalHfError::MissingLease => 0x1001,
-            InternalHfError::BadLease => 0x1002,
-        }
+impl core::convert::TryFrom<u32> for HfError {
+    type Error = ();
+    fn try_from(rc: u32) -> Result<Self, Self::Error> {
+        Self::from_u32(rc).ok_or(())
     }
 }
 
-impl From<HfError> for InternalHfError {
-    fn from(e: HfError) -> Self {
-        Self::Recoverable(e)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct HostFlash(Cell<TaskId>);
-
-impl From<TaskId> for HostFlash {
-    fn from(t: TaskId) -> Self {
-        Self(Cell::new(t))
-    }
-}
-
-impl HostFlash {
-    /// Reads the 20-byte Device ID data from the host flash.
-    pub fn read_id(&self, out: &mut [u8; 20]) -> Result<(), HfError> {
-        let n = self.send(Operation::ReadId, &[], out, &[])?;
-        assert!(n == 20);
-        Ok(())
-    }
-
-    /// Reads the host flash chip's Status Register.
-    pub fn read_status(&self) -> Result<u8, HfError> {
-        let mut status = 0;
-        let n =
-            self.send(Operation::ReadStatus, &[], status.as_bytes_mut(), &[])?;
-        assert!(n == 1);
-        Ok(status)
-    }
-
-    /// Issues a bulk erase command to the host flash and waits for it to
-    /// complete. Note that this can take a rather long time.
-    pub fn bulk_erase(&self) -> Result<(), HfError> {
-        self.send(Operation::BulkErase, &[], &mut [], &[])?;
-        Ok(())
-    }
-
-    /// Issues a page program command to the host flash, writing `data` starting
-    /// at `address`.
-    pub fn page_program(
-        &self,
-        address: u32,
-        data: &[u8],
-    ) -> Result<(), HfError> {
-        self.send(
-            Operation::PageProgram,
-            address.as_bytes(),
-            &mut [],
-            &[Lease::from(data)],
-        )?;
-        Ok(())
-    }
-
-    /// Reads from the host flash starting at `address` into `data`.
-    pub fn read(&self, address: u32, data: &mut [u8]) -> Result<(), HfError> {
-        self.send(
-            Operation::Read,
-            address.as_bytes(),
-            &mut [],
-            &[Lease::from(data)],
-        )?;
-        Ok(())
-    }
-
-    /// Issues a sector erase command to the host flash, for the 64kiB sector
-    /// containing `address`.
-    pub fn sector_erase(&self, address: u32) -> Result<(), HfError> {
-        self.send(Operation::SectorErase, address.as_bytes(), &mut [], &[])?;
-        Ok(())
-    }
-
-    fn send(
-        &self,
-        operation: Operation,
-        outgoing: &[u8],
-        incoming: &mut [u8],
-        leases: &[Lease<'_>],
-    ) -> Result<usize, HfError> {
-        let task = self.0.get();
-
-        let (rc, rlen) =
-            sys_send(task, operation as u16, outgoing, incoming, leases);
-
-        // Detect truncated response messages.
-        assert!(rlen <= incoming.len());
-        // Detect error codes.
-        if rc == 0 {
-            Ok(rlen)
-        } else if let Some(g) = abi::extract_new_generation(rc) {
-            // Detect server death and update task, but do not retry.
-            self.0.set(TaskId::for_index_and_gen(task.index(), g));
-            Err(HfError::ServerRestarted)
-        } else if let Some(err) = HfError::from_u32(rc) {
-            Err(err)
-        } else {
-            // Unexpected error code from server is some sort of configuration
-            // error that we can't reasonably recover from.
-            panic!()
-        }
-    }
-}
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -15,9 +15,12 @@ cfg-if = "0.1.10"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+zerocopy = "0.6.1"
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 default = ["standalone"]

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib"}
 abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
+zerocopy = "0.6.1"
 
 # a target for `cargo xtask check`
 [package.metadata.build]
@@ -20,3 +21,6 @@ standalone = []
 [lib]
 test = false
 bench = false
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/spi-api/build.rs
+++ b/drv/spi-api/build.rs
@@ -3,13 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_target_board();
-
-    idol::server::build_server_support(
-        "../../idl/spi.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
-    )?;
-
+    idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -6,81 +6,31 @@
 
 #![no_std]
 
-use core::cell::Cell;
 use userlib::*;
-
-#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
-pub enum Operation {
-    Read = 0b01,
-    Write = 0b10,
-    Exchange = 0b11,
-    Lock = 0b100,
-    Release = 0b101,
-}
-
-impl Operation {
-    pub fn is_read(self) -> bool {
-        self == Self::Read || self == Self::Exchange
-    }
-
-    pub fn is_write(self) -> bool {
-        self == Self::Write || self == Self::Exchange
-    }
-}
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
 #[repr(u32)]
 pub enum SpiError {
-    /// Malformed response
-    BadResponse = 1,
-
-    /// Bad argument
-    BadArg = 2,
-
-    /// Bad lease argument
-    BadLeaseArg = 3,
-
-    /// Bad lease attributes
-    BadLeaseAttributes = 4,
-
-    /// Bad source lease
-    BadSource = 5,
-
-    /// Bad source lease attibutes
-    BadSourceAttributes = 6,
-
-    /// Bad Sink lease
-    BadSink = 7,
-
-    /// Bad Sink lease attributes
-    BadSinkAttributes = 8,
-
-    /// Short sink length
-    ShortSinkLength = 9,
-
-    /// Bad lease count
-    BadLeaseCount = 10,
-
     /// Transfer size is 0 or exceeds maximum
-    BadTransferSize = 11,
-
-    /// Could not transfer byte out of source
-    BadSourceByte = 12,
-
-    /// Could not transfer byte into sink
-    BadSinkByte = 13,
+    BadTransferSize = 1,
 
     /// Server restarted
-    ServerRestarted = 14,
+    ServerRestarted = 2,
 
     /// Release without successful Lock
-    NothingToRelease = 15,
+    NothingToRelease = 3,
 
     /// Attempt to operate device N when there is no device N, or an attempt to
     /// operate on _any other_ device when you've locked the controller to one.
     ///
     /// This is almost certainly a programming error on the client side.
-    BadDevice = 16,
+    BadDevice = 4,
+}
+
+impl From<SpiError> for u16 {
+    fn from(rc: SpiError) -> Self {
+        rc as u16
+    }
 }
 
 impl From<SpiError> for u32 {
@@ -89,153 +39,23 @@ impl From<SpiError> for u32 {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Spi(Cell<TaskId>);
-
-impl From<TaskId> for Spi {
-    fn from(t: TaskId) -> Self {
-        Self(Cell::new(t))
+impl core::convert::TryFrom<u32> for SpiError {
+    type Error = ();
+    fn try_from(x: u32) -> Result<Self, Self::Error> {
+        Self::from_u32(x).ok_or(())
     }
 }
 
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, zerocopy::AsBytes, FromPrimitive,
+)]
+#[repr(u8)]
+pub enum CsState {
+    NotAsserted = 0,
+    Asserted = 1,
+}
+
 impl Spi {
-    fn result(&self, task: TaskId, code: u32) -> Result<(), SpiError> {
-        if code != 0 {
-            //
-            // If we have an error code, check to see if it denotes a dearly
-            // departed task; if it does, in addition to returning a specific
-            // error code, we will set our task to be the new task as a courtesy.
-            //
-            if let Some(g) = abi::extract_new_generation(code) {
-                self.0.set(TaskId::for_index_and_gen(task.index(), g));
-                Err(SpiError::ServerRestarted)
-            } else {
-                Err(SpiError::from_u32(code).ok_or(SpiError::BadResponse)?)
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Returns a `SpiDevice` that will use this controller with a fixed
-    /// `device_index` for your convenience.
-    ///
-    /// This does _not_ check that `device_index` is valid!
-    pub fn device(&self, device_index: u8) -> SpiDevice {
-        SpiDevice::new(self.clone(), device_index)
-    }
-
-    /// Clock the given device, simultaneously shifting data out of `source` and
-    /// corresponding bytes into `sink`. (The two slices must be the same
-    /// length.)
-    ///
-    /// `device_index` must be in range for the server.
-    ///
-    /// If the controller is not locked, this will assert CS before driving the
-    /// clock and release it after.
-    pub fn exchange(
-        &self,
-        device_index: u8,
-        source: &[u8],
-        sink: &mut [u8],
-    ) -> Result<(), SpiError> {
-        let task = self.0.get();
-
-        let (code, _) = sys_send(
-            task,
-            Operation::Exchange as u16,
-            &[device_index],
-            &mut [],
-            &[Lease::from(source), Lease::from(sink)],
-        );
-
-        self.result(task, code)
-    }
-
-    /// Clock bytes from `source` into the given device.
-    ///
-    /// `device_index` must be in range for the server.
-    ///
-    /// If the controller is not locked, this will assert CS before driving the
-    /// clock and release it after.
-    pub fn write(
-        &self,
-        device_index: u8,
-        source: &[u8],
-    ) -> Result<(), SpiError> {
-        let task = self.0.get();
-
-        let (code, _) = sys_send(
-            task,
-            Operation::Write as u16,
-            &[device_index],
-            &mut [],
-            &[Lease::from(source)],
-        );
-
-        self.result(task, code)
-    }
-
-    /// Clock bytes from the given device into `dest`.
-    ///
-    /// `device_index` must be in range for the server.
-    ///
-    /// If the controller is not locked, this will assert CS before driving the
-    /// clock and release it after.
-    pub fn read(
-        &self,
-        device_index: u8,
-        dest: &mut [u8],
-    ) -> Result<(), SpiError> {
-        let task = self.0.get();
-
-        let (code, _) = sys_send(
-            task,
-            Operation::Read as u16,
-            &[device_index],
-            &mut [],
-            &[Lease::from(dest)],
-        );
-
-        self.result(task, code)
-    }
-
-    /// Locks the SPI controller in communication between your task and the
-    /// given device.
-    ///
-    /// If the server receives this message, it means no other task had locked
-    /// it. It will respond by only listening to messages from your task until
-    /// you send `release` or crash.
-    ///
-    /// During this time, the server will refuse any attempts to manipulate a
-    /// device other than the `device_index` given here.
-    ///
-    /// `assert_cs` can be used to force CS into the asserted (low) state, or
-    /// keep it deasserted. If you choose to assert it, then SPI transactions
-    /// via `read`/`write`/`exchange` will leave it asserted rather than
-    /// toggling it. You can call `lock` while the SPI controller is locked (by
-    /// you) to alter CS state, either to toggle it on its own, or to enable
-    /// per-transaction CS control again. However, if you call `lock` more than
-    /// once, you must keep the same `device_index`. To change devices, use
-    /// `release` first.
-    pub fn lock(
-        &self,
-        device_index: u8,
-        assert_cs: CsState,
-    ) -> Result<(), SpiError> {
-        let task = self.0.get();
-
-        let (code, _) = sys_send(
-            task,
-            Operation::Lock as u16,
-            &[device_index, assert_cs as u8],
-            &mut [],
-            &[],
-        );
-
-        self.result(task, code)
-    }
-
     /// Variant of `lock` that returns a resource management object that, when
     /// dropped, will issue `release`. This makes it much easier to do fallible
     /// operations while locked.
@@ -250,26 +70,13 @@ impl Spi {
         Ok(ControllerLock(self))
     }
 
-    /// Releases a previous lock on the SPI controller (by your task).
+    /// Returns a `SpiDevice` that will use this controller with a fixed
+    /// `device_index` for your convenience.
     ///
-    /// This will also deassert CS, if you had overridden it.
-    ///
-    /// If you call this without `lock` having succeeded, you will get
-    /// `SpiError::NothingToRelease`.
-    pub fn release(&self) -> Result<(), SpiError> {
-        let task = self.0.get();
-
-        let (code, _) =
-            sys_send(task, Operation::Release as u16, &[], &mut [], &[]);
-
-        self.result(task, code)
+    /// This does _not_ check that `device_index` is valid!
+    pub fn device(&self, device_index: u8) -> SpiDevice {
+        SpiDevice::new(self.clone(), device_index)
     }
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum CsState {
-    NotAsserted = 0,
-    Asserted = 1,
 }
 
 pub struct ControllerLock<'a>(&'a Spi);
@@ -375,3 +182,5 @@ impl SpiDevice {
         self.server.release()
     }
 }
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/stm32h7-gpio-api/Cargo.toml
+++ b/drv/stm32h7-gpio-api/Cargo.toml
@@ -9,6 +9,9 @@ zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
 # a target for `cargo xtask check`
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"

--- a/drv/stm32h7-gpio-api/build.rs
+++ b/drv/stm32h7-gpio-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/stm32h7-gpio.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/stm32h7-rcc-api/Cargo.toml
+++ b/drv/stm32h7-rcc-api/Cargo.toml
@@ -9,6 +9,9 @@ zerocopy = "0.6.1"
 byteorder = {version = "1.3", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
 [features]
 default = ["standalone"]
 standalone = ["h753"]

--- a/drv/stm32h7-rcc-api/build.rs
+++ b/drv/stm32h7-rcc-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/stm32h7-rcc.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/stm32h7-rcc/Cargo.toml
+++ b/drv/stm32h7-rcc/Cargo.toml
@@ -9,6 +9,10 @@ zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 stm32h7 = { version = "0.13.0", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 default = ["standalone"]

--- a/drv/stm32h7-rcc/build.rs
+++ b/drv/stm32h7-rcc/build.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::server::build_server_support(
+        "../../idl/stm32h7-rcc.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -15,9 +15,11 @@ drv-spi-api = {path = "../spi-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 stm32h7 = { version = "0.13.0", default-features = false }
 cfg-if = "0.1.10"
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 default = ["standalone"]

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -12,6 +12,7 @@
 #![no_main]
 
 use drv_spi_api::*;
+use idol_runtime::{Leased, LenLimit, RequestError, R, W};
 use ringbuf::*;
 
 #[cfg(feature = "h7b3")]
@@ -34,9 +35,9 @@ task_slot!(GPIO, gpio_driver);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    Start(Operation, (usize, usize)),
-    Tx(usize, u8),
-    Rx(usize, u8),
+    Start(SpiOperation, (u16, u16)),
+    Tx(u16, u8),
+    Rx(u16, u8),
     None,
 }
 
@@ -102,382 +103,350 @@ fn main() -> ! {
     //
     // We deactivate before activate to avoid pin clash if we previously crashed
     // with one of these activated.
-    let mut current_mux_index = 0;
+    let current_mux_index = 0;
     for opt in &CONFIG.mux_options[1..] {
         deactivate_mux_option(&opt, &gpio_driver);
     }
-    activate_mux_option(&CONFIG.mux_options[0], &gpio_driver, &spi);
+    activate_mux_option(
+        &CONFIG.mux_options[current_mux_index],
+        &gpio_driver,
+        &spi,
+    );
 
-    // If we get a lock request, we'll update this with the task ID. We'll then
-    // use it to decide between open and closed receive.
-    let mut lock_holder: Option<LockState> = None;
+    let mut server = ServerImpl {
+        spi,
+        gpio_driver,
+        lock_holder: None,
+        current_mux_index,
+    };
+    let mut incoming = [0u8; INCOMING_SIZE];
     loop {
-        // Note: we process the result of recv at the bottom of the loop.
-        let rr = hl::recv_from_without_notification(
-            // If we are locked, pass Some(taskid) to do a closed receive.
-            // Otherwise pass None to do an open receive.
-            lock_holder.map(|state| state.task),
-            // Our longest operation is two bytes (lock).
-            &mut [0; 2],
-            |op, msg| match op {
-                Operation::Lock => {
-                    let (&[devidx, cs_state], caller) =
-                        msg.fixed::<[u8; 2], ()>().ok_or(SpiError::BadArg)?;
-                    let cs_state = if cs_state == 0 {
-                        CsState::NotAsserted
-                    } else {
-                        CsState::Asserted
-                    };
-                    let cs_asserted = cs_state == CsState::Asserted;
-                    let devidx = usize::from(devidx);
+        idol_runtime::dispatch(&mut incoming, &mut server);
+    }
+}
 
-                    // If we are locked there are more rules:
-                    if let Some(lockstate) = &lock_holder {
-                        // The fact that we received this message _at all_ means
-                        // that the sender matched our closed receive, but just
-                        // in case we have a server logic bug, let's check.
-                        assert!(lockstate.task == caller.task_id());
-                        // The caller is not allowed to change the device index
-                        // once locked.
-                        if lockstate.device_index != devidx {
-                            return Err(SpiError::BadDevice);
-                        }
-                    }
+struct ServerImpl {
+    spi: spi_core::Spi,
+    gpio_driver: gpio_api::Gpio,
+    lock_holder: Option<LockState>,
+    current_mux_index: usize,
+}
 
-                    // OK! We are either (1) just locking now or (2) processing
-                    // a legal state change from the same sender.
+impl InOrderSpiImpl for ServerImpl {
+    fn recv_source(&self) -> Option<userlib::TaskId> {
+        self.lock_holder.map(|s| s.task)
+    }
 
-                    // Reject out-of-range devices.
-                    let device = CONFIG
-                        .devices
-                        .get(devidx)
-                        .ok_or(SpiError::BadDevice)?;
+    fn closed_recv_fail(&mut self) {
+        // Welp, someone had asked us to lock and then died. Release the
+        // lock.
+        self.lock_holder = None;
+    }
 
-                    // If we're asserting CS, we want to *reset* the pin. If
-                    // we're not, we want to *set* it. Because CS is active low.
-                    let pin_mask = device.cs.pin_mask;
-                    gpio_driver
-                        .set_reset(
-                            device.cs.port,
-                            if cs_asserted { 0 } else { pin_mask },
-                            if cs_asserted { pin_mask } else { 0 },
-                        )
-                        .unwrap();
-                    lock_holder = Some(LockState {
-                        task: caller.task_id(),
-                        device_index: devidx,
-                    });
-                    caller.reply(());
-                    Ok(())
-                }
-                Operation::Release => {
-                    let ((), caller) = msg.fixed().ok_or(SpiError::BadArg)?;
-                    if let Some(lockstate) = &lock_holder {
-                        // The fact that we were able to receive this means we
-                        // should be locked by the sender...but double check.
-                        assert!(lockstate.task == caller.task_id());
+    fn read(
+        &mut self,
+        _: &RecvMessage,
+        device_index: u8,
+        dest: LenLimit<Leased<W, [u8]>, 65535>,
+    ) -> Result<(), RequestError<SpiError>> {
+        self.ready_writey(SpiOperation::read, device_index, None, Some(dest))
+    }
+    fn write(
+        &mut self,
+        _: &RecvMessage,
+        device_index: u8,
+        src: LenLimit<Leased<R, [u8]>, 65535>,
+    ) -> Result<(), RequestError<SpiError>> {
+        self.ready_writey(SpiOperation::write, device_index, Some(src), None)
+    }
+    fn exchange(
+        &mut self,
+        _: &RecvMessage,
+        device_index: u8,
+        src: LenLimit<Leased<R, [u8]>, 65535>,
+        dest: LenLimit<Leased<W, [u8]>, 65535>,
+    ) -> Result<(), RequestError<SpiError>> {
+        self.ready_writey(
+            SpiOperation::exchange,
+            device_index,
+            Some(src),
+            Some(dest),
+        )
+    }
+    fn lock(
+        &mut self,
+        rm: &RecvMessage,
+        devidx: u8,
+        cs_state: CsState,
+    ) -> Result<(), RequestError<SpiError>> {
+        let cs_asserted = cs_state == CsState::Asserted;
+        let devidx = usize::from(devidx);
 
-                        let device = &CONFIG.devices[lockstate.device_index];
-
-                        // Deassert CS. If it wasn't asserted, this is a no-op.
-                        // If it was, this fixes that.
-                        gpio_driver
-                            .set_reset(device.cs.port, device.cs.pin_mask, 0)
-                            .unwrap();
-                        lock_holder = None;
-                        caller.reply(());
-                        Ok(())
-                    } else {
-                        Err(SpiError::NothingToRelease)
-                    }
-                }
-                // And now, the readey-writey options
-                Operation::Exchange | Operation::Read | Operation::Write => {
-                    // We can take varying numbers of leases, so we'll do lease
-                    // verification ourselves just below.
-                    let lease_count = msg.lease_count();
-                    let (&device_index, caller) =
-                        msg.fixed::<u8, ()>().ok_or(SpiError::BadArg)?;
-                    let device_index = usize::from(device_index);
-
-                    // If we are locked, check that the caller isn't mistakenly
-                    // addressing the wrong device.
-                    if let Some(lockstate) = &lock_holder {
-                        if lockstate.device_index != device_index {
-                            return Err(SpiError::BadDevice);
-                        }
-                    }
-
-                    // Reject out-of-range devices.
-                    let device = CONFIG
-                        .devices
-                        .get(device_index)
-                        .ok_or(SpiError::BadDevice)?;
-
-                    // Inspect the message and generate two `Option<Borrow>`s
-                    // and a transfer length. Note: the two borrows may refer to
-                    // the same buffer! See the `1` case below for details.
-                    let (data_src, data_dst, xfer_len) = match lease_count {
-                        1 => {
-                            // Caller has provided a single lease, which must
-                            // have different attributes depending on what
-                            // operation they've requested.
-                            let borrow = caller.borrow(0);
-                            let info =
-                                borrow.info().ok_or(SpiError::BadLeaseArg)?;
-
-                            // Note that the attributes _we_ require are the
-                            // inverse of the sense of the SPI operation, e.g.
-                            // to read from SPI we must be able to _write_ the
-                            // lease, and vice versa.
-                            let required_attributes = match op {
-                                Operation::Read => LeaseAttributes::WRITE,
-                                Operation::Write => LeaseAttributes::READ,
-                                _ => {
-                                    LeaseAttributes::WRITE
-                                        | LeaseAttributes::READ
-                                }
-                            };
-
-                            if !info.attributes.contains(required_attributes) {
-                                return Err(SpiError::BadLeaseAttributes);
-                            }
-
-                            let read_borrow = if op.is_write() {
-                                Some(borrow.clone())
-                            } else {
-                                None
-                            };
-                            let write_borrow =
-                                if op.is_read() { Some(borrow) } else { None };
-
-                            (read_borrow, write_borrow, (info.len, info.len))
-                        }
-                        2 if op == Operation::Exchange => {
-                            // Caller has provided two leases, the first as a
-                            // data source and the second as a data sink. This
-                            // is only legal if we are both transmitting and
-                            // receiving. The transmit buffer cannot be larger
-                            // than the receive buffer; for any bytes for which
-                            // the receive buffer exceeds the transmit buffer,
-                            // a zero byte will be put on the wire.
-                            let src_borrow = caller.borrow(0);
-                            let src_info =
-                                src_borrow.info().ok_or(SpiError::BadSource)?;
-
-                            if !src_info
-                                .attributes
-                                .contains(LeaseAttributes::READ)
-                            {
-                                return Err(SpiError::BadSourceAttributes);
-                            }
-
-                            let dst_borrow = caller.borrow(1);
-                            let dst_info =
-                                dst_borrow.info().ok_or(SpiError::BadSink)?;
-
-                            if !dst_info
-                                .attributes
-                                .contains(LeaseAttributes::WRITE)
-                            {
-                                return Err(SpiError::BadSinkAttributes);
-                            }
-
-                            if dst_info.len < src_info.len {
-                                return Err(SpiError::ShortSinkLength);
-                            }
-
-                            (
-                                Some(src_borrow),
-                                Some(dst_borrow),
-                                (dst_info.len, src_info.len),
-                            )
-                        }
-                        _ => return Err(SpiError::BadLeaseCount),
-                    };
-
-                    // That routine should have returned at least one borrow.
-                    // Here's an assert that takes fewer text bytes than assert.
-                    if data_src.is_none() && data_dst.is_none() {
-                        panic!()
-                    }
-
-                    // Due to driver limitations we will only move up to 64kiB
-                    // per transaction. It would be worth lifting this
-                    // limitation, maybe. Doing so would require managing data
-                    // in 64kiB chunks (because the peripheral is 16-bit) and
-                    // using the "reload" facility on the peripheral.
-                    //
-                    // Zero-byte SPI transactions don't make sense and we'll
-                    // decline them.
-                    if xfer_len.0 == 0 || xfer_len.0 >= 0x1_0000 {
-                        return Err(SpiError::BadTransferSize);
-                    }
-
-                    // We have a reasonable-looking request containing (a)
-                    // reasonable-looking lease(s). This is our commit point.
-                    ringbuf_entry!(Trace::Start(op, xfer_len));
-
-                    // Switch the mux to the requested port.
-                    if device.mux_index != current_mux_index {
-                        deactivate_mux_option(
-                            &CONFIG.mux_options[current_mux_index],
-                            &gpio_driver,
-                        );
-                        activate_mux_option(
-                            &CONFIG.mux_options[device.mux_index],
-                            &gpio_driver,
-                            &spi,
-                        );
-                        // Remember this for later to avoid unnecessary
-                        // switching.
-                        current_mux_index = device.mux_index;
-                    }
-
-                    // Make sure SPI is on.
-                    spi.enable(xfer_len.0 as u16);
-
-                    // Load transfer count and start the state machine. At this
-                    // point we _have_ to move the specified number of bytes
-                    // through (or explicitly cancel, but we don't).
-                    spi.start();
-
-                    // As you might expect, we will work from byte 0 to the end
-                    // of each buffer. There are two complications:
-                    //
-                    // 1. Transmit and receive can be at different positions --
-                    //    transmit will tend to lead receive, because the SPI
-                    //    unit contains FIFOs.
-                    //
-                    // 2. We're only keeping track of position in the buffers
-                    //    we're using: both tx and rx are `Option<(Borrow,
-                    //    usize)>`.
-
-                    // Tack a position field onto whichever borrows actually
-                    // exist.
-                    let mut tx = data_src.map(|borrow| (borrow, 0));
-                    let mut rx = data_dst.map(|borrow| (borrow, 0));
-
-                    // Enable interrupt on the conditions we're interested in.
-                    spi.enable_transfer_interrupts();
-
-                    spi.clear_eot();
-
-                    // We're doing this! Check if we need to control CS.
-                    let cs_override = lock_holder.is_some();
-                    if !cs_override {
-                        gpio_driver
-                            .set_reset(device.cs.port, 0, device.cs.pin_mask)
-                            .unwrap();
-                    }
-
-                    // While work remains, we'll attempt to move up to one byte
-                    // in each direction, sleeping if we can do neither.
-                    while tx.is_some() || rx.is_some() {
-                        // Entering RECV to check for interrupts is not free, so
-                        // we only do it if we've filled the TX FIFO and emptied
-                        // the RX and repeating this loop would just burn power
-                        // and CPU. If there is any potential value to repeating
-                        // the loop immediately, we'll set this flag.
-                        let mut made_progress = false;
-
-                        if let Some((tx_data, tx_pos)) = &mut tx {
-                            while spi.can_tx_frame() {
-                                // If our position is less than our tx len,
-                                // transfer a byte from caller to TX FIFO --
-                                // otherwise put a dummy byte on the wire
-                                let byte: u8 = if *tx_pos < xfer_len.1 {
-                                    tx_data
-                                        .read_at(*tx_pos)
-                                        .ok_or(SpiError::BadSourceByte)?
-                                } else {
-                                    0u8
-                                };
-
-                                ringbuf_entry!(Trace::Tx(*tx_pos, byte));
-                                spi.send8(byte);
-                                *tx_pos += 1;
-                                made_progress = true;
-
-                                // If we have _just_ finished...
-                                if *tx_pos == xfer_len.0 {
-                                    // We will finish transmitting well before
-                                    // we're done receiving, so stop getting
-                                    // interrupt notifications for transmit
-                                    // space available during that time.
-                                    spi.disable_can_tx_interrupt();
-                                    tx = None;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if let Some((rx_data, rx_pos)) = &mut rx {
-                            if spi.can_rx_byte() {
-                                // Transfer byte from RX FIFO to caller.
-                                let r = spi.recv8();
-                                rx_data
-                                    .write_at(*rx_pos, r)
-                                    .ok_or(SpiError::BadSinkByte)?;
-                                ringbuf_entry!(Trace::Rx(*rx_pos, r));
-                                *rx_pos += 1;
-
-                                if *rx_pos == xfer_len.0 {
-                                    rx = None;
-                                }
-
-                                made_progress = true;
-                            }
-                        }
-
-                        if !made_progress {
-                            // Allow the controller interrupt to post to our
-                            // notification set.
-                            sys_irq_control(IRQ_MASK, true);
-                            // Wait for our notification set to get, well, set.
-                            sys_recv_closed(&mut [], IRQ_MASK, TaskId::KERNEL)
-                                .expect("kernel died?");
-                        }
-                    }
-
-                    // Wait for the final EOT interrupt to ensure we're really
-                    // done before returning to the client
-                    loop {
-                        sys_irq_control(IRQ_MASK, true);
-                        sys_recv_closed(&mut [], IRQ_MASK, TaskId::KERNEL)
-                            .expect("kernel died?");
-
-                        if spi.check_eot() {
-                            spi.clear_eot();
-                            break;
-                        }
-                    }
-
-                    // Wrap up the transfer and restore things to a reasonable
-                    // state.
-                    spi.end();
-
-                    // Deassert (set) CS.
-                    if !cs_override {
-                        gpio_driver
-                            .set_reset(device.cs.port, device.cs.pin_mask, 0)
-                            .unwrap();
-                    }
-
-                    // As we're done with the borrows, we can now resume the
-                    // caller.
-                    caller.reply(());
-
-                    Ok(())
-                }
-            },
-        );
-
-        if rr.is_err() {
-            // Welp, someone had asked us to lock and then died. Release the
-            // lock.
-            lock_holder = None;
+        // If we are locked there are more rules:
+        if let Some(lockstate) = &self.lock_holder {
+            // The fact that we received this message _at all_ means
+            // that the sender matched our closed receive, but just
+            // in case we have a server logic bug, let's check.
+            assert!(lockstate.task == rm.sender);
+            // The caller is not allowed to change the device index
+            // once locked.
+            if lockstate.device_index != devidx {
+                return Err(SpiError::BadDevice.into());
+            }
         }
+
+        // OK! We are either (1) just locking now or (2) processing
+        // a legal state change from the same sender.
+
+        // Reject out-of-range devices.
+        let device = CONFIG.devices.get(devidx).ok_or(SpiError::BadDevice)?;
+
+        // If we're asserting CS, we want to *reset* the pin. If
+        // we're not, we want to *set* it. Because CS is active low.
+        let pin_mask = device.cs.pin_mask;
+        self.gpio_driver
+            .set_reset(
+                device.cs.port,
+                if cs_asserted { 0 } else { pin_mask },
+                if cs_asserted { pin_mask } else { 0 },
+            )
+            .unwrap();
+        self.lock_holder = Some(LockState {
+            task: rm.sender,
+            device_index: devidx,
+        });
+        Ok(())
+    }
+
+    fn release(
+        &mut self,
+        rm: &RecvMessage,
+    ) -> Result<(), RequestError<SpiError>> {
+        if let Some(lockstate) = &self.lock_holder {
+            // The fact that we were able to receive this means we
+            // should be locked by the sender...but double check.
+            assert!(lockstate.task == rm.sender);
+
+            let device = &CONFIG.devices[lockstate.device_index];
+
+            // Deassert CS. If it wasn't asserted, this is a no-op.
+            // If it was, this fixes that.
+            self.gpio_driver
+                .set_reset(device.cs.port, device.cs.pin_mask, 0)
+                .unwrap();
+            self.lock_holder = None;
+            Ok(())
+        } else {
+            Err(SpiError::NothingToRelease.into())
+        }
+    }
+}
+
+impl ServerImpl {
+    fn ready_writey(
+        &mut self,
+        op: SpiOperation,
+        device_index: u8,
+        data_src: Option<LenLimit<Leased<R, [u8]>, 65535>>,
+        data_dest: Option<LenLimit<Leased<W, [u8]>, 65535>>,
+    ) -> Result<(), RequestError<SpiError>> {
+        let device_index = usize::from(device_index);
+
+        // If we are locked, check that the caller isn't mistakenly
+        // addressing the wrong device.
+        if let Some(lockstate) = &self.lock_holder {
+            if lockstate.device_index != device_index {
+                return Err(SpiError::BadDevice.into());
+            }
+        }
+
+        // Reject out-of-range devices.
+        let device = CONFIG
+            .devices
+            .get(device_index)
+            .ok_or(SpiError::BadDevice)?;
+
+        // At least one lease must be provided. A failure here indicates that
+        // the server stub calling this common routine is broken, not a client
+        // mistake.
+        if data_src.is_none() && data_dest.is_none() {
+            panic!();
+        }
+
+        // Get the required transfer lengths in the src and dest directions.
+        let src_len = data_src
+            .as_ref()
+            .map(|leased| LenLimit::len_as_u16(&leased))
+            .unwrap_or(0);
+        let dest_len = data_dest
+            .as_ref()
+            .map(|leased| LenLimit::len_as_u16(&leased))
+            .unwrap_or(0);
+        let overall_len = src_len.max(dest_len);
+
+        // Zero-byte SPI transactions don't make sense and we'll
+        // decline them.
+        if overall_len == 0 {
+            return Err(SpiError::BadTransferSize.into());
+        }
+
+        // We have a reasonable-looking request containing reasonable-looking
+        // lease(s). This is our commit point.
+        ringbuf_entry!(Trace::Start(op, (src_len, dest_len)));
+
+        // Switch the mux to the requested port.
+        if device.mux_index != self.current_mux_index {
+            deactivate_mux_option(
+                &CONFIG.mux_options[self.current_mux_index],
+                &self.gpio_driver,
+            );
+            activate_mux_option(
+                &CONFIG.mux_options[device.mux_index],
+                &self.gpio_driver,
+                &self.spi,
+            );
+            // Remember this for later to avoid unnecessary
+            // switching.
+            self.current_mux_index = device.mux_index;
+        }
+
+        // Make sure SPI is on.
+        //
+        // Due to driver limitations we will only move up to 64kiB
+        // per transaction. It would be worth lifting this
+        // limitation, maybe. Doing so would require managing data
+        // in 64kiB chunks (because the peripheral is 16-bit) and
+        // using the "reload" facility on the peripheral.
+        self.spi.enable(overall_len);
+
+        // Load transfer count and start the state machine. At this
+        // point we _have_ to move the specified number of bytes
+        // through (or explicitly cancel, but we don't).
+        self.spi.start();
+
+        // As you might expect, we will work from byte 0 to the end
+        // of each buffer. There are two complications:
+        //
+        // 1. Transmit and receive can be at different positions --
+        //    transmit will tend to lead receive, because the SPI
+        //    unit contains FIFOs.
+        //
+        // 2. We're only keeping track of position in the buffers
+        //    we're using: both tx and rx are `Option<(Borrow,
+        //    u16)>`.
+
+        // Tack a position field onto whichever borrows actually
+        // exist.
+        let mut tx = data_src.map(|borrow| (borrow, 0));
+        let mut rx = data_dest.map(|borrow| (borrow, 0));
+
+        // Enable interrupt on the conditions we're interested in.
+        self.spi.enable_transfer_interrupts();
+
+        self.spi.clear_eot();
+
+        // We're doing this! Check if we need to control CS.
+        let cs_override = self.lock_holder.is_some();
+        if !cs_override {
+            self.gpio_driver
+                .set_reset(device.cs.port, 0, device.cs.pin_mask)
+                .unwrap();
+        }
+
+        // While work remains, we'll attempt to move up to one byte
+        // in each direction, sleeping if we can do neither.
+        while tx.is_some() || rx.is_some() {
+            // Entering RECV to check for interrupts is not free, so
+            // we only do it if we've filled the TX FIFO and emptied
+            // the RX and repeating this loop would just burn power
+            // and CPU. If there is any potential value to repeating
+            // the loop immediately, we'll set this flag.
+            let mut made_progress = false;
+
+            if let Some((tx_data, tx_pos)) = &mut tx {
+                while self.spi.can_tx_frame() {
+                    // If our position is less than our tx len,
+                    // transfer a byte from caller to TX FIFO --
+                    // otherwise put a dummy byte on the wire
+                    let byte: u8 = if *tx_pos < src_len {
+                        tx_data
+                            .read_at(usize::from(*tx_pos))
+                            .ok_or(RequestError::went_away())?
+                    } else {
+                        0u8
+                    };
+
+                    ringbuf_entry!(Trace::Tx(*tx_pos, byte));
+                    self.spi.send8(byte);
+                    *tx_pos += 1;
+                    made_progress = true;
+
+                    // If we have _just_ finished...
+                    if *tx_pos == src_len {
+                        // We will finish transmitting well before
+                        // we're done receiving, so stop getting
+                        // interrupt notifications for transmit
+                        // space available during that time.
+                        self.spi.disable_can_tx_interrupt();
+                        tx = None;
+                        break;
+                    }
+                }
+            }
+
+            if let Some((rx_data, rx_pos)) = &mut rx {
+                if self.spi.can_rx_byte() {
+                    // Transfer byte from RX FIFO to caller.
+                    let b = self.spi.recv8();
+                    rx_data
+                        .write_at(usize::from(*rx_pos), b)
+                        .map_err(|_| RequestError::went_away())?;
+                    ringbuf_entry!(Trace::Rx(*rx_pos, b));
+                    *rx_pos += 1;
+
+                    if *rx_pos == dest_len {
+                        rx = None;
+                    }
+
+                    made_progress = true;
+                }
+            }
+
+            if !made_progress {
+                // Allow the controller interrupt to post to our
+                // notification set.
+                sys_irq_control(IRQ_MASK, true);
+                // Wait for our notification set to get, well, set.
+                sys_recv_closed(&mut [], IRQ_MASK, TaskId::KERNEL)
+                    .expect("kernel died?");
+            }
+        }
+
+        // Wait for the final EOT interrupt to ensure we're really
+        // done before returning to the client
+        loop {
+            sys_irq_control(IRQ_MASK, true);
+            sys_recv_closed(&mut [], IRQ_MASK, TaskId::KERNEL)
+                .expect("kernel died?");
+
+            if self.spi.check_eot() {
+                self.spi.clear_eot();
+                break;
+            }
+        }
+
+        // Wrap up the transfer and restore things to a reasonable
+        // state.
+        self.spi.end();
+
+        // Deassert (set) CS.
+        if !cs_override {
+            self.gpio_driver
+                .set_reset(device.cs.port, device.cs.pin_mask, 0)
+                .unwrap();
+        }
+
+        Ok(())
     }
 }
 
@@ -998,3 +967,5 @@ cfg_if::cfg_if! {
         compile_error!("unsupported board-controller combination");
     }
 }
+
+include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
+abi = {path = "../../sys/abi"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 
@@ -17,3 +18,6 @@ target = "thumbv7em-none-eabihf"
 [lib]
 test = false
 bench = false
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/user-leds-api/build.rs
+++ b/drv/user-leds-api/build.rs
@@ -3,13 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_target_board();
-
-    idol::server::build_server_support(
+    idol::client::build_client_stub(
         "../../idl/user-leds.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
+        "client_stub.rs",
     )?;
-
     Ok(())
 }

--- a/drv/user-leds-api/src/lib.rs
+++ b/drv/user-leds-api/src/lib.rs
@@ -6,86 +6,20 @@
 
 #![no_std]
 
-use core::cell::Cell;
-use zerocopy::AsBytes;
-
 use userlib::*;
-
-#[derive(FromPrimitive)]
-enum Op {
-    On = 1,
-    Off = 2,
-    Toggle = 3,
-}
-
-#[derive(Clone, Debug)]
-pub struct UserLeds(Cell<TaskId>);
-
-impl From<TaskId> for UserLeds {
-    fn from(t: TaskId) -> Self {
-        Self(Cell::new(t))
-    }
-}
 
 #[derive(Copy, Clone, Debug)]
 pub enum LedError {
-    Unsupported = 1,
-    NoSuchLed = 2,
+    NotPresent = 1,
 }
 
 impl From<u32> for LedError {
     fn from(x: u32) -> Self {
         match x {
-            1 => LedError::Unsupported,
-            2 => LedError::NoSuchLed,
+            1 => LedError::NotPresent,
             _ => panic!(),
         }
     }
 }
 
-impl UserLeds {
-    /// Turns an LED on by index.
-    pub fn led_on(&self, index: usize) -> Result<(), LedError> {
-        #[derive(AsBytes)]
-        #[repr(C)]
-        struct On(usize);
-
-        impl hl::Call for On {
-            const OP: u16 = Op::On as u16;
-            type Response = ();
-            type Err = LedError;
-        }
-
-        hl::send_with_retry(&self.0, &On(index))
-    }
-
-    /// Turns an LED off by index.
-    pub fn led_off(&self, index: usize) -> Result<(), LedError> {
-        #[derive(AsBytes)]
-        #[repr(C)]
-        struct Off(usize);
-
-        impl hl::Call for Off {
-            const OP: u16 = Op::Off as u16;
-            type Response = ();
-            type Err = LedError;
-        }
-
-        hl::send_with_retry(&self.0, &Off(index))
-    }
-
-    /// Toggles an LED by index.
-    pub fn led_toggle(&self, index: usize) -> Result<(), LedError> {
-        #[derive(AsBytes)]
-        #[repr(C)]
-        struct Tog(usize);
-
-        impl hl::Call for Tog {
-            const OP: u16 = Op::Toggle as u16;
-            type Response = ();
-            type Err = LedError;
-        }
-
-        hl::send_with_retry(&self.0, &Tog(index))
-    }
-}
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -13,9 +13,11 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-gpio-api = {path = "../stm32h7-gpio-api", optional = true}
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", default-features = false, optional = true}
 cfg-if = "0.1.10"
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 default = ["standalone"]

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -1,0 +1,61 @@
+// Gimlet Host Flash API
+
+Interface(
+    name: "HostFlash",
+    ops: {
+        "read_id": (
+            args: {},
+            reply: Result(
+                ok: "[u8; 20]",
+                err: CLike("HfError"),
+            ),
+        ),
+        "read_status": (
+            args: {},
+            reply: Result(
+                ok: "u8",
+                err: CLike("HfError"),
+            ),
+        ),
+        "bulk_erase": (
+            args: {},
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "page_program": (
+            args: {
+                "address": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "read": (
+            args: {
+                "address": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", write: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "sector_erase": (
+            args: {
+                "address": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+    },
+)

--- a/idl/spi.idol
+++ b/idl/spi.idol
@@ -1,0 +1,70 @@
+// SPI server IPC interface
+
+
+Interface(
+    name: "Spi",
+    ops: {
+        "read": (
+            doc: "Read bytes from device `device_index` into `sink`, shifting out 1s.",
+            args: {
+                "device_index": "u8",
+            },
+            leases: {
+                "sink": (type: "[u8]", write: true, max_len: Some(65535)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("SpiError"),
+            ),
+        ),
+        "write": (
+            doc: "Write bytes from `source` and to device `device_index`, ignoring whatever's sent back.",
+            args: {
+                "device_index": "u8",
+            },
+            leases: {
+                "source": (type: "[u8]", read: true, max_len: Some(65535)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("SpiError"),
+            ),
+        ),
+        "exchange": (
+            doc: "Simultaneously write bytes from `source` and read bytes into `sink` using device `device_index`.",
+            args: {
+                "device_index": "u8",
+            },
+            leases: {
+                "source": (type: "[u8]", read: true, max_len: Some(65535)),
+                "sink": (type: "[u8]", write: true, max_len: Some(65535)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("SpiError"),
+            ),
+        ),
+        "lock": (
+            doc: "Take exclusive control of this SPI controller for talking to device `device_index`.",
+            args: {
+                "device_index": "u8",
+                "cs_state": (
+                    type: "CsState",
+                    recv: FromPrimitive("u8"),
+                ),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("SpiError"),
+            ),
+        ),
+        "release": (
+            doc: "Release a previously acquired lock.",
+            args: {},
+            reply: Result(
+                ok: "()",
+                err: CLike("SpiError"),
+            ),
+        ),
+    },
+)

--- a/idl/stm32h7-gpio.idol
+++ b/idl/stm32h7-gpio.idol
@@ -1,0 +1,63 @@
+// STM32H7 GPIO IPC API
+
+Interface(
+    name: "Gpio",
+    ops: {
+        "configure_raw": (
+            args: {
+                "port": (
+                    type: "Port",
+                    recv: FromPrimitive("u8"),
+                ),
+                "pins": "u16",
+                "packed_attributes": "u16",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("GpioError"),
+            ),
+            idempotent: true,
+        ),
+        "set_reset": (
+            args: {
+                "port": (
+                    type: "Port",
+                    recv: FromPrimitive("u8"),
+                ),
+                "set_pins": "u16",
+                "reset_pins": "u16",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("GpioError"),
+            ),
+            idempotent: true,
+        ),
+        "read_input": (
+            args: {
+                "port": (
+                    type: "Port",
+                    recv: FromPrimitive("u8"),
+                ),
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("GpioError"),
+            ),
+            idempotent: true,
+        ),
+        "toggle": (
+            args: {
+                "port": (
+                    type: "Port",
+                    recv: FromPrimitive("u8"),
+                ),
+                "pins": "u16",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("GpioError"),
+            ),
+        ),
+    },
+)

--- a/idl/stm32h7-rcc.idol
+++ b/idl/stm32h7-rcc.idol
@@ -1,0 +1,47 @@
+// STM32H7 RCC IPC API
+
+Interface(
+    name: "Rcc",
+    ops: {
+        "enable_clock_raw": (
+            args: {
+                "peripheral": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("RccError"),
+            ),
+            idempotent: true,
+        ),
+        "disable_clock_raw": (
+            args: {
+                "peripheral": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("RccError"),
+            ),
+            idempotent: true,
+        ),
+        "enter_reset_raw": (
+            args: {
+                "peripheral": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("RccError"),
+            ),
+            idempotent: true,
+        ),
+        "leave_reset_raw": (
+            args: {
+                "peripheral": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("RccError"),
+            ),
+            idempotent: true,
+        ),
+    },
+)

--- a/idl/user-leds.idol
+++ b/idl/user-leds.idol
@@ -1,0 +1,37 @@
+// User LED blinky API
+
+Interface(
+    name: "UserLeds",
+    ops: {
+        "led_on": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("LedError"),
+            ),
+            idempotent: true,
+        ),
+        "led_off": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("LedError"),
+            ),
+            idempotent: true,
+        ),
+        "led_toggle": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("LedError"),
+            ),
+            idempotent: true,
+        ),
+    },
+)

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -155,7 +155,6 @@ pub(crate) fn qspi_read_id(
     _data: &[u8],
     rval: &mut [u8],
 ) -> Result<usize, Failure> {
-    use core::convert::TryInto;
     use drv_gimlet_hf_api as hf;
 
     if rval.len() < 20 {
@@ -163,7 +162,8 @@ pub(crate) fn qspi_read_id(
     }
 
     let server = hf::HostFlash::from(HF.get_task_id());
-    func_err(server.read_id((&mut rval[..20]).try_into().unwrap()))?;
+    let id = func_err(server.read_id())?;
+    rval[..20].copy_from_slice(&id);
     Ok(20)
 }
 

--- a/task/pong/src/main.rs
+++ b/task/pong/src/main.rs
@@ -42,7 +42,7 @@ pub fn main() -> ! {
                         current = current + 1;
                         break;
                     }
-                    Err(drv_user_leds_api::LedError::NoSuchLed) => {
+                    Err(drv_user_leds_api::LedError::NotPresent) => {
                         current = 0;
                     }
                     _ => {


### PR DESCRIPTION
This converts most of the IPC interactions in the Gimlet image to use Idol.

Skipped for now:
- stm32h7-gpio: by accident
- i2c: on purpose to land this faster.