### PR TITLE
stm32h7: upgrade from 0.13 to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -760,6 +760,7 @@ dependencies = [
 name = "drv-lpc55-rng"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 1.0.0",
  "drv-lpc55-syscon-api",
  "lpc55-pac",
  "num-traits",
@@ -928,7 +929,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cortex-m",
  "smoltcp",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -937,7 +938,7 @@ name = "drv-stm32h7-hash"
 version = "0.1.0"
 dependencies = [
  "drv-hash-api",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "vcell",
  "zerocopy",
@@ -956,7 +957,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -971,7 +972,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -991,7 +992,7 @@ dependencies = [
  "fixedmap",
  "num-traits",
  "ringbuf",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -999,7 +1000,7 @@ dependencies = [
 name = "drv-stm32h7-qspi"
 version = "0.1.0"
 dependencies = [
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "vcell",
  "zerocopy",
@@ -1011,7 +1012,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "ringbuf",
- "stm32h7 0.13.0",
+ "stm32h7",
  "vcell",
  "zerocopy",
 ]
@@ -1035,7 +1036,7 @@ dependencies = [
  "quote",
  "ringbuf",
  "serde",
- "stm32h7 0.13.0",
+ "stm32h7",
  "syn",
  "userlib",
  "zerocopy",
@@ -1047,7 +1048,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1057,7 +1058,7 @@ dependencies = [
  "cortex-m",
  "drv-stm32xx-sys-api",
  "num-traits",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1069,7 +1070,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "num-traits",
  "stm32g0",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1085,7 +1086,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "stm32g0",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1255,7 +1256,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1306,7 +1307,7 @@ dependencies = [
  "kern",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1337,7 +1338,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2074,7 +2075,7 @@ dependencies = [
  "kern",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2413,7 +2414,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2554,24 +2555,13 @@ dependencies = [
 
 [[package]]
 name = "stm32h7"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b672c837e0ee8158ecc7fce0f9a948dd0693a9c588338e728d14b73307a0b7d"
-dependencies = [
- "bare-metal 0.2.5",
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "stm32h7"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0faa648e03579befdd7267ab5c669624729028001fcf3c973832f53e310a06"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
+ "cortex-m-rt",
  "vcell",
 ]
 
@@ -2723,7 +2713,7 @@ dependencies = [
  "serde",
  "smoltcp",
  "ssmarshal",
- "stm32h7 0.13.0",
+ "stm32h7",
  "syn",
  "task-net-api",
  "userlib",
@@ -2832,7 +2822,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "spd",
- "stm32h7 0.13.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -2992,7 +2982,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -3064,7 +3054,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -17,7 +17,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup"}
 
 [dependencies.kern]

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 
 [dependencies.kern]

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 
 [dependencies.kern]

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 
 [dependencies.kern]

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 
 [dependencies.kern]

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt", "stm32h753"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 
 [dependencies.kern]

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
 cfg-if = "0.1.10"

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -8,6 +8,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
+cfg-if = { version = "1.0" }
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/drv/stm32h7-eth/Cargo.toml
+++ b/drv/stm32h7-eth/Cargo.toml
@@ -15,7 +15,7 @@ ipv6 = []
 cfg-if = "1"
 cortex-m = "0.7"
 userlib = {path = "../../sys/userlib"}
-stm32h7 = {version = "0.13", default-features = false}
+stm32h7 = {version = "0.14", default-features = false}
 
 [dependencies.smoltcp]
 optional = true

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-hash = {path = "../stm32h7-hash", default-features = false, optional = true}
 cfg-if = "0.1.10"

--- a/drv/stm32h7-hash/Cargo.toml
+++ b/drv/stm32h7-hash/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 vcell = "0.1.2"
 drv-hash-api = {path = "../hash-api"}
 zerocopy = "0.6.1"

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -13,7 +13,7 @@ drv-stm32h7-i2c = {path = "../stm32h7-i2c", default-features = false }
 drv-i2c-api = {path = "../i2c-api"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/drv/stm32h7-i2c/Cargo.toml
+++ b/drv/stm32h7-i2c/Cargo.toml
@@ -12,7 +12,7 @@ drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-i2c-api = {path = "../i2c-api"}
 cfg-if = "0.1.10"
 bitfield = "0.13"
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -764,7 +764,7 @@ impl<'a> I2cController<'a> {
                     continue;
                 }
 
-                if isr.addr().is_match_() {
+                if isr.addr().is_match() {
                     ringbuf_entry!(Trace::AddrMatch);
                     break (isr.dir().is_write(), isr.addcode().bits());
                 }
@@ -797,7 +797,7 @@ impl<'a> I2cController<'a> {
                     let isr = i2c.isr.read();
                     ringbuf_entry!(Trace::RxISR(isr.bits()));
 
-                    if isr.addr().is_match_() {
+                    if isr.addr().is_match() {
                         //
                         // If we have an address match, check to see if this is
                         // change in direction; if it is, break out of our receive
@@ -849,7 +849,7 @@ impl<'a> I2cController<'a> {
                 let isr = i2c.isr.read();
                 ringbuf_entry!(Trace::TxISR(isr.bits()));
 
-                if isr.addr().is_match_() {
+                if isr.addr().is_match() {
                     //
                     // We really aren't expecting this, so kick out to the top
                     // of the loop to try to make sense of it.

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 vcell = "0.1.2"
 zerocopy = "0.6.1"
 userlib = {path = "../../sys/userlib"}

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -12,7 +12,7 @@ drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-spi-api = {path = "../spi-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 cfg-if = "0.1.10"
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -8,7 +8,7 @@ ringbuf = {path = "../../lib/ringbuf"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 vcell = "0.1.2"
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 
 [features]
 h743 = ["stm32h7/stm32h743"]

--- a/drv/stm32h7-startup/Cargo.toml
+++ b/drv/stm32h7-startup/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 cortex-m-rt = "0.6.12"
 

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [features]

--- a/drv/stm32h7-usart/src/main.rs
+++ b/drv/stm32h7-usart/src/main.rs
@@ -203,9 +203,7 @@ fn step_transmit(
 
     if let Some(byte) = txs.caller.borrow(0).read_at::<u8>(txs.pos) {
         // Stuff byte into transmitter.
-        usart
-            .tdr
-            .write(|w| unsafe { w.tdr().bits(u16::from(byte)) });
+        usart.tdr.write(|w| w.tdr().bits(u16::from(byte)));
 
         txs.pos += 1;
         if txs.pos == txs.len {

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -10,7 +10,7 @@ cortex-m = {version = "0.7", features = ["inline-asm"]}
 num-traits = {version = "0.2.12", default-features = false}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
-stm32h7 = {version = "0.13", default-features = false}
+stm32h7 = {version = "0.14", default-features = false}
 zerocopy = "0.6"
 
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -13,7 +13,7 @@ drv-stm32h7-i2c = {path = "../../drv/stm32h7-i2c", features = ["amd_erratum_1394
 drv-i2c-api = {path = "../../drv/i2c-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -16,7 +16,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../sys/kern"

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -17,7 +17,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "0.1.10"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
+stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../sys/kern"


### PR DESCRIPTION
This commit upgrades crates using stm32h7 version 0.13 to 0.14. The only
code changes required were:

stm32h7-usart - removed an unsafe block that's no longer required
stm32h7-spi - update use of 'is_match_' function to 'is_match'

this resolves #463 