### PR TITLE
Add TMP451 driver

### DIFF
--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -18,6 +18,7 @@
 //! - [`raa229618`]: RAA229618 power controller
 //! - [`sbtsi`]: AMD SB-TSI temperature sensor
 //! - [`tmp116`]: TMP116 temperature sensor
+//! - [`tmp451`]: TMP451 temperature sensor
 //! - [`tps546b24a`]: TPS546B24A buck converter
 
 #![no_std]
@@ -119,4 +120,5 @@ pub mod pct2075;
 pub mod raa229618;
 pub mod sbtsi;
 pub mod tmp116;
+pub mod tmp451;
 pub mod tps546b24a;

--- a/drv/i2c-devices/src/tmp451.rs
+++ b/drv/i2c-devices/src/tmp451.rs
@@ -96,6 +96,6 @@ impl TempSensor<Error> for Tmp451 {
         // Reading the high byte locks the low register byte until it is read
         let hi = self.read_reg(hi)?;
         let lo = self.read_reg(lo)?;
-        Ok(Celsius(f32::from(hi) + f32::from(lo) * 0.0625f32))
+        Ok(Celsius(f32::from(hi) + f32::from(lo >> 4) * 0.0625f32))
     }
 }

--- a/drv/i2c-devices/src/tmp451.rs
+++ b/drv/i2c-devices/src/tmp451.rs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Driver for the TMP451 temperature sensor
+
+use crate::TempSensor;
+use drv_i2c_api::*;
+use userlib::units::*;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Register {
+    LocalTempHiByte = 0x00,
+    RemoteTempHiByte = 0x01,
+    Status = 0x02,
+    Config = 0x03,
+    ConverstionRate = 0x04,
+    LocalTempHighLimit = 0x05,
+    LocalTempLowLimit = 0x06,
+    RemoteTempHighLimitHiByte = 0x07,
+    RemoteTempLowLimitHiByte = 0x08,
+    OneShotStart = 0x0F,
+    RemoteTempLoByte = 0x10,
+    RemoteTempOffsetHiByte = 0x11,
+    RemoteTempOffsetLoByte = 0x12,
+    RemoteTempHighLimitLoByte = 0x13,
+    RemoteTempLowLimitLoByte = 0x14,
+    LocalTempLoByte = 0x15,
+    RemoteTempThermBLimit = 0x19,
+    LocalTempThermBLimit = 0x20,
+    ThermBHysteresis = 0x21,
+    ConsecutiveAlertB = 0x22,
+    EtaFactorCorrection = 0x23,
+    DigitalFilterControl = 0x24,
+    ManufacturerId = 0xFE,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    BadRegisterRead { reg: Register, code: ResponseCode },
+}
+
+impl From<Error> for ResponseCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::BadRegisterRead { code, .. } => code,
+        }
+    }
+}
+
+/// Selects whether this sensor reads the local or remote temperature
+pub enum Target {
+    Local,
+    Remote,
+}
+
+pub struct Tmp451 {
+    device: I2cDevice,
+    target: Target,
+}
+
+impl core::fmt::Display for Tmp451 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "tmp451: {}", &self.device)
+    }
+}
+
+impl Tmp451 {
+    pub fn new(device: &I2cDevice, target: Target) -> Self {
+        // By default, the chip runs at 16 conversions per second, which is
+        // plenty fast for our use case.
+        Self {
+            device: *device,
+            target,
+        }
+    }
+
+    fn read_reg(&self, reg: Register) -> Result<u8, Error> {
+        self.device
+            .read_reg::<u8, u8>(reg as u8)
+            .map_err(|code| Error::BadRegisterRead { reg, code })
+    }
+}
+
+impl TempSensor<Error> for Tmp451 {
+    fn read_temperature(&mut self) -> Result<Celsius, Error> {
+        let (hi, lo) = match self.target {
+            Target::Local => {
+                (Register::LocalTempHiByte, Register::LocalTempLoByte)
+            }
+            Target::Remote => {
+                (Register::RemoteTempHiByte, Register::RemoteTempLoByte)
+            }
+        };
+        // Reading the high byte locks the low register byte until it is read
+        let hi = self.read_reg(hi)?;
+        let lo = self.read_reg(lo)?;
+        Ok(Celsius(f32::from(hi) + f32::from(lo) * 0.0625f32))
+    }
+}


### PR DESCRIPTION
This implements a small driver for the TMP451 and adds it to the `task-thermal` sensor list