### PR TITLE
net: specify sockets by name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-net"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "serde",
+]
+
+[[package]]
 name = "build-util"
 version = "0.1.0"
 dependencies = [
@@ -2562,6 +2570,7 @@ dependencies = [
 name = "task-net"
 version = "0.1.0"
 dependencies = [
+ "build-net",
  "build-util",
  "cortex-m",
  "drv-stm32h7-eth",
@@ -2587,6 +2596,7 @@ dependencies = [
 name = "task-net-api"
 version = "0.1.0"
 dependencies = [
+ "build-net",
  "idol",
  "num-traits",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ cargo-features = ["resolver"]
 members = [
     "build/call_rustfmt",
     "build/i2c",
+    "build/net",
     "build/util",
     "build/xtask",
 

--- a/build/net/Cargo.toml
+++ b/build/net/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "build-net"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+build-util = {path = "../util"}
+serde = { version = "1.0.114", features = ["derive"] }

--- a/build/net/src/lib.rs
+++ b/build/net/src/lib.rs
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+///////////////////////////////////////////////////////////////////////////////
+// Network config schema definition.
+//
+
+#[derive(Deserialize)]
+pub struct GlobalConfig {
+    pub net: NetConfig,
+}
+
+#[derive(Deserialize)]
+pub struct NetConfig {
+    /// Sockets known to the system, indexed by name.
+    pub sockets: BTreeMap<String, SocketConfig>,
+}
+
+/// TODO: this type really wants to be an enum, but the toml crate's enum
+/// handling is really, really fragile, and currently it would be an enum with a
+/// single variant anyway.
+#[derive(Deserialize)]
+pub struct SocketConfig {
+    pub kind: String,
+    pub owner: TaskNote,
+    pub port: u16,
+    pub tx: BufSize,
+    pub rx: BufSize,
+}
+
+#[derive(Deserialize)]
+pub struct BufSize {
+    pub packets: usize,
+    pub bytes: usize,
+}
+
+#[derive(Deserialize)]
+pub struct TaskNote {
+    pub name: String,
+    pub notification: u32,
+}
+
+pub fn load_net_config() -> Result<NetConfig, Box<dyn std::error::Error>> {
+    Ok(build_util::config::<GlobalConfig>()?.net)
+}
+
+pub fn generate_socket_enum(
+    config: &NetConfig,
+    mut out: impl std::io::Write,
+) -> Result<(), std::io::Error> {
+    writeln!(out, "#[allow(non_camel_case_types)]")?;
+    writeln!(out, "#[repr(u8)]")?;
+    writeln!(
+        out,
+        "#[derive(Copy, Clone, Debug, Eq, PartialEq, userlib::FromPrimitive)]"
+    )?;
+    writeln!(out, "#[derive(serde::Serialize, serde::Deserialize)]")?;
+    writeln!(out, "pub enum SocketName {{")?;
+    for (i, name) in config.sockets.keys().enumerate() {
+        writeln!(out, "    {} = {},", name, i)?;
+    }
+    writeln!(out, "}}")?;
+    Ok(())
+}

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -7,7 +7,7 @@ Interface(
             encoding: Ssmarshal,
             doc: "Unqueues an incoming packet from a socket.",
             args: {
-                "socket_index": "u32",
+                "socket": "SocketName",
             },
             leases: {
                 "payload": (type: "[u8]", write: true),
@@ -21,7 +21,7 @@ Interface(
             encoding: Ssmarshal,
             doc: "Queues an outgoing packet into a socket.",
             args: {
-                "socket_index": "u32",
+                "socket": "SocketName",
                 "metadata": "UdpMetadata",
             },
             leases: {

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -19,6 +19,7 @@ optional = true
 default-features = false
 
 [build-dependencies]
+build-net = {path = "../../build/net"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/net-api/build.rs
+++ b/task/net-api/build.rs
@@ -4,5 +4,13 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     idol::client::build_client_stub("../../idl/net.idol", "client_stub.rs")?;
+
+    let out_dir = std::env::var("OUT_DIR")?;
+    let dest_path = std::path::Path::new(&out_dir).join("net_config.rs");
+    let net_config = build_net::load_net_config()?;
+    build_net::generate_socket_enum(
+        &net_config,
+        std::fs::File::create(dest_path)?,
+    )?;
     Ok(())
 }

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -98,3 +98,4 @@ impl From<Ipv6Address> for smoltcp::wire::Ipv6Address {
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
+include!(concat!(env!("OUT_DIR"), "/net_config.rs"));

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -36,6 +36,7 @@ standalone = []
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+build-net = {path = "../../build/net"}
 serde = "1"
 quote = "1"
 syn = {version = "1", features = ["parsing"]}

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> ! {
     let net = NET.get_task_id();
     let net = Net::from(net);
 
-    const SOCKET: u32 = 0;
+    const SOCKET: SocketName = SocketName::echo;
 
     loop {
         // Tiiiiiny payload buffer


### PR DESCRIPTION
Previously they were named by index in the API, which was a result of me
being in a hurry. It meant that code could accidentally try to use the
wrong socket pretty easily, which results in a crash.

This starts generating an enum of all socket names, and using it in the
API, so that names are stable.

Note that this does _not_ provide a task-slot-style late-binding
mechanism for sockets, which we might want to do eventually.