### PR TITLE
Add per-device SPI clock divisors.

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -292,6 +292,7 @@ input = {port = "A", pin = 6, af = 5} # miso
 [config.spi.spi1.devices.pins]
 mux = "cn7_arduino"
 cs = {port = "D", pin = 14}
+clock_divider = "DIV32"
 
 
 [config.net]

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -115,15 +115,15 @@ path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
-features = ["spi3", "h743"]
-uses = ["spi3"]
+features = ["spi1", "h743"]
+uses = ["spi1"]
 start = true
-interrupts = {51 = 1}
+interrupts = {35 = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi_driver.config.spi]
-global_config = "spi3"
+global_config = "spi1"
 
 [tasks.net]
 path = "../../task/net"
@@ -279,19 +279,19 @@ af = 4
 # driver = "ltc4306"
 # address = 0b1001_010
 
-[config.spi.spi3]
-controller = 3
+[config.spi.spi1]
+controller = 1
 
-[config.spi.spi3.mux_options.port_b]
+[config.spi.spi1.mux_options.cn7_arduino]
 outputs = [
-    {port = "B", pins = [3], af = 6},
-    {port = "B", pins = [5], af = 7},
+    {port = "A", pins = [5], af = 5}, # sck
+    {port = "B", pins = [5], af = 5}, # mosi
 ]
-input = {port = "B", pin = 4, af = 6}
+input = {port = "A", pin = 6, af = 5} # miso
 
-[config.spi.spi3.devices.pins]
-mux = "port_b"
-cs = {port = "A", pin = 4}
+[config.spi.spi1.devices.pins]
+mux = "cn7_arduino"
+cs = {port = "D", pin = 14}
 
 
 [config.net]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -104,15 +104,15 @@ path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
-features = ["spi3", "h753"]
-uses = ["spi3"]
+features = ["spi1", "h753"]
+uses = ["spi1"]
 start = true
-interrupts = {51 = 1}
+interrupts = {53 = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi_driver.config.spi]
-global_config = "spi3"
+global_config = "spi1"
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
@@ -264,16 +264,17 @@ af = 4
 # address = 0b1001_010
 
 
-[config.spi.spi3]
-controller = 3
+[config.spi.spi1]
+controller = 1
 
-[config.spi.spi3.mux_options.port_b]
+[config.spi.spi1.mux_options.cn7_arduino]
 outputs = [
-    {port = "B", pins = [3], af = 6},
-    {port = "B", pins = [5], af = 7},
+    {port = "A", pins = [3], af = 5},
+    {port = "B", pins = [5], af = 5},
 ]
-input = {port = "B", pin = 4, af = 6}
+input = {port = "A", pin = 6, af = 5}
 
-[config.spi.spi3.devices.pins]
-mux = "port_b"
-cs = {port = "A", pin = 4}
+[config.spi.spi1.devices.pins]
+mux = "cn7_arduino"
+cs = {port = "D", pin = 14}
+clock_divider = "DIV32"

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -201,7 +201,8 @@ impl ToTokens for SpiConfig {
                 DeviceDescriptor {
                     mux_index: #mux_index,
                     cs: #cs,
-                    // `spi1` here is _not_ a typo/oversight.
+                    // `spi1` here is _not_ a typo/oversight, the PAC calls all
+                    // SPI types spi1.
                     clock_divider: device::spi1::cfg1::MBR_A::#div,
                 }
             }

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -319,7 +319,7 @@ impl ServerImpl {
         // limitation, maybe. Doing so would require managing data
         // in 64kiB chunks (because the peripheral is 16-bit) and
         // using the "reload" facility on the peripheral.
-        self.spi.enable(overall_len);
+        self.spi.enable(overall_len, device.clock_divider);
 
         // Load transfer count and start the state machine. At this
         // point we _have_ to move the specified number of bytes
@@ -592,6 +592,9 @@ struct DeviceDescriptor {
     /// Where the CS pin is. While this is a `PinSet`, it should only have one
     /// pin in it, and we check this at startup.
     cs: PinSet,
+    /// Clock divider to apply while speaking with this device. Yes, this says
+    /// spi1 no matter which SPI block we're in charge of.
+    clock_divider: device::spi1::cfg1::MBR_A,
 }
 
 /// Any impl of ServerConfig for Server has to pass these tests at startup.

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -7,6 +7,11 @@
 //! Currently this hardcodes the clock rate.
 //!
 //! See the `spi-api` crate for the protocol being implemented here.
+//!
+//! # Why is everything `spi1`
+//!
+//! As noted in the `stm32h7-spi` driver, the `stm32h7` PAC has decided that all
+//! SPI types should be called `spi1`.
 
 #![no_std]
 #![no_main]

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -105,7 +105,8 @@ impl Spi {
         self.reg.i2scfgr.write(|w| w.i2smod().clear_bit());
     }
 
-    pub fn enable(&mut self, tsize: u16) {
+    pub fn enable(&mut self, tsize: u16, div: device::spi1::cfg1::MBR_A) {
+        self.reg.cfg1.modify(|_, w| w.mbr().variant(div));
         self.reg.cr2.modify(|_, w| w.tsize().bits(tsize));
         self.reg.cr1.modify(|_, w| w.spe().set_bit());
     }

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -28,6 +28,12 @@
 //! # Automagic CRC generation
 //!
 //! We do not currently support the hardware's automatic CRC features.
+//!
+//! # Why is everything `spi1`
+//!
+//! The `stm32h7` PAC crate we currently use has decided that all SPI types
+//! should be called `spi1`. This is despite significant hardware differences
+//! between SPI1-6. Our is not to question why.
 
 #![no_std]
 
@@ -42,9 +48,6 @@ pub struct Spi {
     ///
     /// This is not a `SPIx` type from the `stm32h7` crate because then we're
     /// generic for no good reason and type parameters multiply. Ew.
-    ///
-    /// Pay no heed to the 1 in `spi1` -- that's what the common module is
-    /// called.
     reg: &'static device::spi1::RegisterBlock,
 }
 


### PR DESCRIPTION
This also changes the clock rate on stm32h7 nucleo to demonstrate that it works.