### PR TITLE
Add cargo xtask sizes, to print sizes and suggest improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-api"
 version = "0.1.0"
 dependencies = [
@@ -3013,6 +3022,7 @@ version = "1.0.0"
 dependencies = [
  "abi",
  "anyhow",
+ "atty",
  "byteorder",
  "cargo_metadata",
  "ctrlc",
@@ -3028,6 +3038,7 @@ dependencies = [
  "serde_json",
  "srec",
  "structopt",
+ "termcolor",
  "toml",
  "walkdir",
  "zip",

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atty = "0.2"
 structopt = "0.3.15"
 anyhow = "1.0.32"
 cargo_metadata = "0.12.0"
 ordered-toml = {git = "https://github.com/oxidecomputer/ordered-toml"}
+termcolor = "1.1.2"
 
 # for dist
 serde = { version = "1.0.114", features = ["derive"] }

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -26,7 +26,7 @@ use lpc55_sign::{crc_image, sign_ecc, signed_image};
 /// In practice, applications with active interrupt activity tend to use about
 /// 650 bytes of stack. Because kernel stack overflows are annoying, we've
 /// padded that a bit.
-const DEFAULT_KERNEL_STACK: u32 = 1024;
+pub const DEFAULT_KERNEL_STACK: u32 = 1024;
 
 pub fn package(
     verbose: bool,

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -18,6 +18,7 @@ mod elf;
 mod flash;
 mod gdb;
 mod humility;
+mod sizes;
 mod task_slot;
 mod test;
 
@@ -62,6 +63,15 @@ enum Xtask {
 
     /// Runs `xtask dist` and flashes the image onto an attached target
     Flash {
+        /// Request verbosity from tools we shell out to.
+        #[structopt(short)]
+        verbose: bool,
+        /// Path to the image configuration file, in TOML.
+        cfg: PathBuf,
+    },
+
+    /// Runs `xtask dist` and reports the sizes of resulting tasks
+    Sizes {
         /// Request verbosity from tools we shell out to.
         #[structopt(short)]
         verbose: bool,
@@ -384,6 +394,10 @@ fn main() -> Result<()> {
         Xtask::Flash { verbose, cfg } => {
             dist::package(verbose, false, &cfg, None)?;
             flash::run(verbose, &cfg)?;
+        }
+        Xtask::Sizes { verbose, cfg } => {
+            dist::package(verbose, false, &cfg, None)?;
+            sizes::run(&cfg)?;
         }
         Xtask::Gdb { cfg, gdb_cfg } => {
             dist::package(false, false, &cfg, None)?;

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -382,6 +382,7 @@ fn main() -> Result<()> {
             cfg,
         } => {
             dist::package(verbose, edges, &cfg, None)?;
+            sizes::run(&cfg, true)?;
         }
         Xtask::Build {
             verbose,
@@ -397,7 +398,7 @@ fn main() -> Result<()> {
         }
         Xtask::Sizes { verbose, cfg } => {
             dist::package(verbose, false, &cfg, None)?;
-            sizes::run(&cfg)?;
+            sizes::run(&cfg, false)?;
         }
         Xtask::Gdb { cfg, gdb_cfg } => {
             dist::package(false, false, &cfg, None)?;

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+use goblin::Object;
+use indexmap::IndexMap;
+
+use crate::Config;
+
+fn armv7m_suggest(size: u64) -> u64 {
+    // Nearest power of two
+    let mut i = 1;
+    while i < size {
+        i *= 2;
+    }
+    i
+}
+fn armv8m_suggest(size: u64) -> u64 {
+    // Nearest chunk of 32
+    ((size + 31) / 32) * 32
+}
+
+pub fn run(cfg: &Path) -> anyhow::Result<()> {
+    let cfg_contents = std::fs::read(&cfg)?;
+    let toml: Config = toml::from_slice(&cfg_contents)?;
+
+    let mut dist_dir = PathBuf::from("target");
+    dist_dir.push(&toml.name);
+    dist_dir.push("dist");
+
+    let mut memories = IndexMap::new();
+    for (name, out) in &toml.outputs {
+        // This is called after `dist`, which logs this overflow gracefully
+        let end = out.address.checked_add(out.size).unwrap();
+        memories.insert(name.clone(), out.address..end);
+    }
+
+    let output_region = |vaddr: u64| {
+        memories
+            .iter()
+            .find(|(_, region)| region.contains(&vaddr.try_into().unwrap()))
+            .map(|(name, _)| name.as_str())
+    };
+
+    let mut first = false;
+
+    struct Task<'a> {
+        name: &'a str,
+        stacksize: u32,
+        requires: &'a IndexMap<String, u32>,
+    }
+    let mut tasks: Vec<Task> = toml
+        .tasks
+        .iter()
+        .map(|(name, task)| Task {
+            name,
+            stacksize: task
+                .stacksize
+                .unwrap_or_else(|| toml.stacksize.unwrap()),
+            requires: &task.requires,
+        })
+        .collect();
+    tasks.push(Task {
+        name: "kernel",
+        stacksize: toml.stacksize.unwrap(),
+        requires: &toml.kernel.requires,
+    });
+
+    let suggest = if toml.target.starts_with("thumbv7m")
+        || toml.target.starts_with("thumbv7em")
+    {
+        armv7m_suggest
+    } else if toml.target.starts_with("thumbv8m") {
+        armv8m_suggest
+    } else {
+        panic!("Unknown target {}", toml.target);
+    };
+
+    let mut suggestions = Vec::new();
+    for task in tasks {
+        if !first {
+            first = true;
+        } else {
+            println!();
+        }
+        let mut elf_name = dist_dir.clone();
+        elf_name.push(task.name);
+        let buffer = std::fs::read(elf_name)?;
+        let elf = match Object::parse(&buffer)? {
+            Object::Elf(elf) => elf,
+            o => bail!("Invalid Object {:?}", o),
+        };
+
+        let mut memory_sizes = memories
+            .keys()
+            .map(|name| (name.as_str(), 0))
+            .collect::<IndexMap<_, _>>();
+        for phdr in &elf.program_headers {
+            if let Some(region) = output_region(phdr.p_vaddr) {
+                memory_sizes[region] += phdr.p_memsz;
+            }
+        }
+        memory_sizes["ram"] += task.stacksize as u64;
+
+        println!("{}", task.name);
+        let mut my_suggestions = Vec::new();
+        for name in memories.keys() {
+            let used = memory_sizes[name.as_str()];
+            if let Some(&size) = task.requires.get(name) {
+                let percent = used * 100 / size as u64;
+                println!(
+                    "  {:<6} {: >5} bytes ({}%)",
+                    format!("{}:", name),
+                    used,
+                    percent
+                );
+                let suggestion = suggest(used);
+                if suggestion != size as u64 {
+                    my_suggestions.push((name, size, suggestion));
+                }
+            } else {
+                assert!(used == 0);
+            }
+        }
+        if !my_suggestions.is_empty() {
+            suggestions.push((task.name, my_suggestions));
+        }
+    }
+
+    if !suggestions.is_empty() {
+        let mut savings = memories
+            .keys()
+            .map(|name| (name.as_str(), 0))
+            .collect::<IndexMap<_, _>>();
+        println!("\n========== Suggested changes ==========");
+        for (name, list) in suggestions {
+            println!("{}:", name);
+            for (mem, prev, value) in list {
+                println!(
+                    "  {:<6} {} (from {})",
+                    format!("{}:", mem),
+                    value,
+                    prev
+                );
+                savings[mem.as_str()] += prev as u64 - value;
+            }
+        }
+        println!("\n------------ Total savings ------------");
+        for (mem, savings) in &savings {
+            println!("  {:<6} {}", format!("{}:", mem), savings);
+        }
+    }
+
+    Ok(())
+}

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -12,12 +12,7 @@ use indexmap::IndexMap;
 use crate::Config;
 
 fn armv7m_suggest(size: u64) -> u64 {
-    // Nearest power of two
-    let mut i = 1;
-    while i < size {
-        i *= 2;
-    }
-    i
+    size.next_power_of_two()
 }
 fn armv8m_suggest(size: u64) -> u64 {
     // Nearest chunk of 32
@@ -46,95 +41,87 @@ pub fn run(cfg: &Path) -> anyhow::Result<()> {
             .map(|(name, _)| name.as_str())
     };
 
-    struct Task<'a> {
-        name: &'a str,
-        stacksize: u32,
-        requires: &'a IndexMap<String, u32>,
-    }
-    let mut tasks: Vec<Task> = toml
-        .tasks
-        .iter()
-        .map(|(name, task)| Task {
-            name,
-            stacksize: task
-                .stacksize
-                .unwrap_or_else(|| toml.stacksize.unwrap()),
-            requires: &task.requires,
-        })
-        .collect();
-    tasks.push(Task {
-        name: "kernel",
-        stacksize: toml.stacksize.unwrap(),
-        requires: &toml.kernel.requires,
-    });
-
-    let suggest = if toml.target.starts_with("thumbv7m")
-        || toml.target.starts_with("thumbv7em")
-    {
+    let suggest = if toml.target.starts_with("thumbv7") {
         armv7m_suggest
     } else if toml.target.starts_with("thumbv8m") {
         armv8m_suggest
     } else {
-        panic!("Unknown target {}", toml.target);
+        panic!("Unknown target: {}", toml.target);
     };
 
     let mut suggestions = Vec::new();
-    let mut first = false; // used to print a newline between tasks
-    for task in tasks {
-        if !first {
-            first = true;
-        } else {
-            println!();
-        }
-        let mut elf_name = dist_dir.clone();
-        elf_name.push(task.name);
-        let buffer = std::fs::read(elf_name)?;
-        let elf = match Object::parse(&buffer)? {
-            Object::Elf(elf) => elf,
-            o => bail!("Invalid Object {:?}", o),
+    let mut check_task =
+        |name: &str, stacksize: u32, requires: &IndexMap<String, u32>| {
+            let mut elf_name = dist_dir.clone();
+            elf_name.push(name);
+            let buffer = std::fs::read(elf_name)?;
+            let elf = match Object::parse(&buffer)? {
+                Object::Elf(elf) => elf,
+                o => bail!("Invalid Object {:?}", o),
+            };
+
+            let mut memory_sizes = IndexMap::new();
+            for phdr in &elf.program_headers {
+                // The PhysAddr is always a flash address, meaning we use the
+                // "on-disk" size of this section.
+                if let Some(region) = output_region(phdr.p_paddr) {
+                    *memory_sizes.entry(region).or_default() += phdr.p_filesz;
+                }
+                // If the VirtAddr disagrees with the PhysAddr, then this is a
+                // section which is relocated into RAM, so we also accumulate
+                // its MemSiz.
+                if phdr.p_paddr != phdr.p_vaddr {
+                    let region = output_region(phdr.p_vaddr).unwrap();
+                    *memory_sizes.entry(region).or_default() += phdr.p_memsz;
+                }
+            }
+            *memory_sizes.entry("ram").or_default() += stacksize as u64;
+
+            println!("{}", name);
+            let mut my_suggestions = Vec::new();
+            let mut has_asterisk = false;
+            for (mem_name, used) in memory_sizes {
+                let asterisk = name == "kernel" && mem_name == "ram";
+                has_asterisk |= asterisk;
+                if let Some(&size) = requires.get(mem_name) {
+                    let percent = used * 100 / size as u64;
+                    println!(
+                        "  {:<6} {: >5} bytes ({}%){}",
+                        format!("{}:", mem_name),
+                        used,
+                        percent,
+                        if asterisk { "*" } else { "" },
+                    );
+                    let suggestion = suggest(used);
+                    if suggestion != size as u64 && !asterisk {
+                        my_suggestions.push((mem_name, size, suggestion));
+                    }
+                } else {
+                    assert!(used == 0);
+                }
+            }
+            // TODO: remove this once PR #393 is merged
+            if has_asterisk {
+                println!("  * kernel uses spare RAM for dynamic allocation");
+            }
+            if !my_suggestions.is_empty() {
+                suggestions.push((name.to_owned(), my_suggestions));
+            }
+            Ok(())
         };
 
-        let mut memory_sizes = memories
-            .keys()
-            .map(|name| (name.as_str(), 0))
-            .collect::<IndexMap<_, _>>();
-        for phdr in &elf.program_headers {
-            if let Some(region) = output_region(phdr.p_vaddr) {
-                memory_sizes[region] += phdr.p_memsz;
-            }
-        }
-        memory_sizes["ram"] += task.stacksize as u64;
-
-        println!("{}", task.name);
-        let mut my_suggestions = Vec::new();
-        for name in memories.keys() {
-            let used = memory_sizes[name.as_str()];
-            if let Some(&size) = task.requires.get(name) {
-                let percent = used * 100 / size as u64;
-                println!(
-                    "  {:<6} {: >5} bytes ({}%)",
-                    format!("{}:", name),
-                    used,
-                    percent
-                );
-                let suggestion = suggest(used);
-                if suggestion != size as u64 {
-                    my_suggestions.push((name, size, suggestion));
-                }
-            } else {
-                assert!(used == 0);
-            }
-        }
-        if !my_suggestions.is_empty() {
-            suggestions.push((task.name, my_suggestions));
-        }
+    check_task("kernel", toml.stacksize.unwrap(), &toml.kernel.requires)?;
+    for (name, task) in &toml.tasks {
+        println!();
+        check_task(
+            &name,
+            task.stacksize.unwrap_or_else(|| toml.stacksize.unwrap()),
+            &task.requires,
+        )?;
     }
 
     if !suggestions.is_empty() {
-        let mut savings = memories
-            .keys()
-            .map(|name| (name.as_str(), 0))
-            .collect::<IndexMap<_, _>>();
+        let mut savings: IndexMap<_, u64> = IndexMap::new();
         println!("\n========== Suggested changes ==========");
         for (name, list) in suggestions {
             println!("{}:", name);
@@ -145,7 +132,7 @@ pub fn run(cfg: &Path) -> anyhow::Result<()> {
                     value,
                     prev
                 );
-                savings[mem.as_str()] += prev as u64 - value;
+                *savings.entry(mem).or_default() += prev as u64 - value;
             }
         }
         println!("\n------------ Total savings ------------");

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -130,7 +130,7 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
                         writeln!(out, "{}", if asterisk { "*" } else { "" })?;
                     }
                     let suggestion = suggest(used);
-                    if suggestion != size as u64 && !asterisk {
+                    if suggestion < size as u64 && !asterisk {
                         my_suggestions.push((mem_name, size, suggestion));
                     }
                 } else {

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -151,7 +151,7 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
 
     check_task(
         "kernel",
-        toml.stacksize.unwrap_or(DEFAULT_KERNEL_STACK),
+        toml.kernel.stacksize.unwrap_or(DEFAULT_KERNEL_STACK),
         &toml.kernel.requires,
     )?;
     for (name, task) in &toml.tasks {

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -11,7 +11,7 @@ use goblin::Object;
 use indexmap::IndexMap;
 use termcolor::{Color, ColorSpec, WriteColor};
 
-use crate::Config;
+use crate::{dist::DEFAULT_KERNEL_STACK, Config};
 
 fn armv7m_suggest(size: u64) -> u64 {
     size.next_power_of_two()
@@ -150,14 +150,18 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
             Ok(())
         };
 
-    check_task("kernel", toml.stacksize.unwrap(), &toml.kernel.requires)?;
+    check_task(
+        "kernel",
+        toml.stacksize.unwrap_or(DEFAULT_KERNEL_STACK),
+        &toml.kernel.requires,
+    )?;
     for (name, task) in &toml.tasks {
         if !only_suggest {
             println!();
         }
         check_task(
             &name,
-            task.stacksize.unwrap_or_else(|| toml.stacksize.unwrap()),
+            task.stacksize.or(toml.stacksize).unwrap(),
             &task.requires,
         )?;
     }

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -46,8 +46,6 @@ pub fn run(cfg: &Path) -> anyhow::Result<()> {
             .map(|(name, _)| name.as_str())
     };
 
-    let mut first = false;
-
     struct Task<'a> {
         name: &'a str,
         stacksize: u32,
@@ -81,6 +79,7 @@ pub fn run(cfg: &Path) -> anyhow::Result<()> {
     };
 
     let mut suggestions = Vec::new();
+    let mut first = false; // used to print a newline between tasks
     for task in tasks {
         if !first {
             first = true;


### PR DESCRIPTION
Sample output for `cargo xtask sizes app/sidecar/app.toml`:

```
jefe
  flash:  7148 bytes (43%)
  ram:    1620 bytes (79%)

rcc_driver
  flash:  4156 bytes (50%)
  ram:    1024 bytes (100%)

gpio_driver
  flash:  5400 bytes (65%)
  ram:    1024 bytes (100%)

spi2_driver
  flash:  9256 bytes (56%)
  ram:    2036 bytes (49%)

spi5_driver
  flash:  9276 bytes (56%)
  ram:    2036 bytes (49%)

i2c_driver
  flash:  8756 bytes (53%)
  ram:    2008 bytes (98%)

hiffy
  flash: 15456 bytes (47%)
  ram:    8752 bytes (26%)

sensor
  flash:  4372 bytes (26%)
  ram:    2000 bytes (97%)

sidecar_seq
  flash: 19296 bytes (58%)
  ram:    2316 bytes (56%)

idle
  flash:    88 bytes (34%)
  ram:     256 bytes (100%)

kernel
  flash: 31732 bytes (96%)
  ram:    1072 bytes (26%)

========== Suggested changes ==========
jefe:
  flash: 8192 (from 16384)
spi2_driver:
  ram:   2048 (from 4096)
spi5_driver:
  ram:   2048 (from 4096)
hiffy:
  flash: 16384 (from 32768)
  ram:   16384 (from 32768)
sensor:
  flash: 8192 (from 16384)
idle:
  flash: 128 (from 256)
kernel:
  ram:   2048 (from 4096)

------------ Total savings ------------
  flash: 32896
  ram:   22528
```