### PR TITLE
Allow Clippy to accept extra options after --

### DIFF
--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -7,7 +7,11 @@ use std::process::Command;
 
 use anyhow::{bail, Result};
 
-pub fn run(package: Option<String>, target: Option<String>) -> Result<()> {
+pub fn run(
+    package: Option<String>,
+    target: Option<String>,
+    options: &[String],
+) -> Result<()> {
     let package = package.unwrap_or_else(|| {
         let path = env::current_dir().unwrap();
         let manifest_path = path.join("Cargo.toml");
@@ -52,6 +56,10 @@ pub fn run(package: Option<String>, target: Option<String>) -> Result<()> {
     cmd.arg("clippy::identity_op");
     cmd.arg("-A");
     cmd.arg("clippy::too_many_arguments");
+
+    for opt in options {
+        cmd.arg(opt);
+    }
 
     // this is only actually used for demo-stm32h7 but is harmless to include, so let's do
     // it unconditionally

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -124,6 +124,9 @@ enum Xtask {
         /// check all packages, not only one
         #[clap(long)]
         all: bool,
+
+        /// Extra options to pass to clippy
+        options: Vec<String>,
     },
 
     /// Show a task's .task_slot_table contents
@@ -493,9 +496,10 @@ fn main() -> Result<()> {
             package,
             target,
             all,
+            options,
         } => {
             let requested = RequestedPackages::new(package, target, all);
-            run_for_packages(requested, clippy::run)?;
+            run_for_packages(requested, |p, t| clippy::run(p, t, &options))?;
         }
         Xtask::TaskSlots { task_bin } => {
             task_slot::dump_task_slot_table(&task_bin)?;


### PR DESCRIPTION
This lets you pass extra options to Clippy, e.g.

`cargo xtask clippy --target thumbv7em-none-eabihf -p drv-i2c-devices -- -A clippy::unusual_byte_groupings`

which can be useful in development.