### PR TITLE
Implement Gimletlet NIC BSP

### DIFF
--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -181,9 +181,9 @@ controller = 4
 
 [config.spi.spi4.mux_options.port_e]
 outputs = [
-    {port = "E", pins = [12, 13], af = 5},
+    {port = "E", pins = [12, 14], af = 5},
 ]
-input = {port = "E", pin = 14, af = 5}
+input = {port = "E", pin = 13, af = 5}
 
 [config.spi.spi4.devices.spi4_header]
 mux = "port_e"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -38,6 +38,15 @@ read = true
 write = true
 execute = false  # let's assume XN until proven otherwise
 
+# Network buffers are placed in sram1, which is directly accessible by the
+# Ethernet MAC.
+[outputs.sram1]
+address = 0x30000000
+size = 0x20000
+read = true
+write = true
+dma = true
+
 [tasks.jefe]
 path = "../../task/jefe"
 name = "task-jefe"
@@ -149,6 +158,28 @@ uses = ["quadspi"]
 interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys"]
 
+[tasks.net]
+path = "../../task/net"
+name = "task-net"
+stacksize = 3800
+priority = 2
+features = ["h753", "gimletlet-nic"]
+requires = {flash = 131072, ram = 16384, sram1 = 16384}
+sections = {eth_bulk = "sram1"}
+uses = ["eth", "eth_dma", "system_flash"]
+start = true
+interrupts = {"eth.irq" = 0b1}
+task-slots = ["sys", "spi_driver" ]
+
+[tasks.udpecho]
+path = "../../task/udpecho"
+name = "task-udpecho"
+priority = 3
+requires = {flash = 16384, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
@@ -225,24 +256,18 @@ controller = 4
 
 [config.spi.spi4.mux_options.port_e]
 outputs = [
-    {port = "E", pins = [12, 13], af = 5},
+    {port = "E", pins = [12, 14], af = 5},
 ]
-input = {port = "E", pin = 14, af = 5}
+input = {port = "E", pin = 13, af = 5}
 
 [config.spi.spi4.devices.spi4_header]
 mux = "port_e"
 cs = [{port = "E", pin = 11}]
 
-
-[config.spi.spi6]
-controller = 6
-
-[config.spi.spi6.mux_options.port_g]
-outputs = [
-    {port = "G", pins = [13, 14], af = 5},
-]
-input = {port = "E", pin = 12, af = 5}
-
-[config.spi.spi6.devices.spi6_header]
-mux = "port_g"
-cs = [{port = "G", pin = 8}]
+[config.net]
+[config.net.sockets.echo]
+kind = "udp"
+owner = {name = "udpecho", notification = 1}
+port = 7
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -47,6 +47,7 @@ gimlet = ["drv-gimlet-seq-api"]
 sidecar = ["drv-sidecar-seq-api"]
 h743 = ["drv-stm32h7-eth/h743", "stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["drv-stm32h7-eth/h753", "stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
+gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api"]
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/task/net/src/bsp.rs
+++ b/task/net/src/bsp.rs
@@ -21,6 +21,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_board = "gimletlet-1")] {
         mod gimletlet_mgmt;
         pub use gimletlet_mgmt::*;
+    } else if #[cfg(target_board = "gimletlet-2")] {
+        mod gimletlet_nic;
+        pub use gimletlet_nic::*;
     } else {
         compile_error!("Board is not supported by the task/net");
     }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -3,11 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{mgmt, miim_bridge::MiimBridge, pins};
