### PR TITLE
Introduce UnwrapLite.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "cortex-m-semihosting",
  "serde",
  "ssmarshal",
+ "unwrap-lite",
  "zerocopy",
 ]
 
@@ -2881,6 +2882,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "unwrap-lite"
+version = "0.1.0"
+
+[[package]]
 name = "userlib"
 version = "0.1.0"
 dependencies = [
@@ -2891,6 +2896,7 @@ dependencies = [
  "paste",
  "serde",
  "ssmarshal",
+ "unwrap-lite",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "lib/gnarle",
     "lib/hypocalls",
     "lib/ringbuf",
+    "lib/unwrap-lite",
 
     "app/demo-stm32f4-discovery",
     "app/demo-stm32h7-nucleo",

--- a/lib/unwrap-lite/Cargo.toml
+++ b/lib/unwrap-lite/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "unwrap-lite"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/lib/unwrap-lite/src/lib.rs
+++ b/lib/unwrap-lite/src/lib.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+
+/// Extension trait for adding the `unwrap_lite` operation to types that can be
+/// unwrapped.
+pub trait UnwrapLite {
+    /// Type produced when `Self` is unwrapped.
+    type Output;
+
+    /// Unwraps `self` without invoking `Debug` formatting, and with a minimal
+    /// error message.
+    fn unwrap_lite(self) -> Self::Output;
+}
+
+impl<T, E> UnwrapLite for Result<T, E> {
+    type Output = T;
+
+    #[track_caller]
+    #[inline]
+    fn unwrap_lite(self) -> Self::Output {
+        match self {
+            Ok(x) => x,
+            Err(_) => panic!(),
+        }
+    }
+}
+
+impl<T> UnwrapLite for Option<T> {
+    type Output = T;
+
+    #[track_caller]
+    #[inline]
+    fn unwrap_lite(self) -> Self::Output {
+        match self {
+            Some(x) => x,
+            None => panic!(),
+        }
+    }
+}

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -18,6 +18,7 @@ cortex-m = {version = "0.7", features = ["inline-asm"]}
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
+unwrap-lite = { path = "../../lib/unwrap-lite" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -81,6 +81,7 @@ use crate::task;
 use crate::time::Timestamp;
 use crate::umem::USlice;
 use abi::{FaultInfo, FaultSource};
+use unwrap_lite::UnwrapLite;
 
 /// Log things from kernel context. This macro is made visible to the rest of
 /// the kernel by a chain of `#[macro_use]` attributes, but its implementation
@@ -343,7 +344,7 @@ pub fn reinitialize(task: &mut task::Task) {
     uassert!(initial_stack as usize >= frame_size);
     // Ok. Generate a uslice for the task's starting stack frame.
     let mut frame_uslice: USlice<ExtendedExceptionFrame> =
-        USlice::from_raw(initial_stack as usize - frame_size, 1).unwrap();
+        USlice::from_raw(initial_stack as usize - frame_size, 1).unwrap_lite();
     // Before we set our frame, find the region that contains our initial stack
     // pointer, and zap the region from the base to the stack pointer with a
     // distinct (and storied) pattern.
@@ -360,16 +361,16 @@ pub fn reinitialize(task: &mut task::Task) {
             region.base as usize,
             (initial_stack as usize - frame_size - region.base as usize) >> 2,
         )
-        .unwrap();
+        .unwrap_lite();
 
-        let zap = task.try_write(&mut uslice).unwrap();
+        let zap = task.try_write(&mut uslice).unwrap_lite();
         for word in zap.iter_mut() {
             *word = 0xbaddcafe;
         }
     }
 
     let descriptor = task.descriptor();
-    let frame = &mut task.try_write(&mut frame_uslice).unwrap()[0];
+    let frame = &mut task.try_write(&mut frame_uslice).unwrap_lite()[0];
 
     // Conservatively/defensively zero the entire frame.
     *frame = ExtendedExceptionFrame::default();

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -33,6 +33,7 @@ use abi::{
     FaultInfo, LeaseAttributes, SchedState, Sysnum, TaskId, TaskState,
     UsageError,
 };
+use unwrap_lite::UnwrapLite;
 
 use crate::arch;
 use crate::err::{InteractFault, UserError};
@@ -565,7 +566,7 @@ fn borrow_lease(
         // Attempt to offset the lease. Handle cases where the offset is bogus.
         // First, we must convert to u32, which _should be_ a no-op but we'll do
         // it the careful way:
-        let offset = u32::try_from(offset).unwrap();
+        let offset = u32::try_from(offset).unwrap_lite();
         // Now, proceed only if both neither the length nor address computation
         // wrap.
         if let (Some(off_len), Some(off_addr)) = (

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
+unwrap-lite = { path = "../../lib/unwrap-lite" }
 
 #
 # In order to use macros as discriminants in enums that make use of derive

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -4,6 +4,7 @@
 
 //! Operations implemented by IPC with the kernel task.
 
+use unwrap_lite::UnwrapLite;
 use zerocopy::AsBytes;
 
 use crate::*;
@@ -15,19 +16,14 @@ pub fn read_task_status(task: usize) -> abi::TaskState {
     let (rc, len) =
         sys_send(TaskId::KERNEL, 1, task.as_bytes(), &mut response, &[]);
     assert_eq!(rc, 0);
-    ssmarshal::deserialize(&response[..len])
-        .map_err(|_| ())
-        .unwrap()
-        .0
+    ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
 
 pub fn restart_task(task: usize, start: bool) {
     // Coerce `task` to a known size (Rust doesn't assume that usize == u32)
     let msg = (task as u32, start);
     let mut buf = [0; core::mem::size_of::<(u32, bool)>()];
-    ssmarshal::serialize(&mut buf, &msg)
-        .map_err(|_| ())
-        .unwrap();
+    ssmarshal::serialize(&mut buf, &msg).unwrap_lite();
     let (rc, _len) = sys_send(TaskId::KERNEL, 2, &mut buf, &mut [], &[]);
     assert_eq!(rc, 0);
 }


### PR DESCRIPTION
This provides a syntactically-convenient equivalent to unwrap() on
Result/Option that is _significantly_ cheaper from a code generation
perspective, because it doesn't invoke any type's formatting routines.

This knocked like 5 kiB off one incarnation of the kernel.