### PR TITLE
gimlet: implement board rev detection.

### DIFF
--- a/app/gimlet/src/main.rs
+++ b/app/gimlet/src/main.rs
@@ -36,47 +36,121 @@ fn main() -> ! {
 }
 
 fn system_init() {
+    // Gimlet, starting at Rev B, has resistors strapping three pins to indicate
+    // the board revision. Rev A left the pins floating, so, we have a
+    // backwards-compatibility scheme where we use our internal pull-up
+    // resistors, causing Rev A to read as 0b111.
+    //
+    // We read the board version very early in boot to try and detect the
+    // firmware being flashed on the wrong board. In particular, we read the
+    // version _before_ setting up the clock tree below, just in case we change
+    // the crystal configuration in a subsequent rev.
+    //
+    // Note that the firmware _does not_ adapt to different board revs. We still
+    // require different firmware per revision; this check serves to detect if
+    // you've flashed the wrong one, only.
+    //
+    // The revision is on pins PG[2:0], with PG2 as the MSB.
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let p = device::Peripherals::take().unwrap();
+
+    // Un-gate the clock to GPIO bank G.
+    p.RCC.ahb4enr.modify(|_, w| w.gpiogen().set_bit());
+    cortex_m::asm::dsb();
+    // PG2:0 are already inputs after reset, but without any pull resistors.
+    #[rustfmt::skip]
+    p.GPIOG.moder.modify(|_, w| w
+        .moder0().input()
+        .moder1().input()
+        .moder2().input());
+    // Enable the pullups.
+    #[rustfmt::skip]
+    p.GPIOG.pupdr.modify(|_, w| w
+        .pupdr0().pull_up()
+        .pupdr1().pull_up()
+        .pupdr2().pull_up());
+    // We are now charging up the board revision traces through the ~40kR
+    // internal pullup resistors. The floating trace is the biggie, since we're
+    // responsible for putting in any charge that we detect. While the
+    // capacitance should be low, it's not zero, and even running at the reset
+    // frequency of 64MHz, we are very much racing the trace charging.
+    //
+    // Assuming 50pF for the trace plus the iCE40's tristated input on the far
+    // end, we get
+    //
+    // RC = 40 kR * 50 pF = 2e-6
+    // Time to reach Vil of 2.31 V (0.7 VDD) = 2.405 us
+    //
+    // Maximum speed of 64MHz oscillator after ST manufacturing calibration, per
+    // the datasheet, is 64.3 MHz.
+    //
+    // 2.405us @ 64.3MHz = 154.64 cycles ~= 155 cycles.
+    //
+    // The cortex_m delay routine is written for single-issue simple cores and
+    // is simply wrong on the M7 (they know this). So, let's conservatively pad
+    // it by a factor of 2.
+    cortex_m::asm::delay(155 * 2);
+
+    // Okay! What does the fox^Wpins say?
+    let rev = p.GPIOG.idr.read().bits() & 0b111;
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_board = "gimlet-a")] {
+            let expected_rev = 0b111;
+        } else if #[cfg(target_board = "gimlet-b")] {
+            let expected_rev = 0b001;
+        } else {
+            compile_error!("not a recognized gimlet board")
+        }
+    }
+
+    assert_eq!(rev, expected_rev);
+
     // Do most of the setup with the common implementation.
