### PR TITLE
pin fetch-gh-release-asset to 0.0.8

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -110,7 +110,7 @@ jobs:
           args: dist ${{ matrix.app_toml}}
 
       - name: Fetch Humility 
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@0.0.8
         if: matrix.os == 'ubuntu-latest'
         with:
           repo: "oxidecomputer/humility"


### PR DESCRIPTION
Apparently https://github.com/dsaltares/fetch-gh-release-asset/pull/36 broke our builds, by saying that "nightly" is a "malformed version." Let's pin it to a known good one, and I'll report upstream.