### PR TITLE
bump toolchain to last night's nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -399,6 +399,15 @@ name = "cortex-m-semihosting"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c23234600452033cc77e4b761e740e02d2c4168e11dbf36ab14a0f58973592b0"
 dependencies = [
  "cortex-m",
 ]
@@ -1167,7 +1176,7 @@ name = "drv-stm32g0-usart"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
- "cortex-m-semihosting",
+ "cortex-m-semihosting 0.5.0",
  "drv-stm32xx-sys-api",
  "num-traits",
  "stm32g0",
@@ -2243,7 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
 dependencies = [
  "cortex-m",
- "cortex-m-semihosting",
+ "cortex-m-semihosting 0.3.7",
 ]
 
 [[package]]
@@ -3083,7 +3092,7 @@ dependencies = [
  "armv6m-atomic-hack",
  "build-util",
  "cortex-m",
- "cortex-m-semihosting",
+ "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "idol",
  "idol-runtime",
@@ -3425,7 +3434,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cortex-m",
- "cortex-m-semihosting",
+ "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
  "test-api",
@@ -3468,7 +3477,7 @@ dependencies = [
  "build-util",
  "cfg-if",
  "cortex-m",
- "cortex-m-semihosting",
+ "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
  "test-api",

--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -44,7 +44,7 @@ stacksize = 1536
 name = "drv-stm32fx-rcc"
 features = ["f3"]
 priority = 1
-max-sizes = {flash = 4096, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["rcc"]
 start = true
 
@@ -96,4 +96,3 @@ priority = 5
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
-

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -44,7 +44,7 @@ stacksize = 1536
 name = "drv-stm32fx-rcc"
 features = ["f4"]
 priority = 1
-max-sizes = {flash = 4096, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["rcc"]
 start = true
 

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -153,7 +153,7 @@ task-slots = ["sys", "hash_driver"]
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
-max-sizes = {flash = 8192, ram=4096 }
+max-sizes = {flash = 16384, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -138,7 +138,7 @@ task-slots = ["sys", "hash_driver"]
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
-max-sizes = {flash = 8192, ram=4096 }
+max-sizes = {flash = 16384, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -177,7 +177,7 @@ register_defs = "gimlet-regs-b.json"
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 8192, ram=4096 }
+max-sizes = {flash = 16384, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]
@@ -224,7 +224,7 @@ features = ["vlan"]
 [tasks.validate]
 name = "task-validate"
 priority = 5
-max-sizes = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
 start = true
 task-slots = ["i2c_driver"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -111,7 +111,7 @@ features = ["stm32h753", "usart2"]
 uses = ["usart2"]
 interrupts = {"usart2.irq" = 0b01}
 priority = 3
-max-sizes = {flash = 8192, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys"]
@@ -199,7 +199,7 @@ task-slots = ["sys", "user_leds"]
 [tasks.update_server]
 name = "stm32h7-update-server"
 priority = 3
-max-sizes = {flash = 8192, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 uses = ["flash_controller", "bank2"]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -244,7 +244,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 [tasks.validate]
 name = "task-validate"
 priority = 5
-max-sizes = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
 start = true
 task-slots = ["i2c_driver"]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -551,15 +551,14 @@ impl BuildConfig<'_> {
             None => PathBuf::from("cargo"),
         });
 
-        // nightly features that we use: asm_sym,named-profiles,naked_functions
-        // cmse_nonsecure_entry,array_methods,destructuring_assignment
-        // nightly features that our dependencies use: proc_macro_span,backtrace
-        // asm,llvm_asm
+        // nightly features that we use: asm_sym,asm_const,
+        // named-profiles,naked_functions,cmse_nonsecure_entry,array_methods
+        //
+        // nightly features that our dependencies use: backtrace,proc_macro_span
 
         cmd.arg(
-            "-Zallow-features=asm,asm_sym,named-profiles,naked_functions,\
-cmse_nonsecure_entry,array_methods,destructuring_assignment,proc_macro_span,\
-backtrace,llvm_asm",
+            "-Zallow-features=asm_sym,asm_const,named-profiles,naked_functions,\
+cmse_nonsecure_entry,array_methods,backtrace,proc_macro_span",
         );
 
         cmd.arg(subcommand);

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1287,6 +1287,7 @@ fn link(
     cmd.arg("-m").arg(m);
     cmd.arg("-z").arg("common-page-size=0x20");
     cmd.arg("-z").arg("max-page-size=0x20");
+    cmd.arg("-rustc-lld-flavor=ld");
 
     cmd.current_dir(working_dir);
 

--- a/drv/lpc55-romapi/src/lib.rs
+++ b/drv/lpc55-romapi/src/lib.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![feature(asm)]
 #![feature(naked_functions)]
 #![no_std]
 

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(destructuring_assignment)]
 
 use crate::clock_generator::ClockGenerator;
 use crate::front_io::FrontIOBoard;

--- a/drv/stm32g0-usart/Cargo.toml
+++ b/drv/stm32g0-usart/Cargo.toml
@@ -10,7 +10,7 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"] }
+cortex-m-semihosting = { version = "0.5.0" }
 
 [features]
 g031 = ["stm32g0/stm32g031", "drv-stm32xx-sys-api/g031"]

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![no_main]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "family-stm32g0")] {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-09-22"
+channel = "nightly-2022-07-27"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "rustfmt" ]

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -3,11 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![feature(cmse_nonsecure_entry)]
-#![feature(asm)]
 #![feature(naked_functions)]
 #![feature(array_methods)]
 #![no_main]
 #![no_std]
+
+use core::arch;
 
 extern crate lpc55_pac;
 extern crate panic_halt;
@@ -98,7 +99,7 @@ unsafe fn branch_to_image(image: Image) -> ! {
     let stack = image.get_sp();
 
     // and branch
-    asm!("
+    arch::asm!("
             msr MSP_NS, {stack}
             bxns {entry}",
         stack = in(reg) stack,
@@ -125,7 +126,7 @@ unsafe fn branch_to_image(image: Image) -> ! {
     let stack = image.get_sp();
 
     // and branch
-    asm!("
+    arch::asm!("
             msr MSP, {stack}
             bx {entry}",
         stack = in(reg) stack,

--- a/sys/kern/src/lib.rs
+++ b/sys/kern/src/lib.rs
@@ -27,8 +27,9 @@
 //!    most clever algorithms used in kernels wind up requiring `unsafe`.)
 
 #![cfg_attr(target_os = "none", no_std)]
-#![feature(asm)]
 #![feature(naked_functions)]
+#![feature(asm_sym)]
+#![feature(asm_const)]
 // Require an unsafe block even in an unsafe fn, because unsafe fns are about
 // contract, not implementation.
 #![forbid(unsafe_op_in_unsafe_fn)]

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -25,7 +25,8 @@
 //! See: https://github.com/rust-lang/rust/issues/73450#issuecomment-650463347
 
 #![no_std]
-#![feature(asm)]
+#![feature(asm_const)]
+#![feature(asm_sym)]
 #![feature(naked_functions)]
 
 #[macro_use]
@@ -36,6 +37,7 @@ pub use num_derive::{FromPrimitive, ToPrimitive};
 pub use num_traits::{FromPrimitive, ToPrimitive};
 pub use unwrap_lite::UnwrapLite;
 
+use core::arch;
 use core::marker::PhantomData;
 
 pub mod hl;
@@ -154,7 +156,7 @@ struct SendArgs<'a> {
 unsafe extern "C" fn sys_send_stub(_args: &mut SendArgs<'_>) -> RcLen {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r8
@@ -191,7 +193,7 @@ unsafe extern "C" fn sys_send_stub(_args: &mut SendArgs<'_>) -> RcLen {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r11}}
                 @ Load in args from the struct.
@@ -338,7 +340,7 @@ unsafe extern "C" fn sys_recv_stub(
 ) -> u32 {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r8
@@ -384,7 +386,7 @@ unsafe extern "C" fn sys_recv_stub(
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r11}}
                 @ Move register arguments into their proper positions.
@@ -453,7 +455,7 @@ unsafe extern "C" fn sys_reply_stub(
 ) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff. Note
                 @ that we're being clever and pushing only the registers we
                 @ need; this means the pop sequence at the end needs to match!
@@ -485,7 +487,7 @@ unsafe extern "C" fn sys_reply_stub(
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff. Note
                 @ that we're being clever and pushing only the registers we
                 @ need; this means the pop sequence at the end needs to match!
@@ -552,7 +554,7 @@ unsafe extern "C" fn sys_set_timer_stub(
 ) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r11
@@ -582,7 +584,7 @@ unsafe extern "C" fn sys_set_timer_stub(
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, r11, lr}}
 
@@ -635,7 +637,7 @@ pub fn sys_borrow_read(
 unsafe extern "C" fn sys_borrow_read_stub(_args: *mut BorrowReadArgs) -> RcLen {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r8
@@ -668,7 +670,7 @@ unsafe extern "C" fn sys_borrow_read_stub(_args: *mut BorrowReadArgs) -> RcLen {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r8, r11}}
 
@@ -732,7 +734,7 @@ unsafe extern "C" fn sys_borrow_write_stub(
 ) -> RcLen {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r8
@@ -766,7 +768,7 @@ unsafe extern "C" fn sys_borrow_write_stub(
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r8, r11}}
 
@@ -851,7 +853,7 @@ unsafe extern "C" fn sys_borrow_info_stub(
 ) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r6, lr}}
                 mov r4, r11
@@ -880,7 +882,7 @@ unsafe extern "C" fn sys_borrow_info_stub(
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r6, r11}}
 
@@ -923,7 +925,7 @@ pub fn sys_irq_control(mask: u32, enable: bool) {
 unsafe extern "C" fn sys_irq_control_stub(_mask: u32, _enable: u32) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, lr}}
                 mov r4, r11
@@ -951,7 +953,7 @@ unsafe extern "C" fn sys_irq_control_stub(_mask: u32, _enable: u32) {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, r11, lr}}
 
@@ -990,7 +992,7 @@ pub fn sys_panic(msg: &[u8]) -> ! {
 unsafe extern "C" fn sys_panic_stub(_msg: *const u8, _len: usize) -> ! {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ We're not going to return, so technically speaking we don't
                 @ need to save registers. However, we save them anyway, so that
                 @ we can reconstruct the state that led to the panic.
@@ -1014,7 +1016,7 @@ unsafe extern "C" fn sys_panic_stub(_msg: *const u8, _len: usize) -> ! {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ We're not going to return, so technically speaking we don't
                 @ need to save registers. However, we save them anyway, so that
                 @ we can reconstruct the state that led to the panic.
@@ -1100,7 +1102,7 @@ struct RawTimerState {
 unsafe extern "C" fn sys_get_timer_stub(_out: *mut RawTimerState) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r7, lr}}
                 mov r4, r8
@@ -1133,7 +1135,7 @@ unsafe extern "C" fn sys_get_timer_stub(_out: *mut RawTimerState) {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r11}}
                 @ Load the constant syscall number.
@@ -1172,7 +1174,7 @@ pub unsafe extern "C" fn _start() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Copy data initialization image into data section.
                 @ Note: this assumes that both source and destination are 32-bit
                 @ aligned and padded to 4-byte boundary.
@@ -1222,7 +1224,7 @@ pub unsafe extern "C" fn _start() -> ! {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Copy data initialization image into data section.
                 @ Note: this assumes that both source and destination are 32-bit
                 @ aligned and padded to 4-byte boundary.
@@ -1459,7 +1461,7 @@ pub fn sys_refresh_task_id(task_id: TaskId) -> TaskId {
 unsafe extern "C" fn sys_refresh_task_id_stub(_tid: u32) -> u32 {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 @ match!
                 push {{r4, r5, lr}}
@@ -1489,7 +1491,7 @@ unsafe extern "C" fn sys_refresh_task_id_stub(_tid: u32) -> u32 {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, r11, lr}}
 
@@ -1528,7 +1530,7 @@ pub fn sys_post(task_id: TaskId, bits: u32) -> u32 {
 unsafe extern "C" fn sys_post_stub(_tid: u32, _mask: u32) -> u32 {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, lr}}
                 mov r4, r11
@@ -1558,7 +1560,7 @@ unsafe extern "C" fn sys_post_stub(_tid: u32, _mask: u32) -> u32 {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, r11, lr}}
 
@@ -1598,7 +1600,7 @@ pub fn sys_reply_fault(task_id: TaskId, reason: ReplyFaultReason) {
 unsafe extern "C" fn sys_reply_fault_stub(_tid: u32, _reason: u32) {
     cfg_if::cfg_if! {
         if #[cfg(armv6m)] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, lr}}
                 mov r4, r11
@@ -1626,7 +1628,7 @@ unsafe extern "C" fn sys_reply_fault_stub(_tid: u32, _reason: u32) {
                 options(noreturn),
             )
         } else if #[cfg(any(armv7m, armv8m))] {
-            asm!("
+            arch::asm!("
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4, r5, r11, lr}}
 

--- a/sys/userlib/src/macros.rs
+++ b/sys/userlib/src/macros.rs
@@ -11,13 +11,13 @@ cfg_if::cfg_if! {
         macro_rules! sys_log {
             ($s:expr) => {
                 unsafe {
-                    let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
+                    let stim = &mut (*cortex_m::peripheral::ITM::PTR).stim[1];
                     cortex_m::iprintln!(stim, $s);
                 }
             };
             ($s:expr, $($tt:tt)*) => {
                 unsafe {
-                    let stim = &mut (*cortex_m::peripheral::ITM::ptr()).stim[1];
+                    let stim = &mut (*cortex_m::peripheral::ITM::PTR).stim[1];
                     cortex_m::iprintln!(stim, $s, $($tt)*);
                 }
             };

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -11,7 +11,7 @@ ringbuf = {path = "../../lib/ringbuf" }
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"], optional = true }
+cortex-m-semihosting = { version = "0.5.0", optional = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 task-jefe-api = {path = "../jefe-api"}

--- a/task/ping/src/main.rs
+++ b/task/ping/src/main.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
 
 use userlib::*;
 
@@ -29,7 +28,7 @@ fn divzero() {
         let p: u32 = 123;
         let q: u32 = 0;
         let _res: u32;
-        asm!("udiv r2, r1, r0", in("r1") p, in("r0") q, out("r2") _res);
+        core::arch::asm!("udiv r2, r1, r0", in("r1") p, in("r0") q, out("r2") _res);
     }
 }
 

--- a/task/uartecho/src/main.rs
+++ b/task/uartecho/src/main.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
 
 #[cfg(any(feature = "stm32h743", feature = "stm32h753"))]
 use drv_stm32h7_usart as drv_usart;

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -10,7 +10,7 @@ hubris-num-tasks = {path = "../../sys/num-tasks"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 test-api = {path = "../test-api"}
-cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"], optional = true }
+cortex-m-semihosting = { version = "0.5.0", optional = true }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -10,7 +10,7 @@ test-api = {path = "../test-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
-cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"], optional = true }
+cortex-m-semihosting = { version = "0.5.0", optional = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 cfg-if = "1"
 


### PR DESCRIPTION
The decision to re-purpose the `asm` feature flag [was changed](https://github.com/rust-lang/rust/issues/72016#issuecomment-1021679663), which is great. Let's get us on a version of the toolchain that uses the new flags.

~~This won't be quite ready just yet; I tested using the f4 demo; gonna use one CI run to show me what else breaks so I can fix it up.~~ Now ready!