### PR TITLE
Shorten panic messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2793,7 @@ dependencies = [
  "byteorder",
  "cargo_metadata",
  "ctrlc",
+ "dunce",
  "filetime",
  "goblin",
  "indexmap",

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -19,6 +19,7 @@ goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
 serde_json = "1.0.56"
 path-slash = "0.1.3"
 ctrlc = "3.1.5"
+dunce = "1.0.2"
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
 # on the version that works for us
 zip = "=0.5.6"

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -543,8 +543,8 @@ pub fn package(
         writeln!(
             gdb_script,
             "set substitute-path {} {}",
-            path.display(),
-            remap
+            remap,
+            path.display()
         )?;
     }
     drop(gdb_script);


### PR DESCRIPTION
This uses `--remap-path-prefix` to shorten the paths embedded in panic messages.  Since we're limited to 128 bytes, this could make the difference between seeing and not seeing the full path + line number.

In particular, it remaps `git` dependencies from `/Users/mjk/.cargo/git/checkouts/...` to just `git/...` (the original will vary depending on OS and username), and crates within the same checkout from `/Users/mjk/oxide/hubris/...` to `hubris/...`.

As far as I can tell, this doesn't affect Humility's backtracing, since that's all baked into the ELF files.

However, [the docs](https://doc.rust-lang.org/rustc/command-line-arguments.html#--remap-path-prefix-remap-source-names-in-output) say this also affects "debug information, macro expansions, etc" – @steveklabnik , any idea if this is going to break something more subtly?