### PR TITLE
Fix LPC55 fallout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "cortex-m",
  "hubris-num-tasks",
- "hypocalls",
  "num-traits",
  "test-api",
  "userlib",

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -92,6 +92,11 @@ unsafe fn branch_to_image(image: Image) -> ! {
     // Write the NS_VTOR
     core::ptr::write_volatile(0xE002ED08 as *mut u32, image.get_vectors());
 
+    // Route all interrupts to the NS world
+    // TODO use only the interrupts we've enabled
+    core::ptr::write_volatile(0xe000e380 as *mut u32, 0xffffffff);
+    core::ptr::write_volatile(0xe000e384 as *mut u32, 0xffffffff);
+
     // For secure we do not set the thumb bit!
     let entry_pt = image.get_pc() & !1u32;
     let stack = image.get_sp();

--- a/task/ping/build.rs
+++ b/task/ping/build.rs
@@ -2,6 +2,37 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() {
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
+
+    generate_consts()?;
+
+    Ok(())
+}
+
+fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let mut const_file = File::create(out.join("consts.rs")).unwrap();
+
+    // If hubris is non-secure (i.e. TZ is enabled) we need to use a
+    // different address for our bad address testing since NULL will
+    // trigger a secure fault
+    if let Ok(secure) = env::var("HUBRIS_SECURE") {
+        if secure == "0" {
+            // This corresponds to USB SRAM on the LPC55
+            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")
+                .unwrap();
+        } else {
+            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
+        }
+    } else {
+        writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
+    }
+
+    Ok(())
 }

--- a/task/ping/src/main.rs
+++ b/task/ping/src/main.rs
@@ -15,8 +15,8 @@ task_slot!(UART, usart_driver);
 #[inline(never)]
 fn nullread() {
     unsafe {
-        // 0 is not in a region we can access; memory fault
-        (0 as *const u8).read_volatile();
+        // This constant is in a region we can't access; memory fault
+        (BAD_ADDRESS as *const u8).read_volatile();
     }
 }
 
@@ -73,3 +73,5 @@ fn uart_send(text: &[u8]) {
 
 #[cfg(not(feature = "uart"))]
 fn uart_send(_: &[u8]) {}
+
+include!(concat!(env!("OUT_DIR"), "/consts.rs"));

--- a/test/test-assist/src/main.rs
+++ b/test/test-assist/src/main.rs
@@ -58,9 +58,9 @@ fn illop(_arg: u32) {
 }
 
 #[inline(never)]
-fn badexec(_arg: u32) {
+fn badexec(arg: u32) {
     unsafe {
-        let val: u32 = 1;
+        let val: u32 = arg | 1;
         let f: extern "C" fn() = core::mem::transmute(val);
         f();
     }

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -10,7 +10,6 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 hubris-num-tasks = {path = "../../sys/num-tasks"}
 num-traits = { version = "0.2.12", default-features = false }
 test-api = {path = "../test-api"}
-hypocalls = {path = "../../lib/hypocalls", default-features = false, optional = true }
 cfg-if = "0.1"
 
 [build-dependencies]
@@ -19,7 +18,6 @@ build-util = {path = "../../build/util"}
 [features]
 itm = [ "userlib/log-itm" ]
 semihosting = [ "userlib/log-semihosting" ]
-lpc55 = ["hypocalls"]
 
 [[bin]]
 name = "test-suite"

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -2,7 +2,36 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
+
+    generate_consts()?;
+    Ok(())
+}
+
+fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let mut const_file = File::create(out.join("consts.rs")).unwrap();
+
+    // If hubris is non-secure (i.e. TZ is enabled) we need to use a
+    // different address for our bad address testing since NULL will
+    // trigger a secure fault
+    if let Ok(secure) = env::var("HUBRIS_SECURE") {
+        if secure == "0" {
+            // This corresponds to USB SRAM on the LPC55
+            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")
+                .unwrap();
+        } else {
+            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
+        }
+    } else {
+        writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
+    }
+
     Ok(())
 }

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -69,7 +69,6 @@ priority = 0
 requires = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
-uses = ["stage0"]
 
 [tasks.suite]
 path = "../test-suite"
@@ -77,8 +76,6 @@ name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
-features = ["lpc55"]
-uses = ["stage0", "rom", "syscon", "flash"]
 stacksize = 2048
 task-slots = ["assist", "suite", "runner"]
 
@@ -89,7 +86,6 @@ priority = 1
 requires = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
-uses = ["stage0"]
 
 [tasks.idle]
 path = "../../task/idle"
@@ -99,11 +95,3 @@ requires = {flash = 256, ram = 256}
 stacksize = 256
 start = true
 
-# Hmmm put this in a better region?
-[extratext.stage0]
-address = 0x0
-size = 0x8000
-
-[extratext.rom]
-address = 0x13000000
-size = 0x20000

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -3,6 +3,7 @@ target = "thumbv8m.main-none-eabihf"
 board = "lpcxpresso55s69"
 chip = "../../chips/lpc55.toml"
 stacksize = 2048
+secure-separation = true
 
 [kernel]
 path = "../../app/lpc55xpresso"
@@ -61,6 +62,7 @@ imagea-flash-start = 0x8000
 imagea-flash-size = 0x88000
 imagea-ram-start = 0x20004000
 imagea-ram-size = 0x18000
+features = ["tz_support"]
 
 [tasks.runner]
 path = "../test-runner"
@@ -69,7 +71,6 @@ priority = 0
 requires = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
-uses = ["stage0"]
 
 [tasks.suite]
 path = "../test-suite"
@@ -77,8 +78,7 @@ name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
 start = true
-features = ["itm", "lpc55"]
-uses = ["stage0", "rom", "syscon", "flash"]
+features = ["itm"]
 stacksize = 2048
 task-slots = ["assist", "suite", "runner"]
 
@@ -89,7 +89,6 @@ priority = 1
 requires = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
-uses = ["stage0"]
 
 [tasks.idle]
 path = "../../task/idle"
@@ -98,12 +97,3 @@ priority = 3
 requires = {flash = 256, ram = 256}
 stacksize = 256
 start = true
-
-# Hmmm put this in a better region?
-[extratext.stage0]
-address = 0x0
-size = 0x8000
-
-[extratext.rom]
-address = 0x13000000
-size = 0x20000


### PR DESCRIPTION
Fix some unexpected fallout from recent LPC55 changes. Main changes:

- Fix SWO to run at the same rate as the CPU clock
- Route all interrupts to the non secure world
- Fix some of our testing to use addresses that will not trigger secure faults