### PR TITLE
Delete leftover `standalone` feature

### DIFF
--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -13,8 +13,5 @@ zerocopy = "0.6.1"
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
 
-[features]
-standalone = []
-
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -13,8 +13,5 @@ zerocopy = "0.6.1"
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
 
-[features]
-standalone = []
-
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -40,8 +40,6 @@ features = [
 ]
 
 [features]
-default = ["standalone"]
-standalone = []
 mgmt = ["vsc85xx/mgmt", "vsc7448-pac", "drv-spi-api", "ksz8463", "drv-user-leds-api"]
 gimlet = ["drv-gimlet-seq-api"]
 sidecar = ["drv-sidecar-seq-api"]


### PR DESCRIPTION
This was removed back in 8e0b13b86564fc7316428943dfe5fde88bb60ef4, but lingered in a few Cargo.toml files.