### PR TITLE
Remove `assert_eq` to avoid float formatting in test suite

### DIFF
--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -26,7 +26,7 @@ impl From<IdolTestError> for u16 {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct FancyTestType {
     pub u: u32,
     pub b: bool,

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -498,9 +498,13 @@ fn test_idol_ssmarshal() {
             f: 1.0,
         })
         .unwrap();
+
+    // We deliberately avoid using assert_eq! for float comparison, because
+    // it brings in 14K of float formatting code and overflows our smaller
+    // targets.
     assert_eq!(r.u, 134);
     assert_eq!(r.b, true);
-    assert_eq!(r.f, 1.0);
+    assert!(r.f == 1.0);
 
     let r = idol
         .fancy_increment(test_idol_api::FancyTestType {
@@ -511,7 +515,7 @@ fn test_idol_ssmarshal() {
         .unwrap();
     assert_eq!(r.u, 101);
     assert_eq!(r.b, false);
-    assert_eq!(r.f, 1.0);
+    assert!(r.f == 1.0);
 }
 
 /// Tests that task restart works as expected.


### PR DESCRIPTION
`test_restart`: 420 bytes
`test_borrow_info`: 440 bytes
`main`: 532 bytes
`float_to_decimal_common_shortest`: 8.2 KB
someone please help me budget this, my microcontroller is dying

(fixes the `test/tests-stm32g0/app-g070.toml` build)