-    let p = drv_stm32h7_startup::system_init(ClockConfig {
-        source: drv_stm32h7_startup::ClockSource::ExternalCrystal,
-        // 8MHz HSE freq is within VCO input range of 2-16, so, DIVM=1 to bypass
-        // the prescaler.
-        divm: 1,
-        // VCO must tolerate an 8MHz input range:
-        vcosel: device::rcc::pllcfgr::PLL1VCOSEL_A::WIDEVCO,
-        pllrange: device::rcc::pllcfgr::PLL1RGE_A::RANGE8,
-        // DIVN governs the multiplication of the VCO input frequency to produce
-        // the intermediate frequency. We want an IF of 800MHz, or a
-        // multiplication of 100x.
-        //
-        // We subtract 1 to get the DIVN value because the PLL effectively adds
-        // one to what we write.
-        divn: 100 - 1,
-        // P is the divisor from the VCO IF to the system frequency. We want
-        // 400MHz, so:
-        divp: device::rcc::pll1divr::DIVP1_A::DIV2,
-        // Q produces kernel clocks; we set it to 200MHz:
-        divq: 4 - 1,
-        // R is mostly used by the trace unit and we leave it fast:
-        divr: 2 - 1,
+    let p = drv_stm32h7_startup::system_init_custom(
+        cp,
+        p,
+        ClockConfig {
+            source: drv_stm32h7_startup::ClockSource::ExternalCrystal,
+            // 8MHz HSE freq is within VCO input range of 2-16, so, DIVM=1 to bypass
+            // the prescaler.
+            divm: 1,
+            // VCO must tolerate an 8MHz input range:
+            vcosel: device::rcc::pllcfgr::PLL1VCOSEL_A::WIDEVCO,
+            pllrange: device::rcc::pllcfgr::PLL1RGE_A::RANGE8,
+            // DIVN governs the multiplication of the VCO input frequency to produce
+            // the intermediate frequency. We want an IF of 800MHz, or a
+            // multiplication of 100x.
+            //
+            // We subtract 1 to get the DIVN value because the PLL effectively adds
+            // one to what we write.
+            divn: 100 - 1,
+            // P is the divisor from the VCO IF to the system frequency. We want
+            // 400MHz, so:
+            divp: device::rcc::pll1divr::DIVP1_A::DIV2,
+            // Q produces kernel clocks; we set it to 200MHz:
+            divq: 4 - 1,
+            // R is mostly used by the trace unit and we leave it fast:
+            divr: 2 - 1,
 
-        // We run the CPU at the full core rate of 400MHz:
-        cpu_div: device::rcc::d1cfgr::D1CPRE_A::DIV1,
-        // We down-shift the AHB by a factor of 2, to 200MHz, to meet its
-        // constraints:
-        ahb_div: device::rcc::d1cfgr::HPRE_A::DIV2,
-        // We configure all APB for 100MHz. These are relative to the AHB
-        // frequency.
-        apb1_div: device::rcc::d2cfgr::D2PPRE1_A::DIV2,
-        apb2_div: device::rcc::d2cfgr::D2PPRE2_A::DIV2,
-        apb3_div: device::rcc::d1cfgr::D1PPRE_A::DIV2,
-        apb4_div: device::rcc::d3cfgr::D3PPRE_A::DIV2,
+            // We run the CPU at the full core rate of 400MHz:
+            cpu_div: device::rcc::d1cfgr::D1CPRE_A::DIV1,
+            // We down-shift the AHB by a factor of 2, to 200MHz, to meet its
+            // constraints:
+            ahb_div: device::rcc::d1cfgr::HPRE_A::DIV2,
+            // We configure all APB for 100MHz. These are relative to the AHB
+            // frequency.
+            apb1_div: device::rcc::d2cfgr::D2PPRE1_A::DIV2,
+            apb2_div: device::rcc::d2cfgr::D2PPRE2_A::DIV2,
+            apb3_div: device::rcc::d1cfgr::D1PPRE_A::DIV2,
+            apb4_div: device::rcc::d3cfgr::D3PPRE_A::DIV2,
 
-        // Flash runs at 200MHz: 2WS, 2 programming cycles. See reference manual
-        // Table 13.
-        flash_latency: 2,
-        flash_write_delay: 2,
-    });
+            // Flash runs at 200MHz: 2WS, 2 programming cycles. See reference manual
+            // Table 13.
+            flash_latency: 2,
+            flash_write_delay: 2,
+        },
+    );
 
     // Gimlet uses PA0_C instead of PA0. Flip this.
     p.SYSCFG.pmcr.modify(|_, w| {

--- a/drv/stm32h7-startup/src/lib.rs
+++ b/drv/stm32h7-startup/src/lib.rs
@@ -80,14 +80,22 @@ pub enum ClockSource {
 }
 
 pub fn system_init(config: ClockConfig) -> device::Peripherals {
+    // Use the crate peripheral take mechanism to get peripherals.
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let p = device::Peripherals::take().unwrap();
+
+    system_init_custom(cp, p, config)
+}
+
+pub fn system_init_custom(
+    mut cp: cortex_m::Peripherals,
+    p: device::Peripherals,
+    config: ClockConfig,
+) -> device::Peripherals {
     // Basic RAMs are working, power is stable, and the runtime has initialized
     // static variables.
     //
     // We are running at 64MHz on the HSI oscillator at voltage scale VOS3.
-
-    // Use the crate peripheral take mechanism to get peripherals.
-    let mut cp = cortex_m::Peripherals::take().unwrap();
-    let p = device::Peripherals::take().unwrap();
 
     #[cfg(any(feature = "h743", feature = "h753"))]
     {


### PR DESCRIPTION
This can now distinguish Rev A from Rev B, and (with any luck) both from
any future revs.

- gimlet-a firmware will now refuse to boot on rev B or C+
- gimlet-b firmware will now refuse to boot on rev A or C+
- Board mismatch is detected while all pins are still tristate, not even
  the crystal is started.