### PR TITLE
Remove unused `abi` dep and duplicate `LedError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,6 @@ dependencies = [
 name = "drv-gimlet-hf-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "drv-hash-api",
  "idol",
  "num-traits",
@@ -634,7 +633,6 @@ dependencies = [
 name = "drv-gimlet-seq-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",
@@ -673,7 +671,6 @@ dependencies = [
 name = "drv-hash-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",
@@ -838,7 +835,6 @@ dependencies = [
 name = "drv-sidecar-seq-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",
@@ -871,7 +867,6 @@ dependencies = [
 name = "drv-spi-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",
@@ -1104,6 +1099,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "drv-lpc55-gpio-api",
  "drv-stm32xx-sys-api",
+ "drv-user-leds-api",
  "idol",
  "idol-runtime",
  "lpc55-pac",
@@ -1118,7 +1114,6 @@ dependencies = [
 name = "drv-user-leds-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",
@@ -2789,7 +2784,6 @@ dependencies = [
 name = "task-sensor-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "drv-i2c-api",
  "idol",
  "num-traits",
@@ -2850,7 +2844,6 @@ dependencies = [
 name = "task-thermal-api"
 version = "0.1.0"
 dependencies = [
- "abi",
  "idol",
  "num-traits",
  "userlib",

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 drv-hash-api = {path = "../hash-api"}

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/hash-api/Cargo.toml
+++ b/drv/hash-api/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 

--- a/drv/user-leds-api/src/lib.rs
+++ b/drv/user-leds-api/src/lib.rs
@@ -8,7 +8,7 @@
 
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive)]
+#[derive(Copy, Clone, Debug)]
 pub enum LedError {
     NotPresent = 1,
 }

--- a/drv/user-leds-api/src/lib.rs
+++ b/drv/user-leds-api/src/lib.rs
@@ -8,9 +8,15 @@
 
 use userlib::*;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, FromPrimitive)]
 pub enum LedError {
     NotPresent = 1,
+}
+
+impl From<LedError> for u16 {
+    fn from(rc: LedError) -> Self {
+        rc as u16
+    }
 }
 
 impl From<u32> for LedError {

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
+drv-user-leds-api = {path = "../user-leds-api"}
 stm32f3 = { version = "0.13.0", features = ["stm32f303"], optional = true }
 stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
 lpc55-pac = { version = "0.3.0", optional = true }

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -30,6 +30,7 @@
 #![no_std]
 #![no_main]
 
+use drv_user_leds_api::LedError;
 use idol_runtime::RequestError;
 use userlib::*;
 
@@ -71,17 +72,6 @@ cfg_if::cfg_if! {
             Zero = 0,
             One = 1,
         }
-    }
-}
-
-#[repr(u32)]
-pub enum LedError {
-    NotPresent = 1,
-}
-
-impl From<LedError> for u16 {
-    fn from(rc: LedError) -> Self {
-        rc as u16
     }
 }
 

--- a/task/sensor-api/Cargo.toml
+++ b/task/sensor-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-i2c-api = {path = "../../drv/i2c-api"}

--- a/task/thermal-api/Cargo.toml
+++ b/task/thermal-api/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib"}
-abi = {path = "../../sys/abi"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 


### PR DESCRIPTION
Now that we're using Idol, we don't need to depend on `abi` explicitly.

In passing, I also consolidated the `LedError`, which was defined in two places instead of just in the `drv-user-leds-api` crate.