### PR TITLE
Expand list of uarts/usarts in `chips/stm32h7.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ name = "task-uartecho"
 version = "0.1.0"
 dependencies = [
  "build-util",
+ "cfg-if 1.0.0",
  "cortex-m",
  "drv-stm32h7-usart",
  "ringbuf",

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -7,7 +7,8 @@ stacksize = 896
 [kernel]
 path = "."
 name = "demo-stm32h7-nucleo"
-requires = {flash = 22000, ram = 4096}
+requires = {flash = 21376, ram = 4096}
+
 #
 # For the kernel (and for any task that logs), we are required to enable
 # either "itm" (denoting logging/panicking via ARM's Instrumentation Trace
@@ -138,14 +139,14 @@ task-slots = ["user_leds"]
 [tasks.uartecho]
 path = "../../task/uartecho"
 name = "task-uartecho"
-features = ["stm32h743"]
+features = ["stm32h743", "usart3"]
+uses = ["usart3"]
+interrupts = {"usart3.irq" = 1}
 priority = 3
 requires = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys"]
-uses = ["usart3"]
-interrupts = {"usart3.irq" = 1}
 
 [tasks.udpecho]
 path = "../../task/udpecho"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -115,6 +115,18 @@ requires = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
+[tasks.uartecho]
+path = "../../task/uartecho"
+name = "task-uartecho"
+features = ["stm32h743", "usart2"]
+uses = ["usart2"]
+interrupts = {"usart2.irq" = 1}
+priority = 3
+requires = {flash = 16384, ram = 4096}
+stacksize = 2048
+start = true
+task-slots = ["sys"]
+
 [tasks.hiffy]
 path = "../../task/hiffy"
 name = "task-hiffy"

--- a/chips/stm32h7.toml
+++ b/chips/stm32h7.toml
@@ -44,10 +44,45 @@ address = 0x58001400
 size = 1024
 interrupts = { irq = 86 }
 
+[usart1]
+address = 0x40011000
+size = 1024
+interrupts = { irq = 37 }
+
+[usart2]
+address = 0x40004400
+size = 1024
+interrupts = { irq = 38 }
+
 [usart3]
 address = 0x40004800
 size = 1024
 interrupts = { irq = 39 }
+
+[uart4]
+address = 0x40004c00
+size = 1024
+interrupts = { irq = 52 }
+
+[uart5]
+address = 0x40005000
+size = 1024
+interrupts = { irq = 53 }
+
+[usart6]
+address = 0x40011400
+size = 1024
+interrupts = { irq = 71 }
+
+[uart7]
+address = 0x40007800
+size = 1024
+interrupts = { irq = 82 }
+
+[uart8]
+address = 0x40007c00
+size = 1024
+interrupts = { irq = 83 }
 
 [i2c1]
 address = 0x40005400

--- a/drv/stm32h7-usart/src/lib.rs
+++ b/drv/stm32h7-usart/src/lib.rs
@@ -40,8 +40,7 @@ impl Usart {
         sys: &Sys,
         usart: &'static device::usart1::RegisterBlock,
         peripheral: Peripheral,
-        tx_rx_mask: PinSet,
-        alternate: Alternate,
+        pins: &[(PinSet, Alternate)],
         clock_hz: u32,
         baud_rate: u32,
     ) -> Self {
@@ -75,14 +74,16 @@ impl Usart {
         // Enable the transmitter and receiver.
         usart.cr1.modify(|_, w| w.te().enabled().re().enabled());
 
-        sys.gpio_configure_alternate(
-            tx_rx_mask,
-            drv_stm32xx_sys_api::OutputType::PushPull,
-            drv_stm32xx_sys_api::Speed::Low,
-            drv_stm32xx_sys_api::Pull::None,
-            alternate,
-        )
-        .unwrap_lite();
+        for &(mask, alternate) in pins {
+            sys.gpio_configure_alternate(
+                mask,
+                drv_stm32xx_sys_api::OutputType::PushPull,
+                drv_stm32xx_sys_api::Speed::Low,
+                drv_stm32xx_sys_api::Pull::None,
+                alternate,
+            )
+            .unwrap_lite();
+        }
 
         // Enable RX interrupts from the USART side.
         usart.cr1.modify(|_, w| w.rxneie().enabled());

--- a/task/uartecho/Cargo.toml
+++ b/task/uartecho/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cfg-if = "1"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 ringbuf = {path = "../../lib/ringbuf"}
 tinyvec = "1.5.1"
@@ -19,6 +20,13 @@ build-util = {path = "../../build/util"}
 [features]
 stm32h743 = ["drv-stm32h7-usart/h743"]
 stm32h753 = ["drv-stm32h7-usart/h753"]
+usart1 = []
+usart2 = []
+usart3 = []
+uart4 = []
+uart5 = []
+usart6 = []
+uart7 = []
 
 [[bin]]
 name = "task-uartecho"

--- a/task/uartecho/src/main.rs
+++ b/task/uartecho/src/main.rs
@@ -173,19 +173,79 @@ fn configure_uart_device() -> Usart {
 
     const BAUD_RATE: u32 = 115_200;
 
-    // From thin air, pluck a pointer to the USART register block.
-    //
-    // Safety: this is needlessly unsafe in the API. The USART is essentially a
-    // static, and we access it through a & reference so aliasing is not a
-    // concern. Were it literally a static, we could just reference it.
-    let usart = unsafe { &*device::USART3::ptr() };
+    let usart;
+    let peripheral;
+    let pins;
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "usart1")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::B.pin(6), Alternate::AF7),
+                (Port::B.pin(15), Alternate::AF4),
+            ];
+
+            // From thin air, pluck a pointer to the USART register block.
+            //
+            // Safety: this is needlessly unsafe in the API. The USART is
+            // essentially a static, and we access it through a & reference so
+            // aliasing is not a concern. Were it literally a static, we could
+            // just reference it.
+            usart = unsafe { &*device::USART1::ptr() };
+            peripheral = Peripheral::Usart1;
+            pins = PINS;
+        } else if #[cfg(feature = "usart2")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::D.pin(5).and_pin(6), Alternate::AF7),
+            ];
+            usart = unsafe { &*device::USART2::ptr() };
+            peripheral = Peripheral::Usart2;
+            pins = PINS;
+        } else if #[cfg(feature = "usart3")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::D.pin(8).and_pin(9), Alternate::AF7),
+            ];
+            usart = unsafe { &*device::USART3::ptr() };
+            peripheral = Peripheral::Usart3;
+            pins = PINS;
+        } else if #[cfg(feature = "uart4")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::D.pin(0).and_pin(1), Alternate::AF8),
+            ];
+            usart = unsafe { &*device::UART4::ptr() };
+            peripheral = Peripheral::Uart4;
+            pins = PINS;
+        } else if #[cfg(feature = "uart5")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::C.pin(12), Alternate::AF8),
+                (Port::D.pin(2), Alternate::AF8),
+            ];
+            usart = unsafe { &*device::UART5::ptr() };
+            peripheral = Peripheral::Uart5;
+            pins = PINS;
+        } else if #[cfg(feature = "usart6")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::C.pin(6).and_pin(7), Alternate::AF7),
+            ];
+            usart = unsafe { &*device::USART6::ptr() };
+            peripheral = Peripheral::Usart6;
+            pins = PINS;
+        } else if #[cfg(feature = "uart7")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::E.pin(7).and_pin(8), Alternate::AF7),
+            ];
+            usart = unsafe { &*device::UART7::ptr() };
+            peripheral = Peripheral::Uart7;
+            pins = PINS;
+        } else {
+            compiler_error!("no usartX/uartX feature specified");
+        }
+    }
 
     Usart::turn_on(
         &Sys::from(SYS.get_task_id()),
         usart,
-        Peripheral::Usart3,
-        Port::D.pin(8).and_pin(9),
-        Alternate::AF7,
+        peripheral,
+        pins,
         CLOCK_HZ,
         BAUD_RATE,
     )


### PR DESCRIPTION
Also adds the `uartecho` task to `gimletlet`.

Builds on #475; I pointed this PR to that branch to show only the new changes. Should merge the other first.