### PR TITLE
lpc55-pac: Bump version from 0.3.0 to 0.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "lpc55-pac"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee47591d506a22d56bc591abb955176b1ad3c22122c2395a69e426ea76e25ab"
+checksum = "cf1b5b32d313af526145882f5115a55177f479e9328ca667a84aaaa1ae6d65d3"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.3.0", features = ["rt"]}
+lpc55-pac = {version = "0.4", features = ["rt"]}
 cfg-if = "1"
 abi = { path = "../../sys/abi"}
 

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.3.0", features = ["rt"]}
+lpc55-pac = {version = "0.4", features = ["rt"]}
 cfg-if = "1"
 abi = { path = "../../sys/abi"}
 

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.3.0", features = ["rt"]}
+lpc55-pac = {version = "0.4", features = ["rt"]}
 cfg-if = "1"
 abi = { path = "../../sys/abi"}
 

--- a/drv/lpc55-gpio/Cargo.toml
+++ b/drv/lpc55-gpio/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 num-traits = { version = "0.2.12", default-features = false }
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 num-traits = { version = "0.2.12", default-features = false }
 cfg-if = "1"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}

--- a/drv/lpc55-romapi/Cargo.toml
+++ b/drv/lpc55-romapi/Cargo.toml
@@ -10,7 +10,7 @@ log-itm = []
 log-semihosting = []
 
 [dependencies]
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 num-derive = "0.3.3"
 num-traits = { version = "0.2", default-features = false }
 cfg-if = "1"

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 drv-lpc55-spi = {path = "../lpc55-spi"}
 num-traits = { version = "0.2.12", default-features = false }

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 num-traits = { version = "0.2.12", default-features = false }

--- a/drv/lpc55-swd/Cargo.toml
+++ b/drv/lpc55-swd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 drv-lpc55-spi = {path = "../lpc55-spi"}
 ringbuf = {path = "../../lib/ringbuf"}
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 num-traits = { version = "0.2.12", default-features = false }
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -8,7 +8,7 @@ lib-lpc55-usart = {path = "../../lib/lpc55-usart"}
 nb = "1.0"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib"}
 drv-user-leds-api = {path = "../user-leds-api"}
 stm32f3 = { version = "0.13.0", features = ["stm32f303"], optional = true }
 stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
-lpc55-pac = { version = "0.3.0", optional = true }
+lpc55-pac = { version = "0.4", optional = true }
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", optional = true}

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 hkdf = { version = "0.12", default-features = false }
 hubpack = "0.1"
-lpc55-pac = "0.3"
+lpc55-pac = "0.4"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"
 sha3 = { version = "0.10", default-features = false }

--- a/lib/lpc55-usart/Cargo.toml
+++ b/lib/lpc55-usart/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 embedded-hal = "0.2"
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 nb = "1"
 unwrap-lite = { path = "../../lib/unwrap-lite" }

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -14,7 +14,7 @@ digest = { version = "0.10", optional = true }
 panic-semihosting = "0.5.3"
 lpc55_romapi = { path = "../drv/lpc55-romapi" }
 panic-halt = "0.2.0"
-lpc55-pac = {version = "0.3.0", features = ["rt"]}
+lpc55-pac = {version = "0.4", features = ["rt"]}
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 hmac = { version = "0.10.1", default-features = false }

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 cfg-if = "1"
 
 [dependencies.kern]

--- a/test/tests-lpc55xpresso/Cargo.toml
+++ b/test/tests-lpc55xpresso/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = "0.3.0"
+lpc55-pac = "0.4"
 cfg-if = "1"
 
 [dependencies.kern]


### PR DESCRIPTION
After sending a patch upstream to the lpc55-pac adding a missing feature yesterday I took a swing at upgrading to the latest version of this crate. This was an attempt to determine how painful an upgrade will be if lpc55-pac merges my PR and we then upgrade to benefit. Going from 0.3 to 0.4 was thankfully trivial.