### PR TITLE
xtask: Include textaddress for each symbol file.

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -486,14 +486,15 @@ pub fn package(
     let mut gdb_script = File::create(out.join("script.gdb"))?;
     writeln!(
         gdb_script,
-        "add-symbol-file {}",
+        "symbol-file {}",
         out.join("kernel").to_slash().unwrap()
     )?;
     for name in toml.tasks.keys() {
         writeln!(
             gdb_script,
-            "add-symbol-file {}",
-            out.join(name).to_slash().unwrap()
+            "add-symbol-file {} {}",
+            out.join(name).to_slash().unwrap(),
+            allocs.tasks.get(name).unwrap().get("flash").unwrap().start
         )?;
     }
     if let Some(bootloader) = toml.bootloader.as_ref() {


### PR DESCRIPTION
I don't know if it's just that I'm using an older gdb than everyone else, but on my system the default `script.gdb` generated by xtask doesn't work as gdb cannot match up the files against their corresponding addresses:

```
Reading symbols from target/demo-stm32g0b1-nucleo/dist/final.elf...(no debugging symbols found)...done.
target/demo-stm32g0b1-nucleo/dist/script.gdb:1: Error in sourced command file:
The address where target/demo-stm32g0b1-nucleo/dist/kernel has been loaded is missing
0x08004eca in ?? ()
No symbol table is loaded.  Use the "file" command.
```

By specifying the correct `textaddress` for each symbol file they are loaded correctly:

```
Reading symbols from target/demo-stm32g0b1-nucleo/dist/final.elf...(no debugging symbols found)...done.
add symbol table from file "target/demo-stm32g0b1-nucleo/dist/kernel" at
        .text_addr = 0x8000000
add symbol table from file "target/demo-stm32g0b1-nucleo/dist/jefe" at
        .text_addr = 0x8008000
add symbol table from file "target/demo-stm32g0b1-nucleo/dist/rcc_driver" at
        .text_addr = 0x800c000
add symbol table from file "target/demo-stm32g0b1-nucleo/dist/idle" at
        .text_addr = 0x800e000
0x08004eca in __aeabi_memset4 ()
    at /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/arm.rs:219
```