### PR TITLE
Reduce kernel-link deltas relative to cortex-m-rt

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,8 +21,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet-a, gimlet-b, sidecar]
+        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet-a, gimlet-b, sidecar, stm32g0]
         include:
+          - build: stm32g0
+            app_name: demo-stm32g070-nucleo
+            app_toml: app/demo-stm32g0-nucleo/app-g070.toml
+            target: thumbv6m-none-eabi
           - build: stm32f3
             app_name: demo-stm32f3-discovery
             app_toml: app/demo-stm32f4-discovery/app-f3.toml


### PR DESCRIPTION
While this contains a number of small formatting/layout changes to try
and reduce the diff, the critical change is the re-insertion of the
PreResetTrampoline section and its accompanying comment. Removing these
broke the build on M0, where branches have very limited range.