### PR TITLE
Clean up I2C codegen

### DIFF
--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -59,7 +59,7 @@ start = true
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h753", "itm", "target-enable"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -68,7 +68,7 @@ start = true
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
-features = ["h753", "itm", "target-enable"]
+features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -625,6 +625,22 @@ impl ConfigGenerator {
             },
         };
 
+        let segment = match (d.mux, d.segment) {
+            (Some(mux), Some(segment)) => {
+                format!(
+                    "Some((drv_i2c_api::Mux::M{}, drv_i2c_api::Segment::S{}))",
+                    mux, segment
+                )
+            }
+            (None, None) => "None".to_owned(),
+            (Some(_), None) => {
+                panic!("device {} specifies a mux but no segment", d.device)
+            }
+            (None, Some(_)) => {
+                panic!("device {} specifies a segment but no mux", d.device)
+            }
+        };
+
         format!(
             r##"
             // {description}
@@ -637,7 +653,7 @@ impl ConfigGenerator {
             description = d.description,
             controller = controller,
             port = port,
-            segment = "None",
+            segment = segment,
             address = d.address,
         )
     }

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -26,28 +26,6 @@ h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32xx-sys-api/h743",
 h753 = ["stm32h7/stm32h753", "drv-stm32h7-i2c/h753", "drv-stm32xx-sys-api/h753", "build-i2c/h753"]
 itm = [ "userlib/log-itm" ]
 
-# These options allow for external muxes on the Gemini bringup board:
-#
-# - external-max7358 assumes an external MAX7358 on I2C4 port D
-# - external-pca9548 assumes an external PCA9548 on I2C4 port H
-#
-# Both options may be set, but neither option should be set when the part that
-# it denotes isn't present.
-external-max7358 = []
-external-pca9548 = []
-
-#
-# This option allows for the Nucleo to be used as an initiator for the
-# purposes of testing the spd-proxy
-#
-external-spd = []
-
-#
-# This option will -- on Gimletlet -- leave I2C2 available to be used by
-# SPD proxy
-#
-target-enable = []
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]


### PR DESCRIPTION
Consider this code in `app/gimlet/rev-b.toml`:

```toml
[[config.i2c.devices]]
bus = "m2"
mux = 1
segment = 4
address = 0x4c
device = "tmp451"
sensors = { temperature = 1 }
description = "T6 temperature sensorrrrr"
refdes = "U491"
```

This generates code that's missing the mux / segment:
```rust
mod i2c_config {
    pub mod devices {
        ...
        #[allow(dead_code)]
        pub fn tmp451(task: TaskId) -> [I2cDevice; 1] {
            [
            // T6 temperature sensorrrrr
            I2cDevice::new(task,
                Controller::I2C2,
                PortIndex(0),
                None,
                0x4c
            ),
            ]
        }
```

After this PR, the mux and segment are populated:
```rust
        #[allow(dead_code)]
        pub fn tmp451(task: TaskId) -> [I2cDevice; 1] {
            [
            // T6 temperature sensorrrrr
            I2cDevice::new(task,
                Controller::I2C2,
                PortIndex(0),
                Some((drv_i2c_api::Mux::M1, drv_i2c_api::Segment::S4)),
                0x4c
            ),
            ]
        }
```

(I also removed some dead features)