### PR TITLE
port xtask to env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1415,12 @@ dependencies = [
 [[package]]
 name = "hubris-num-tasks"
 version = "0.1.0"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hypocalls"
@@ -3254,10 +3273,12 @@ dependencies = [
  "cargo_metadata",
  "ctrlc",
  "dunce",
+ "env_logger",
  "filetime",
  "fnv",
  "goblin",
  "indexmap",
+ "log",
  "lpc55_sign",
  "ordered-toml",
  "path-slash",

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -12,6 +12,8 @@ anyhow = "1.0.32"
 cargo_metadata = "0.12.0"
 ordered-toml = {git = "https://github.com/oxidecomputer/ordered-toml"}
 termcolor = "1.1.2"
+log = "0.4.0"
+env_logger = "0.9.0"
 
 # for dist
 serde = { version = "1.0.114", features = ["derive"] }

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -22,7 +22,7 @@ pub fn run(package: Option<String>, target: Option<String>) -> Result<()> {
             .to_string()
     });
 
-    println!("Running clippy on: {}", package);
+    log::info!("Running clippy on: {}", package);
 
     let mut cmd = Command::new("cargo");
     cmd.arg("clippy");

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -446,6 +446,10 @@ where
 }
 
 fn main() -> Result<()> {
+    let env = env_logger::Env::default().filter_or("RUST_LOG", "info");
+
+    env_logger::init_from_env(env);
+
     let xtask = Xtask::from_args();
 
     match xtask {

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -148,7 +148,7 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
     )?;
     for (name, task) in &toml.tasks {
         if !only_suggest {
-            println!();
+            log::info!("");
         }
         check_task(
             &name,

--- a/build/xtask/src/task_slot.rs
+++ b/build/xtask/src/task_slot.rs
@@ -101,8 +101,8 @@ pub fn dump_task_slot_table(task_path: &PathBuf) -> Result<()> {
     let task_bin = std::fs::read(task_path)?;
     let elf = goblin::elf::Elf::parse(&task_bin)?;
 
-    println!("Task Slot          Address      File Offset   Task Index");
-    println!("------------------------------------------------------------");
+    log::info!("Task Slot          Address      File Offset   Task Index");
+    log::info!("------------------------------------------------------------");
 
     for entry in get_task_slot_table_entries(&task_bin, &elf)? {
         let task_idx = task_bin.pread_with::<u16>(
@@ -110,7 +110,7 @@ pub fn dump_task_slot_table(task_path: &PathBuf) -> Result<()> {
             elf::get_endianness(&elf),
         )?;
 
-        println!(
+        log::info!(
             "{:16}   0x{:08x}   0x{:08x}    0x{:04x}",
             entry.slot_name,
             entry.taskidx_address,


### PR DESCRIPTION
So, after doing this for Humility, we had talked about doing it for Hubris. Here's what the naïve version of it looks like:

<img width="953" alt="image" src="https://user-images.githubusercontent.com/27786/155610581-0c1a9848-9bb6-4989-9fec-1d3187424915.png">
<img width="948" alt="image" src="https://user-images.githubusercontent.com/27786/155610701-fe662019-7da8-4901-aa9b-e78bb862d491.png">

As you can see, it is, uh. Lots noisier. We can change that, but before doing so I figured I'd at least show the defaults. I also didn't touch the memory allocation warning just yet, it looks so good as it is now, and this would uh, make it a bit worse.

So, thoughts? I'm not sure if this is an improvement strictly speaking. In general I kind of feel like the build output is a bit of a mess at the moment, but I'm also not 100% sure what I would want it to be like in an ideal world yet.