### PR TITLE
Factor common GPIO code out of stm32{g0,h7}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
  "zerocopy",
 ]
@@ -846,6 +846,7 @@ name = "drv-stm32g0-sys"
 version = "0.1.0"
 dependencies = [
  "drv-stm32g0-sys-api",
+ "drv-stm32xx-gpio-common",
  "idol",
  "idol-runtime",
  "num-traits",
@@ -859,6 +860,7 @@ name = "drv-stm32g0-sys-api"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "drv-stm32xx-gpio-common",
  "idol",
  "num-traits",
  "unwrap-lite",
@@ -885,7 +887,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "smoltcp",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
 ]
 
@@ -896,8 +898,9 @@ dependencies = [
  "byteorder",
  "cortex-m",
  "drv-stm32h7-rcc-api",
+ "drv-stm32xx-gpio-common",
  "num-traits",
- "stm32h7",
+ "stm32h7 0.14.0",
  "userlib",
  "zerocopy",
 ]
@@ -907,6 +910,7 @@ name = "drv-stm32h7-gpio-api"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "drv-stm32xx-gpio-common",
  "idol",
  "num-traits",
  "userlib",
@@ -924,7 +928,7 @@ dependencies = [
  "drv-stm32h7-rcc-api",
  "num-traits",
  "ringbuf",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
  "zerocopy",
 ]
@@ -945,7 +949,7 @@ dependencies = [
  "fixedmap",
  "num-traits",
  "ringbuf",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
 ]
 
@@ -953,7 +957,7 @@ dependencies = [
 name = "drv-stm32h7-qspi"
 version = "0.1.0"
 dependencies = [
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
  "vcell",
  "zerocopy",
@@ -967,7 +971,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
  "zerocopy",
 ]
@@ -989,7 +993,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "ringbuf",
- "stm32h7",
+ "stm32h7 0.13.0",
  "vcell",
  "zerocopy",
 ]
@@ -1014,7 +1018,7 @@ dependencies = [
  "quote",
  "ringbuf",
  "serde",
- "stm32h7",
+ "stm32h7 0.13.0",
  "syn",
  "userlib",
  "zerocopy",
@@ -1026,7 +1030,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -1037,7 +1041,19 @@ dependencies = [
  "drv-stm32h7-gpio-api",
  "drv-stm32h7-rcc-api",
  "num-traits",
- "stm32h7",
+ "stm32h7 0.13.0",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "drv-stm32xx-gpio-common"
+version = "0.1.0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num-traits",
+ "stm32g0",
+ "stm32h7 0.14.0",
  "userlib",
  "zerocopy",
 ]
@@ -1185,7 +1201,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -1236,7 +1252,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -1266,7 +1282,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -2302,7 +2318,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -2453,6 +2469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stm32h7"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0faa648e03579befdd7267ab5c669624729028001fcf3c973832f53e310a06"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cortex-m",
+ "vcell",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,7 +2621,7 @@ dependencies = [
  "serde",
  "smoltcp",
  "ssmarshal",
- "stm32h7",
+ "stm32h7 0.13.0",
  "syn",
  "task-net-api",
  "userlib",
@@ -2700,7 +2727,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "spd",
- "stm32h7",
+ "stm32h7 0.13.0",
  "userlib",
 ]
 
@@ -2840,7 +2867,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]
@@ -2912,7 +2939,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7",
+ "stm32h7 0.13.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "drv/stm32fx-rcc",
     "drv/stm32fx-usart",
 
+    "drv/stm32xx-gpio-common",
+
     "drv/stm32g0-sys",
     "drv/stm32g0-sys-api",
     "drv/stm32g0-usart",