-use drv_spi_api::{Spi, SpiError};
+use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use drv_user_leds_api::UserLeds;
-use ksz8463::{MIBCounter, MIBCounterValue, Register as KszRegister};
+use ksz8463::{
+    Error as KszError, MIBCounter, MIBCounterValue, Register as KszRegister,
+};
 use ringbuf::*;
 use userlib::task_slot;
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
@@ -22,7 +24,7 @@ enum Trace {
     BspConfigured,
 
     KszErr {
-        err: SpiError,
+        err: KszError,
     },
     Ksz8463Status {
         port: u8,

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -41,9 +41,9 @@ pub fn configure_ethernet_pins(sys: &Sys) {
     pins::RmiiPins {
         refclk: Port::A.pin(1),
         crs_dv: Port::A.pin(7),
-        tx_en: Port::G.pin(11),
-        txd0: Port::G.pin(13),
-        txd1: Port::G.pin(12),
+        tx_en: Port::B.pin(11),
+        txd0: Port::B.pin(12),
+        txd1: Port::B.pin(13),
         rxd0: Port::C.pin(4),
         rxd1: Port::C.pin(5),
         af: Alternate::AF11,

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::pins;
+use drv_spi_api::Spi;
+use drv_stm32h7_eth as eth;
+use drv_stm32xx_sys_api::{Alternate, Port, Sys};
+use ksz8463::{
+    Error as KszError, Ksz8463, MIBCounter, MIBCounterValue,
+    Register as KszRegister,
+};
+use ringbuf::*;
+use userlib::{hl::sleep_for, task_slot};
+
+task_slot!(SPI, spi_driver);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum Trace {
+    None,
+    BspConfigured,
+
+    KszErr { err: KszError },
+    Ksz8463Status { port: u8, status: u16 },
+    Ksz8463Control { port: u8, control: u16 },
+    Ksz8463Counter { port: u8, counter: MIBCounterValue },
+    Ksz8463MacTable(ksz8463::MacTableEntry),
+}
+ringbuf!(Trace, 32, Trace::None);
+
+// This system wants to be woken periodically to do logging
+pub const WAKE_INTERVAL: Option<u64> = Some(5000);
+
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn preinit() {
+    // Nothing to do here
+}
+
+pub fn configure_ethernet_pins(sys: &Sys) {
+    pins::RmiiPins {
+        refclk: Port::A.pin(1),
+        crs_dv: Port::A.pin(7),
+        tx_en: Port::G.pin(11),
+        txd0: Port::G.pin(13),
+        txd1: Port::G.pin(12),
+        rxd0: Port::C.pin(4),
+        rxd1: Port::C.pin(5),
+        af: Alternate::AF11,
+    }
+    .configure(sys);
+}
+
+pub struct Bsp {
+    ksz8463: Ksz8463,
+}
+
+impl Bsp {
+    pub fn new(_eth: &mut eth::Ethernet, sys: &Sys) -> Self {
+        let ksz8463 = loop {
+            // SPI device is based on ordering in app.toml
+            let ksz8463_spi = Spi::from(SPI.get_task_id()).device(0);
+
+            // Initialize the KSZ8463 (using SPI4_RESET, PB10)
+            sys.gpio_init_reset_pulse(Port::B.pin(10), 10, 1).unwrap();
+            let ksz8463 = Ksz8463::new(ksz8463_spi);
+            match ksz8463
+                .configure(ksz8463::Mode::Copper, ksz8463::VLanMode::Optional)
+            {
+                Err(err) => {
+                    ringbuf_entry!(Trace::KszErr { err });
+                    sleep_for(100);
+                }
+                _ => break ksz8463,
+            }
+        };
+        ringbuf_entry!(Trace::BspConfigured);
+
+        Self { ksz8463 }
+    }
+
+    pub fn wake(&self, _eth: &mut eth::Ethernet) {
+        for port in [1, 2] {
+            ringbuf_entry!(
+                match self.ksz8463.read(KszRegister::PxMBSR(port)) {
+                    Ok(status) => Trace::Ksz8463Status { port, status },
+                    Err(err) => Trace::KszErr { err },
+                }
+            );
+            ringbuf_entry!(
+                match self.ksz8463.read(KszRegister::PxMBCR(port)) {
+                    Ok(control) => Trace::Ksz8463Control { port, control },
+                    Err(err) => Trace::KszErr { err },
+                }
+            );
+            ringbuf_entry!(match self
+                .ksz8463
+                .read_mib_counter(port, MIBCounter::RxLoPriorityByte)
+            {
+                Ok(counter) => Trace::Ksz8463Counter { port, counter },
+                Err(err) => Trace::KszErr { err },
+            });
+
+            // Read the MAC table for fun
+            ringbuf_entry!(match self.ksz8463.read_dynamic_mac_table(0) {
+                Ok(mac) => Trace::Ksz8463MacTable(mac),
+                Err(err) => Trace::KszErr { err },
+            });
+        }
+    }
+}

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -7,8 +7,9 @@
 
 mod bsp;
 mod buf;
-mod pins;
 mod server;
+
+pub mod pins;
 
 #[cfg(feature = "mgmt")]
 mod miim_bridge;

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -3,10 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::miim_bridge::MiimBridge;
-use drv_spi_api::{SpiDevice, SpiError};
+use drv_spi_api::SpiDevice;
 use drv_stm32h7_eth::Ethernet;
 use drv_stm32xx_sys_api::{self as sys_api, OutputType, Pull, Speed, Sys};
-use ksz8463::{Ksz8463, Register as KszRegister};
+use ksz8463::{Error as KszError, Ksz8463, Register as KszRegister};
 use ringbuf::*;
 use userlib::hl::sleep_for;
 use vsc7448_pac::phy;
@@ -44,7 +44,7 @@ pub struct Status {
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum Trace {
     None,
-    Ksz8463Err { port: u8, err: SpiError },
+    Ksz8463Err { port: u8, err: KszError },
     Vsc85x2Err { port: u8, err: VscError },
     Status(Status),
 }
@@ -92,34 +92,28 @@ impl Config {
     }
 
     fn configure_ksz8463(self, sys: &Sys) -> ksz8463::Ksz8463 {
-        sys.gpio_reset(self.ksz8463_nrst).unwrap();
-        sys.gpio_configure_output(
-            self.ksz8463_nrst,
-            OutputType::PushPull,
-            Speed::Low,
-            Pull::None,
-        )
-        .unwrap();
-
-        // Toggle the reset line
-        sleep_for(10); // Reset must be held low for 10 ms after power up
-        sys.gpio_set(self.ksz8463_nrst).unwrap();
-
         // The datasheet recommends a particular combination of diodes and
         // capacitors which dramatically slow down the rise of the reset
         // line, meaning you have to wait for extra long here.
         //
         // Otherwise, the minimum wait time is 1 µs, so 1 ms is fine.
-        sleep_for(match self.ksz8463_rst_type {
-            Ksz8463ResetSpeed::Slow => 150,
-            Ksz8463ResetSpeed::Normal => 1,
-        });
+        sys.gpio_init_reset_pulse(
+            self.ksz8463_nrst,
+            10,
+            match self.ksz8463_rst_type {
+                Ksz8463ResetSpeed::Slow => 150,
+                Ksz8463ResetSpeed::Normal => 1,
+            },
+        )
+        .unwrap();
 
         let ksz8463 = Ksz8463::new(self.ksz8463_spi);
 
         // The KSZ8463 connects to the SP over RMII, then sends data to the
         // VSC8552 over 100-BASE FX
-        ksz8463.configure(self.ksz8463_vlan_mode).unwrap();
+        ksz8463
+            .configure(ksz8463::Mode::Fiber, self.ksz8463_vlan_mode)
+            .unwrap();
         ksz8463
     }
 
@@ -149,25 +143,19 @@ impl Config {
 
         // Do a hard reset of power, if that's present on this board
         if let Some(power_en) = self.power_en {
-            sys.gpio_reset(power_en).unwrap();
-            sys.gpio_configure_output(
+            sys.gpio_init_reset_pulse(
                 power_en,
-                OutputType::PushPull,
-                Speed::Low,
-                Pull::None,
+                // TODO: how long does this need to be?
+                10,
+                // For some reason, certain boards have longer startup
+                // times than others.
+                if self.slow_power_en {
+                    sleep_for(200);
+                } else {
+                    sleep_for(4);
+                },
             )
             .unwrap();
-            sys.gpio_reset(power_en).unwrap();
-            sleep_for(10); // TODO: how long does this need to be?
-
-            // Power on, then sleep.  For some reason, certain boards are
-            // much slower to come up than others, so we have a flag for that.
-            sys.gpio_set(power_en).unwrap();
-            if self.slow_power_en {
-                sleep_for(200);
-            } else {
-                sleep_for(4);
-            }
         }
 
         // TODO: sleep for PG lines going high here

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -147,13 +147,10 @@ impl Config {
                 power_en,
                 // TODO: how long does this need to be?
                 10,
-                // For some reason, certain boards have longer startup
-                // times than others.
-                if self.slow_power_en {
-                    sleep_for(200);
-                } else {
-                    sleep_for(4);
-                },
+                // Certain boards have longer startup times than others.
+                // See hardware-psc/issues/48 for analysis; it appears to
+                // be an issue with the level shifter rise times.
+                if self.slow_power_en { 200 } else { 4 },
             )
             .unwrap();
         }

--- a/task/vsc7448/src/bsp/sidecar_1.rs
+++ b/task/vsc7448/src/bsp/sidecar_1.rs
@@ -200,7 +200,8 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         .unwrap();
         sys.gpio_reset(coma_mode).unwrap();
 
-        // Make NRST low then switch it to output mode
+        // Make NRST low then switch it to output mode, before resetting
+        // power to the chip.
         let nrst = Port::I.pin(9);
         sys.gpio_reset(nrst).unwrap();
         sys.gpio_configure_output(
@@ -211,25 +212,11 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         )
         .unwrap();
 
-        // Jiggle reset line, then wait 120 ms
         // SP_TO_LDO_PHY4_EN (PI6)
-        let phy4_pwr_en = Port::I.pin(6);
-        sys.gpio_reset(phy4_pwr_en).unwrap();
-        sys.gpio_configure_output(
-            phy4_pwr_en,
-            OutputType::PushPull,
-            Speed::Low,
-            Pull::None,
-        )
-        .unwrap();
-        sys.gpio_reset(phy4_pwr_en).unwrap();
-        sleep_for(10);
-
-        // Power on!
-        sys.gpio_set(phy4_pwr_en).unwrap();
-        sleep_for(4);
+        sys.gpio_init_reset_pulse(Port::I.pin(6), 10, 4);
         // TODO: sleep for PG lines going high here
 
+        // Deassert reset line, then wait 120 ms
         sys.gpio_set(nrst).unwrap();
         sleep_for(120); // Wait for the chip to come out of reset
 

--- a/task/vsc7448/src/bsp/sidecar_1.rs
+++ b/task/vsc7448/src/bsp/sidecar_1.rs
@@ -213,7 +213,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         .unwrap();
 
         // SP_TO_LDO_PHY4_EN (PI6)
-        sys.gpio_init_reset_pulse(Port::I.pin(6), 10, 4);
+        sys.gpio_init_reset_pulse(Port::I.pin(6), 10, 4).unwrap();
         // TODO: sleep for PG lines going high here
 
         // Deassert reset line, then wait 120 ms


### PR DESCRIPTION
This PR implements the BSP for the Gimletlet NIC, which breaks out a KSZ8463.

There are also a few drive-by changes:
- Adding `gpio_init_reset_pulse`, to combine a common series of GPIO operations
- Adding a dedicated error type for KSZ8463 errors (and then using it in the driver)