### PR TITLE
WIP on RAM ECC driver - Open Questions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-stm32h7-ecc"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "stm32h7",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-stm32h7-gpio"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "drv/stm32fx-rcc",
     "drv/stm32fx-usart",
 
+    "drv/stm32h7-ecc",
     "drv/stm32h7-gpio",
     "drv/stm32h7-gpio-api",
     "drv/stm32h7-rcc",

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -55,6 +55,15 @@ requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
 start = true
 
+[tasks.ecc_driver]
+path = "../../drv/stm32h7-ecc"
+name = "drv-stm32h7-ecc"
+features = ["h753"]
+priority = 1
+requires = {flash = 1024, ram = 1024}
+interrupts = { 145 = 1 }
+start = true
+
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
 name = "drv-stm32h7-gpio"

--- a/drv/stm32h7-ecc/Cargo.toml
+++ b/drv/stm32h7-ecc/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "drv-stm32h7-ecc"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+zerocopy = "0.3.0"
+num-traits = { version = "0.2.12", default-features = false }
+stm32h7 = { version = "0.13.0" }
+
+[features]
+default = ["standalone"]
+standalone = [ "h753" ]
+h743 = ["stm32h7/stm32h743"]
+h753 = ["stm32h7/stm32h753"]
+h7b3 = ["stm32h7/stm32h7b3"]
+
+# a target for `cargo xtask check`
+[package.metadata.build]
+target = "thumbv7em-none-eabihf"
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-stm32h7-ecc"
+test = false
+bench = false

--- a/drv/stm32h7-ecc/src/main.rs
+++ b/drv/stm32h7-ecc/src/main.rs
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A driver for the STM32H7 ECC management
+
+#![no_std]
+#![no_main]
+
+use userlib::*;
+
+#[cfg(feature = "h743")]
+use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
+#[cfg(feature = "h7b3")]
+use stm32h7::stm32h7b3 as device;
+
+#[export_name = "main"]
+fn main() -> ! {
+    init();
+
+    sys_irq_control(1, true);
+
+    loop {
+        let _ = sys_recv_closed(&mut [], 1, TaskId::KERNEL);
+
+        // There are three types of errors to handle. They fit into two
+        // categories - single and double error.
+
+        // If the error is in an address range we don't care about, we can
+        // ignore it (i.e. if the kernel or a task isn't mapped to that region)
+
+        // Single error:
+        // SEDCF: ECC single error detected and corrected flag
+        // We can recover by re-writing the same data back to that address.
+        // This will be a kernel concern as we'd need access to the full
+        // address space to read an address and re-write to it
+
+        // DEBWDF: ECC double error on byte write (BW) detected flag
+        // DEDF: ECC double error detected flag
+        // We cannot recover by re-writing the same data back to that address.
+        // We need to get it from a source of truth or declare it lost.
+
+        // If it's in a task .data region - we can rewrite that memory with the
+        // correct data from flash, and restart the task as a precaution.
+        // If it's in a task stack region - we can restart the task, after
+        // which we don't care what we lost from that address.
+
+        // If it's in kernel .data region - we could rewrite that memory with
+        // the correct data from flash, though might choose to reboot the
+        // machine instead.
+        // If it's in the kernel stack region - rebooting the machine may be
+        // the only safe option.
+    }
+}
+
+// Enable the interrupts for error correction and detection
+// Currently only using DTCM so using ECC monitors 3 and 4
+fn init() {
+    // Clear the RAM ECC status register flags for monitors 3 and 4
+    let ramecc1 = unsafe { &*device::RAMECC1::ptr() };
+    ramecc1.m3sr.modify(|_, w| { w.debwdf().clear_bit().dedf().clear_bit().sedcf().clear_bit() });
+    ramecc1.m4sr.modify(|_, w| { w.debwdf().clear_bit().dedf().clear_bit().sedcf().clear_bit() });
+
+    // Next activate ECC error latching and interrupts for monitors 3 and 4.
+    // ECCELEN: ECC error latching enable - capture context for ECC error generated
+    // ECCDEBWIE: ECC double error on byte write (BW) interrupt enable
+    // ECCDEIE: ECC double error interrupt enable
+    // ECCSEIE: ECC single error interrupt enable
+    ramecc1.m3cr.modify(|_, w| { w.eccelen().bit(true).eccdebwie().bit(true).eccdeie().bit(true).eccseie().bit(true) });
+    ramecc1.m4cr.modify(|_, w| { w.eccelen().bit(true).eccdebwie().bit(true).eccdeie().bit(true).eccseie().bit(true) });
+
+    // Finally enable the global RAM ECC interrupts, which should only fire for
+    // monitors 3 and 4 currently
+    ramecc1.ier.modify(|_, w| { w.geccdebwie().bit(true).geccdeie().bit(true).geccseie().bit(true).gie().bit(true) });
+}


### PR DESCRIPTION
The STM32H742, STM32H743/753 and STM32H750 boards have ECC modules on their RAM, however they don't automatically handle correcting detected errors nor resetting the microcontroller if the errors are unrecoverable. I started work on a driver to handle these interrupts, but there's some challenges involved though which I'm not sure how to navigate. I'm opening this WIP PR to start a discussion about how (or if) to proceed.

## Problems

When handling single errors, we need to read from that address and re-write the same value back to that address. The only place we could do this is the kernel as memory protection will prevent us from doing it otherwise.

We need access to the task table when handling double errors to determine how to handle the error based on where it is:

- in a task stack region, we can restart the task
- in a task data region, we can reload the task data from flash and restart the task
- in the kernel data region, we could reload that data from flash but might choose to reboot entirely instead
- in the kernel stack region, the only safe option may be to reboot

Unfortunately there's currently no way to get access to the task region description outside of the kernel to make this determination. There's also no way to force a task's data to be reloaded from flash.

## Solution

Perhaps handling ECC errors should be something offered by the supervisor - it already has a tighter coupling with the kernel, and it has the capability to reboot the system. The missing kernel capabilities could be added to the existing kernel IPC leveraged by the supervisor - specifically:

- Load and rewrite the same value at this memory address
- Ask what is present at a given memory address - kernel, task stack or data (including task number), or unallocated memory
- Reload the task data from flash, perhaps as an extension to restart_task

I'm not sure how best to extend the supervisor to add these board-specific capabilities. It's a small piece of code so perhaps a board-specific supervisor duplicating and extending the capabilities of jefe wouldn't be so bad in practice.

There's also an open question of the value of handling ECC faults at all - the chances of ECC catching data corruption depends on the uptime of the board. The chances of a memory fault due to cosmic rays seems small given the amount of memory we're working with, though that chance increases the longer the expected uptime of the board is.

## References

[Error correction code (ECC) management for internal memories protection on
STM32H7 Series](https://www.st.com/resource/en/application_note/dm00623136-error-correction-code-ecc-management-for-internal-memories-protection-on-stm32h7-series-stmicroelectronics.pdf)
[Reference manual for STM32H742, STM32H743/753 and STM32H750 - Section 3 RAM ECC monitoring, Page 139](https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743-753-and-stm32h750-value-line-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf)
