### PR TITLE
Avoid unwrapping while waiting for clock config

### DIFF
--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -45,7 +45,7 @@ pub struct Bsp(mgmt::Bsp);
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
+    while seq.is_clock_config_loaded().unwrap_or(0) == 0 {
         sleep_for(10);
     }
 }

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -45,7 +45,7 @@ pub struct Bsp(mgmt::Bsp);
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().unwrap() == 0 {
+    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
         sleep_for(10);
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -45,7 +45,7 @@ pub struct Bsp(mgmt::Bsp);
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
+    while seq.is_clock_config_loaded().unwrap_or(0) == 0 {
         sleep_for(10);
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -45,7 +45,7 @@ pub struct Bsp(mgmt::Bsp);
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().unwrap() == 0 {
+    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
         sleep_for(10);
     }
 }

--- a/task/vsc7448/src/bsp/sidecar_1.rs
+++ b/task/vsc7448/src/bsp/sidecar_1.rs
@@ -77,7 +77,7 @@ impl<'a> PhyRw for NetPhyRw<'a> {
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
+    while seq.is_clock_config_loaded().unwrap_or(0) == 0 {
         sleep_for(10);
     }
 }

--- a/task/vsc7448/src/bsp/sidecar_1.rs
+++ b/task/vsc7448/src/bsp/sidecar_1.rs
@@ -77,7 +77,7 @@ impl<'a> PhyRw for NetPhyRw<'a> {
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while seq.is_clock_config_loaded().unwrap() == 0 {
+    while seq.is_clock_config_loaded().map(|b| b == 0).unwrap_or(true) {
         sleep_for(10);
     }
 }


### PR DESCRIPTION
Otherwise, the `net` and `vsc7448` tasks will crash if the sequencer task reboots.