### PR TITLE
Move pin configuration for lpc55 targets into TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-lpc55pins"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "build-util",
+ "cfg-if 0.1.10",
+ "convert_case 0.4.0",
+ "indexmap",
+ "multimap",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "build-net"
 version = "0.1.0"
 dependencies = [
@@ -792,12 +808,15 @@ dependencies = [
 name = "drv-lpc55-spi-server"
 version = "0.1.0"
 dependencies = [
+ "build-lpc55pins",
+ "build-util",
  "drv-lpc55-gpio-api",
  "drv-lpc55-spi",
  "drv-lpc55-syscon-api",
  "lpc55-pac",
  "num-traits",
  "ringbuf",
+ "serde",
  "userlib",
  "zerocopy",
 ]
@@ -832,9 +851,13 @@ dependencies = [
 name = "drv-lpc55-usart"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "build-lpc55pins",
+ "build-util",
  "drv-lpc55-gpio-api",
  "drv-lpc55-syscon-api",
  "lpc55-pac",
+ "serde",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "build/net",
     "build/util",
     "build/xtask",
+    "build/lpc55pins",
 
     "sys/abi",
     "sys/kern",

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -113,6 +113,12 @@ start = true
 interrupts = {"flexcomm0.irq" = 1}
 task-slots = ["gpio_driver", "syscon_driver"]
 
+[tasks.usart_driver.config]
+pins = [
+{ pin = { port = 0, pin = 29}, alt = 1},
+{ pin = { port = 0, pin = 30}, alt = 1}
+]
+
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
 name = "drv-lpc55-rng"
@@ -134,6 +140,18 @@ start = true
 interrupts = {"flexcomm8.hs_spi" = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
+
+[tasks.spi0_driver.config]
+pins = [
+# HS_SPI_MOSI = P0_26 = FUN9
+{ pin = { port = 0, pin = 26}, alt = 9},
+# HS_SPI_MISO = P1_3 = FUN6
+{ pin = { port = 1, pin = 3}, alt = 6},
+# HS_SPI_SCK = P1_2 = FUN6
+{ pin = { port = 1, pin = 2}, alt = 6},
+# HS_SSEL1 = P1_1 = FUN5
+{ pin = { port = 1, pin = 1}, alt = 5},
+]
 
 [tasks.ping]
 path = "../../task/ping"

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -85,6 +85,12 @@ start = true
 interrupts = {"flexcomm0.irq" = 1}
 task-slots = ["gpio_driver", "syscon_driver"]
 
+[tasks.usart_driver.config]
+pins = [
+{ pin = { port = 0, pin = 29}, alt = 1},
+{ pin = { port = 0, pin = 30}, alt = 1}
+]
+
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
@@ -96,3 +102,15 @@ start = true
 interrupts = {"flexcomm8.hs_spi" = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
+
+[tasks.spi0_driver.config]
+pins = [
+# HS_SPI_MOSI = P0_26 = FUN9
+{ pin = { port = 0, pin = 26}, alt = 9},
+# HS_SPI_MISO = P1_3 = FUN6
+{ pin = { port = 1, pin = 3}, alt = 6},
+# HS_SPI_SCK = P1_2 = FUN6
+{ pin = { port = 1, pin = 2}, alt = 6},
+# HS_SSEL1 = P1_1 = FUN5
+{ pin = { port = 1, pin = 1}, alt = 5},
+]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -130,6 +130,12 @@ interrupts = {"flexcomm0.irq" = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
 
+[tasks.usart_driver.config]
+pins = [
+{ pin = { port = 0, pin = 29}, alt = 1},
+{ pin = { port = 0, pin = 30}, alt = 1}
+]
+
 [tasks.i2c_driver]
 path = "../../drv/lpc55-i2c"
 name = "drv-lpc55-i2c"
@@ -162,6 +168,18 @@ interrupts = {"flexcomm8.hs_spi" = 1}
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
 
+[tasks.spi0_driver.config]
+pins = [
+# HS_SPI_MOSI = P0_26 = FUN9
+{ pin = { port = 0, pin = 26}, alt = 9},
+# HS_SPI_MISO = P1_3 = FUN6
+{ pin = { port = 1, pin = 3}, alt = 6},
+# HS_SPI_SCK = P1_2 = FUN6
+{ pin = { port = 1, pin = 2}, alt = 6},
+# HS_SSEL1 = P1_1 = FUN5
+{ pin = { port = 1, pin = 1}, alt = 5},
+]
+
 [tasks.ping]
 path = "../../task/ping"
 name = "task-ping"
@@ -180,3 +198,4 @@ requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["user_leds"]
+

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "build-lpc55pins"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+build-util = {path = "../util"}
+serde = { version = "1", features = ["derive"] }
+indexmap = { version = "1.4.0", features = ["serde-1"] }
+anyhow = "1.0.31"
+cfg-if = "0.1.10"
+multimap = "0.8.3"
+convert_case = "0.4"
+syn = {version = "1", features = ["parsing"]}
+proc-macro2 = "1"
+quote = "1"
+
+[features]

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::Result;
+use proc_macro2::TokenStream;
+use quote::{format_ident, ToTokens, TokenStreamExt};
+use serde::Deserialize;
+use std::io::Write;
+
+#[derive(Clone, Debug, Deserialize)]
+struct Pin {
+    port: usize,
+    pin: usize,
+}
+
+impl Pin {
+    fn get_port_pin(&self) -> (usize, usize) {
+        assert!(self.pin < 32, "Invalid pin {}", self.pin);
+        assert!(self.port < 2, "Invalid port {}", self.port);
+
+        (self.port, self.pin)
+    }
+}
+
+impl ToTokens for Pin {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let (port, pin) = self.get_port_pin();
+        let final_pin = format_ident!("PIO{}_{}", port, pin);
+        tokens.append_all(quote::quote! {
+            // Yes we want the trailing comma
+            Pin::#final_pin,
+        });
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PinConfig {
+    pin: Pin,
+    alt: usize,
+    mode: Option<String>,
+    slew: Option<String>,
+    invert: Option<String>,
+    digimode: Option<String>,
+    opendrain: Option<String>,
+    direction: Option<String>,
+}
+
+impl PinConfig {
+    fn get_mode(&self) -> String {
+        match &self.mode {
+            None => "NoPull".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    fn get_slew(&self) -> String {
+        match &self.slew {
+            None => "Standard".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    fn get_invert(&self) -> String {
+        match &self.invert {
+            None => "Disable".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    fn get_digimode(&self) -> String {
+        match &self.digimode {
+            None => "Digital".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    fn get_opendrain(&self) -> String {
+        match &self.opendrain {
+            None => "Normal".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    fn get_alt(&self) -> usize {
+        if self.alt > 9 {
+            panic!("Invalid alt setting {}", self.alt);
+        }
+
+        self.alt
+    }
+}
+
+impl ToTokens for PinConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let final_pin = self.pin.to_token_stream();
+        let alt_num = format_ident!("Alt{}", self.get_alt());
+        let mode = format_ident!("{}", self.get_mode());
+        let slew = format_ident!("{}", self.get_slew());
+        let invert = format_ident!("{}", self.get_invert());
+        let digimode = format_ident!("{}", self.get_digimode());
+        let od = format_ident!("{}", self.get_opendrain());
+
+        tokens.append_all(final_pin);
+        tokens.append_all(quote::quote! {
+            AltFn::#alt_num,
+            Mode::#mode,
+            Slew::#slew,
+            Invert::#invert,
+            Digimode::#digimode,
+            Opendrain::#od,
+        });
+    }
+}
+
+pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
+    let out_dir = std::env::var("OUT_DIR")?;
+    let dest_path = std::path::Path::new(&out_dir).join("pin_config.rs");
+    let mut file = std::fs::File::create(&dest_path)?;
+
+    writeln!(
+        &mut file,
+        "fn setup_pins(task : TaskId) -> Result<(), ()> {{"
+    )?;
+    writeln!(&mut file, "use drv_lpc55_gpio_api::*;")?;
+    writeln!(&mut file, "let iocon = Pins::from(task);")?;
+    for p in pins {
+        writeln!(&mut file, "iocon.iocon_configure(")?;
+        writeln!(&mut file, "{}", p.to_token_stream())?;
+        writeln!(&mut file, ").unwrap_lite();")?;
+        match p.direction {
+            None => (),
+            Some(d) => {
+                writeln!(&mut file, "iocon.set_dir(")?;
+                writeln!(&mut file, "{}", p.pin.to_token_stream())?;
+                if d == "output" {
+                    writeln!(&mut file, "Direction::Output")?;
+                } else {
+                    writeln!(&mut file, "Direction::Input")?;
+                }
+                writeln!(&mut file, ").unwrap_lite();")?;
+            }
+        }
+    }
+
+    writeln!(&mut file, "Ok(())")?;
+    writeln!(&mut file, "}}")?;
+
+    Ok(())
+}

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -13,6 +13,11 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
 ringbuf = {path = "../../lib/ringbuf"}
 
+[build-dependencies]
+build-util = {path = "../../build/util"}
+build-lpc55pins = {path = "../../build/lpc55pins"}
+serde = "1"
+
 [features]
 spi0 = []
 

--- a/drv/lpc55-spi-server/build.rs
+++ b/drv/lpc55-spi-server/build.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use build_lpc55pins::PinConfig;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct TaskConfig {
+    pins: Vec<PinConfig>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let task_config = build_util::task_config::<TaskConfig>()?;
+
+    build_lpc55pins::codegen(task_config.pins)?;
+    Ok(())
+}

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -10,6 +10,13 @@ lpc55-pac = "0.3.0"
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+build-lpc55pins = {path = "../../build/lpc55pins"}
+serde = "1"
+anyhow = "1.0.31"
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/lpc55-usart/build.rs
+++ b/drv/lpc55-usart/build.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use build_lpc55pins::PinConfig;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct TaskConfig {
+    pins: Vec<PinConfig>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let task_config = build_util::task_config::<TaskConfig>()?;
+
+    build_lpc55pins::codegen(task_config.pins)?;
+    Ok(())
+}


### PR DESCRIPTION
Hubris now supports TOML based configuration. Move the settings
for UART and SPI.