### PR TITLE
Fix broken IRQ by using numbers instead of name

### DIFF
--- a/app/gimlet/app.toml
+++ b/app/gimlet/app.toml
@@ -64,7 +64,7 @@ requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
-interrupts = {"spi4.irq" = 1}
+interrupts = {84 = 1}
 stacksize = 872
 task-slots = ["sys"]
 


### PR DESCRIPTION
#423 broke `humility manifest` because the IRQ names are no longer part of the `app.toml` file.  This fixes it temporarily, until our bright future of named IRQs arrives (in #424).