--- a/drv/stm32g0-sys-api/Cargo.toml
+++ b/drv/stm32g0-sys-api/Cargo.toml
@@ -9,14 +9,15 @@ zerocopy = "0.6.1"
 byteorder = {version = "1.3", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 unwrap-lite = {path = "../../lib/unwrap-lite"}
+drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["family-stm32g0"]}
 
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
-g031 = []
-g070 = []
-g0b1 = []
+g031 = ["drv-stm32xx-gpio-common/model-stm32g031"]
+g070 = ["drv-stm32xx-gpio-common/model-stm32g070"]
+g0b1 = ["drv-stm32xx-gpio-common/model-stm32g0b1"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32g0-sys-api/src/lib.rs
+++ b/drv/stm32g0-sys-api/src/lib.rs
@@ -8,7 +8,10 @@
 
 use unwrap_lite::UnwrapLite;
 use userlib::*;
-use zerocopy::AsBytes;
+
+pub use drv_stm32xx_gpio_common::{
+    Alternate, Mode, OutputType, PinSet, Port, Pull, Speed,
+};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
@@ -189,105 +192,6 @@ pub enum Peripheral {
     Spi1 = apb2!(12),
     Tim1 = apb2!(11),
     Syscfg = apb2!(0),
-}
-
-/// Enumeration of all GPIO ports on the STM32G0 series. Note that not all these
-/// ports may be externally exposed on your device/package. We do not check this
-/// at compile time.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive, AsBytes)]
-#[repr(u8)]
-pub enum Port {
-    A = 0,
-    B = 1,
-    C = 2,
-    D = 3,
-    F = 4,
-
-    #[cfg(feature = "g0b1")]
-    E = 5,
-}
-
-impl Port {
-    /// Turns a `Port` into a `PinSet` containing one pin, number `index`.
-    pub const fn pin(self, index: usize) -> PinSet {
-        PinSet {
-            port: self,
-            pin_mask: 1 << index,
-        }
-    }
-}
-
-/// The STM32G0 GPIO hardware lets us configure up to 16 pins on the same port
-/// at a time, and we expose this in the IPC API. A `PinSet` describes the
-/// target of a configuration operation.
-///
-/// A `PinSet` can technically be empty (`pin_mask` of zero) but that's rarely
-/// useful.
-#[derive(Copy, Clone, Debug)]
-pub struct PinSet {
-    /// Port we're talking about.
-    pub port: Port,
-    /// Mask with 1s in affected positions, 0s in others.
-    pub pin_mask: u16,
-}
-
-impl PinSet {
-    /// Derives a `PinSet` by setting mask bit `index`.
-    pub const fn and_pin(self, index: usize) -> Self {
-        Self {
-            pin_mask: self.pin_mask | 1 << index,
-            ..self
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Mode {
-    Input = 0b00,
-    Output = 0b01,
-    Alternate = 0b10,
-    Analog = 0b11,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum OutputType {
-    PushPull = 0,
-    OpenDrain = 1,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Speed {
-    Low = 0b00,
-    Medium = 0b01,
-    High = 0b10,
-    VeryHigh = 0b11,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Pull {
-    None = 0b00,
-    Up = 0b01,
-    Down = 0b10,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Alternate {
-    AF0 = 0,
-    AF1 = 1,
-    AF2 = 2,
-    AF3 = 3,
-    AF4 = 4,
-    AF5 = 5,
-    AF6 = 6,
-    AF7 = 7,
-    AF8 = 8,
-    AF9 = 9,
-    AF10 = 10,
-    AF11 = 11,
-    AF12 = 12,
-    AF13 = 13,
-    AF14 = 14,
-    AF15 = 15,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/drv/stm32g0-sys/Cargo.toml
+++ b/drv/stm32g0-sys/Cargo.toml
@@ -9,16 +9,16 @@ zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
 drv-stm32g0-sys-api = {path = "../stm32g0-sys-api"}
+drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["family-stm32g0", "server-support"]}
 
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
-g031 = ["stm32g0/stm32g031", "drv-stm32g0-sys-api/g031"]
-g070 = ["stm32g0/stm32g070", "drv-stm32g0-sys-api/g070"]
-g0b1 = ["stm32g0/stm32g0b1", "drv-stm32g0-sys-api/g0b1"]
+g031 = ["stm32g0/stm32g031", "drv-stm32g0-sys-api/g031", "drv-stm32xx-gpio-common/model-stm32g031"]
+g070 = ["stm32g0/stm32g070", "drv-stm32g0-sys-api/g070", "drv-stm32xx-gpio-common/model-stm32g070"]
+g0b1 = ["stm32g0/stm32g0b1", "drv-stm32g0-sys-api/g0b1", "drv-stm32xx-gpio-common/model-stm32g0b1"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32g0-sys/src/main.rs
+++ b/drv/stm32g0-sys/src/main.rs
@@ -16,7 +16,8 @@ use stm32g0::stm32g070 as device;
 #[cfg(feature = "g0b1")]
 use stm32g0::stm32g0b1 as device;
 
-use drv_stm32g0_sys_api::{GpioError, Port, RccError};
+use drv_stm32g0_sys_api::{GpioError, RccError};
+use drv_stm32xx_gpio_common::{server::get_gpio_regs, Port};
 use idol_runtime::RequestError;
 use userlib::*;
 
@@ -79,106 +80,6 @@ fn main() -> ! {
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
     }
-}
-
-// These macros are required as the different GPIO ports return different types
-// for some reason (GPIOA returns gpioa, GPIO[B-F] return gpiob?!).
-macro_rules! do_configure {
-    ($reg:expr, $pins:expr, $packed_attributes:expr) => {{
-        // The GPIO config registers come in 1, 2, and 4-bit per
-        // field variants. The user-submitted mask is already
-        // correct for the 1-bit fields; we need to expand it
-        // into corresponding 2- and 4-bit masks. We use an
-        // outer perfect shuffle operation for this, which
-        // interleaves zeroes from the top 16 bits into the
-        // bottom 16.
-
-        // 1 in each targeted 1bit field.
-        let mask_1 = u32::from($pins);
-        // 0b01 in each targeted 2bit field.
-        let lsbs_2 = outer_perfect_shuffle(mask_1);
-        // 0b0001 in each targeted 4bit field for low half.
-        let lsbs_4l = outer_perfect_shuffle(lsbs_2 & 0xFFFF);
-        // Same for high half.
-        let lsbs_4h = outer_perfect_shuffle(lsbs_2 >> 16);
-
-        // Corresponding masks, with 1s in all field bits
-        // instead of just the LSB:
-        let mask_2 = lsbs_2.wrapping_mul(0b11);
-        let mask_4l = lsbs_4l.wrapping_mul(0b1111);
-        let mask_4h = lsbs_4h.wrapping_mul(0b1111);
-
-        let atts = $packed_attributes;
-
-        // MODER contains 16x 2-bit fields.
-        let moder_val = u32::from(atts & 0b11);
-        $reg.moder.write(|w| unsafe {
-            w.bits(
-                ($reg.moder.read().bits() & !mask_2)
-                    | (moder_val.wrapping_mul(lsbs_2)),
-            )
-        });
-        // OTYPER contains 16x 1-bit fields.
-        let otyper_val = u32::from((atts >> 2) & 1);
-        $reg.otyper.write(|w| unsafe {
-            w.bits(
-                ($reg.otyper.read().bits() & !mask_1)
-                    | (otyper_val.wrapping_mul(mask_1)),
-            )
-        });
-        // OSPEEDR contains 16x 2-bit fields.
-        let ospeedr_val = u32::from((atts >> 3) & 0b11);
-        $reg.ospeedr.write(|w| unsafe {
-            w.bits(
-                ($reg.ospeedr.read().bits() & !mask_2)
-                    | (ospeedr_val.wrapping_mul(lsbs_2)),
-            )
-        });
-        // PUPDR contains 16x 2-bit fields.
-        let pupdr_val = u32::from((atts >> 5) & 0b11);
-        $reg.pupdr.write(|w| unsafe {
-            w.bits(
-                ($reg.pupdr.read().bits() & !mask_2)
-                    | (pupdr_val.wrapping_mul(lsbs_2)),
-            )
-        });
-        // AFRx contains 8x 4-bit fields.
-        let af_val = u32::from((atts >> 7) & 0b1111);
-        $reg.afrl.write(|w| unsafe {
-            w.bits(
-                ($reg.afrl.read().bits() & !mask_4l)
-                    | (af_val.wrapping_mul(lsbs_4l)),
-            )
-        });
-        $reg.afrh.write(|w| unsafe {
-            w.bits(
-                ($reg.afrh.read().bits() & !mask_4h)
-                    | (af_val.wrapping_mul(lsbs_4h)),
-            )
-        });
-    }};
-}
-
-macro_rules! do_set_reset {
-    ($reg:expr, $set:expr, $reset:expr) => {
-        $reg.bsrr.write(|w| unsafe {
-            w.bits((u32::from($reset) << 16) | u32::from($set))
-        })
-    };
-}
-
-macro_rules! do_toggle {
-    ($reg:expr, $pins:expr) => {{
-        // Read current pin *output* states.
-        let state = $reg.odr.read().bits();
-        // Compute BSRR value to toggle all pins. That is, move
-        // currently set bits into reset position, and set unset
-        // bits.
-        let bsrr_all = state << 16 | state ^ 0xFFFF;
-        // Write that value, but masked as the user requested.
-        let bsrr_mask = u32::from($pins) | u32::from($pins) << 16;
-        $reg.bsrr.write(|w| unsafe { w.bits(bsrr_all & bsrr_mask) });
-    }};
 }
 
 struct ServerImpl<'a> {
@@ -257,24 +158,7 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
         pins: u16,
         packed_attributes: u16,
     ) -> Result<(), RequestError<GpioError>> {
-        match port {
-            Port::A => {
-                let gpio = unsafe { &*device::GPIOA::ptr() };
-                do_configure!(gpio, pins, packed_attributes);
-            }
-            _ => {
-                let gpio = match port {
-                    Port::B => unsafe { &*device::GPIOB::ptr() },
-                    Port::C => unsafe { &*device::GPIOC::ptr() },
-                    Port::D => unsafe { &*device::GPIOD::ptr() },
-                    #[cfg(feature = "g0b1")]
-                    Port::E => unsafe { &*device::GPIOE::ptr() },
-                    Port::F => unsafe { &*device::GPIOF::ptr() },
-                    _ => unreachable!(),
-                };
-                do_configure!(gpio, pins, packed_attributes);
-            }
-        }
+        unsafe { get_gpio_regs(port) }.configure(pins, packed_attributes);
         Ok(())
     }
 
@@ -285,24 +169,7 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
         set_pins: u16,
         reset_pins: u16,
     ) -> Result<(), RequestError<GpioError>> {
-        match port {
-            Port::A => {
-                let gpio = unsafe { &*device::GPIOA::ptr() };
-                do_set_reset!(gpio, set_pins, reset_pins);
-            }
-            _ => {
-                let gpio = match port {
-                    Port::B => unsafe { &*device::GPIOB::ptr() },
-                    Port::C => unsafe { &*device::GPIOC::ptr() },
-                    Port::D => unsafe { &*device::GPIOD::ptr() },
-                    #[cfg(feature = "g0b1")]
-                    Port::E => unsafe { &*device::GPIOE::ptr() },
-                    Port::F => unsafe { &*device::GPIOF::ptr() },
-                    _ => unreachable!(),
-                };
-                do_set_reset!(gpio, set_pins, reset_pins);
-            }
-        }
+        unsafe { get_gpio_regs(port) }.set_reset(set_pins, reset_pins);
         Ok(())
     }
 
@@ -312,24 +179,7 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
         port: Port,
         pins: u16,
     ) -> Result<(), RequestError<GpioError>> {
-        match port {
-            Port::A => {
-                let gpio = unsafe { &*device::GPIOA::ptr() };
-                do_toggle!(gpio, pins);
-            }
-            _ => {
-                let gpio = match port {
-                    Port::B => unsafe { &*device::GPIOB::ptr() },
-                    Port::C => unsafe { &*device::GPIOC::ptr() },
-                    Port::D => unsafe { &*device::GPIOD::ptr() },
-                    #[cfg(feature = "g0b1")]
-                    Port::E => unsafe { &*device::GPIOE::ptr() },
-                    Port::F => unsafe { &*device::GPIOF::ptr() },
-                    _ => unreachable!(),
-                };
-                do_toggle!(gpio, pins);
-            }
-        }
+        unsafe { get_gpio_regs(port) }.toggle(pins);
         Ok(())
     }
 
@@ -338,48 +188,10 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
         _: &RecvMessage,
         port: Port,
     ) -> Result<u16, RequestError<GpioError>> {
-        match port {
-            Port::A => {
-                let gpio = unsafe { &*device::GPIOA::ptr() };
-                Ok(gpio.idr.read().bits() as u16)
-            }
-            _ => {
-                let gpio = match port {
-                    Port::B => unsafe { &*device::GPIOB::ptr() },
-                    Port::C => unsafe { &*device::GPIOC::ptr() },
-                    Port::D => unsafe { &*device::GPIOD::ptr() },
-                    #[cfg(feature = "g0b1")]
-                    Port::E => unsafe { &*device::GPIOE::ptr() },
-                    Port::F => unsafe { &*device::GPIOF::ptr() },
-                    _ => unreachable!(),
-                };
-                Ok(gpio.idr.read().bits() as u16)
-            }
-        }
+        Ok(unsafe { get_gpio_regs(port) }.read())
     }
 }
 
-/// Interleaves bits in `input` as follows:
-///
-/// - Output bit 0 = input bit 0
-/// - Output bit 1 = input bit 15
-/// - Output bit 2 = input bit 1
-/// - Output bit 3 = input bit 16
-/// ...and so forth.
-///
-/// This is a great example of one of those bit twiddling tricks you never
-/// expected to need. Method from Hacker's Delight.
-const fn outer_perfect_shuffle(mut input: u32) -> u32 {
-    let mut tmp = (input ^ (input >> 8)) & 0x0000ff00;
-    input ^= tmp ^ (tmp << 8);
-    tmp = (input ^ (input >> 4)) & 0x00f000f0;
-    input ^= tmp ^ (tmp << 4);
-    tmp = (input ^ (input >> 2)) & 0x0c0c0c0c;
-    input ^= tmp ^ (tmp << 2);
-    tmp = (input ^ (input >> 1)) & 0x22222222;
-    input ^= tmp ^ (tmp << 1);
-    input
-}
 mod idl {
     use super::{GpioError, Port, RccError};
 

--- a/drv/stm32h7-gpio-api/Cargo.toml
+++ b/drv/stm32h7-gpio-api/Cargo.toml
@@ -8,6 +8,7 @@ userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
+drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["family-stm32h7"]}
 
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/stm32h7-gpio-api/src/lib.rs
+++ b/drv/stm32h7-gpio-api/src/lib.rs
@@ -6,111 +6,11 @@
 
 #![no_std]
 
-use zerocopy::AsBytes;
-
 use userlib::*;
 
-/// Enumeration of all GPIO ports on the STM32H7 series. Note that not all these
-/// ports may be externally exposed on your device/package. We do not check this
-/// at compile time.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive, AsBytes)]
-#[repr(u8)]
-pub enum Port {
-    A = 0,
-    B = 1,
-    C = 2,
-    D = 3,
-    E = 4,
-    F = 5,
-    G = 6,
-    H = 7,
-    I = 8,
-    J = 9,
-    K = 10,
-}
-
-impl Port {
-    /// Turns a `Port` into a `PinSet` containing one pin, number `index`.
-    pub const fn pin(self, index: usize) -> PinSet {
-        PinSet {
-            port: self,
-            pin_mask: 1 << index,
-        }
-    }
-}
-
-/// The STM32H7 GPIO hardware lets us configure up to 16 pins on the same port
-/// at a time, and we expose this in the IPC API. A `PinSet` describes the
-/// target of a configuration operation.
-///
-/// A `PinSet` can technically be empty (`pin_mask` of zero) but that's rarely
-/// useful.
-#[derive(Copy, Clone, Debug)]
-pub struct PinSet {
-    /// Port we're talking about.
-    pub port: Port,
-    /// Mask with 1s in affected positions, 0s in others.
-    pub pin_mask: u16,
-}
-
-impl PinSet {
-    /// Derives a `PinSet` by setting mask bit `index`.
-    pub const fn and_pin(self, index: usize) -> Self {
-        Self {
-            pin_mask: self.pin_mask | 1 << index,
-            ..self
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Mode {
-    Input = 0b00,
-    Output = 0b01,
-    Alternate = 0b10,
-    Analog = 0b11,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum OutputType {
-    PushPull = 0,
-    OpenDrain = 1,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Speed {
-    Low = 0b00,
-    Medium = 0b01,
-    High = 0b10,
-    VeryHigh = 0b11,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Pull {
-    None = 0b00,
-    Up = 0b01,
-    Down = 0b10,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
-pub enum Alternate {
-    AF0 = 0,
-    AF1 = 1,
-    AF2 = 2,
-    AF3 = 3,
-    AF4 = 4,
-    AF5 = 5,
-    AF6 = 6,
-    AF7 = 7,
-    AF8 = 8,
-    AF9 = 9,
-    AF10 = 10,
-    AF11 = 11,
-    AF12 = 12,
-    AF13 = 13,
-    AF14 = 14,
-    AF15 = 15,
-}
+pub use drv_stm32xx_gpio_common::{
+    Alternate, Mode, OutputType, PinSet, Port, Pull, Speed,
+};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]

--- a/drv/stm32h7-gpio/Cargo.toml
+++ b/drv/stm32h7-gpio/Cargo.toml
@@ -9,13 +9,13 @@ zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-rcc-api = {path = "../stm32h7-rcc-api", default-features = false }
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
+drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["family-stm32h7", "server-support"]}
 
 [features]
-h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743"]
-h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753"]
-h7b3 = ["stm32h7/stm32h7b3", "drv-stm32h7-rcc-api/h7b3"]
+h743 = ["stm32h7/stm32h743", "drv-stm32h7-rcc-api/h743", "drv-stm32xx-gpio-common/model-stm32h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32h7-rcc-api/h753", "drv-stm32xx-gpio-common/model-stm32h753"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32h7-gpio/src/main.rs
+++ b/drv/stm32h7-gpio/src/main.rs
@@ -82,16 +82,9 @@
 use byteorder::LittleEndian;
 use drv_stm32h7_rcc_api::{Peripheral, Rcc};
 use userlib::*;
-use zerocopy::{AsBytes, FromBytes, Unaligned, U16, U32};
+use zerocopy::{AsBytes, FromBytes, Unaligned, U16};
 
-#[cfg(feature = "h743")]
-use stm32h7::stm32h743 as device;
-
-#[cfg(feature = "h753")]
-use stm32h7::stm32h753 as device;
-
-#[cfg(feature = "h7b3")]
-use stm32h7::stm32h7b3 as device;
+use drv_stm32xx_gpio_common::{server::get_gpio_regs, Port};
 
 #[derive(FromPrimitive)]
 enum Op {
@@ -99,21 +92,6 @@ enum Op {
     SetReset = 2,
     ReadInput = 3,
     Toggle = 4,
-}
-
-#[derive(FromPrimitive)]
-enum Port {
-    A = 0,
-    B = 1,
-    C = 2,
-    D = 3,
-    E = 4,
-    F = 5,
-    G = 6,
-    H = 7,
-    I = 8,
-    J = 9,
-    K = 10,
 }
 
 #[derive(FromBytes, Unaligned)]
@@ -128,7 +106,8 @@ struct ConfigureRequest {
 #[repr(C)]
 struct SetResetRequest {
     port: u8,
-    set_reset: U32<LittleEndian>,
+    set: U16<LittleEndian>,
+    reset: U16<LittleEndian>,
 }
 
 #[derive(FromBytes, Unaligned)]
@@ -171,79 +150,11 @@ fn main() -> ! {
                             .ok_or(ResponseCode::BadArg)?;
                         let port = Port::from_u8(msg.port)
                             .ok_or(ResponseCode::BadArg)?;
-                        let reg = gpio_reg(port);
-
-                        // The GPIO config registers come in 1, 2, and 4-bit per
-                        // field variants. The user-submitted mask is already
-                        // correct for the 1-bit fields; we need to expand it
-                        // into corresponding 2- and 4-bit masks. We use an
-                        // outer perfect shuffle operation for this, which
-                        // interleaves zeroes from the top 16 bits into the
-                        // bottom 16.
-
-                        // 1 in each targeted 1bit field.
-                        let mask_1 = u32::from(msg.pins.get());
-                        // 0b01 in each targeted 2bit field.
-                        let lsbs_2 = outer_perfect_shuffle(mask_1);
-                        // 0b0001 in each targeted 4bit field for low half.
-                        let lsbs_4l = outer_perfect_shuffle(lsbs_2 & 0xFFFF);
-                        // Same for high half.
-                        let lsbs_4h = outer_perfect_shuffle(lsbs_2 >> 16);
-
-                        // Corresponding masks, with 1s in all field bits
-                        // instead of just the LSB:
-                        let mask_2 = lsbs_2 * 0b11;
-                        let mask_4l = lsbs_4l * 0b1111;
-                        let mask_4h = lsbs_4h * 0b1111;
-
-                        let atts = msg.packed_attributes.get();
-
-                        // MODER contains 16x 2-bit fields.
-                        let moder_val = u32::from(atts & 0b11);
-                        reg.moder.write(|w| unsafe {
-                            w.bits(
-                                (reg.moder.read().bits() & !mask_2)
-                                    | (moder_val * lsbs_2),
-                            )
-                        });
-                        // OTYPER contains 16x 1-bit fields.
-                        let otyper_val = u32::from((atts >> 2) & 1);
-                        reg.otyper.write(|w| unsafe {
-                            w.bits(
-                                (reg.otyper.read().bits() & !mask_1)
-                                    | (otyper_val * mask_1),
-                            )
-                        });
-                        // OSPEEDR contains 16x 2-bit fields.
-                        let ospeedr_val = u32::from((atts >> 3) & 0b11);
-                        reg.ospeedr.write(|w| unsafe {
-                            w.bits(
-                                (reg.ospeedr.read().bits() & !mask_2)
-                                    | (ospeedr_val * lsbs_2),
-                            )
-                        });
-                        // PUPDR contains 16x 2-bit fields.
-                        let pupdr_val = u32::from((atts >> 5) & 0b11);
-                        reg.pupdr.write(|w| unsafe {
-                            w.bits(
-                                (reg.pupdr.read().bits() & !mask_2)
-                                    | (pupdr_val * lsbs_2),
-                            )
-                        });
-                        // AFRx contains 8x 4-bit fields.
-                        let af_val = u32::from((atts >> 7) & 0b1111);
-                        reg.afrl.write(|w| unsafe {
-                            w.bits(
-                                (reg.afrl.read().bits() & !mask_4l)
-                                    | (af_val * lsbs_4l),
-                            )
-                        });
-                        reg.afrh.write(|w| unsafe {
-                            w.bits(
-                                (reg.afrh.read().bits() & !mask_4h)
-                                    | (af_val * lsbs_4h),
-                            )
-                        });
+                        let reg = unsafe { get_gpio_regs(port) };
+                        reg.configure(
+                            msg.pins.get(),
+                            msg.packed_attributes.get(),
+                        );
                         caller.reply(());
                     }
                     Op::SetReset => {
@@ -252,10 +163,8 @@ fn main() -> ! {
                             .ok_or(ResponseCode::BadArg)?;
                         let port = Port::from_u8(msg.port)
                             .ok_or(ResponseCode::BadArg)?;
-                        let reg = gpio_reg(port);
-
-                        reg.bsrr
-                            .write(|w| unsafe { w.bits(msg.set_reset.get()) });
+                        let reg = unsafe { get_gpio_regs(port) };
+                        reg.set_reset(msg.set.get(), msg.reset.get());
                         caller.reply(());
                     }
                     Op::ReadInput => {
@@ -264,9 +173,9 @@ fn main() -> ! {
                             .ok_or(ResponseCode::BadArg)?;
                         let port =
                             Port::from_u8(*msg).ok_or(ResponseCode::BadArg)?;
-                        let reg = gpio_reg(port);
+                        let reg = unsafe { get_gpio_regs(port) };
 
-                        caller.reply(reg.idr.read().bits() as u16);
+                        caller.reply(reg.read());
                     }
                     Op::Toggle => {
                         let (msg, caller) = msg
@@ -274,18 +183,8 @@ fn main() -> ! {
                             .ok_or(ResponseCode::BadArg)?;
                         let port = Port::from_u8(msg.port)
                             .ok_or(ResponseCode::BadArg)?;
-                        let reg = gpio_reg(port);
-
-                        // Read current pin *output* states.
-                        let state = reg.odr.read().bits();
-                        // Compute BSRR value to toggle all pins. That is, move
-                        // currently set bits into reset position, and set unset
-                        // bits.
-                        let bsrr_all = state << 16 | state ^ 0xFFFF;
-                        // Write that value, but masked as the user requested.
-                        let bsrr_mask = u32::from(msg.pins.get()) * 0x1_0001;
-                        reg.bsrr
-                            .write(|w| unsafe { w.bits(bsrr_all & bsrr_mask) });
+                        let reg = unsafe { get_gpio_regs(port) };
+                        reg.toggle(msg.pins.get());
                         caller.reply(());
                     }
                 }
@@ -304,42 +203,4 @@ fn turn_on_all_gpios() {
         rcc_driver.enable_clock_raw(pnum).unwrap();
         rcc_driver.leave_reset_raw(pnum).unwrap();
     }
-}
-
-fn gpio_reg(port: Port) -> &'static device::gpioa::RegisterBlock {
-    match port {
-        Port::A => unsafe { &*device::GPIOA::ptr() },
-        Port::B => unsafe { &*device::GPIOB::ptr() },
-        Port::C => unsafe { &*device::GPIOC::ptr() },
-        Port::D => unsafe { &*device::GPIOD::ptr() },
-        Port::E => unsafe { &*device::GPIOE::ptr() },
-        Port::F => unsafe { &*device::GPIOF::ptr() },
-        Port::G => unsafe { &*device::GPIOG::ptr() },
-        Port::H => unsafe { &*device::GPIOH::ptr() },
-        Port::I => unsafe { &*device::GPIOI::ptr() },
-        Port::J => unsafe { &*device::GPIOJ::ptr() },
-        Port::K => unsafe { &*device::GPIOK::ptr() },
-    }
-}
-
-/// Interleaves bits in `input` as follows:
-///
-/// - Output bit 0 = input bit 0
-/// - Output bit 1 = input bit 15
-/// - Output bit 2 = input bit 1
-/// - Output bit 3 = input bit 16
-/// ...and so forth.
-///
-/// This is a great example of one of those bit twiddling tricks you never
-/// expected to need. Method from Hacker's Delight.
-const fn outer_perfect_shuffle(mut input: u32) -> u32 {
-    let mut tmp = (input ^ (input >> 8)) & 0x0000ff00;
-    input ^= tmp ^ (tmp << 8);
-    tmp = (input ^ (input >> 4)) & 0x00f000f0;
-    input ^= tmp ^ (tmp << 4);
-    tmp = (input ^ (input >> 2)) & 0x0c0c0c0c;
-    input ^= tmp ^ (tmp << 2);
-    tmp = (input ^ (input >> 1)) & 0x22222222;
-    input ^= tmp ^ (tmp << 1);
-    input
 }

--- a/drv/stm32xx-gpio-common/Cargo.toml
+++ b/drv/stm32xx-gpio-common/Cargo.toml
@@ -1,0 +1,87 @@
+[package]
+name = "drv-stm32xx-gpio-common"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cfg-if = "1"
+stm32h7 = { version = "0.14", default-features = false, optional = true }
+userlib = {path = "../../sys/userlib"}
+num-traits = {version = "0.2", default-features = false}
+zerocopy = "0.6.1"
+
+[dependencies.stm32g0]
+optional = true
+git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
+branch = "stm32g0b1-initial-support"
+default-features = false
+
+[features]
+# When enabled, the `server` submodule is included, providing code for modeling
+# register accesses. This requires that you set a `model` feature so that we
+# can reference the right PAC submodule.
+server-support = []
+
+#
+# family- and model- features
+#
+# The family-XXX features switch on support for a specific family of parts. The
+# model-XXX features switch on model-specific code for a part available within
+# the family. The model-XXX features imply the family-XXX features, so if you
+# know the model you don't need to set the family.
+
+# Switches SoC family support to the STM32G0 series. Most G0 client code
+# needn't set a model feature, but note that the G0B1 adds a GPIO port.
+family-stm32g0 = [
+    "stm32g0",
+    "has-gpioa-type",
+    "has-gpiob-type",
+    "has-port-gpiof",
+]
+model-stm32g031 = ["family-stm32g0"]
+model-stm32g070 = ["family-stm32g0"]
+model-stm32g0b1 = ["family-stm32g0", "has-port-gpioe"]
+
+# Switches SoC family support to the STM32H7 series. Most H7 client code
+# needn't set a model feature, since the models we target are _almost_
+# identical.
+family-stm32h7 = [
+    "stm32h7",
+    "has-gpioa-type",
+    "has-af8-thru-af15",
+    "has-port-gpioe",
+    "has-port-gpiof",
+    "has-port-gpiog",
+    "has-port-gpioh",
+    "has-port-gpioi",
+    "has-port-gpioj",
+    "has-port-gpiok",
+]
+model-stm32h743 = ["family-stm32h7"]
+model-stm32h753 = ["family-stm32h7"]
+
+# The has-gpioX-type features indicates that the PAC for the chosen model calls
+# at least some of the GPIO ports `gpioX`. Note that this has nothing to do
+# with the actual identity of the port; GPIOX is probably called `gpioX` but
+# GPIOZ might be too.
+has-gpioa-type = []
+has-gpiob-type = []
+
+# The has-port-gpioX features indicate that the model or family includes the
+# given GPIO port in the memory map. Numbering here starts at E because it is a
+# rare STM32 part that is missing GPIOD and below.
+has-port-gpioe = []
+has-port-gpiof = []
+has-port-gpiog = []
+has-port-gpioh = []
+has-port-gpioi = []
+has-port-gpioj = []
+has-port-gpiok = []
+
+# Indicates that the Alternate Function field in the GPIO blocks has 16
+# possible options rather than 8. (The field is always 4 bits wide, but on
+# simpler STM32 implementations missing this feature the top 8 values are
+# reserved.)
+has-af8-thru-af15 = []

--- a/drv/stm32xx-gpio-common/src/lib.rs
+++ b/drv/stm32xx-gpio-common/src/lib.rs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! GPIO-related things needed by all STM32 parts.
+
+#![no_std]
+
+use userlib::FromPrimitive;
+use zerocopy::AsBytes;
+
+#[cfg(feature = "server-support")]
+pub mod server;
+
+/// Enumerates the GPIO ports available on this chip, from the perspective of
+/// driver software. This does not mean the GPIO port is physically available on
+/// pins of the package -- we don't model package differences.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive, AsBytes)]
+#[repr(u8)]
+pub enum Port {
+    A = 0,
+    B,
+    C,
+    D,
+    #[cfg(feature = "has-port-gpioe")]
+    E,
+    #[cfg(feature = "has-port-gpiof")]
+    F,
+    #[cfg(feature = "has-port-gpiog")]
+    G,
+    #[cfg(feature = "has-port-gpioh")]
+    H,
+    #[cfg(feature = "has-port-gpioi")]
+    I,
+    #[cfg(feature = "has-port-gpioj")]
+    J,
+    #[cfg(feature = "has-port-gpiok")]
+    K,
+}
+
+impl Port {
+    /// Turns a `Port` into a `PinSet` containing one pin, number `index`.
+    #[inline(always)]
+    pub const fn pin(self, index: usize) -> PinSet {
+        PinSet {
+            port: self,
+            pin_mask: 1 << index,
+        }
+    }
+}
+
+/// The STM32xx GPIO hardware lets us configure up to 16 pins on the same port
+/// at a time, and we expose this in the API. A `PinSet` describes the target of
+/// a configuration operation.
+///
+/// A `PinSet` can technically be empty (`pin_mask` of zero) but that's rarely
+/// useful.
+#[derive(Copy, Clone, Debug)]
+pub struct PinSet {
+    /// Port we're talking about.
+    pub port: Port,
+    /// Mask with 1s in affected positions, 0s in others.
+    pub pin_mask: u16,
+}
+
+impl PinSet {
+    /// Derives a `PinSet` by setting mask bit `index`.
+    #[inline(always)]
+    pub const fn and_pin(self, index: usize) -> Self {
+        Self {
+            pin_mask: self.pin_mask | 1 << index,
+            ..self
+        }
+    }
+}
+
+/// Possible modes for a GPIO pin.
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+pub enum Mode {
+    /// Digital input. This activates a Schmitt trigger on the pin, which is
+    /// great for receiving digital signals, but can burn a lot of current if
+    /// faced with signals intermediate between 1 and 0. As a result, to treat a
+    /// pin as unused, set it to `Analog`.
+    Input = 0b00,
+    /// Software-controlled output. Values written to the corresponding bit of
+    /// the ODR register will control the pin's driver.
+    Output = 0b01,
+    /// Alternate function. This disconnects the direct GPIO driver from the pin
+    /// and instead connects it to the function mux, which in turn connects it
+    /// to a peripheral signal chosen by one of the `AFx` values written to
+    /// AFRL/AFRH.
+    Alternate = 0b10,
+    /// Analog input. This disconnects the output driver, input Schmitt trigger,
+    /// and function mux from the pin, and is the highest-impedance state. It is
+    /// _also_ useful for analog if the pin has an ADC channel attached.
+    Analog = 0b11,
+}
+
+/// Drive modes for a GPIO pin.
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+pub enum OutputType {
+    /// The pin will be driven both high and low in `Output` and `Alternate`
+    /// modes.
+    PushPull = 0,
+    /// Turns off the pin's high side driver in `Output` and `Alternate` modes,
+    /// so that setting the pin to 0 pulls low, but 1 enters a high impedance
+    /// state.
+    OpenDrain = 1,
+}
+
+/// Drive speeds / slew rate limits for GPIO pins.
+///
+/// When in doubt, use `Low`. It's fast enough for most things and is less prone
+/// to generating reflections and EMI. Note that you need to check the datasheet
+/// for the specific part you're targeting to get the actual speeds of these
+/// drive settings. The notes below are thus vague.
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+pub enum Speed {
+    /// Slowest and generally correct drive speed (up to, say, 10MHz or so).
+    Low = 0b00,
+    /// Somewhat faster (say, 50MHz).
+    Medium = 0b01,
+    /// Somewhat faster-er (idk like 80MHz? Go read the datasheet)
+    High = 0b10,
+    /// Go read the datasheet.
+    VeryHigh = 0b11,
+}
+
+/// Settings for the switchable weak pull resistors on GPIO pins.
+///
+/// Note that the pull resistors apply in all modes, so, you can apply these to
+/// an input, and you will want to turn them off for `Analog`.
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+pub enum Pull {
+    /// Both resistors off.
+    None = 0b00,
+    /// Weak pull up.
+    Up = 0b01,
+    /// Weak pull down.
+    Down = 0b10,
+}
+
+/// Enumeration of alternate functions that can be stuffed into the AFRL/AFRH
+/// registers to change pin muxes. These only apply when the pin is in
+/// `Alternate` mode.
+///
+/// These are numbers and not, like, convenient human-readable peripheral names
+/// because the mapping from pin + AF to signal is very complex. See the
+/// datasheet.
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+pub enum Alternate {
+    AF0 = 0,
+    AF1 = 1,
+    AF2 = 2,
+    AF3 = 3,
+    AF4 = 4,
+    AF5 = 5,
+    AF6 = 6,
+    AF7 = 7,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF8 = 8,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF9 = 9,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF10 = 10,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF11 = 11,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF12 = 12,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF13 = 13,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF14 = 14,
+    #[cfg(feature = "has-af8-thru-af15")]
+    AF15 = 15,
+}

--- a/drv/stm32xx-gpio-common/src/server.rs
+++ b/drv/stm32xx-gpio-common/src/server.rs
@@ -1,0 +1,283 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Server support functions, types, etc.
+
+use crate::Port;
+
+// Every PAC includes the same traits and types describing register access. One
+// would expect them to be defined in a common crate that all PACs depend upon,
+// but no, they are generated whole-cloth in every PAC. As a result, we can't
+// simply depend on the common types here, and we need to know which SoC family
+// we're targeting to generate these SoC-family-independent APIs. :-(
+cfg_if::cfg_if! {
+    if #[cfg(feature = "family-stm32g0")] {
+        use stm32g0 as pac;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "model-stm32g031")] {
+                use pac::stm32g031 as device;
+            } else if #[cfg(feature = "model-stm32g070")] {
+                use pac::stm32g070 as device;
+            } else if #[cfg(feature = "model-stm32g0b1")] {
+                use pac::stm32g0b1 as device;
+            } else {
+                compiler_error!("unsupported or missing SoC model feature");
+            }
+        }
+    } else if #[cfg(feature = "family-stm32h7")] {
+        use stm32h7 as pac;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "model-stm32h743")] {
+                use pac::stm32h743 as device;
+            } else if #[cfg(feature = "model-stm32h753")] {
+                use pac::stm32h753 as device;
+            } else {
+                compiler_error!("unsupported or missing SoC model feature");
+            }
+        }
+    } else {
+        compiler_error!("unsupported or missing SoC family feature");
+    }
+}
+
+/// Returns a reference to the GPIO peripheral corresponding to `port`. Because
+/// GPIO peripherals tend to have many different types, this hides the true type
+/// behind a `&dyn AnyGpioPeriph`.
+///
+/// # Safety
+///
+/// I guess this could be used unsafely if you used it within a system using the
+/// Embedded HAL which relies on uniqueness of peripheral access? In practice,
+/// as long as you ensure you're not doing this, you're probably ok.
+pub unsafe fn get_gpio_regs(port: Port) -> &'static dyn AnyGpioPeriph {
+    match port {
+        Port::A => &*device::GPIOA::ptr(),
+        Port::B => &*device::GPIOB::ptr(),
+        Port::C => &*device::GPIOC::ptr(),
+        Port::D => &*device::GPIOD::ptr(),
+
+        #[cfg(feature = "has-port-gpioe")]
+        Port::E => &*device::GPIOE::ptr(),
+        #[cfg(feature = "has-port-gpiof")]
+        Port::F => &*device::GPIOF::ptr(),
+        #[cfg(feature = "has-port-gpiog")]
+        Port::G => &*device::GPIOG::ptr(),
+        #[cfg(feature = "has-port-gpioh")]
+        Port::H => &*device::GPIOH::ptr(),
+        #[cfg(feature = "has-port-gpioi")]
+        Port::I => &*device::GPIOI::ptr(),
+        #[cfg(feature = "has-port-gpioj")]
+        Port::J => &*device::GPIOJ::ptr(),
+        #[cfg(feature = "has-port-gpiok")]
+        Port::K => &*device::GPIOK::ptr(),
+    }
+}
+
+/// A GPIO peripheral that can be manipulated in abstract ways without knowing
+/// its type.
+pub trait AnyGpioPeriph {
+    fn configure(&self, pins: u16, atts: u16);
+    fn set_reset(&self, set: u16, reset: u16);
+    fn toggle(&self, pins: u16);
+    fn read(&self) -> u16;
+}
+
+/// Adapter from `GpioPeriph`, the trait implemented for disjoint GPIO
+/// peripheral types, to the general `AnyGpioPeriph`.
+impl<T: GpioPeriph> AnyGpioPeriph for T {
+    fn configure(&self, pins: u16, atts: u16) {
+        // The GPIO config registers come in 1, 2, and 4-bit per field variants.
+        // The user-submitted mask is already correct for the 1-bit fields; we
+        // need to expand it into corresponding 2- and 4-bit masks. We use an
+        // outer perfect shuffle operation for this, which interleaves zeroes
+        // from the top 16 bits into the bottom 16.
+
+        // 1 in each targeted 1bit field.
+        let mask_1 = u32::from(pins);
+
+        let lsbs_1 = mask_1;
+        // 0b01 in each targeted 2bit field.
+        let lsbs_2 = outer_perfect_shuffle(mask_1);
+        // 0b0001 in each targeted 4bit field for low half.
+        let lsbs_4l = outer_perfect_shuffle(lsbs_2 & 0xFFFF);
+        // Same for high half.
+        let lsbs_4h = outer_perfect_shuffle(lsbs_2 >> 16);
+
+        // Corresponding masks, with 1s in all field bits instead of just the
+        // LSB.  We use multiplication to distribute a constant over all 1
+        // positions because multiplication is cheap on ARMvx-M devices.
+        //
+        // Overflows in these multiplications can't happen, since we're
+        // basically using multiplies as a cheaper shift-and-or sequence.
+        // However, the compiler doesn't always see that, and so we're using
+        // explicitly wrapping operations to avoid generating overflow checks.
+        // This helps to eliminate panics from the GPIO servers and (at the time
+        // of this writing) produced a notable text size reduction on M0+.
+        let mask_2 = lsbs_2.wrapping_mul(0b11);
+        let mask_4l = lsbs_4l.wrapping_mul(0b1111);
+        let mask_4h = lsbs_4h.wrapping_mul(0b1111);
+
+        // MODER contains 16x 2-bit fields.
+        let moder_val = u32::from(atts & 0b11);
+        self.moder().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_2) | moder_val.wrapping_mul(lsbs_2))
+        });
+
+        // OTYPER contains 16x 1-bit fields.
+        let otyper_val = u32::from((atts >> 2) & 1);
+        self.otyper().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_1) | otyper_val.wrapping_mul(lsbs_1))
+        });
+        // OSPEEDR contains 16x 2-bit fields.
+        let ospeedr_val = u32::from((atts >> 3) & 0b11);
+        self.ospeedr().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_2) | ospeedr_val.wrapping_mul(lsbs_2))
+        });
+        // PUPDR contains 16x 2-bit fields.
+        let pupdr_val = u32::from((atts >> 5) & 0b11);
+        self.pupdr().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_2) | pupdr_val.wrapping_mul(lsbs_2))
+        });
+        // AFRx contains 8x 4-bit fields.
+        let af_val = u32::from((atts >> 7) & 0b1111);
+        self.afrl().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_4l) | af_val.wrapping_mul(lsbs_4l))
+        });
+        self.afrh().modify(|r, w| unsafe {
+            // See comment re: wrapping_mul above.
+            w.bits((r.bits() & !mask_4h) | af_val.wrapping_mul(lsbs_4h))
+        });
+    }
+
+    fn set_reset(&self, set: u16, reset: u16) {
+        self.bsrr().write(|w| unsafe {
+            w.bits((u32::from(reset) << 16) | u32::from(set))
+        });
+    }
+
+    fn toggle(&self, pins: u16) {
+        // Read current pin *output* states.
+        let state = self.odr().read().bits() as u16;
+        // Use set/reset to toggle the requested pins.
+        self.set_reset(!state & pins, state & pins);
+    }
+
+    fn read(&self) -> u16 {
+        self.idr().read().bits() as u16
+    }
+}
+
+/// Models a GPIO peripheral on the STM32xx series.
+///
+/// Use this trait if you want your code to be specialized to a _specific_ GPIO
+/// peripheral at compile time. If you want your code to be able to choose a
+/// peripheral at runtime, as in the GPIO server, use `AnyGpioPeriph`
+/// instead.
+///
+/// ...in practice you probably don't want to use this trait.
+pub trait GpioPeriph {
+    type ModeSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type OtypeSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type OspeedSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type PupdSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type AflSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type AfhSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type BsrSpec: pac::RegisterSpec<Ux = u32> + pac::Writable + pac::Resettable;
+    type OdSpec: pac::RegisterSpec<Ux = u32> + pac::Readable + pac::Writable;
+    type IdSpec: pac::RegisterSpec<Ux = u32> + pac::Readable;
+
+    fn moder(&self) -> &pac::Reg<Self::ModeSpec>;
+    fn otyper(&self) -> &pac::Reg<Self::OtypeSpec>;
+    fn ospeedr(&self) -> &pac::Reg<Self::OspeedSpec>;
+    fn pupdr(&self) -> &pac::Reg<Self::PupdSpec>;
+    fn afrl(&self) -> &pac::Reg<Self::AflSpec>;
+    fn afrh(&self) -> &pac::Reg<Self::AfhSpec>;
+    fn bsrr(&self) -> &pac::Reg<Self::BsrSpec>;
+    fn odr(&self) -> &pac::Reg<Self::OdSpec>;
+    fn idr(&self) -> &pac::Reg<Self::IdSpec>;
+}
+
+// We need to implement GpioPeriph for the various disjoint GPIO types. To avoid
+// excessive repetetition, a macro:
+macro_rules! impl_gpio_periph {
+    ($module:ident) => {
+        impl GpioPeriph for device::$module::RegisterBlock {
+            type ModeSpec = device::$module::moder::MODER_SPEC;
+            type OtypeSpec = device::$module::otyper::OTYPER_SPEC;
+            type OspeedSpec = device::$module::ospeedr::OSPEEDR_SPEC;
+            type PupdSpec = device::$module::pupdr::PUPDR_SPEC;
+            type AflSpec = device::$module::afrl::AFRL_SPEC;
+            type AfhSpec = device::$module::afrh::AFRH_SPEC;
+            type BsrSpec = device::$module::bsrr::BSRR_SPEC;
+            type OdSpec = device::$module::odr::ODR_SPEC;
+            type IdSpec = device::$module::idr::IDR_SPEC;
+
+            fn moder(&self) -> &pac::Reg<Self::ModeSpec> {
+                &self.moder
+            }
+            fn otyper(&self) -> &pac::Reg<Self::OtypeSpec> {
+                &self.otyper
+            }
+            fn ospeedr(&self) -> &pac::Reg<Self::OspeedSpec> {
+                &self.ospeedr
+            }
+            fn pupdr(&self) -> &pac::Reg<Self::PupdSpec> {
+                &self.pupdr
+            }
+            fn afrl(&self) -> &pac::Reg<Self::AflSpec> {
+                &self.afrl
+            }
+            fn afrh(&self) -> &pac::Reg<Self::AfhSpec> {
+                &self.afrh
+            }
+            fn bsrr(&self) -> &pac::Reg<Self::BsrSpec> {
+                &self.bsrr
+            }
+            fn odr(&self) -> &pac::Reg<Self::OdSpec> {
+                &self.odr
+            }
+            fn idr(&self) -> &pac::Reg<Self::IdSpec> {
+                &self.idr
+            }
+        }
+    };
+}
+
+// At least G0, F4, H7, and L4 distinguish gpioa from other ports.
+#[cfg(feature = "has-gpioa-type")]
+impl_gpio_periph!(gpioa);
+
+// At least G0, F4, H7, and L4 distinguish gpiob from other ports.
+#[cfg(feature = "has-gpiob-type")]
+impl_gpio_periph!(gpiob);
+
+// Add add'l types here as PAC crates invent more - L4 in particular
+// distinguishes gpioc, so if we support that family, gpioc would go here.
+
+/// Interleaves bits in `input` as follows:
+///
+/// - Output bit 0 = input bit 0
+/// - Output bit 1 = input bit 15
+/// - Output bit 2 = input bit 1
+/// - Output bit 3 = input bit 16
+/// ...and so forth.
+///
+/// This is a great example of one of those bit twiddling tricks you never
+/// expected to need. Method from Hacker's Delight.
+const fn outer_perfect_shuffle(mut input: u32) -> u32 {
+    let mut tmp = (input ^ (input >> 8)) & 0x0000ff00;
+    input ^= tmp ^ (tmp << 8);
+    tmp = (input ^ (input >> 4)) & 0x00f000f0;
+    input ^= tmp ^ (tmp << 4);
+    tmp = (input ^ (input >> 2)) & 0x0c0c0c0c;
+    input ^= tmp ^ (tmp << 2);
+    tmp = (input ^ (input >> 1)) & 0x22222222;
+    input ^= tmp ^ (tmp << 1);
+    input
+}


### PR DESCRIPTION
This is a step toward reducing the overall high level of code
duplication between stm32 targets. It exploits some traits that the PACs
started generating circa 0.14, which are unfortunately not put into a
common crate, but, hey, at least they exist now.

Knocks some bytes (100+) off GPIO servers by reducing macro-driven code
duplication and giving the compiler an easier task.

This is sort of a HAL, but unlike most HALs it's very careful to allow
static monomorphization on properties you know at compile time (like
your SoC model target) and only use dynamic dispatch for things you vary
at runtime (like which gpio port you're poking).

Scary bits are mostly hidden in the server.rs file.