### PR TITLE
gimlet: always reprogram FPGA

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -206,7 +206,12 @@ fn main() -> ! {
     // serve up a recognizable ident code.
     let seq = seq_spi::SequencerFpga::new(spi.device(SEQ_SPI_DEVICE));
 
-    let reprogram = !seq.valid_ident();
+    // TODO: the ident is not sufficient for distinguishing the various Gimlet
+    // FPGA images that are floating around, so, we need to always reprogram it.
+    //
+    //let reprogram = !seq.valid_ident();
+    let reprogram = true;
+
     ringbuf_entry!(Trace::Reprogram(reprogram));
 
     // We only want to reset and reprogram the FPGA when absolutely required.


### PR DESCRIPTION
The ident check we were doing is not sufficient to distinguish the FPGA
images that are flying around -- they all have the same ident. Thus we
run the real risk of the firmware booting with the wrong FPGA image
still configured on the FPGA. This disables (temporarily!) the check
while we build a proper mechanism for distinguishing images.