### PR TITLE
port from structopt to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,39 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1355,6 +1385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1806,15 @@ source = "git+https://github.com/oxidecomputer/ordered-toml#3fdce7ade3610b84e2bb
 dependencies = [
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2527,7 +2572,7 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2538,7 +2583,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3006,6 +3051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3303,7 @@ dependencies = [
  "atty",
  "byteorder",
  "cargo_metadata",
+ "clap 3.0.14",
  "ctrlc",
  "dunce",
  "filetime",
@@ -3266,7 +3318,6 @@ dependencies = [
  "serde",
  "serde_json",
  "srec",
- "structopt",
  "termcolor",
  "toml",
  "walkdir",

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
-structopt = "0.3.15"
+clap = { version = "3.0.14", features = ["derive"] }
 anyhow = "1.0.32"
 cargo_metadata = "0.12.0"
 ordered-toml = {git = "https://github.com/oxidecomputer/ordered-toml"}

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
-use structopt::StructOpt;
+use clap::Parser;
 
 use serde::Deserialize;
 
@@ -23,22 +23,19 @@ mod sizes;
 mod task_slot;
 mod test;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    max_term_width = 80,
-    about = "extra tasks to help you work on Hubris"
-)]
+#[derive(Debug, Parser)]
+#[clap(max_term_width = 80, about = "extra tasks to help you work on Hubris")]
 enum Xtask {
     /// Builds a collection of cross-compiled binaries at non-overlapping
     /// addresses, and then combines them into a system image with an
     /// application descriptor.
     Dist {
         /// Request verbosity from tools we shell out to.
-        #[structopt(short)]
+        #[clap(short)]
         verbose: bool,
         /// Run `cargo tree --edges features ...` before each invocation of
         /// `cargo rustc ...`
-        #[structopt(short, long)]
+        #[clap(short, long)]
         edges: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
@@ -49,23 +46,23 @@ enum Xtask {
     /// archive. This is useful for iterating on a single task.
     Build {
         /// Request verbosity from tools we shell out to.
-        #[structopt(short)]
+        #[clap(short)]
         verbose: bool,
         /// Run `cargo tree --edges features ...` before each invocation of
         /// `cargo rustc ...`
-        #[structopt(short, long)]
+        #[clap(short, long)]
         edges: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
         /// Name of task(s) to build.
-        #[structopt(min_values = 1)]
+        #[clap(min_values = 1)]
         tasks: Vec<String>,
     },
 
     /// Runs `xtask dist` and flashes the image onto an attached target
     Flash {
         /// Request verbosity from tools we shell out to.
-        #[structopt(short)]
+        #[clap(short)]
         verbose: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
@@ -74,7 +71,7 @@ enum Xtask {
     /// Runs `xtask dist` and reports the sizes of resulting tasks
     Sizes {
         /// Request verbosity from tools we shell out to.
-        #[structopt(short)]
+        #[clap(short)]
         verbose: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
@@ -104,11 +101,11 @@ enum Xtask {
         cfg: PathBuf,
 
         /// Do not flash a new image; just run `humility test`
-        #[structopt(short)]
+        #[clap(short)]
         noflash: bool,
 
         /// Request verbosity from tools we shell out to.
-        #[structopt(short)]
+        #[clap(short)]
         verbose: bool,
     },
 
@@ -116,16 +113,16 @@ enum Xtask {
     Clippy {
         /// the target to build for, uses [package.metadata.build.target] if not
         /// passed
-        #[structopt(long)]
+        #[clap(long)]
         target: Option<String>,
 
         /// the package you're trying to build, uses current directory if not
         /// passed
-        #[structopt(short)]
+        #[clap(short)]
         package: Option<String>,
 
         /// check all packages, not only one
-        #[structopt(long)]
+        #[clap(long)]
         all: bool,
     },
 
@@ -446,7 +443,7 @@ where
 }
 
 fn main() -> Result<()> {
-    let xtask = Xtask::from_args();
+    let xtask = Xtask::parse();
 
     match xtask {
         Xtask::Dist {


### PR DESCRIPTION
structopt is still in Cargo.lock thanks to lpc55_support, cc https://github.com/oxidecomputer/lpc55_support/pull/15