### PR TITLE
Cargo.toml: Remove 'package.metadata.build.target' leftover from 8e0b…

### DIFF
--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -20,9 +20,6 @@ sha2 = { version = "0.9.2", default-features = false }
 zerocopy = "0.6.1"
 cfg-if = "0.1.10"
 
-[package.metadata.build]
-target = "thumbv8m.main-none-eabihf"
-
 [[bin]]
 name = "stage0"
 test = false

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -3,9 +3,6 @@ name = "task-hiffy"
 version = "0.1.0"
 edition = "2018"
 
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -3,9 +3,6 @@ name = "task-power"
 version = "0.1.0"
 edition = "2018"
 
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -3,9 +3,6 @@ name = "task-thermal"
 version = "0.1.0"
 edition = "2018"
 
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }


### PR DESCRIPTION
…13b8.

A number of these configuration sections were removed along with the
related 'standalone' build stuff. A few appear to have been missed and
AFAIK they're no longer required.