### PR TITLE
Add SPI Loopback for the RoT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "lpc55-pac",
  "num-traits",
+ "ringbuf",
  "userlib",
  "zerocopy",
 ]
@@ -2424,6 +2425,15 @@ dependencies = [
  "ringbuf",
  "spd",
  "stm32h7",
+ "userlib",
+]
+
+[[package]]
+name = "task-spi-loopback"
+version = "0.1.0"
+dependencies = [
+ "drv-spi-api",
+ "ringbuf",
  "userlib",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "task/power",
     "task/spd",
     "task/thermal",
+    "task/spi-loopback",
 
     "drv/stm32fx-rcc",
     "drv/stm32fx-usart",

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -125,7 +125,7 @@ task-slots = ["syscon_driver"]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 1024}
+requires = {flash = 16384, ram = 2048}
 features = ["spi0"]
 uses = ["flexcomm3", "flexcomm8"]
 start = true
@@ -159,6 +159,15 @@ requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["gpio_driver"]
+
+[tasks.spi_loopback]
+path = "../../task/spi-loopback"
+name = "task-spi-loopback"
+priority = 2
+requires = {flash = 8192, ram = 2048}
+start = true
+stacksize = 1000
+task-slots = ["spi0_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -84,16 +84,26 @@ start = true
 interrupts = {14 = 1}
 task-slots = ["gpio_driver", "syscon_driver"]
 
-[tasks.spi_driver]
+[tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 1024}
+requires = {flash = 16384, ram = 2048}
 uses = ["iocon", "flexcomm3", "flexcomm8"]
+features = ["spi0"]
 start = true
 interrupts = {59 = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
+
+[tasks.spi_loopback]
+path = "../../task/spi-loopback"
+name = "task-spi-loopback"
+priority = 2
+requires = {flash = 8192, ram = 2048}
+start = true
+stacksize = 1000
+task-slots = ["spi0_driver"]
 
 [peripherals.syscon]
 address = 0x40000000

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -148,11 +148,12 @@ start = true
 stacksize = 1000
 task-slots = ["syscon_driver"]
 
-[tasks.spi_driver]
+[tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 1024}
+requires = {flash = 16384, ram = 2048}
+features = ["spi0"]
 uses = ["flexcomm8"]
 start = true
 interrupts = {59 = 1}

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -11,6 +11,7 @@ drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 drv-lpc55-spi = {path = "../lpc55-spi"}
 num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
+ringbuf = {path = "../../lib/ringbuf"}
 
 [features]
 spi0 = []

--- a/drv/lpc55-spi/src/lib.rs
+++ b/drv/lpc55-spi/src/lib.rs
@@ -114,7 +114,14 @@ impl Spi {
         });
     }
 
+    pub fn drain(&mut self) {
+        self.reg
+            .fifocfg
+            .modify(|_, w| w.emptytx().set_bit().emptyrx().set_bit());
+    }
+
     pub fn enable(&mut self) {
+        self.drain();
         self.reg
             .fifocfg
             .modify(|_, w| w.enabletx().enabled().enablerx().enabled());

--- a/task/spi-loopback/Cargo.toml
+++ b/task/spi-loopback/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "task-spi-loopback"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+drv-spi-api = {path = "../../drv/spi-api"}
+ringbuf = {path = "../../lib/ringbuf"}
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "task-spi-loopback"
+test = false
+bench = false

--- a/task/spi-loopback/README.mkdn
+++ b/task/spi-loopback/README.mkdn
@@ -1,0 +1,5 @@
+# Task Template
+
+Copy this directory to get started writing a new task. Don't forget to add your
+task to `workspace.members` in the root `Cargo.toml`! (If you forget, `cargo`
+will remind you.)

--- a/task/spi-loopback/src/main.rs
+++ b/task/spi-loopback/src/main.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use ringbuf::*;
+use userlib::*;
+
+task_slot!(SPI, spi0_driver);
+
+#[derive(Copy, Clone, PartialEq)]
+enum Trace {
+    Tx([u8; 8]),
+    Rx([u8; 8]),
+    Start,
+    None,
+}
+
+ringbuf!(Trace, 16, Trace::None);
+
+#[export_name = "main"]
+fn main() -> ! {
+    let spi = drv_spi_api::Spi::from(SPI.get_task_id());
+
+    let mut a_bytes: [u8; 8] = [0; 8];
+    let mut b_bytes: [u8; 8] = [0; 8];
+
+    loop {
+        ringbuf_entry!(Trace::Start);
+        let ret = spi.exchange(0, &a_bytes, &mut b_bytes);
+        if ret.is_err() {
+            sys_panic(b"exchange failed!");
+        }
+
+        ringbuf_entry!(Trace::Tx(a_bytes));
+        ringbuf_entry!(Trace::Rx(b_bytes));
+
+        let ret = spi.exchange(0, &b_bytes, &mut a_bytes);
+        if ret.is_err() {
+            sys_panic(b"exhange failed!");
+        }
+
+        ringbuf_entry!(Trace::Tx(b_bytes));
+        ringbuf_entry!(Trace::Rx(a_bytes));
+    }
+}


### PR DESCRIPTION
Add as simple loopback task for testing SPI. This stores 8 bytes of what was previously sent and sends it back next time a request comes in.

```
[labbott@labbott-the-desktop humility]$ ./target/debug/humility -a ~/hubristic-sketching/target/gemini-bu/dist/build-gemini-bu.zip -p usb-1 spi -p 4 --write 1,2,3,4,5,6,7,8 --read --nbytes 8
humility: attached via ST-Link
humility: SPI master is spi4_driver
             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0x00000000 | 00 00 00 00 00 00 00 00                         | ........        
[labbott@labbott-the-desktop humility]$ ./target/debug/humility -a ~/hubristic-sketching/target/gemini-bu/dist/build-gemini-bu.zip -p usb-1 spi -p 4 --write 8,7,6,5,4,3,2,1 --read --nbytes 8
humility: attached via ST-Link
humility: SPI master is spi4_driver
             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0x00000000 | 01 02 03 04 05 06 07 08   
```