### PR TITLE
Allow humility xtask to set the humility path via HUMILITY_PATH

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -461,7 +461,7 @@ ID ADDR     TASK               GEN STATE
  6 200003a8 idle                 0 Healthy(Runnable)         
 ```
 
-If the `humility` binary is not available on your `$PATH`, the `HUMILITY_PATH` environment
+If the `humility` binary is not available on your `$PATH`, the `HUBRIS_HUMILITY_PATH` environment
 variable may be used to provide the path to the binary.
 
 ## Testing

--- a/README.mkdn
+++ b/README.mkdn
@@ -461,6 +461,9 @@ ID ADDR     TASK               GEN STATE
  6 200003a8 idle                 0 Healthy(Runnable)         
 ```
 
+If the `humility` binary is not available on your `$PATH`, the `HUMILITY_PATH` environment
+variable may be used to provide the path to the binary.
+
 ## Testing
 
 The Hubris kernel is tested with a dedicated _test image_ that includes a test

--- a/README.mkdn
+++ b/README.mkdn
@@ -438,6 +438,9 @@ depends on the board:
 - ST STM32H7B3I-DK board: `cargo xtask flash app/demo-stm32h7-nucleo/app-h7b3.toml`
 - Gemini bringup board: `cargo xtask flash app/gemini-bu/app.toml`
 
+Note: If the `humility` binary is not available on your `$PATH`, the `HUBRIS_HUMILITY_PATH`
+environment variable may be used to provide the path to the binary.
+
 ## Debug
 
 The Hubris debugger, [Humility](https://github.com/oxidecomputer/humility),
@@ -461,8 +464,8 @@ ID ADDR     TASK               GEN STATE
  6 200003a8 idle                 0 Healthy(Runnable)         
 ```
 
-If the `humility` binary is not available on your `$PATH`, the `HUBRIS_HUMILITY_PATH` environment
-variable may be used to provide the path to the binary.
+Note: If the `humility` binary is not available on your `$PATH`, the `HUBRIS_HUMILITY_PATH`
+environment variable may be used to provide the path to the binary.
 
 ## Testing
 
@@ -484,6 +487,9 @@ and `cargo xtask humility test`.  The exact invocation depends on the board:
 Note: `cargo xtask humility test` runs OpenOCD to connect to the device.
 You must exit any other instances of OpenOCD that you have connected to the device
 before running tests.
+
+If the `humility` binary is not available on your `$PATH`, the `HUBRIS_HUMILITY_PATH`
+environment variable may be used to provide the path to the binary.
 
 See the [documentation for `humility
 test`](https://github.com/oxidecomputer/humility#humility-test) for details

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use serde::Serialize;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -233,7 +234,12 @@ pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
     archive.push("dist");
     archive.push(format!("build-{}.zip", &toml.name));
 
-    let mut humility = Command::new("humility");
+    let humility_path = match env::var("HUBRIS_HUMILITY_PATH") {
+        Ok(path) => path,
+        _ => "humility".to_string(),
+    };
+
+    let mut humility = Command::new(humility_path);
 
     humility.arg("-a").arg(archive);
     humility.arg("-c").arg(chip_name(&toml.board)?);

--- a/build/xtask/src/humility.rs
+++ b/build/xtask/src/humility.rs
@@ -18,7 +18,7 @@ pub fn run(cfg: &Path, options: &Vec<String>) -> anyhow::Result<()> {
     archive.push("dist");
     archive.push(format!("build-{}.zip", &toml.name));
 
-    let humility_path = match env::var("HUMILITY_PATH") {
+    let humility_path = match env::var("HUBRIS_HUMILITY_PATH") {
         Ok(path) => path,
         _ => "humility".to_string(),
     };

--- a/build/xtask/src/humility.rs
+++ b/build/xtask/src/humility.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -17,7 +18,12 @@ pub fn run(cfg: &Path, options: &Vec<String>) -> anyhow::Result<()> {
     archive.push("dist");
     archive.push(format!("build-{}.zip", &toml.name));
 
-    let mut humility = Command::new("humility");
+    let humility_path = match env::var("HUMILITY_PATH") {
+        Ok(path) => path,
+        _ => "humility".to_string(),
+    };
+
+    let mut humility = Command::new(humility_path);
     humility.arg("-a").arg(archive);
 
     for opt in options {

--- a/build/xtask/src/test.rs
+++ b/build/xtask/src/test.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -17,7 +18,12 @@ pub fn run(verbose: bool, cfg: &Path) -> anyhow::Result<()> {
     archive.push("dist");
     archive.push(format!("build-{}.zip", &toml.name));
 
-    let mut humility = Command::new("humility");
+    let humility_path = match env::var("HUBRIS_HUMILITY_PATH") {
+        Ok(path) => path,
+        _ => "humility".to_string(),
+    };
+
+    let mut humility = Command::new(humility_path);
     humility.arg("-a").arg(archive);
 
     if verbose {


### PR DESCRIPTION
I don't have Humility installed on my `$PATH` at the moment, and I anticipate needing to iterate on both Hubris and Humility at the same time, so I added a way to configure the path! I made it so if you provide `HUMILITY_PATH` in the environment, the `cargo xtask humility` command will use that as the path to the Humility binary instead of just `"humility"`.