### PR TITLE
Move chip peripherals into a separate file

### DIFF
--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -1,6 +1,7 @@
 name = "demo-stm32f3-discovery"
 target = "thumbv7em-none-eabihf"
 board = "stm32f3-discovery"
+chip = "../../chips/stm32f3.toml"
 stacksize = 896
 
 [kernel]
@@ -108,18 +109,3 @@ requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
-[peripherals.usart2]
-address = 0x40004400
-size = 1024
-
-[peripherals.rcc]
-address = 0x40021000
-size = 1024
-
-[peripherals.gpioa]
-address = 0x48000000
-size = 1024
-
-[peripherals.gpioe]
-address = 0x48001000
-size = 1024

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -1,6 +1,7 @@
 name = "demo-stm32f4-discovery"
 target = "thumbv7em-none-eabihf"
 board = "stm32f4-discovery"
+chip = "../../chips/stm32f4.toml"
 stacksize = 896
 
 [kernel]
@@ -107,19 +108,3 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.usart2]
-address = 0x40004400
-size = 1024
-
-[peripherals.rcc]
-address = 0x40023800
-size = 1024
-
-[peripherals.gpioa]
-address = 0x40020000
-size = 1024
-
-[peripherals.gpiod]
-address = 0x40020c00
-size = 1024

--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -1,5 +1,6 @@
 name = "demo-stm32g031-nucleo"
 target = "thumbv6m-none-eabi"
+chip = "../../chips/stm32g0.toml"
 board = "stm32g031"
 
 [kernel]
@@ -80,11 +81,3 @@ priority = 5
 requires = {flash = 128, ram = 64}
 stacksize = 64
 start = true
-
-[peripherals.rcc]
-address = 0x40021000
-size = 1024
-
-[peripherals.gpio]
-address = 0x50000000
-size = 0x2000

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -1,5 +1,6 @@
 name = "demo-stm32g070-nucleo"
 target = "thumbv6m-none-eabi"
+chip = "../../chips/stm32g0.toml"
 board = "stm32g070"
 stacksize = 944
 
@@ -100,15 +101,3 @@ priority = 5
 requires = {flash = 128, ram = 64}
 stacksize = 64
 start = true
-
-[peripherals.rcc]
-address = 0x40021000
-size = 1024
-
-[peripherals.gpio]
-address = 0x50000000
-size = 0x2000
-
-[peripherals.usart1]
-address = 0x40013800
-size = 1024

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -1,6 +1,7 @@
 name = "demo-stm32h743-nucleo"
 target = "thumbv7em-none-eabihf"
 board = "nucleo-h743zi2"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -179,78 +180,6 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi1]
-address = 0x40013000
-size = 1024
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi3]
-address = 0x40003c00
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-
-[peripherals.spi5]
-address = 0x40015000
-size = 1024
-
-[peripherals.spi6]
-address = 0x58001400
-size = 1024
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
-
-[peripherals.quadspi]
-address = 0x52005000
-size = 4096
-
-[peripherals.eth]
-address = 0x40028000
-size = 0x1000
-
-[peripherals.eth_dma]
-address = 0x40029000
-size = 0x400
 
 [config]
 

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -1,6 +1,7 @@
 name = "demo-stm32h753-nucleo"
 target = "thumbv7em-none-eabihf"
 board = "nucleo-h753zi"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -160,84 +161,7 @@ requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi1]
-address = 0x40013000
-size = 1024
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi3]
-address = 0x40003c00
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-
-[peripherals.spi5]
-address = 0x40015000
-size = 1024
-
-[peripherals.spi6]
-address = 0x58001400
-size = 1024
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
-
-[peripherals.quadspi]
-address = 0x52005000
-size = 4096
-
-[peripherals.hash]
-address = 0x48021400
-size = 4096
-
-#[peripherals.rng]
-#address = 0x48021800
-#size = 4096
-
-#[peripherals.cryp]
-#address = 0x48021000
-#size = 4096
-
 [config]
