### PR TITLE
fix V3P3_SYS_A0 rail to match RFD 160

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -391,7 +391,7 @@ refdes = "U522"
 
 [[config.i2c.devices]]
 bus = "mid"
-address = 0x25
+address = 0x26
 device = "tps546b24a"
 description = "A0 3.3V rail"
 pmbus = { rails = [ "V3P3_SYS_A0" ] }


### PR DESCRIPTION
This fixes the address of the `V3P3_SYS_A0` rail in the Gimlet Rev B
TOML to match the address specified in RFD 160.