### PR TITLE
Minor README installation fixes

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -90,13 +90,14 @@ You will need:
   as `libftdi1-dev` or similar.
 
 - `arm-none-eabi-objcopy` and `arm-none-eabi-gdb`, typically from your system's
-  package manager using package names like `arm-none-eabi-binutils` and
-  `arm-none-eabi-gdb`.  macOS users can run
+  package manager using package names like
+  `arm-none-eabi-binutils`/`binutils-arm-none-eabi` and
+  `arm-none-eabi-gdb`/`gdb-multiarch`.  macOS users can run
   `brew install --cask gcc-arm-embedded` to install the
   [official ARM binaries](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm).
 
 - The Hubris debugger, [Humility](https://github.com/oxidecomputer/humility):
-  - `cargo install --git https://github.com/oxidecomputer/humility.git --locked`
+  - `cargo install --git https://github.com/oxidecomputer/humility.git --locked humility`
 
 ### Windows
 


### PR DESCRIPTION
The update to `cargo install... humility` is required to avoid an error from cargo in which it doesn't know whether you want to install `humility` or `xtask`.

The updates to the package names are for ubuntu.