### PR TITLE
Add derive macro for Idol errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-idol-err"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +611,7 @@ dependencies = [
 name = "drv-gimlet-hf-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "drv-hash-api",
  "idol",
  "num-traits",
@@ -633,6 +642,7 @@ dependencies = [
 name = "drv-gimlet-seq-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",
@@ -671,6 +681,7 @@ dependencies = [
 name = "drv-hash-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",
@@ -835,6 +846,7 @@ dependencies = [
 name = "drv-sidecar-seq-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",
@@ -867,6 +879,7 @@ dependencies = [
 name = "drv-spi-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",
@@ -1083,6 +1096,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "cfg-if 1.0.0",
+ "derive-idol-err",
  "drv-stm32xx-gpio-common",
  "idol",
  "num-traits",
@@ -1114,6 +1128,7 @@ dependencies = [
 name = "drv-user-leds-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",
@@ -2713,6 +2728,7 @@ name = "task-net-api"
 version = "0.1.0"
 dependencies = [
  "build-net",
+ "derive-idol-err",
  "idol",
  "num-traits",
  "serde",
@@ -2784,6 +2800,7 @@ dependencies = [
 name = "task-sensor-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "drv-i2c-api",
  "idol",
  "num-traits",
@@ -2844,6 +2861,7 @@ dependencies = [
 name = "task-thermal-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
  "num-traits",
  "userlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "sys/num-tasks",
 
     "lib/armv6m-atomic-hack",
+    "lib/derive-idol-err",
     "lib/fixedmap",
     "lib/gnarle",
     "lib/hypocalls",

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -110,24 +110,12 @@ task-slots = ["sys"]
 [tasks.hiffy]
 path = "../../task/hiffy"
 name = "task-hiffy"
-features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
+features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
-task-slots = ["hf", "sys", "i2c_driver", "user_leds"]
-
-[tasks.hf]
-path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
-features = ["h753"]
-priority = 3
-requires = {flash = 8192, ram = 2048 }
-stacksize = 1920
-start = true
-uses = ["quadspi"]
-interrupts = {"quadspi.irq" = 1}
-task-slots = ["sys"]
+task-slots = ["sys", "i2c_driver", "user_leds"]
 
 [tasks.vsc7448]
 path = "../../task/vsc7448"

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use drv_hash_api::SHA256_SZ;
 use userlib::*;
 use zerocopy::AsBytes;
@@ -14,7 +15,7 @@ use zerocopy::AsBytes;
 ///
 /// This enumeration doesn't include errors that result from configuration
 /// issues, like sending host flash messages to some other task.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum HfError {
     WriteEnableFailed = 1,
     ServerRestarted = 2,
@@ -22,25 +23,6 @@ pub enum HfError {
     HashBadRange = 4,
     HashError = 5,
     HashNotConfigured = 6,
-}
-
-impl From<HfError> for u16 {
-    fn from(rc: HfError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<HfError> for u32 {
-    fn from(rc: HfError) -> Self {
-        rc as u32
-    }
-}
-
-impl core::convert::TryFrom<u32> for HfError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
-    }
 }
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"

--- a/drv/gimlet-seq-api/src/lib.rs
+++ b/drv/gimlet-seq-api/src/lib.rs
@@ -6,28 +6,16 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum SeqError {
     IllegalTransition = 1,
     MuxToHostCPUFailed = 2,
     MuxToSPFailed = 3,
     ClockConfigFailed = 4,
-}
-
-impl From<SeqError> for u16 {
-    fn from(rc: SeqError) -> Self {
-        rc as u16
-    }
-}
-
-impl core::convert::TryFrom<u32> for SeqError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
-    }
 }
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]

--- a/drv/hash-api/Cargo.toml
+++ b/drv/hash-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"

--- a/drv/hash-api/src/lib.rs
+++ b/drv/hash-api/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 
 pub const SHA256_SZ: usize = 32;
@@ -14,32 +15,13 @@ pub const SHA256_SZ: usize = 32;
 ///
 /// This enumeration doesn't include errors that result from configuration
 /// issues, like sending host flash messages to some other task.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum HashError {
     NotInitialized = 1,
     InvalidState = 2,
     Busy = 3, // Some other owner is using the Hash block
     ServerRestarted = 4,
     NoData = 5,
-}
-
-impl From<HashError> for u16 {
-    fn from(rc: HashError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<HashError> for u32 {
-    fn from(rc: HashError) -> Self {
-        rc as u32
-    }
-}
-
-impl core::convert::TryFrom<u32> for HashError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
-    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"

--- a/drv/sidecar-seq-api/src/lib.rs
+++ b/drv/sidecar-seq-api/src/lib.rs
@@ -6,26 +6,14 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum SeqError {
     IllegalTransition = 1,
     ClockConfigFailed = 2,
-}
-
-impl From<SeqError> for u16 {
-    fn from(rc: SeqError) -> Self {
-        rc as u16
-    }
-}
-
-impl core::convert::TryFrom<u32> for SeqError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
-    }
 }
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -6,9 +6,10 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 #[repr(u32)]
 pub enum SpiError {
     /// Transfer size is 0 or exceeds maximum
@@ -28,25 +29,6 @@ pub enum SpiError {
 
     /// Receive FIFO overflow
     DataOverrun = 5,
-}
-
-impl From<SpiError> for u16 {
-    fn from(rc: SpiError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<SpiError> for u32 {
-    fn from(rc: SpiError) -> Self {
-        rc as u32
-    }
-}
-
-impl core::convert::TryFrom<u32> for SpiError {
-    type Error = ();
-    fn try_from(x: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(x).ok_or(())
-    }
 }
 
 #[derive(

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 byteorder = {version = "1.3", default-features = false}

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -18,6 +18,7 @@ cfg_if::cfg_if! {
     }
 }
 
+use derive_idol_err::IdolError;
 use unwrap_lite::UnwrapLite;
 use userlib::*;
 
@@ -25,26 +26,10 @@ pub use drv_stm32xx_gpio_common::{
     Alternate, Mode, OutputType, PinSet, Port, Pull, Speed,
 };
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
 #[repr(u32)]
 pub enum RccError {
     NoSuchPeripheral = 1,
-}
-
-impl TryFrom<u32> for RccError {
-    type Error = ();
-    fn try_from(x: u32) -> Result<Self, Self::Error> {
-        match x {
-            1 => Ok(RccError::NoSuchPeripheral),
-            _ => Err(()),
-        }
-    }
-}
-
-impl From<RccError> for u16 {
-    fn from(x: RccError) -> Self {
-        x as u16
-    }
 }
 
 impl Sys {
@@ -138,33 +123,10 @@ impl Peripheral {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
 #[repr(u32)]
 pub enum GpioError {
     BadArg = 2,
-}
-
-impl From<GpioError> for u32 {
-    fn from(rc: GpioError) -> Self {
-        rc as u32
-    }
-}
-
-impl From<GpioError> for u16 {
-    fn from(rc: GpioError) -> Self {
-        rc as u16
-    }
-}
-
-impl TryFrom<u32> for GpioError {
-    type Error = ();
-
-    fn try_from(x: u32) -> Result<Self, Self::Error> {
-        match x {
-            2 => Ok(GpioError::BadArg),
-            _ => Err(()),
-        }
-    }
 }
 
 impl Sys {

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/user-leds-api/src/lib.rs
+++ b/drv/user-leds-api/src/lib.rs
@@ -6,26 +6,12 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
 pub enum LedError {
     NotPresent = 1,
-}
-
-impl From<LedError> for u16 {
-    fn from(rc: LedError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<u32> for LedError {
-    fn from(x: u32) -> Self {
-        match x {
-            1 => LedError::NotPresent,
-            _ => panic!(),
-        }
-    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/lib/derive-idol-err/Cargo.toml
+++ b/lib/derive-idol-err/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "derive-idol-err"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1", features = ["full"] }
+quote = "1"
+
+[lib]
+proc-macro = true

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -1,0 +1,29 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(IdolError)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let DeriveInput { ident, .. } = parse_macro_input!(input);
+    // We need to implement From for both u16 *and* u32, because Idol uses
+    // one and Hiffy uses the other.
+    let output = quote! {
+        impl From<#ident> for u16 {
+            fn from(v: #ident) -> Self {
+                v as u16
+            }
+        }
+        impl From<#ident> for u32 {
+            fn from(v: #ident) -> Self {
+                v as u32
+            }
+        }
+        impl core::convert::TryFrom<u32> for #ident {
+            type Error = ();
+            fn try_from(v: u32) -> Result<Self, Self::Error> {
+                Self::from_u32(v).ok_or(())
+            }
+        }
+    };
+    output.into()
+}

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -6,11 +6,17 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
+/// Adds three `impl` blocks for the given error type:
+/// - `From<E> for u16` (Idol encoding)
+/// - `From<E> for u32` (Hiffy encoding)
+/// - `TryFrom<u32> for E` (Idol decoding)
+///
+/// The given type must also derive `FromPrimitive`, which is used in the
+/// `TryFrom<u32>` implementation.  Sadly, this cannot be automatically added
+/// to the type by this macro.
 #[proc_macro_derive(IdolError)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, .. } = parse_macro_input!(input);
-    // We need to implement From for both u16 *and* u32, because Idol uses
-    // one and Hiffy uses the other.
     let output = quote! {
         impl From<#ident> for u16 {
             fn from(v: #ident) -> Self {

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 use-smoltcp = ["smoltcp"]
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -6,30 +6,15 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use serde::{Deserialize, Serialize};
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive, IdolError)]
 #[repr(u32)]
 pub enum NetError {
     QueueEmpty = 1,
     NotYours = 2,
-}
-
-impl From<u32> for NetError {
-    fn from(x: u32) -> Self {
-        match x {
-            1 => NetError::QueueEmpty,
-            2 => NetError::NotYours,
-            _ => panic!(),
-        }
-    }
-}
-
-impl From<NetError> for u16 {
-    fn from(x: NetError) -> Self {
-        x as u16
-    }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/task/sensor-api/Cargo.toml
+++ b/task/sensor-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use drv_i2c_api::ResponseCode;
 use userlib::*;
 
@@ -55,7 +56,7 @@ impl From<ResponseCode> for NoData {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum SensorError {
     InvalidSensor = 1,
     NoReading = 2,
@@ -75,25 +76,6 @@ impl From<NoData> for SensorError {
             NoData::DeviceUnavailable => SensorError::DeviceUnavailable,
             NoData::DeviceTimeout => SensorError::DeviceTimeout,
         }
-    }
-}
-
-impl From<SensorError> for u16 {
-    fn from(rc: SensorError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<SensorError> for u32 {
-    fn from(rc: SensorError) -> Self {
-        rc as u32
-    }
-}
-
-impl core::convert::TryFrom<u32> for SensorError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
     }
 }
 

--- a/task/thermal-api/Cargo.toml
+++ b/task/thermal-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
+derive-idol-err = {path = "../../lib/derive-idol-err" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -6,32 +6,14 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum ThermalError {
     InvalidFan = 1,
     InvalidPWM = 2,
     DeviceError = 3,
-}
-
-impl From<ThermalError> for u16 {
-    fn from(rc: ThermalError) -> Self {
-        rc as u16
-    }
-}
-
-impl From<ThermalError> for u32 {
-    fn from(rc: ThermalError) -> Self {
-        rc as u32
-    }
-}
-
-impl core::convert::TryFrom<u32> for ThermalError {
-    type Error = ();
-    fn try_from(rc: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(rc).ok_or(())
-    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));


### PR DESCRIPTION
This removes a bunch of boilerplate for error types which are used in Idol / Hiffy.

(I also removed an unused task from `gimletlet/app-vsc7448`, since it was complaining about being oversized)