### PR TITLE
different images can have the same HUBRIS_IMAGE_ID

### DIFF
--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -57,6 +57,7 @@ fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
 
 fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
     let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
+    println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
 
     let kconfig: KernelConfig =
         ron::de::from_str(&env::var("HUBRIS_KCONFIG")?)?;


### PR DESCRIPTION
@mkeeter observed that he had images that we quite clearly very different that had the same `HUBRIS_IMAGE_ID`:

[archive-1.zip](https://github.com/oxidecomputer/hubris/files/8128553/archive-1.zip)
[archive-2.zip](https://github.com/oxidecomputer/hubris/files/8128554/archive-2.zip)

The problem is that while we calculate the `HUBRIS_IMAGE_ID` correctly, we don't rebuild the kernel if/when that changes, resulting in a stale image ID being captured.  The fix, fortunately, is trivial: we need to indicate in the `build.rs` to rerun if the `HUBRIS_IMAGE_ID` environment variable changes.