### PR TITLE
add TOML for Gimlet Rev B

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet, sidecar]
+        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet-a, gimlet-b, sidecar]
         include:
           - build: stm32f3
             app_name: demo-stm32f3-discovery
@@ -51,9 +51,13 @@ jobs:
             app_name: gemini-bu-rot
             app_toml: app/gemini-bu-rot/app.toml
             target: thumbv8m.main-none-eabihf
-          - build: gimlet
+          - build: gimlet-a
             app_name: gimlet
-            app_toml: app/gimlet/app.toml
+            app_toml: app/gimlet/rev-a.toml
+            target: thumbv7em-none-eabihf
+          - build: gimlet-b
+            app_name: gimlet
+            app_toml: app/gimlet/rev-b.toml
             target: thumbv7em-none-eabihf
           - build: sidecar
             app_name: sidecar

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -1,0 +1,558 @@
+name = "gimlet"
+target = "thumbv7em-none-eabihf"
+board = "gimlet-a"
+chip = "../../chips/stm32h7.toml"
+stacksize = 896
+
+[kernel]
+path = "."
+name = "gimlet"
+requires = {flash = 32768, ram = 4096}
+#
+# For the kernel (and for any task that logs), we are required to enable
+# either "itm" (denoting logging/panicking via ARM's Instrumentation Trace
+# Macrocell) or "semihosting" (denoting logging/panicking via ARM
+# semihosting).  We are biased to ITM because semihosting is excruciatingly
+# slow (it is breakpoint based) and has an undesirable failure mode if logging
+# output is generated and debugger is not attached (namely, the target stops).
+# If one does choose to change this to semihosting for purposes of
+# development, be sure to also change it in every task of interest.
+#
+features = ["itm"]
+
+[supervisor]
+notification = 1
+
+# Flash sections are mapped into flash bank 1 (of 2).
+[outputs.flash]
+address = 0x08000000
+size = 1048576
+read = true
+execute = true
+
+# RAM sections are currently mapped into DTCM, a small but fast SRAM.
+[outputs.ram]
+address = 0x20000000
+size = 131072
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise
+
+[tasks.jefe]
+path = "../../task/jefe"
+name = "task-jefe"
+priority = 0
+requires = {flash = 8192, ram = 2048}
+start = true
+features = ["itm"]
+stacksize = 1536
+
+[tasks.sys]
+path = "../../drv/stm32xx-sys"
+name = "drv-stm32xx-sys"
+features = ["h753"]
+priority = 1
+requires = {flash = 2048, ram = 1024}
+uses = ["rcc", "gpios1", "gpios2", "gpios3"]
+start = true
+
+[tasks.spi4_driver]
+path = "../../drv/stm32h7-spi-server"
+name = "drv-stm32h7-spi-server"
+priority = 2
+requires = {flash = 16384, ram = 2048}
+features = ["spi4", "h753"]
+uses = ["spi4"]
+start = true
+interrupts = {"spi4.irq" = 1}
+stacksize = 872
+task-slots = ["sys"]
+
+[tasks.spi4_driver.config.spi]
+global_config = "spi4"
+
+[tasks.spi2_driver]
+path = "../../drv/stm32h7-spi-server"
+name = "drv-stm32h7-spi-server"
+priority = 2
+requires = {flash = 16384, ram = 2048}
+features = ["spi2", "h753"]
+uses = ["spi2"]
+start = true
+interrupts = {"spi2.irq" = 1}
+stacksize = 872
+task-slots = ["sys"]
+
+[tasks.spi2_driver.config.spi]
+global_config = "spi2"
+
+[tasks.i2c_driver]
+path = "../../drv/stm32h7-i2c-server"
+name = "drv-stm32h7-i2c-server"
+features = ["h753", "itm"]
+priority = 2
+requires = {flash = 16384, ram = 2048}
+uses = ["i2c2", "i2c3", "i2c4"]
+start = true
+task-slots = ["sys"]
+
+[tasks.i2c_driver.interrupts]
+"i2c2.event" = 0b0000_0010
+"i2c2.error" = 0b0000_0010
+"i2c3.event" = 0b0000_0100
+"i2c3.error" = 0b0000_0100
+"i2c4.event" = 0b0000_1000
+"i2c4.error" = 0b0000_1000
+
+[tasks.spd]
+path = "../../task/spd"
+name = "task-spd"
+features = ["h753", "itm"]
+priority = 2
+requires = {flash = 16384, ram = 16384}
+uses = ["i2c1"]
+start = true
+task-slots = ["sys", "i2c_driver"]
+
+[tasks.spd.interrupts]
+"i2c1.event" = 0b0000_0001
+"i2c1.error" = 0b0000_0001
+
+[tasks.thermal]
+path = "../../task/thermal"
+name = "task-thermal"
+features = ["itm", "h753"]
+priority = 3
+requires = {flash = 8192, ram = 2048 }
+stacksize = 1920
+start = true
+task-slots = ["i2c_driver", "sensor"]
+
+[tasks.power]
+path = "../../task/power"
+name = "task-power"
+features = ["itm", "h753"]
+priority = 3
+requires = {flash = 16384, ram = 4096 }
+stacksize = 2048
+start = true
+task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
+
+[tasks.hiffy]
+path = "../../task/hiffy"
+name = "task-hiffy"
+features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
+priority = 3
+requires = {flash = 32768, ram = 32768 }
+stacksize = 1024
+start = true
+task-slots = ["sys", "hf", "i2c_driver"]
+
+[tasks.gimlet_seq]
+path = "../../drv/gimlet-seq-server"
+name = "drv-gimlet-seq-server"
+features = ["h753"]
+priority = 3
+requires = {flash = 65536, ram = 4096 }
+stacksize = 1600
+start = true
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
+
+[tasks.hf]
+path = "../../drv/gimlet-hf-server"
+name = "drv-gimlet-hf-server"
+features = ["h753"]
+priority = 3
+requires = {flash = 16384, ram = 2048 }
+stacksize = 1920
+start = true
+uses = ["quadspi"]
+interrupts = {"quadspi.irq" = 1}
+task-slots = ["sys"]
+
+[tasks.sensor]
+path = "../../task/sensor"
+name = "task-sensor"
+features = ["itm"]
+priority = 3
+requires = {flash = 8192, ram = 2048 }
+stacksize = 1920        # Sensor data is stored on the stack
+start = true
+
+[tasks.idle]
+path = "../../task/idle"
+name = "task-idle"
+priority = 5
+requires = {flash = 128, ram = 256}
+stacksize = 256
+start = true
+
+[config]
+
+#
+# I2C1: SPD proxy bus
+#
+[[config.i2c.controllers]]
+controller = 1
+target = true
+
+#
+# SMBUS_SPD_PROXY_SP3_TO_SP_SMCLK
+# SMBUS_SPD_PROXY_SP3_TO_SP_SMDAT
+#
+[config.i2c.controllers.ports.B]
+name = "spd"
+description = "SPD proxy"
+pins = [ { pins = [ 6, 7 ], af = 4 } ]
+
+#
+# I2C2: Front/M.2 bus
+#
+[[config.i2c.controllers]]
+controller = 2
+
+#
+# SMBUS_SP_TO_M2_SMCLK_A2_V3P3
+# SMBUS_SP_TO_M2_SMDAT_A2_V3P3
+#
+[config.i2c.controllers.ports.B]
+name = "m2"
+description = "M.2 bus"
+pins = [ { pins = [ 10, 11 ], af = 4 } ]
+muxes = [ { driver = "pca9548", address = 0x73 } ]
+
+#
+# SMBUS_SP_TO_LVL_FRONT_SMDAT
+# SMBUS_SP_TO_LVL_FRONT_SMCLK
+#
+[config.i2c.controllers.ports.F]
+name = "front"
+description = "Front bus"
+pins = [ { pins = [ 0, 1 ], af = 4 } ]
+
+#
+# Shark fin muxes
+#
+[[config.i2c.controllers.ports.F.muxes]]
+driver = "pca9548"
+address = 0x70
+
+[[config.i2c.controllers.ports.F.muxes]]
+driver = "pca9548"
+address = 0x71
+
+[[config.i2c.controllers.ports.F.muxes]]
+driver = "pca9548"
+address = 0x72
+
+#
+# I2C3: Mid bus
+#
+[[config.i2c.controllers]]
+controller = 3
+
+#
+# SMBUS_SP_TO_LVL_MID_SMCLK
+# SMBUS_SP_TO_LVL_MID_SMDAT
+#
+[config.i2c.controllers.ports.H]
+name = "mid"
+description = "Mid bus"
+pins = [ { pins = [ 7, 8 ], af = 4 } ]
+
+#
+# I2C4: Rear bus
+#
+[[config.i2c.controllers]]
+controller = 4
+
+#
+# SMBUS_SP_TO_LVL_REAR_SMCLK
+# SMBUS_SP_TO_LVL_REAR_SMDAT
+#
+[config.i2c.controllers.ports.F]
+name = "rear"
+description = "Rear bus"
+pins = [ { pins = [ 14, 15 ], af = 4 } ]
+
+#
+# Note that the north and south temperature boards are inverted with respect
+# to one another; see Gimlet issue #1302 for details
+#
+[[config.i2c.devices]]
+bus = "front"
+address = 0x48
+device = "tmp117"
+name = "Southwest"
+description = "Front temperature sensor (zone 1)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "front"
+address = 0x49
+device = "tmp117"
+name = "South"
+description = "Front temperature sensor (zone 2)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "front"
+address = 0x4a
+device = "tmp117"
+name = "Southeast"
+description = "Front temperature sensor (zone 3)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "front"
+address = 0x70
+device = "pca9545"
+description = "U.2 ABCD mux"
+
+[[config.i2c.devices]]
+bus = "front"
+address = 0x71
+device = "pca9545"
+description = "U.2 EFGH mux"
+
+[[config.i2c.devices]]
+bus = "front"
+address = 0x72
+device = "pca9545"
+description = "U.2 IJ mux"
+
+[[config.i2c.devices]]
+bus = "m2"
+address = 0x73
+device = "pca9545"
+description = "M.2 mux"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x24
+device = "tps546b24a"
+description = "A2 3.3V rail"
+pmbus = { rails = [ "V3P3_SP_A2" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U522"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x27
+device = "tps546b24a"
+description = "A2 1.8V rail"
+pmbus = { rails = [ "V1P8_SP3" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U523"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x29
+device = "tps546b24a"
+description = "A2 5V rail"
+pmbus = { rails = [ "V5_SYS_A2" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U524"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x3a
+device = "max5970"
+description = "M.2 hot plug controller"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x4c
+device = "sbtsi"
+name = "CPU"
+description = "CPU temperature sensor"
+sensors = { temperature = 1 }
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x58
+device = "idt8a34003"
+description = "Clock generator"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x5a
+device = "raa229618"
+description = "CPU power controller"
+pmbus = { rails = [ "VDD_VCORE", "VDD_MEM_ABCD" ] }
+sensors = { temperature = 2, power = 2, voltage = 2, current = 2 }
+refdes = "U350"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x5b
+device = "raa229618"
+description = "SoC power controller"
+pmbus = { rails = [ "VDDCR_SOC", "VDD_MEM_EFGH" ] }
+sensors = { temperature = 2, power = 2, voltage = 2, current = 2 }
+refdes = "U351"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x5c
+device = "isl68224"
+description = "DIMM ABCD power controller"
+pmbus = { rails = [ "VPP_ABCD", "V3P3_SYS", "" ] }
+sensors = { voltage = 2, current = 2 }
+refdes = "U352"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x5d
+device = "isl68224"
+description = "DIMM EFGH power controller"
+pmbus = { rails = [ "VPP_EFGH", "", "" ] }
+sensors = { voltage = 1, current = 1 }
+refdes = "U418"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x10
+device = "adm1272"
+description = "Fan hot swap controller"
+pmbus = { rails = [ "V54_FAN" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U419"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x14
+device = "adm1272"
+description = "Sled hot swap controller"
+pmbus = { rails = [ "V54_HS_OUTPUT" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U452"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x20
+device = "max31790"
+description = "Fan controller"
+sensors = { speed = 6 }
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x48
+device = "tmp117"
+name = "Northeast"
+description = "Rear temperature sensor (zone 1)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x49
+device = "tmp117"
+name = "North"
+description = "Rear temperature sensor (zone 2)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x4a
+device = "tmp117"
+name = "Northwest"
+description = "Rear temperature sensor (zone 3)"
+sensors = { temperature = 1 }
+removable = true
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x4c
+device = "tmp451"
+sensors = { temperature = 1 }
+description = "T6 temperature sensor"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x5f
+device = "isl68224"
+description = "T6 power controller"
+pmbus = { rails = [ "V0P96_NIC_VDD", "V1P8_NIC_A0HP" ] }
+refdes = "U357"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x67
+device = "bmr491"
+name = "IBC"
+description = "Intermediate bus converter"
+pmbus = { rails = [ "V12_SYS_A2" ] }
+sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
+refdes = "U431"
+
+
+[config.spi.spi2]
+controller = 2
+
+[config.spi.spi2.mux_options.port_i]
+outputs = [
+    {port = "I", pins = [1, 3], af = 5},
+]
+input = {port = "I", pin = 2, af = 5}
+
+[config.spi.spi2.mux_options.port_b]
+outputs = [
+    {port = "B", pins = [13, 14], af = 5},
+]
+input = {port = "B", pin = 15, af = 5}
+swap_data = true
+
+#
+# ATTENTION REWORKED CS
+#
+# On a very small number of EVT1 Gimlets, one of the pins used for chip
+# select was found to be damaged and needed to be reworked to be a different
+# pin.  If you find yourself on one of these Gimlets, the borked CS pin
+# (port A, pin 0) is connected to nothing and the sequencer won't correctly
+# program -- and the sequencer task will explicitly panic with a message
+# directing the user here.  To fix this, you will need to comment out the
+# lines below marked "Uncomment the below line" -- and it should go without
+# saying that this change should NOT be checked back in!
+#
+[config.spi.spi2.devices.sequencer]
+mux = "port_b"
+cs = {port = "A", pin = 0}
+# ATTENTION REWORKED CS: Uncomment the below line
+# cs = {port = "H", pin = 2}
+
+[config.spi.spi2.devices.ice40]
+mux = "port_b"
+cs = {port = "A", pin = 0}
+# ATTENTION REWORKED CS: Uncomment the below line
+# cs = {port = "H", pin = 2}
+
+[config.spi.spi2.devices.ksz8463]
+mux = "port_i"
+cs = {port = "A", pin = 0}
+# ATTENTION REWORKED CS: Uncomment the below line
+# cs = {port = "H", pin = 2}
+
+[config.spi.spi2.devices.local_flash]
+mux = "port_b"
+cs = {port = "B", pin = 12}
+
+
+[config.spi.spi4]
+controller = 4
+
+[config.spi.spi4.mux_options.rot]
+outputs = [
+    {port = "E", pins = [2, 6], af = 5},
+]
+input = {port = "E", pin = 5, af = 5}
+
+[config.spi.spi4.devices.rot]
+mux = "rot"
+cs = {port = "E", pin = 4}
+clock_divider = "DIV16"
+

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -336,7 +336,7 @@ refdes = "U422"
 [[config.i2c.devices]]
 bus = "m2"
 mux = 1
-segment = 3
+segment = 4
 address = 0x4c
 device = "tmp451"
 sensors = { temperature = 1 }
@@ -423,7 +423,7 @@ refdes = "U351"
 bus = "mid"
 address = 0x5c
 device = "isl68224"
-description = "DIMM/SP3 1.8V power controller"
+description = "DIMM/SP3 1.8V A0 power controller"
 pmbus = { rails = [ "VPP_ABCD", "VPP_EFGH", "V1P8_SP3" ] }
 sensors = { voltage = 3, current = 3 }
 refdes = "U352"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -463,6 +463,7 @@ pmbus = { rails = [ "V0P96_NIC_VDD_A0HP" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = "U565"
 
+
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x48

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -463,7 +463,6 @@ pmbus = { rails = [ "V0P96_NIC_VDD_A0HP" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = "U565"
 
-
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x48

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -1,6 +1,6 @@
 name = "gimlet"
 target = "thumbv7em-none-eabihf"
-board = "gimlet-1"
+board = "gimlet-b"
 chip = "../../chips/stm32h7.toml"
 stacksize = 896
 
@@ -275,60 +275,73 @@ name = "rear"
 description = "Rear bus"
 pins = [ { pins = [ 14, 15 ], af = 4 } ]
 
-#
-# Note that the north and south temperature boards are inverted with respect
-# to one another; see Gimlet issue #1302 for details
-#
 [[config.i2c.devices]]
 bus = "front"
 address = 0x48
 device = "tmp117"
 name = "Southwest"
-description = "Front temperature sensor (zone 1)"
+description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J194"
 
 [[config.i2c.devices]]
 bus = "front"
 address = 0x49
 device = "tmp117"
 name = "South"
-description = "Front temperature sensor (zone 2)"
+description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J195"
 
 [[config.i2c.devices]]
 bus = "front"
 address = 0x4a
 device = "tmp117"
 name = "Southeast"
-description = "Front temperature sensor (zone 3)"
+description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J196"
 
 [[config.i2c.devices]]
 bus = "front"
 address = 0x70
 device = "pca9545"
 description = "U.2 ABCD mux"
+refdes = "U336"
 
 [[config.i2c.devices]]
 bus = "front"
 address = 0x71
 device = "pca9545"
 description = "U.2 EFGH mux"
+refdes = "U339"
 
 [[config.i2c.devices]]
 bus = "front"
 address = 0x72
 device = "pca9545"
-description = "U.2 IJ mux"
+description = "U.2 IJ/FRUID mux"
+refdes = "U337"
 
 [[config.i2c.devices]]
 bus = "m2"
 address = 0x73
 device = "pca9545"
 description = "M.2 mux"
+refdes = "U422"
+
+[[config.i2c.devices]]
+bus = "m2"
+mux = 1
+segment = 3
+address = 0x4c
+device = "tmp451"
+sensors = { temperature = 1 }
+description = "T6 temperature sensor"
+refdes = "U491"
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -341,16 +354,16 @@ refdes = "U522"
 
 [[config.i2c.devices]]
 bus = "mid"
-address = 0x27
+address = 0x25
 device = "tps546b24a"
-description = "A2 1.8V rail"
-pmbus = { rails = [ "V1P8_SP3" ] }
+description = "A0 3.3V rail"
+pmbus = { rails = [ "V3P3_SYS_A0" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "U523"
+refdes = "U560"
 
 [[config.i2c.devices]]
 bus = "mid"
-address = 0x29
+address = 0x27
 device = "tps546b24a"
 description = "A2 5V rail"
 pmbus = { rails = [ "V5_SYS_A2" ] }
@@ -359,9 +372,19 @@ refdes = "U524"
 
 [[config.i2c.devices]]
 bus = "mid"
+address = 0x29
+device = "tps546b24a"
+description = "A2 1.8V rail"
+pmbus = { rails = [ "V1P8_SYS_A2" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U561"
+
+[[config.i2c.devices]]
+bus = "mid"
 address = 0x3a
 device = "max5970"
 description = "M.2 hot plug controller"
+refdes = "U275"
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -376,6 +399,7 @@ bus = "mid"
 address = 0x58
 device = "idt8a34003"
 description = "Clock generator"
+refdes = "U446"
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -399,19 +423,10 @@ refdes = "U351"
 bus = "mid"
 address = 0x5c
 device = "isl68224"
-description = "DIMM ABCD power controller"
-pmbus = { rails = [ "VPP_ABCD", "V3P3_SYS", "" ] }
-sensors = { voltage = 2, current = 2 }
+description = "DIMM/SP3 1.8V power controller"
+pmbus = { rails = [ "VPP_ABCD", "VPP_EFGH", "V1P8_SP3" ] }
+sensors = { voltage = 3, current = 3 }
 refdes = "U352"
-
-[[config.i2c.devices]]
-bus = "mid"
-address = 0x5d
-device = "isl68224"
-description = "DIMM EFGH power controller"
-pmbus = { rails = [ "VPP_EFGH", "", "" ] }
-sensors = { voltage = 1, current = 1 }
-refdes = "U418"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -437,48 +452,46 @@ address = 0x20
 device = "max31790"
 description = "Fan controller"
 sensors = { speed = 6 }
+refdes = "U321"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x25
+device = "tps546b24a"
+description = "T6 power controller"
+pmbus = { rails = [ "V0P96_NIC_VDD_A0HP" ] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U565"
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x48
 device = "tmp117"
 name = "Northeast"
-description = "Rear temperature sensor (zone 1)"
+description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J197"
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x49
 device = "tmp117"
 name = "North"
-description = "Rear temperature sensor (zone 2)"
+description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J198"
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x4a
 device = "tmp117"
 name = "Northwest"
-description = "Rear temperature sensor (zone 3)"
+description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-
-[[config.i2c.devices]]
-bus = "rear"
-address = 0x4c
-device = "tmp451"
-sensors = { temperature = 1 }
-description = "T6 temperature sensor"
-
-[[config.i2c.devices]]
-bus = "rear"
-address = 0x5f
-device = "isl68224"
-description = "T6 power controller"
-pmbus = { rails = [ "V0P96_NIC_VDD", "V1P8_NIC_A0HP" ] }
-refdes = "U357"
+refdes = "J199"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -489,7 +502,6 @@ description = "Intermediate bus converter"
 pmbus = { rails = [ "V12_SYS_A2" ] }
 sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
 refdes = "U431"
-
 
 [config.spi.spi2]
 controller = 2
@@ -507,40 +519,21 @@ outputs = [
 input = {port = "B", pin = 15, af = 5}
 swap_data = true
 
-#
-# ATTENTION REWORKED CS
-#
-# On a very small number of EVT1 Gimlets, one of the pins used for chip
-# select was found to be damaged and needed to be reworked to be a different
-# pin.  If you find yourself on one of these Gimlets, the borked CS pin
-# (port A, pin 0) is connected to nothing and the sequencer won't correctly
-# program -- and the sequencer task will explicitly panic with a message
-# directing the user here.  To fix this, you will need to comment out the
-# lines below marked "Uncomment the below line" -- and it should go without
-# saying that this change should NOT be checked back in!
-#
 [config.spi.spi2.devices.sequencer]
 mux = "port_b"
-cs = {port = "A", pin = 0}
-# ATTENTION REWORKED CS: Uncomment the below line
-# cs = {port = "H", pin = 2}
+cs = {port = "B", pin = 5}
 
 [config.spi.spi2.devices.ice40]
 mux = "port_b"
-cs = {port = "A", pin = 0}
-# ATTENTION REWORKED CS: Uncomment the below line
-# cs = {port = "H", pin = 2}
+cs = {port = "B", pin = 5}
 
 [config.spi.spi2.devices.ksz8463]
 mux = "port_i"
-cs = {port = "A", pin = 0}
-# ATTENTION REWORKED CS: Uncomment the below line
-# cs = {port = "H", pin = 2}
+cs = {port = "I", pin = 0}
 
 [config.spi.spi2.devices.local_flash]
 mux = "port_b"
 cs = {port = "B", pin = 12}
-
 
 [config.spi.spi4]
 controller = 4

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -165,8 +165,8 @@ pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
         }
         "stm32f3-discovery" | "stm32f4-discovery" | "nucleo-h743zi2"
         | "nucleo-h753zi" | "stm32h7b3i-dk" | "gemini-bu-1" | "gimletlet-1"
-        | "gimletlet-2" | "gimlet-1" | "psc-1" | "sidecar-1" | "stm32g031"
-        | "stm32g070" | "stm32g0b1" => {
+        | "gimletlet-2" | "gimlet-a" | "gimlet-b" | "psc-1" | "sidecar-1"
+        | "stm32g031" | "stm32g070" | "stm32g0b1" => {
             let (dir, file) = if board == "stm32f3-discovery" {
                 ("demo-stm32f4-discovery", "openocd-f3.cfg")
             } else if board == "stm32f4-discovery" {

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let qspi = Qspi::new(reg, QSPI_IRQ);
     // Board specific goo
     cfg_if::cfg_if! {
-        if #[cfg(target_board = "gimlet-1")] {
+        if #[cfg(any(target_board = "gimlet-a", target_board = "gimlet-b"))] {
             let clock = 5; // 200MHz kernel / 5 = 40MHz clock
             qspi.configure(
                 clock,

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -494,7 +494,7 @@ static COMPRESSED_BITSTREAM: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/fpga.bin.rle"));
 
 cfg_if::cfg_if! {
-    if #[cfg(target_board = "gimlet-1")] {
+    if #[cfg(any(target_board = "gimlet-a", target_board = "gimlet-b"))] {
         const SEQ_SPI_DEVICE: u8 = 0;
         const ICE40_SPI_DEVICE: u8 = 1;
 
@@ -512,15 +512,19 @@ cfg_if::cfg_if! {
             1 << 6,
         ));
 
-        // gimlet-1 needs to have a pin flipped to mux the iCE40 SPI flash out
+        // gimlet-a needs to have a pin flipped to mux the iCE40 SPI flash out
         // of circuit to be able to program the FPGA, because we accidentally
         // share a CS net between Flash and the iCE40.
         //
         // (port, mask, high_flag)
+        #[cfg(target_board = "gimlet-a")]
         const FPGA_HACK_PINS: Option<&[(sys_api::Port, u16, bool)]> = Some(&[
             // SEQ_TO_SEQ_MUX_SEL, pulled high, we drive it low
             (sys_api::Port::I, 1 << 8, false),
         ]);
+
+        #[cfg(target_board = "gimlet-b")]
+        const FPGA_HACK_PINS: Option<&[(sys_api::Port, u16, bool)]> = None;
 
         const ENABLES_PORT: sys_api::Port = sys_api::Port::A;
         const ENABLE_V1P2_MASK: u16 = 1 << 15;

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -42,7 +42,8 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(any(
-        target_board = "gimlet-1",
+        target_board = "gimlet-a",
+        target_board = "gimlet-b",
         target_board = "gimletlet-2",
         target_board = "nucleo-h743zi2",
         target_board = "nucleo-h753zi"

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -162,6 +162,7 @@ macro_rules! adm1272_controller {
     };
 }
 
+#[cfg(target_board = "gimlet-a")]
 fn controllers() -> [PowerController; 10] {
     let task = I2C.get_task_id();
 
@@ -174,6 +175,25 @@ fn controllers() -> [PowerController; 10] {
         rail_controller!(task, Sys, tps546b24a, v3p3_sp_a2, A2),
         rail_controller!(task, Sys, tps546b24a, v1p8_sp3, A0),
         rail_controller!(task, Sys, tps546b24a, v5_sys_a2, A2),
+        adm1272_controller!(task, HotSwap, v54_hs_output, A2, Ohms(0.001)),
+        adm1272_controller!(task, Fan, v54_fan, A2, Ohms(0.002)),
+    ]
+}
+
+#[cfg(target_board = "gimlet-b")]
+fn controllers() -> [PowerController; 11] {
+    let task = I2C.get_task_id();
+
+    [
+        rail_controller!(task, IBC, bmr491, v12_sys_a2, A2),
+        rail_controller!(task, Core, raa229618, vdd_vcore, A0),
+        rail_controller!(task, Core, raa229618, vddcr_soc, A0),
+        rail_controller!(task, Mem, raa229618, vdd_mem_abcd, A0),
+        rail_controller!(task, Mem, raa229618, vdd_mem_efgh, A0),
+        rail_controller!(task, Sys, tps546b24a, v3p3_sp_a2, A2),
+        rail_controller!(task, Sys, tps546b24a, v3p3_sys_a0, A0),
+        rail_controller!(task, Sys, tps546b24a, v5_sys_a2, A2),
+        rail_controller!(task, Sys, tps546b24a, v1p8_sys_a2, A0),
         adm1272_controller!(task, HotSwap, v54_hs_output, A2, Ohms(0.001)),
         adm1272_controller!(task, Fan, v54_fan, A2, Ohms(0.002)),
     ]

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -13,6 +13,7 @@
 use drv_gimlet_seq_api as seq_api;
 use drv_i2c_devices::adm1272::*;
 use drv_i2c_devices::bmr491::*;
+use drv_i2c_devices::isl68224::*;
 use drv_i2c_devices::raa229618::*;
 use drv_i2c_devices::tps546b24a::*;
 use task_sensor_api as sensor_api;
@@ -37,6 +38,7 @@ enum Device {
     IBC(Bmr491),
     Core(Raa229618),
     Mem(Raa229618),
+    MemVpp(Isl68224),
     Sys(Tps546b24a),
     HotSwap(Adm1272),
     Fan(Adm1272),
@@ -100,6 +102,7 @@ impl PowerController {
         match &mut self.device {
             Device::IBC(dev) => read_temperature(dev),
             Device::Core(dev) | Device::Mem(dev) => read_temperature(dev),
+            Device::MemVpp(_) => panic!(),
             Device::Sys(dev) => read_temperature(dev),
             Device::HotSwap(dev) | Device::Fan(dev) => read_temperature(dev),
         }
@@ -109,6 +112,7 @@ impl PowerController {
         match &mut self.device {
             Device::IBC(dev) => read_current(dev),
             Device::Core(dev) | Device::Mem(dev) => read_current(dev),
+            Device::MemVpp(dev) => read_current(dev),
             Device::Sys(dev) => read_current(dev),
             Device::HotSwap(dev) | Device::Fan(dev) => read_current(dev),
         }
@@ -118,6 +122,7 @@ impl PowerController {
         match &mut self.device {
             Device::IBC(dev) => read_voltage(dev),
             Device::Core(dev) | Device::Mem(dev) => read_voltage(dev),
+            Device::MemVpp(dev) => read_voltage(dev),
             Device::Sys(dev) => read_voltage(dev),
             Device::HotSwap(dev) | Device::Fan(dev) => read_voltage(dev),
         }
@@ -143,6 +148,23 @@ macro_rules! rail_controller {
     };
 }
 
+macro_rules! rail_controller_notemp {
+    ($task:expr, $which:ident, $dev:ident, $rail:ident, $state:ident) => {
+        paste::paste! {
+            PowerController {
+                state: seq_api::PowerState::$state,
+                device: Device::$which({
+                    let (device, rail) = i2c_config::pmbus::$rail($task);
+                    [<$dev:camel>]::new(&device, rail)
+                }),
+                voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
+                current: sensors::[<$dev:upper _ $rail:upper _CURRENT_SENSOR>],
+                temperature: None,
+            }
+        }
+    };
+}
+
 macro_rules! adm1272_controller {
     ($task:expr, $which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
@@ -163,7 +185,7 @@ macro_rules! adm1272_controller {
 }
 
 #[cfg(target_board = "gimlet-a")]
-fn controllers() -> [PowerController; 10] {
+fn controllers() -> [PowerController; 13] {
     let task = I2C.get_task_id();
 
     [
@@ -172,6 +194,9 @@ fn controllers() -> [PowerController; 10] {
         rail_controller!(task, Core, raa229618, vddcr_soc, A0),
         rail_controller!(task, Mem, raa229618, vdd_mem_abcd, A0),
         rail_controller!(task, Mem, raa229618, vdd_mem_efgh, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, vpp_abcd, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, vpp_efgh, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, v3p3_sys, A0),
         rail_controller!(task, Sys, tps546b24a, v3p3_sp_a2, A2),
         rail_controller!(task, Sys, tps546b24a, v1p8_sp3, A0),
         rail_controller!(task, Sys, tps546b24a, v5_sys_a2, A2),
@@ -181,7 +206,7 @@ fn controllers() -> [PowerController; 10] {
 }
 
 #[cfg(target_board = "gimlet-b")]
-fn controllers() -> [PowerController; 11] {
+fn controllers() -> [PowerController; 15] {
     let task = I2C.get_task_id();
 
     [
@@ -190,10 +215,14 @@ fn controllers() -> [PowerController; 11] {
         rail_controller!(task, Core, raa229618, vddcr_soc, A0),
         rail_controller!(task, Mem, raa229618, vdd_mem_abcd, A0),
         rail_controller!(task, Mem, raa229618, vdd_mem_efgh, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, vpp_abcd, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, vpp_efgh, A0),
+        rail_controller_notemp!(task, MemVpp, isl68224, v1p8_sp3, A0),
         rail_controller!(task, Sys, tps546b24a, v3p3_sp_a2, A2),
         rail_controller!(task, Sys, tps546b24a, v3p3_sys_a0, A0),
         rail_controller!(task, Sys, tps546b24a, v5_sys_a2, A2),
-        rail_controller!(task, Sys, tps546b24a, v1p8_sys_a2, A0),
+        rail_controller!(task, Sys, tps546b24a, v1p8_sys_a2, A2),
+        rail_controller!(task, Sys, tps546b24a, v0p96_nic_vdd_a0hp, A0),
         adm1272_controller!(task, HotSwap, v54_hs_output, A2, Ohms(0.001)),
         adm1272_controller!(task, Fan, v54_fan, A2, Ohms(0.002)),
     ]

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -209,7 +209,10 @@ fn main() -> ! {
                 (Controller::I2C3, i2c3_c(), None),
                 (Controller::I2C4, i2c4_f(), None),
             ];
-        } else if #[cfg(target_board = "gimlet-1")] {
+        } else if #[cfg(any(
+            target_board = "gimlet-a",
+            target_board = "gimlet-b",
+        ))] {
             //
             // On Gimlet, we have two banks of up to 8 DIMMs apiece:
             //

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -213,7 +213,10 @@ fn main() -> ! {
     let task = I2C.get_task_id();
 
     cfg_if::cfg_if! {
-        if #[cfg(target_board = "gimlet-1")] {
+        if #[cfg(any(
+            target_board = "gimlet-a",
+            target_board = "gimlet-b",
+        ))] {
             let fctrl = Max31790::new(&devices::max31790(task)[0]);
         } else {
             compile_error!("unknown board");


### PR DESCRIPTION
This also renames `gimlet-1` to `gimlet-a`.  Here is the `humility manifest` for `gimlet-a`:

```
     version => hubris build archive v1.0.0
     git rev => 0b79f4805dd8fa6be21f1eaf5740253a63fc1052-dirty
    image id => [3f, e4, ec, be, ab, 4, 14, aa]
       board => gimlet-a
      target => thumbv7em-none-eabihf
    features => itm
  total size => 214K
 kernel size => 23K
       tasks => 13
                ID TASK                SIZE FEATURES
                 0 hiffy              44.0K h753, stm32h7, itm, i2c, gpio, spi, qspi
                 1 gimlet_seq         52.5K h753
                 2 spi4_driver        11.1K spi4, h753
                 3 spi2_driver        11.6K spi2, h753
                 4 i2c_driver         11.8K h753, itm
                 5 spd                19.5K h753, itm
                 6 power              11.5K itm, h753
                 7 hf                  8.2K h753
                 8 jefe                7.0K itm
                 9 thermal             7.6K itm, h753
                10 sensor              4.2K itm
                11 sys                 1.6K h753
                12 idle                0.1K 
   i2c buses => 4 controllers, 5 buses
                C PORT MODE NAME          DESCRIPTION
                1 B    trgt spd           SPD proxy
                2 B    init m2            M.2 bus
                2 F    init front         Front bus
                3 H    init mid           Mid bus
                4 F    init rear          Rear bus
 i2c devices => 26 devices
                C P  MUX ADDR DEVICE        DESCRIPTION
                2 F  -   0x48 tmp117        Front temperature sensor (zone 1)
                2 F  -   0x49 tmp117        Front temperature sensor (zone 2)
                2 F  -   0x4a tmp117        Front temperature sensor (zone 3)
                2 F  -   0x70 pca9545       U.2 ABCD mux
                2 F  -   0x71 pca9545       U.2 EFGH mux
                2 F  -   0x72 pca9545       U.2 IJ mux
                2 B  -   0x73 pca9545       M.2 mux
                3 H  -   0x24 tps546b24a    A2 3.3V rail
                3 H  -   0x27 tps546b24a    A2 1.8V rail
                3 H  -   0x29 tps546b24a    A2 5V rail
                3 H  -   0x3a max5970       M.2 hot plug controller
                3 H  -   0x4c sbtsi         CPU temperature sensor
                3 H  -   0x58 idt8a34003    Clock generator
                3 H  -   0x5a raa229618     CPU power controller
                3 H  -   0x5b raa229618     SoC power controller
                3 H  -   0x5c isl68224      DIMM ABCD power controller
                3 H  -   0x5d isl68224      DIMM EFGH power controller
                4 F  -   0x10 adm1272       Fan hot swap controller
                4 F  -   0x14 adm1272       Sled hot swap controller
                4 F  -   0x20 max31790      Fan controller
                4 F  -   0x48 tmp117        Rear temperature sensor (zone 1)
                4 F  -   0x49 tmp117        Rear temperature sensor (zone 2)
                4 F  -   0x4a tmp117        Rear temperature sensor (zone 3)
                4 F  -   0x4c tmp451        T6 temperature sensor
                4 F  -   0x5f isl68224      T6 power controller
                4 F  -   0x67 bmr491        Intermediate bus converter
```

And here is the manifest for `gimlet-b`:

```
     version => hubris build archive v1.0.0
     git rev => 0b79f4805dd8fa6be21f1eaf5740253a63fc1052-dirty
    image id => [77, 44, fb, f, ad, aa, 84, 1a]
       board => gimlet-b
      target => thumbv7em-none-eabihf
    features => itm
  total size => 214K
 kernel size => 23K
       tasks => 13
                ID TASK                SIZE FEATURES
                 0 hiffy              44.0K h753, stm32h7, itm, i2c, gpio, spi, qspi
                 1 gimlet_seq         52.3K h753
                 2 spi4_driver        11.1K spi4, h753
                 3 spi2_driver        11.6K spi2, h753
                 4 i2c_driver         11.8K h753, itm
                 5 spd                19.5K h753, itm
                 6 power              11.5K itm, h753
                 7 hf                  8.2K h753
                 8 jefe                7.0K itm
                 9 thermal             7.6K itm, h753
                10 sensor              4.2K itm
                11 sys                 1.6K h753
                12 idle                0.1K 
   i2c buses => 4 controllers, 5 buses
                C PORT MODE NAME          DESCRIPTION
                1 B    trgt spd           SPD proxy
                2 B    init m2            M.2 bus
                2 F    init front         Front bus
                3 H    init mid           Mid bus
                4 F    init rear          Rear bus
 i2c devices => 26 devices
                C P  MUX ADDR DEVICE        DESCRIPTION
                2 F  -   0x48 tmp117        Southwest temperature sensor
                2 F  -   0x49 tmp117        South temperature sensor
                2 F  -   0x4a tmp117        Southeast temperature sensor
                2 F  -   0x70 pca9545       U.2 ABCD mux
                2 F  -   0x71 pca9545       U.2 EFGH mux
                2 F  -   0x72 pca9545       U.2 IJ/FRUID mux
                2 B  -   0x73 pca9545       M.2 mux
                2 B  1:3 0x4c tmp451        T6 temperature sensor
                3 H  -   0x24 tps546b24a    A2 3.3V rail
                3 H  -   0x25 tps546b24a    A0 3.3V rail
                3 H  -   0x27 tps546b24a    A2 5V rail
                3 H  -   0x29 tps546b24a    A2 1.8V rail
                3 H  -   0x3a max5970       M.2 hot plug controller
                3 H  -   0x4c sbtsi         CPU temperature sensor
                3 H  -   0x58 idt8a34003    Clock generator
                3 H  -   0x5a raa229618     CPU power controller
                3 H  -   0x5b raa229618     SoC power controller
                3 H  -   0x5c isl68224      DIMM/SP3 1.8V power controller
                4 F  -   0x10 adm1272       Fan hot swap controller
                4 F  -   0x14 adm1272       Sled hot swap controller
                4 F  -   0x20 max31790      Fan controller
                4 F  -   0x25 tps546b24a    T6 power controller
                4 F  -   0x48 tmp117        Northeast temperature sensor
                4 F  -   0x49 tmp117        North temperature sensor
                4 F  -   0x4a tmp117        Northwest temperature sensor
                4 F  -   0x67 bmr491        Intermediate bus converter
```
