### PR TITLE
kern/arm_m: properly dispatch to irq0 handler

### DIFF
--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -953,7 +953,7 @@ pub unsafe extern "C" fn DefaultHandler() {
         // 13 is currently reserved
         // 14=PendSV is handled above by its own handler
         // 15=SysTick is handled above by its own handler
-        x if x > 16 => {
+        x if x >= 16 => {
             // Hardware interrupt
             let irq_num = exception_num - 16;
             let switch = with_task_table(|tasks| {


### PR DESCRIPTION
Off-by-one error in DefaultHandler() meant IRQ0 would result in an
unknown exception panic instead of looking for a task to dispatch to.

Fixes #367