-
 [[config.i2c.controllers]]
 controller = 2
 

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -1,6 +1,7 @@
 name = "gemini-bu-rot"
 target = "thumbv8m.main-none-eabihf"
 board = "gemini-bu-rot-1"
+chip = "../../chips/lpc55.toml"
 stacksize = 1024
 
 [kernel]
@@ -168,43 +169,3 @@ requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["spi0_driver"]
-
-[peripherals.syscon]
-address = 0x40000000
-size = 4096
-
-[peripherals.anactrl]
-address = 0x40013000
-size = 4096
-
-[peripherals.gpio]
-address = 0x4008c000
-size = 9348
-
-[peripherals.iocon]
-address = 0x40001000
-size = 4096
-
-[peripherals.flexcomm0]
-address = 0x40086000
-size = 4096
-
-[peripherals.flexcomm3]
-address = 0x40089000
-size = 4096
-
-[peripherals.flexcomm4]
-address = 0x4008A000
-size = 4096
-
-[peripherals.pmc]
-address = 0x40020000
-size = 4096
-
-[peripherals.flexcomm8]
-address = 0x4009F000
-size = 4096
-
-[peripherals.rng]
-address = 0x4003A000
-size = 4096

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -1,6 +1,7 @@
 name = "gemini-bu"
 target = "thumbv7em-none-eabihf"
 board = "gemini-bu-1"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -171,66 +172,6 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi1]
-address = 0x40013000
-size = 1024
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi3]
-address = 0x40003c00
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-
-[peripherals.spi5]
-address = 0x40015000
-size = 1024
-
-[peripherals.spi6]
-address = 0x58001400
-size = 1024
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
 
 [config]
 

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -1,6 +1,7 @@
 name = "gimlet-rot"
 target = "thumbv8m.main-none-eabihf"
 board = "gimlet-rot-1"
+chip = "../../chips/lpc55.toml"
 stacksize = 1024
 
 [kernel]
@@ -104,43 +105,3 @@ requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["spi0_driver"]
-
-[peripherals.syscon]
-address = 0x40000000
-size = 4096
-
-[peripherals.anactrl]
-address = 0x40013000
-size = 4096
-
-[peripherals.gpio]
-address = 0x4008c000
-size = 9348
-
-[peripherals.iocon]
-address = 0x40001000
-size = 4096
-
-[peripherals.flexcomm0]
-address = 0x40086000
-size = 4096
-
-[peripherals.flexcomm3]
-address = 0x40089000
-size = 4096
-
-[peripherals.flexcomm4]
-address = 0x4008A000
-size = 4096
-
-[peripherals.pmc]
-address = 0x40020000
-size = 4096
-
-[peripherals.flexcomm8]
-address = 0x4009F000
-size = 4096
-
-[peripherals.rng]
-address = 0x4003A000
-size = 4096

--- a/app/gimlet/app.toml
+++ b/app/gimlet/app.toml
@@ -1,6 +1,7 @@
 name = "gimlet"
 target = "thumbv7em-none-eabihf"
 board = "gimlet-1"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -186,55 +187,6 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-interrupts = { irq = 84 }
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
-
-[peripherals.quadspi]
-address = 0x52005000
-size = 4096
 
 [config]
 

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -1,6 +1,7 @@
 name = "gimletlet"
 target = "thumbv7em-none-eabihf"
 board = "gimletlet-2"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -166,70 +167,6 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi1]
-address = 0x40013000
-size = 1024
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi3]
-address = 0x40003c00
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-
-[peripherals.spi5]
-address = 0x40015000
-size = 1024
-
-[peripherals.spi6]
-address = 0x58001400
-size = 1024
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
-
-[peripherals.quadspi]
-address = 0x52005000
-size = 4096
 
 [config]
 [[config.i2c.controllers]]

--- a/app/lpc55xpresso/app-a0.toml
+++ b/app/lpc55xpresso/app-a0.toml
@@ -1,6 +1,7 @@
 name = "lpc55xpresso"
 target = "thumbv8m.main-none-eabihf"
 board = "lpcxpresso55s69"
