### PR TITLE
add support for "humility flash"

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -624,6 +624,12 @@ pub fn package(
     archive.copy(out.join("final.ihex"), img_dir.join("final.ihex"))?;
     archive.copy(out.join("final.bin"), img_dir.join("final.bin"))?;
 
+    //
+    // To allow for the image to be flashed based only on the archive (e.g.,
+    // by Humility), we pull in our flash configuration, flatten it to pull in
+    // any external configuration files, serialize it, and add it to the
+    // archive.
+    //
     let mut config = crate::flash::config(&toml.board.as_str())?;
     config.flatten()?;
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -609,6 +609,7 @@ pub fn package(
     archive.copy(out.join("combined.elf"), img_dir.join("combined.elf"))?;
     archive.copy(out.join("combined.ihex"), img_dir.join("combined.ihex"))?;
     archive.copy(out.join("combined.bin"), img_dir.join("combined.bin"))?;
+
     if let Some(bootloader) = toml.bootloader.as_ref() {
         archive
             .copy(out.join(&bootloader.name), img_dir.join(&bootloader.name))?;
@@ -617,6 +618,16 @@ pub fn package(
         let name = format!("{}_{}.bin", s, toml.signing.get(s).unwrap().method);
         archive.copy(out.join(&name), img_dir.join(&name))?;
     }
+
+    archive.copy(out.join("final.srec"), img_dir.join("final.srec"))?;
+    archive.copy(out.join("final.elf"), img_dir.join("final.elf"))?;
+    archive.copy(out.join("final.ihex"), img_dir.join("final.ihex"))?;
+    archive.copy(out.join("final.bin"), img_dir.join("final.bin"))?;
+
+    let mut config = crate::flash::config(&toml.board.as_str())?;
+    config.flatten()?;
+
+    archive.text(img_dir.join("flash.ron"), ron::to_string(&config)?)?;
 
     archive.finish()?;
 

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use path_slash::PathBufExt;
+use serde::Serialize;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -10,6 +11,159 @@ use std::process::Command;
 use anyhow::Context;
 
 use crate::Config;
+
+#[derive(Debug, Serialize)]
+pub enum FlashProgram {
+    PyOcd(Vec<FlashArgument>),
+    OpenOcd(FlashProgramConfig),
+}
+
+#[derive(Debug, Serialize)]
+pub enum FlashProgramConfig {
+    Path(Vec<String>),
+    Payload(String),
+}
+
+#[derive(Debug, Serialize)]
+pub enum FlashArgument {
+    Direct(String),
+    Payload,
+    FormattedPayload(String, String),
+    Config,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FlashConfig {
+    program: FlashProgram,
+    args: Vec<FlashArgument>,
+}
+
+impl FlashProgramConfig {
+    fn new(path: Vec<&str>) -> Self {
+        FlashProgramConfig::Path(path.iter().map(|f| f.to_string()).collect())
+    }
+}
+
+impl FlashConfig {
+    fn new(program: FlashProgram) -> Self {
+        FlashConfig {
+            program: program,
+            args: vec![],
+        }
+    }
+
+    fn arg<'a>(&'a mut self, val: &str) -> &'a mut Self {
+        self.args.push(FlashArgument::Direct(val.to_string()));
+        self
+    }
+
+    fn payload<'a>(&'a mut self) -> &'a mut Self {
+        self.args.push(FlashArgument::Payload);
+        self
+    }
+
+    fn formatted_payload<'a>(
+        &'a mut self,
+        pfx: &str,
+        sfx: &str,
+    ) -> &'a mut Self {
+        self.args.push(FlashArgument::FormattedPayload(
+            pfx.to_string(),
+            sfx.to_string(),
+        ));
+        self
+    }
+
+    fn config<'a>(&'a mut self) -> &'a mut Self {
+        self.args.push(FlashArgument::Config);
+        self
+    }
+
+    ///
+    /// Called to slurp in any configuration file
+    ///
+    pub fn flatten(&mut self) -> anyhow::Result<()> {
+        if let FlashProgram::OpenOcd(ref config) = self.program {
+            if let FlashProgramConfig::Path(ref path) = config {
+                let p: PathBuf = path.iter().collect();
+                let text = std::fs::read_to_string(p)?;
+                self.program =
+                    FlashProgram::OpenOcd(FlashProgramConfig::Payload(text));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
+    match board {
+        "lpcxpresso55s69" | "gemini-bu-rot-1" | "gimlet-rot-1" => {
+            let chip = if board == "lpcxpresso55s69" {
+                "lpc55s69"
+            } else {
+                "lpc55s28"
+            };
+
+            let mut args = vec![];
+
+            for arg in ["reset", "-t", chip].iter() {
+                args.push(FlashArgument::Direct(arg.to_string()));
+            }
+
+            let mut flash = FlashConfig::new(FlashProgram::PyOcd(args));
+
+            flash
+                .arg("flash")
+                .arg("-t")
+                .arg(chip)
+                .arg("--format")
+                .arg("hex")
+                .payload();
+
+            Ok(flash)
+        }
+        "stm32f3-discovery" | "stm32f4-discovery" | "nucleo-h743zi2"
+        | "nucleo-h753zi" | "stm32h7b3i-dk" | "gemini-bu-1" | "gimletlet-1"
+        | "gimletlet-2" | "gimlet-1" | "psc-1" | "sidecar-1" | "stm32g031"
+        | "stm32g070" | "stm32g0b1" => {
+            let (dir, file) = if board == "stm32f3-discovery" {
+                ("demo-stm32f4-discovery", "openocd-f3.cfg")
+            } else if board == "stm32f4-discovery" {
+                ("demo-stm32f4-discovery", "openocd.cfg")
+            } else if board == "stm32g031" {
+                ("demo-stm32g0-nucleo", "openocd.cfg")
+            } else if board == "stm32g070" {
+                ("demo-stm32g0-nucleo", "openocd.cfg")
+            } else if board == "stm32g0b1" {
+                ("demo-stm32g0-nucleo", "openocd.cfg")
+            } else if board == "gemini-bu-1" {
+                ("gemini-bu", "openocd.cfg")
+            } else if board == "gimletlet-2" {
+                ("gimletlet", "openocd.cfg")
+            } else {
+                ("demo-stm32h7-nucleo", "openocd.cfg")
+            };
+
+            let cfg = FlashProgramConfig::new(["app", dir, file].to_vec());
+
+            let mut flash = FlashConfig::new(FlashProgram::OpenOcd(cfg));
+
+            flash
+                .arg("-f")
+                .config()
+                .arg("-c")
+                .formatted_payload("program", "verify reset")
+                .arg("-c")
+                .arg("exit");
+
+            Ok(flash)
+        }
+        _ => {
+            anyhow::bail!("unrecnogized board {}", board);
+        }
+    }
+}
 
 pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
     ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
@@ -20,23 +174,33 @@ pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
     out.push(toml.name);
     out.push("dist");
 
-    let (mut flash, reset) = match toml.board.as_str() {
-        "lpcxpresso55s69" => {
+    let config = config(&toml.board.as_str())?;
+
+    let (mut flash, reset) = match config.program {
+        FlashProgram::PyOcd(ref reset_args) => {
             let mut flash = Command::new("pyocd");
-            flash
-                .arg("flash")
-                .arg("-t")
-                .arg("lpc55s69")
-                .arg("--format")
-                .arg("hex")
-                .arg(out.join("final.ihex"));
-
             let mut reset = Command::new("pyocd");
-            reset.arg("reset").arg("-t").arg("lpc55s69");
 
-            if verbose {
-                flash.arg("-v");
-                reset.arg("-v");
+            for arg in config.args {
+                match arg {
+                    FlashArgument::Direct(ref val) => {
+                        flash.arg(val);
+                    }
+                    FlashArgument::Payload => {
+                        flash.arg(out.join("final.ihex"));
+                    }
+                    _ => {
+                        anyhow::bail!("unexpected PyOCD argument {:?}", arg);
+                    }
+                }
+            }
+
+            for arg in reset_args {
+                if let FlashArgument::Direct(ref val) = arg {
+                    reset.arg(val);
+                } else {
+                    anyhow::bail!("unexpected PyOCD reset argument {:?}", arg);
+                }
             }
 
             if let Ok(id) = env::var("PYOCD_PROBE_ID") {
@@ -46,78 +210,52 @@ pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
                 reset.arg(&id);
             }
 
-            (flash, Some(reset))
-        }
-        "gemini-bu-rot-1" | "gimlet-rot-1" => {
-            let mut flash = Command::new("pyocd");
-            flash
-                .arg("flash")
-                .arg("-t")
-                .arg("lpc55s28")
-                .arg("--format")
-                .arg("hex")
-                .arg(out.join("final.ihex"));
-
-            let mut reset = Command::new("pyocd");
-            reset.arg("reset").arg("-t").arg("lpc55s28");
-
             if verbose {
                 flash.arg("-v");
                 reset.arg("-v");
             }
 
-            if let Ok(id) = env::var("PYOCD_PROBE_ID") {
-                flash.arg("-u");
-                flash.arg(&id);
-                reset.arg("-u");
-                reset.arg(&id);
-            }
-
             (flash, Some(reset))
         }
-        "stm32f3-discovery" | "stm32f4-discovery" | "nucleo-h743zi2"
-        | "nucleo-h753zi" | "stm32h7b3i-dk" | "gemini-bu-1" | "gimletlet-1"
-        | "gimletlet-2" | "gimlet-1" | "psc-1" | "sidecar-1" | "stm32g031"
-        | "stm32g070" | "stm32g0b1" => {
-            let cfg = if toml.board == "stm32f3-discovery" {
-                "./app/demo-stm32f4-discovery/openocd-f3.cfg"
-            } else if toml.board == "stm32f4-discovery" {
-                "./app/demo-stm32f4-discovery/openocd.cfg"
-            } else if toml.board == "stm32g031" {
-                "./app/demo-stm32g0-nucleo/openocd.cfg"
-            } else if toml.board == "stm32g070" {
-                "./app/demo-stm32g0-nucleo/openocd.cfg"
-            } else if toml.board == "stm32g0b1" {
-                "./app/demo-stm32g0-nucleo/openocd.cfg"
-            } else if toml.board == "gemini-bu-1" {
-                "./app/gemini-bu/openocd.cfg"
-            } else if toml.board == "gimletlet-2" {
-                "./app/gimletlet/openocd.cfg"
-            } else {
-                "./app/demo-stm32h7-nucleo/openocd.cfg"
-            };
 
+        FlashProgram::OpenOcd(conf) => {
             let mut flash = Command::new("openocd");
 
             // Note that OpenOCD only deals with slash paths, not native paths
             // (that is, its file arguments are forward-slashed delimited even
-            // when/where the path separator is a back-slash) -- so we be sure
-            // to always give it a slash path for the `program` argument.
-            flash
-                .arg("-f")
-                .arg(cfg)
-                .arg("-c")
-                .arg(format!(
-                    "program {} verify reset",
-                    out.join("final.srec").to_slash().unwrap()
-                ))
-                .arg("-c")
-                .arg("exit");
+            // when/where the path separator is a back-slash) -- so whenever
+            // dealing with a path that is an argument, we be sure to always
+            // give it a slash path regardless of platform.
+            let path = match conf {
+                FlashProgramConfig::Path(ref path) => path,
+                _ => {
+                    anyhow::bail!("unexpected OpenOCD conf {:?}", conf);
+                }
+            };
+
+            for arg in config.args {
+                match arg {
+                    FlashArgument::Direct(ref val) => {
+                        flash.arg(val);
+                    }
+                    FlashArgument::FormattedPayload(ref pre, ref post) => {
+                        flash.arg(format!(
+                            "{} {} {}",
+                            pre,
+                            out.join("final.srec").to_slash().unwrap(),
+                            post,
+                        ));
+                    }
+                    FlashArgument::Config => {
+                        flash.arg(path.join("/"));
+                    }
+                    _ => {
+                        anyhow::bail!("unexpected OpenOCD argument {:?}", arg);
+                    }
+                }
+            }
 
             (flash, None)
-        }
-        _ => {
-            anyhow::bail!("unrecognized board {}", toml.board);
         }
     };
 

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -47,8 +47,10 @@ pub enum FlashArgument {
     // The filesystem path of the binary flash payload itself
     Payload,
 
-    // A single argument consisting of a prefix, the path of the flash
-    // payload, and a suffix
+    // A single argument consisting of a prefix and a suffix.  When the
+    // argument is processed, a single argument should be generated consisting
+    // of the prefix, the path of the flash, and the suffix, all joined by
+    // spaces.
     FormattedPayload(String, String),
 
     // The filesystem path of the flash program configuration
@@ -92,9 +94,9 @@ impl FlashConfig {
     }
 
     //
-    // Add a formatted payload as a single argument to the flash program that
-    // consists of the prefix followed by the path to the payload, followed by
-    // the suffix.
+    // Add a formatted payload as a single argument to the flash program.  The
+    // argument will consists of the specified prefix, followed by the path to
+    // the payload, followed by the specified suffix.
     //
     fn formatted_payload<'a>(
         &'a mut self,
@@ -198,7 +200,7 @@ pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
             Ok(flash)
         }
         _ => {
-            anyhow::bail!("unrecnogized board {}", board);
+            anyhow::bail!("unrecognized board {}", board);
         }
     }
 }


### PR DESCRIPTION
Draft commit message:

```
This work adds two bits to the archive:  the final binaries that we
actually flashed, and some metadata to explain how that can be
reproduced via a flashing program (i.e., OpenOCD or pyOCD depending on
the target).
```
