### PR TITLE
More informative size info

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -90,7 +90,7 @@ pub fn package(
         }
     }
     for (name, range) in &memories {
-        println!("{} = {:x?}", name, range);
+        println!("{:<5} = 0x{:0>8x}..0x{:0>8x}", name, range.start, range.end);
     }
     let starting_memories = memories.clone();
 
@@ -100,7 +100,9 @@ pub fn package(
     println!("Used:");
     for (name, new_range) in &memories {
         let orig_range = &starting_memories[name];
-        println!("{}: 0x{:x}", name, new_range.start - orig_range.start);
+        let size = new_range.start - orig_range.start;
+        let percent = size * 100 / (orig_range.end - orig_range.start);
+        println!("  {:<6} 0x{:x} ({}%)", format!("{}:", name), size, percent);
     }
 
     let mut infofile = File::create(out.join("allocations.txt"))?;


### PR DESCRIPTION
Before:
```
flash = 8000000..8100000
ram = 20000000..20020000
Used:
flash: 0x5e100
ram: 0x13500
```

After:
```
flash = 0x08000000..0x08100000
ram   = 0x20000000..0x20020000
Used:
  flash: 0x5e100 (36%)
  ram:   0x13500 (60%)
```