### PR TITLE
[RFC] RNG driver API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ name = "drv-lpc55-rng"
 version = "0.1.0"
 dependencies = [
  "drv-lpc55-syscon-api",
+ "drv-rng-api",
  "lpc55-pac",
  "num-traits",
  "userlib",
@@ -750,6 +751,16 @@ dependencies = [
  "num-traits",
  "userlib",
  "zerocopy",
+]
+
+[[package]]
+name = "drv-rng-api"
+version = "0.1.0"
+dependencies = [
+ "abi",
+ "getrandom",
+ "num-traits",
+ "userlib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "drv/gimlet-seq-server",
     "drv/gimlet-hf-server",
     "drv/gimlet-hf-api",
+    "drv/rng-api",
 
     "drv/sidecar-seq-server",
 

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -9,6 +9,7 @@ zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
+drv-rng-api = {path = "../rng-api"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/rng-api/Cargo.toml
+++ b/drv/rng-api/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "drv-rng-api"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+abi = { path = "../../sys/abi" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+num-traits = { version = "0.2.12", default-features = false }
+getrandom = { version = "0.2", default-features = false, optional = true}
+
+[features]
+custom-getrandom = ["getrandom/custom"]
+
+[lib]
+name = "drv_rng_api"
+test = false
+bench = false

--- a/drv/rng-api/src/lib.rs
+++ b/drv/rng-api/src/lib.rs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+
+#[cfg(feature = "custom-getrandom")]
+use core::num::NonZeroU32;
+#[cfg(feature = "custom-getrandom")]
+use getrandom::Error;
+
+use userlib::*;
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, FromPrimitive)]
+pub enum RngError {
+    BadArg = 1,
+    PoweredOff = 2,
+}
+
+impl From<RngError> for u32 {
+    fn from(rc: RngError) -> Self {
+        rc as u32
+    }
+}
+
+#[cfg(feature = "custom-getrandom")]
+task_slot!(RNG, rng_driver);
+
+#[cfg(feature = "custom-getrandom")]
+pub fn rng_getrandom(dest: &mut [u8]) -> Result<(), Error> {
+    match rng_fill(RNG.get_task_id(), dest) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            let rc = NonZeroU32::new(err as u32).unwrap();
+            Err(Error::from(rc))
+        }
+    }
+}
+
+pub fn rng_fill(task: TaskId, buf: &mut [u8]) -> Result<usize, RngError> {
+    let mut response = [0; 4];
+    let (rc, len) = sys_send(task, 0, &[], &mut response, &[Lease::from(buf)]);
+    if let Some(err) = RngError::from_u32(rc) {
+        Err(err)
+    } else {
+        assert_eq!(len, 4);
+        Ok(usize::from_ne_bytes(response))
+    }
+}


### PR DESCRIPTION
This is a request for comments on some work to improve the interface to the RNGs. Currently it's limited to the lpc55 dev board but the goal is for this to be a common API crate for our RNG drivers. This was needed for compatibility with the 'getrandom' crate that's a dependency of the 'ring' crate currently required by the SPDM crate @andrewjstone has been developing. General support for ring in a hubris task is likely not possible (https://github.com/briansmith/ring/issues/813) but supporting 'getrandom' may still have its benefits. TIA for any and all feedback.