+chip = "../../chips/lpc55.toml"
 stacksize = 1024
 secure = true
 
@@ -179,38 +180,5 @@ start = true
 stacksize = 1000
 task-slots = ["user_leds"]
 
-[peripherals.syscon]
-address = 0x40000000
-size = 4096
-
-[peripherals.anactrl]
-address = 0x40013000
-size = 4096
-
-[peripherals.gpio]
-address = 0x4008c000
-size = 9348
-
-[peripherals.iocon]
-address = 0x40001000
-size = 4096
-
-[peripherals.flexcomm0]
-address = 0x40086000
-size = 4096
-
-[peripherals.flexcomm4]
-address = 0x4008A000
-size = 4096
-
-[peripherals.pmc]
-address = 0x40020000
-size = 4096
-
-[peripherals.flexcomm8]
-address = 0x4009F000
-size = 4096
-
-[peripherals.rng]
 address = 0x4003A000
 size = 4096

--- a/app/lpc55xpresso/app-a0.toml
+++ b/app/lpc55xpresso/app-a0.toml
@@ -179,6 +179,3 @@ requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 1000
 task-slots = ["user_leds"]
-
-address = 0x4003A000
-size = 4096

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -1,6 +1,7 @@
 name = "lpc55xpresso"
 target = "thumbv8m.main-none-eabihf"
 board = "lpcxpresso55s69"
+chip = "../../chips/lpc55.toml"
 stacksize = 1024
 secure = true
 
@@ -178,39 +179,3 @@ requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["user_leds"]
-
-[peripherals.syscon]
-address = 0x40000000
-size = 4096
-
-[peripherals.anactrl]
-address = 0x40013000
-size = 4096
-
-[peripherals.gpio]
-address = 0x4008c000
-size = 9348
-
-[peripherals.iocon]
-address = 0x40001000
-size = 4096
-
-[peripherals.flexcomm0]
-address = 0x40086000
-size = 4096
-
-[peripherals.flexcomm4]
-address = 0x4008A000
-size = 4096
-
-[peripherals.pmc]
-address = 0x40020000
-size = 4096
-
-[peripherals.flexcomm8]
-address = 0x4009F000
-size = 4096
-
-[peripherals.rng]
-address = 0x4003A000
-size = 4096

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -1,6 +1,7 @@
 name = "sidecar"
 target = "thumbv7em-none-eabihf"
 board = "sidecar-1"
+chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
 [kernel]
@@ -141,58 +142,6 @@ priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-
-[peripherals.rcc]
-address = 0x58024400
-size = 1024
-
-[peripherals.gpios1]
-address = 0x58020000
-size = 0x2000
-
-[peripherals.gpios2]
-address = 0x58022000
-size = 0x0800
-
-[peripherals.gpios3]
-address = 0x58022800
-size = 0x0400
-
-[peripherals.spi2]
-address = 0x40003800
-size = 1024
-
-[peripherals.spi4]
-address = 0x40013400
-size = 1024
-
-[peripherals.spi5]
-address = 0x40015000
-size = 1024
-
-[peripherals.usart3]
-address = 0x40004800
-size = 1024
-
-[peripherals.i2c1]
-address = 0x40005400
-size = 1024
-
-[peripherals.i2c2]
-address = 0x40005800
-size = 1024
-
-[peripherals.i2c3]
-address = 0x40005c00
-size = 1024
-
-[peripherals.i2c4]
-address = 0x58001c00
-size = 1024
-
-[peripherals.quadspi]
-address = 0x52005000
-size = 4096
 
 [config]
 

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -14,8 +14,7 @@ use crate::Config;
 pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
     ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
 
-    let cfg_contents = std::fs::read(&cfg)?;
-    let toml: Config = toml::from_slice(&cfg_contents)?;
+    let toml = Config::from_file(&cfg)?;
 
     let mut out = PathBuf::from("target");
     out.push(toml.name);

