### PR TITLE
stm32h7-spi-server: add remaining IO ports.

### DIFF
--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -77,6 +77,8 @@ enum ConfigPort {
     G,
     H,
     I,
+    J,
+    K,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Oversight on my part.