### PR TITLE
improve errors for missing config sections

### DIFF
--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use serde::de::DeserializeOwned;
 use std::env;
 
@@ -48,16 +48,35 @@ pub fn expose_target_board() {
 /// reflect that by having its member (or members) be an `Option` type.
 ///
 pub fn config<T: DeserializeOwned>() -> Result<T> {
-    toml_from_env("HUBRIS_APP_CONFIG")
+    toml_from_env("HUBRIS_APP_CONFIG", Some("[config]"))
 }
 
 /// Pulls the task configuration. See `config` for more details.
 pub fn task_config<T: DeserializeOwned>() -> Result<T> {
-    toml_from_env("HUBRIS_TASK_CONFIG")
+    let section = match env::var("HUBRIS_TASK_NAME") {
+        Ok(task_name) => Some(format!("[tasks.{}.config]", task_name)),
+        _ => None
+    };
+    toml_from_env("HUBRIS_TASK_CONFIG", section.as_deref())
 }
 
-fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<T> {
-    let config = env::var(var)?;
+/// Parse the contents of an environment variable as toml. `section_name_pattern` is a string
+/// indicating what section of original toml file the variable should have come from to improve error reporting. `{task}` in the pattern is replaced with HUBRIS_TASK_NAME.
+fn toml_from_env<T: DeserializeOwned>(
+    var: &str,
+    section_name: Option<&str>,
+) -> Result<T> {
+    let config = env::var(var).map_err(|err|
+        match err {
+            env::VarError::NotPresent =>
+                match section_name {
+                    Some(section_name) => anyhow!("{} environment variable is undefined, but it should contain toml. Are you missing the {} section in your app.toml?", var, section_name),
+                    None => anyhow!("{} environment variable should contain toml, but it's missing, and we don't know why. Something has gone horribly wrong.", var)
+                },
+            _ => anyhow!(err)
+        }
+    )?;
+
     println!("--- toml for ${} ---", var);
     println!("{}", config);
     let rval = toml::from_slice(config.as_bytes())?;

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -55,7 +55,7 @@ pub fn config<T: DeserializeOwned>() -> Result<T> {
 pub fn task_config<T: DeserializeOwned>() -> Result<T> {
     let section = match env::var("HUBRIS_TASK_NAME") {
         Ok(task_name) => Some(format!("[tasks.{}.config]", task_name)),
-        _ => None
+        _ => None,
     };
     toml_from_env("HUBRIS_TASK_CONFIG", section.as_deref())
 }

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -237,6 +237,7 @@ pub fn package(
             out.join(&bootloader.name),
             verbose,
             edges,
+            None,
             &task_names,
             &remap_paths,
             &None,
@@ -351,6 +352,7 @@ Did you mean to run `cargo xtask dist`?"
             out.join(name),
             verbose,
             edges,
+            Some(&name),
             &task_names,
             &remap_paths,
             &toml.secure_separation,
@@ -424,6 +426,7 @@ Did you mean to run `cargo xtask dist`?"
         out.join("kernel"),
         verbose,
         edges,
+        None,
         "",
         &remap_paths,
         &toml.secure_separation,
@@ -1033,6 +1036,7 @@ fn build(
     dest: PathBuf,
     verbose: bool,
     edges: bool,
+    current_task_name: Option<&str>,
     task_names: &str,
     remap_paths: &BTreeMap<PathBuf, &str>,
     secure_separation: &Option<bool>,
@@ -1132,6 +1136,12 @@ fn build(
     if let Some(app_config) = app_config {
         let env = toml::to_string(&app_config).unwrap();
         cmd.env("HUBRIS_APP_CONFIG", env);
+    }
+
+    // Expose the current task's name to allow for better error messages if
+    // a required configuration section is missing
+    if let Some(current_task_name) = current_task_name {
+        cmd.env("HUBRIS_TASK_NAME", current_task_name);
     }
 
     if edges {


### PR DESCRIPTION
This is a first crack at resolving #482. It improves the error reporting in `toml_from_env` when a config section is missing. It exposes the task's toml key basename (i.e `tasks.spi` exposes `spi`) for tasks to aid with the error hints. The two error cases I mentioned in #482 now result in these errors that tell you what you're probably missing:

Missing task config:
```
error: failed to run custom build command for `drv-stm32h7-spi-server v0.1.0 (/home/artemis/z/hubris/drv/stm32h7-spi-server)`

Caused by:
  process didn't exit successfully: `/home/artemis/z/hubris/target/release/build/drv-stm32h7-spi-server-9f4f9b676721a4da/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-cfg=target_board="nucleo-h743zi2"
  cargo:rerun-if-env-changed=HUBRIS_BOARD

  --- stderr
  Error: HUBRIS_TASK_CONFIG environment variable is undefined, but it should contain toml. Are you missing the [tasks.spi_driver.config] section in your app.toml?
Error: failed to build spi_driver

Caused by:
    command failed, see output for details
```

Missing app config:
```
error: failed to run custom build command for `drv-stm32h7-spi-server v0.1.0 (/home/artemis/z/hubris/drv/stm32h7-spi-server)`

Caused by:
  process didn't exit successfully: `/home/artemis/z/hubris/target/release/build/drv-stm32h7-spi-server-9f4f9b676721a4da/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-cfg=target_board="nucleo-h743zi2"
  cargo:rerun-if-env-changed=HUBRIS_BOARD
  --- toml for $HUBRIS_TASK_CONFIG ---
  [spi]
  global_config = "spi1"

  cargo:rerun-if-env-changed=HUBRIS_TASK_CONFIG

  --- stderr
  Error: HUBRIS_APP_CONFIG environment variable is undefined, but it should contain toml. Are you missing the [config] section in your app.toml?
Error: failed to build spi_driver

Caused by:
    command failed, see output for details
```