### PR TITLE
Redo stm32h7 SPI state machine

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -280,6 +280,7 @@ af = 4
 
 [config.spi.spi1]
 controller = 1
+fifo_depth = 16
 
 [config.spi.spi1.mux_options.cn7_arduino]
 outputs = [

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -55,6 +55,7 @@ struct GlobalConfig {
 #[derive(Deserialize)]
 struct SpiConfig {
     controller: usize,
+    fifo_depth: Option<usize>,
     mux_options: BTreeMap<String, SpiMuxOptionConfig>,
     devices: IndexMap<String, DeviceDescriptorConfig>,
 }
@@ -210,7 +211,12 @@ impl ToTokens for SpiConfig {
 
         let muxes = self.mux_options.values();
 
+        // If the user does not specify a fifo depth, we default to the
+        // _minimum_ on any SPI block on the STM32H7, which is 8.
+        let fifo_depth = self.fifo_depth.unwrap_or(8);
+
         tokens.append_all(quote::quote! {
+            const FIFO_DEPTH: usize = #fifo_depth;
             const CONFIG: ServerConfig = ServerConfig {
                 registers: device::#devname::ptr(),
                 peripheral: rcc_api::Peripheral::#pname,

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -369,13 +369,13 @@ impl ServerImpl {
         }
 
         // We use this to exert backpressure on the TX state machine as the RX
-        // FIFO fills. Its initial value is the minimum FIFO size across any
-        // implemented SPI block on the H7; it would be nice if we could read
-        // the configured FIFO size out of the block, but that does not appear
-        // to be possible. So, we are currently conservative.
+        // FIFO fills. Its initial value is the configured FIFO size, because
+        // the FIFO size varies on SPI blocks on the H7; it would be nice if we
+        // could read the configured FIFO size out of the block, but that does
+        // not appear to be possible.
         //
         // See reference manual table 409 for details.
-        let mut tx_permits = 16;
+        let mut tx_permits = FIFO_DEPTH;
 
         // Track number of bytes sent and received. Sent bytes will lead
         // received bytes. Received bytes indicate overall progress and

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> ! {
     let registers = unsafe { &*CONFIG.registers };
 
     rcc_driver.enable_clock(CONFIG.peripheral);
+    rcc_driver.enter_reset(CONFIG.peripheral);
     rcc_driver.leave_reset(CONFIG.peripheral);
     let mut spi = spi_core::Spi::from(registers);
 

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -253,6 +253,10 @@ impl Spi {
         self.reg.ier.modify(|_, w| w.txpie().clear_bit());
     }
 
+    pub fn enable_can_tx_interrupt(&mut self) {
+        self.reg.ier.modify(|_, w| w.txpie().set_bit());
+    }
+
     pub fn check_eot(&self) -> bool {
         self.reg.sr.read().eot().is_completed()
     }


### PR DESCRIPTION
My last round of fixes left things in a sort of mostly-working state, but I didn't like that very much, so I revisited the state machine.

I have also included a fix for SPI4/5/6 on STM32H7, which have shallower FIFOs.