### PR TITLE
Add tests and fix for Idolatry multiarg + ssmarshal bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#136bff2f2cd69d5eca6dd3e30016538175d9fcff"
+source = "git+https://github.com/oxidecomputer/idolatry.git#4e128559292fae2776b71ab0c47ae7deb0d98cab"
 dependencies = [
  "indexmap",
  "quote",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#136bff2f2cd69d5eca6dd3e30016538175d9fcff"
+source = "git+https://github.com/oxidecomputer/idolatry.git#4e128559292fae2776b71ab0c47ae7deb0d98cab"
 dependencies = [
  "userlib",
  "zerocopy",

--- a/test/test-idol-api/api.idol
+++ b/test/test-idol-api/api.idol
@@ -65,5 +65,16 @@ Interface(
             ),
             encoding: Ssmarshal,
         ),
+        "extract_vid": (
+            args: {
+                "a": "u8",
+                "b": "UdpMetadata",
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("IdolTestError"),
+            ),
+            encoding: Ssmarshal,
+        ),
     },
 )

--- a/test/test-idol-api/api.idol
+++ b/test/test-idol-api/api.idol
@@ -76,5 +76,16 @@ Interface(
             ),
             encoding: Ssmarshal,
         ),
+        "extract_vid_enum": (
+            args: {
+                "a": "SocketName",
+                "b": "UdpMetadata",
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("IdolTestError"),
+            ),
+            encoding: Ssmarshal,
+        ),
     },
 )

--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -33,4 +33,15 @@ pub struct FancyTestType {
     pub f: f32,
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// The struct below is used to replicate an Idolatry bug related to
+// serialization of multiple arguments through ssmarshal
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct UdpMetadata {
+    pub addr: [u8; 16],
+    pub port: u16,
+    pub size: u32,
+    pub vid: u16,
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -34,11 +34,27 @@ pub struct FancyTestType {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// The struct below is used to replicate an Idolatry bug related to
-// serialization of multiple arguments through ssmarshal
+// The structs below replicate an Idolatry bug related to serialization
+// using ssmarshal
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum SocketName {
+    Echo = 1,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Ipv6Address(pub [u8; 16]);
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum Address {
+    Ipv6(Ipv6Address),
+}
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct UdpMetadata {
-    pub addr: [u8; 16],
+    pub addr: Address,
     pub port: u16,
     pub size: u32,
     pub vid: u16,

--- a/test/test-idol-server/src/main.rs
+++ b/test/test-idol-server/src/main.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use idol_runtime::RequestError;
-use test_idol_api::{FancyTestType, IdolTestError, UdpMetadata};
+use test_idol_api::{FancyTestType, IdolTestError, SocketName, UdpMetadata};
 use userlib::*;
 
 struct ServerImpl;
@@ -67,6 +67,14 @@ impl idl::InOrderIdolTestImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
         _a: u8,
+        b: UdpMetadata,
+    ) -> Result<u16, RequestError<IdolTestError>> {
+        Ok(b.vid)
+    }
+    fn extract_vid_enum(
+        &mut self,
+        _: &RecvMessage,
+        _a: SocketName,
         b: UdpMetadata,
     ) -> Result<u16, RequestError<IdolTestError>> {
         Ok(b.vid)

--- a/test/test-idol-server/src/main.rs
+++ b/test/test-idol-server/src/main.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use idol_runtime::RequestError;
-use test_idol_api::{FancyTestType, IdolTestError};
+use test_idol_api::{FancyTestType, IdolTestError, UdpMetadata};
 use userlib::*;
 
 struct ServerImpl;
@@ -63,6 +63,14 @@ impl idl::InOrderIdolTestImpl for ServerImpl {
             ..a
         })
     }
+    fn extract_vid(
+        &mut self,
+        _: &RecvMessage,
+        _a: u8,
+        b: UdpMetadata,
+    ) -> Result<u16, RequestError<IdolTestError>> {
+        Ok(b.vid)
+    }
 }
 
 #[export_name = "main"]
@@ -76,7 +84,7 @@ fn main() -> ! {
 }
 
 mod idl {
-    use super::{FancyTestType, IdolTestError};
+    use super::*;
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -104,6 +104,7 @@ test_cases! {
     test_idol_err_ret,
     test_idol_ssmarshal,
     test_idol_ssmarshal_multiarg,
+    test_idol_ssmarshal_multiarg_enum,
 }
 
 /// Tests that we can send a message to our assistant, and that the assistant
@@ -534,9 +535,11 @@ fn test_idol_ssmarshal_multiarg() {
     let idol = idol_handle();
     let r = idol
         .extract_vid(
-            12,
+            0xAA,
             UdpMetadata {
-                addr: [1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 2, 2, 3, 3, 4, 4],
+                addr: Address::Ipv6(Ipv6Address([
+                    1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 2, 2, 3, 3, 4, 4,
+                ])),
                 port: 1021,
                 size: 1,
                 vid: 12,
@@ -545,6 +548,26 @@ fn test_idol_ssmarshal_multiarg() {
         .unwrap();
 
     assert_eq!(r, 12);
+}
+
+fn test_idol_ssmarshal_multiarg_enum() {
+    use test_idol_api::*;
+    let idol = idol_handle();
+    let r = idol
+        .extract_vid_enum(
+            SocketName::Echo,
+            UdpMetadata {
+                addr: Address::Ipv6(Ipv6Address([
+                    1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 2, 2, 3, 3, 4, 4,
+                ])),
+                port: 1021,
+                size: 1,
+                vid: 14,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(r, 14);
 }
 
 /// Tests that task restart works as expected.

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -103,6 +103,7 @@ test_cases! {
     test_idol_bool_xor,
     test_idol_err_ret,
     test_idol_ssmarshal,
+    test_idol_ssmarshal_multiarg,
 }
 
 /// Tests that we can send a message to our assistant, and that the assistant
@@ -526,6 +527,24 @@ fn test_idol_ssmarshal() {
     assert_eq!(r.u, 101);
     assert_eq!(r.b, false);
     assert!(r.f == 1.0);
+}
+
+fn test_idol_ssmarshal_multiarg() {
+    use test_idol_api::*;
+    let idol = idol_handle();
+    let r = idol
+        .extract_vid(
+            12,
+            UdpMetadata {
+                addr: [1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 2, 2, 3, 3, 4, 4],
+                port: 1021,
+                size: 1,
+                vid: 12,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(r, 12);
 }
 
 /// Tests that task restart works as expected.

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -98,8 +98,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -73,8 +73,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-gimletlet/app.toml
+++ b/test/tests-gimletlet/app.toml
@@ -73,8 +73,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-lpc55xpresso/app-a0.toml
+++ b/test/tests-lpc55xpresso/app-a0.toml
@@ -103,8 +103,8 @@ uses = ["stage0"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -101,8 +101,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -60,8 +60,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -61,8 +61,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -74,8 +74,8 @@ stacksize = 1504
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 2048, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -73,8 +73,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]

--- a/test/tests-stm32h7/app-h753.toml
+++ b/test/tests-stm32h7/app-h753.toml
@@ -73,8 +73,8 @@ features = ["itm"]
 path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
-requires = {flash = 1024, ram = 256}
-stacksize = 256
+requires = {flash = 4096, ram = 1024}
+stacksize = 1024
 start = true
 
 [tasks.idle]


### PR DESCRIPTION
This bumps Idolatry to include https://github.com/oxidecomputer/idolatry/pull/15 , and adds unit tests which fail before the bump.