--- a/build/xtask/src/gdb.rs
+++ b/build/xtask/src/gdb.rs
@@ -10,8 +10,7 @@ use crate::Config;
 pub fn run(cfg: &Path, gdb_cfg: &Path) -> anyhow::Result<()> {
     ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
 
-    let cfg_contents = std::fs::read(&cfg)?;
-    let toml: Config = toml::from_slice(&cfg_contents)?;
+    let toml = Config::from_file(&cfg)?;
 
     let mut out = PathBuf::from("target");
     out.push(toml.name);

--- a/build/xtask/src/humility.rs
+++ b/build/xtask/src/humility.rs
@@ -10,8 +10,7 @@ use anyhow::Context;
 use crate::Config;
 
 pub fn run(cfg: &Path, options: &Vec<String>) -> anyhow::Result<()> {
-    let cfg_contents = std::fs::read(&cfg)?;
-    let toml: Config = toml::from_slice(&cfg_contents)?;
+    let toml = Config::from_file(&cfg)?;
 
     let mut archive = PathBuf::from("target");
     archive.push(&toml.name);

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -198,9 +198,8 @@ impl Config {
             if !toml.peripherals.is_empty() {
                 bail!("Cannot specify both chip and peripherals");
             }
-            let mut src_dir = cfg.to_path_buf();
-            src_dir.pop();
-            let chip_contents = std::fs::read(src_dir.join(chip))?;
+            let chip_file = cfg.parent().unwrap().join(chip);
+            let chip_contents = std::fs::read(chip_file)?;
             hasher.write(&chip_contents);
             toml::from_slice(&chip_contents)?
         } else {

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::BTreeMap;
-use std::hash::Hash;
-use std::path::PathBuf;
+use std::collections::{hash_map::DefaultHasher, BTreeMap};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use structopt::StructOpt;
 
 use serde::Deserialize;
@@ -136,12 +136,17 @@ enum Xtask {
     },
 }
 
+/// A `RawConfig` represents an `app.toml` file that has been deserialized,
+/// but may not be ready for use.  In particular, we use the `chip` field
+/// to load a second file containing peripheral register addresses.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-struct Config {
+struct RawConfig {
     name: String,
     target: String,
     board: String,
+    #[serde(default)]
+    chip: Option<String>,
     #[serde(default)]
     signing: IndexMap<String, Signing>,
     secure: Option<bool>,
@@ -157,6 +162,71 @@ struct Config {
     supervisor: Option<Supervisor>,
     #[serde(default)]
     config: Option<ordered_toml::Value>,
+}
+
+#[derive(Clone, Debug)]
+struct Config {
+    name: String,
+    target: String,
+    board: String,
+    signing: IndexMap<String, Signing>,
+    secure: Option<bool>,
+    stacksize: Option<u32>,
+    bootloader: Option<Bootloader>,
+    kernel: Kernel,
+    outputs: IndexMap<String, Output>,
+    tasks: IndexMap<String, Task>,
+    peripherals: IndexMap<String, Peripheral>,
+    extratext: IndexMap<String, Peripheral>,
+    supervisor: Option<Supervisor>,
+    config: Option<ordered_toml::Value>,
+    buildhash: u64,
+}
+
+impl Config {
+    pub fn from_file(cfg: &Path) -> Result<Self> {
+        let cfg_contents = std::fs::read(&cfg)?;
+        let toml: RawConfig = toml::from_slice(&cfg_contents)?;
+
+        let mut hasher = DefaultHasher::new();
+        hasher.write(&cfg_contents);
+
+        // If the app.toml specifies a `chip` key, then load the peripheral
+        // register map from a separate file and accumulate that file in the
+        // buildhash.
+        let peripherals = if let Some(chip) = toml.chip {
+            if !toml.peripherals.is_empty() {
+                bail!("Cannot specify both chip and peripherals");
+            }
+            let mut src_dir = cfg.to_path_buf();
+            src_dir.pop();
+            let chip_contents = std::fs::read(src_dir.join(chip))?;
+            hasher.write(&chip_contents);
+            toml::from_slice(&chip_contents)?
+        } else {
+            toml.peripherals
+        };
+
+        let buildhash = hasher.finish();
+
+        Ok(Config {
+            name: toml.name,
+            target: toml.target,
+            board: toml.board,
+            signing: toml.signing,
+            secure: toml.secure,
+            stacksize: toml.stacksize,
+            bootloader: toml.bootloader,
+            kernel: toml.kernel,
+            outputs: toml.outputs,
+            tasks: toml.tasks,
+            peripherals,
+            extratext: toml.extratext,
+            supervisor: toml.supervisor,
+            config: toml.config,
+            buildhash,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -11,7 +11,7 @@ use goblin::Object;
 use indexmap::IndexMap;
 use termcolor::{Color, ColorSpec, WriteColor};
 
-use crate::{dist::DEFAULT_KERNEL_STACK, Config};
+use crate::{Config, dist::DEFAULT_KERNEL_STACK};
 
 fn pow2_suggest(size: u64) -> u64 {
     size.next_power_of_two()
@@ -43,8 +43,7 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
     }(color_choice);
     let out = &mut out_stream;
 
-    let cfg_contents = std::fs::read(&cfg)?;
-    let toml: Config = toml::from_slice(&cfg_contents)?;
+    let toml = Config::from_file(&cfg)?;
 
     let mut dist_dir = PathBuf::from("target");
     dist_dir.push(&toml.name);

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -11,7 +11,7 @@ use goblin::Object;
 use indexmap::IndexMap;
 use termcolor::{Color, ColorSpec, WriteColor};
 
-use crate::{Config, dist::DEFAULT_KERNEL_STACK};
+use crate::{dist::DEFAULT_KERNEL_STACK, Config};
 
 fn pow2_suggest(size: u64) -> u64 {
     size.next_power_of_two()

--- a/build/xtask/src/test.rs
+++ b/build/xtask/src/test.rs
@@ -10,8 +10,7 @@ use anyhow::Context;
 use crate::Config;
 
 pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
-    let cfg_contents = std::fs::read(&cfg)?;
-    let toml: Config = toml::from_slice(&cfg_contents)?;
+    let toml = Config::from_file(&cfg)?;
 
     let mut archive = PathBuf::from("target");
     archive.push(&toml.name);

--- a/chips/lpc55.toml
+++ b/chips/lpc55.toml
@@ -1,0 +1,43 @@
+[syscon]
+address = 0x40000000
+size = 4096
+
+[anactrl]
+address = 0x40013000
+size = 4096
+
+[gpio]
+address = 0x4008c000
+size = 9348
+
+[iocon]
+address = 0x40001000
+size = 4096
+
+[flexcomm0]
+address = 0x40086000
+size = 4096
+
+[flexcomm3]
+address = 0x40089000
+size = 4096
+
+[flexcomm4]
+address = 0x4008A000
+size = 4096
+
+[flexcomm8]
+address = 0x4009F000
+size = 4096
+
+[pmc]
+address = 0x40020000
+size = 4096
+
+[rng]
+address = 0x4003A000
+size = 4096
+
+[flash]
+address = 0x50034000
+size = 0x1000

--- a/chips/stm32f3.toml
+++ b/chips/stm32f3.toml
@@ -1,0 +1,15 @@
+[usart2]
+address = 0x40004400
+size = 1024
+
+[rcc]
+address = 0x40021000
+size = 1024
+
+[gpioa]
+address = 0x48000000
+size = 1024
+
+[gpioe]
+address = 0x48001000
+size = 1024

--- a/chips/stm32f4.toml
+++ b/chips/stm32f4.toml
@@ -1,0 +1,15 @@
+[usart2]
+address = 0x40004400
+size = 1024
+
+[rcc]
+address = 0x40023800
+size = 1024
+
+[gpioa]
+address = 0x40020000
+size = 1024
+
+[gpiod]
+address = 0x40020c00
+size = 1024

--- a/chips/stm32g0.toml
+++ b/chips/stm32g0.toml
@@ -5,3 +5,7 @@ size = 1024
 [gpio]
 address = 0x50000000
 size = 0x2000
+
+[usart1]
+address = 0x40013800
+size = 1024

--- a/chips/stm32g0.toml
+++ b/chips/stm32g0.toml
@@ -1,0 +1,7 @@
+[rcc]
+address = 0x40021000
+size = 1024
+
+[gpio]
+address = 0x50000000
+size = 0x2000

--- a/chips/stm32h7.toml
+++ b/chips/stm32h7.toml
@@ -1,0 +1,84 @@
+[rcc]
+address = 0x58024400
+size = 1024
+
+[gpios1]
+address = 0x58020000
+size = 0x2000
+
+[gpios2]
+address = 0x58022000
+size = 0x0800
+
+[gpios3]
+address = 0x58022800
+size = 0x0400
+
+[spi1]
+address = 0x40013000
+size = 1024
+
+[spi2]
+address = 0x40003800
+size = 1024
+
+[spi3]
+address = 0x40003c00
+size = 1024
+
+[spi4]
+address = 0x40013400
+size = 1024
+interrupts = { irq = 84 }
+
+[spi5]
+address = 0x40015000
+size = 1024
+
+[spi6]
+address = 0x58001400
+size = 1024
+
+[usart3]
+address = 0x40004800
+size = 1024
+
+[i2c1]
+address = 0x40005400
+size = 1024
+
+[i2c2]
+address = 0x40005800
+size = 1024
+
+[i2c3]
+address = 0x40005c00
+size = 1024
+
+[i2c4]
+address = 0x58001c00
+size = 1024
+
+[quadspi]
+address = 0x52005000
+size = 4096
+
+[eth]
+address = 0x40028000
+size = 0x1000
+
+[eth_dma]
+address = 0x40029000
+size = 0x400
+
+[hash]
+address = 0x48021400
+size = 4096
+
+#[rng]
+#address = 0x48021800
+#size = 4096
+
+#[cryp]
+#address = 0x48021000
+#size = 4096

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -1,6 +1,7 @@
 name = "tests-gemini-bu-rot"
 target = "thumbv8m.main-none-eabihf"
 board = "gemini-bu-rot-1"
+chip = "../../chips/lpc55.toml"
 stacksize = 1400
 
 [kernel]
@@ -106,11 +107,3 @@ size = 0x8000
 [extratext.rom]
 address = 0x13000000
 size = 0x20000
-
-[peripherals.syscon]
-address = 0x50000000
-size = 0x1000
-
-[peripherals.flash]
-address = 0x50034000
-size = 0x1000

--- a/test/tests-lpc55xpresso/app-a0.toml
+++ b/test/tests-lpc55xpresso/app-a0.toml
@@ -1,6 +1,7 @@
 name = "tests-lpc55xpresso"
 target = "thumbv8m.main-none-eabihf"
 board = "lpcxpresso55s69"
+chip = "../../chips/lpc55.toml"
 stacksize = 2048
 
 [kernel]
@@ -107,11 +108,3 @@ size = 0x8000
 [extratext.rom]
 address = 0x13000000
 size = 0x20000
-
-[peripherals.syscon]
-address = 0x50000000
-size = 0x1000
-
-[peripherals.flash]
-address = 0x50034000
-size = 0x1000

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -1,6 +1,7 @@
 name = "tests-lpc55xpresso"
 target = "thumbv8m.main-none-eabihf"
 board = "lpcxpresso55s69"
+chip = "../../chips/lpc55.toml"
 stacksize = 2048
 
 [kernel]
@@ -106,11 +107,3 @@ size = 0x8000
 [extratext.rom]
 address = 0x13000000
 size = 0x20000
-
-[peripherals.syscon]
-address = 0x50000000
-size = 0x1000
-
-[peripherals.flash]
-address = 0x50034000
-size = 0x1000


### PR DESCRIPTION
This PR adds a new `chip` field to `app.toml` which specifies a file from which to load peripheral addresses.

It's still backwards-compatible, but I've gone through and changed all of the `app.toml`s that I could lay my hands on.

Having peripheral addresses in one place reduces copy-pasta, and will make it easier to switch to named interrupts consistently through all of our `app.toml`'s.