### PR TITLE
Gimlet build ergonomics improvements for Rev B

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -56,11 +56,11 @@ jobs:
             app_toml: app/gemini-bu-rot/app.toml
             target: thumbv8m.main-none-eabihf
           - build: gimlet-a
-            app_name: gimlet
+            app_name: gimlet-a
             app_toml: app/gimlet/rev-a.toml
             target: thumbv7em-none-eabihf
           - build: gimlet-b
-            app_name: gimlet
+            app_name: gimlet-b
             app_toml: app/gimlet/rev-b.toml
             target: thumbv7em-none-eabihf
           - build: sidecar

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -169,6 +169,7 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga.bin"
+register_defs = "gimlet_regs.json"
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -167,6 +167,9 @@ stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
+[tasks.gimlet_seq.config]
+fpga_image = "fpga.bin"
+
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -1,4 +1,4 @@
-name = "gimlet"
+name = "gimlet-a"
 target = "thumbv7em-none-eabihf"
 board = "gimlet-a"
 chip = "../../chips/stm32h7.toml"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -182,6 +182,9 @@ stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
+[tasks.gimlet_seq.config]
+fpga_image = "fpga.bin"
+
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -184,6 +184,7 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga.bin"
+register_defs = "gimlet_regs.json"
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -1,4 +1,4 @@
-name = "gimlet"
+name = "gimlet-b"
 target = "thumbv7em-none-eabihf"
 board = "gimlet-b"
 chip = "../../chips/stm32h7.toml"

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -455,7 +455,7 @@ fn reprogram_fpga(
 }
 
 static COMPRESSED_BITSTREAM: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/fpga.bin.rle"));
+    include_bytes!(env!("GIMLET_FPGA_IMAGE_PATH"));
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_board = "gimlet-a", target_board = "gimlet-b"))] {

--- a/drv/gimlet-seq-server/src/seq_spi.rs
+++ b/drv/gimlet-seq-server/src/seq_spi.rs
@@ -19,7 +19,7 @@ pub enum Cmd {
     BitClear = 3,
 }
 
-include!(concat!(env!("OUT_DIR"), "/gimlet_regs.rs"));
+include!(env!("GIMLET_FPGA_REGS"));
 
 pub const EXPECTED_IDENT: u16 = 0x1DE;
 


### PR DESCRIPTION
- The FPGA image filename is no longer hardcoded and is now set in the configuration, which allows rev A and B to reference different bitstreams.
- Same for the register layout JSON file, so they can diverge _if they need to._
- Build output is now called `gimlet-a` or `gimlet-b` instead of just `gimlet` because the latter was hella confusing.