### PR TITLE
Bind to our specific address, not just a port

### DIFF
--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -154,7 +154,7 @@ fn main() -> ! {
     // Bind sockets to their ports.
     for (&h, &port) in socket_handles.iter().zip(&generated::SOCKET_PORTS) {
         eth.get_socket::<UdpSocket>(h)
-            .bind(port)
+            .bind((ipv6_addr, port))
             .map_err(|_| ())
             .unwrap();
     }


### PR DESCRIPTION
Works around https://github.com/smoltcp-rs/smoltcp/issues/599 (not yet
released, but handy if we're going to try to make any updates to smoltcp
based on its current master branch).