### PR TITLE
xtask: don't require flashing instructions to build

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -639,10 +639,10 @@ Did you mean to run `cargo xtask dist`?"
     // any external configuration files, serialize it, and add it to the
     // archive.
     //
-    let mut config = crate::flash::config(&toml.board.as_str())?;
-    config.flatten()?;
-
-    archive.text(img_dir.join("flash.ron"), ron::to_string(&config)?)?;
+    if let Some(mut config) = crate::flash::config(&toml.board.as_str())? {
+        config.flatten()?;
+        archive.text(img_dir.join("flash.ron"), ron::to_string(&config)?)?;
+    }
 
     archive.finish()?;
 

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -135,7 +135,7 @@ impl FlashConfig {
     }
 }
 
-pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
+pub fn config(board: &str) -> anyhow::Result<Option<FlashConfig>> {
     match board {
         "lpcxpresso55s69" | "gemini-bu-rot-1" | "gimlet-rot-1" => {
             let chip = if board == "lpcxpresso55s69" {
@@ -160,7 +160,7 @@ pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
                 .arg("hex")
                 .payload();
 
-            Ok(flash)
+            Ok(Some(flash))
         }
         "stm32f3-discovery" | "stm32f4-discovery" | "nucleo-h743zi2"
         | "nucleo-h753zi" | "stm32h7b3i-dk" | "gemini-bu-1" | "gimletlet-1"
@@ -196,10 +196,11 @@ pub fn config(board: &str) -> anyhow::Result<FlashConfig> {
                 .arg("-c")
                 .arg("exit");
 
-            Ok(flash)
+            Ok(Some(flash))
         }
         _ => {
-            anyhow::bail!("unrecognized board {}", board);
+            eprintln!("Warning: unrecognized board, won't know how to flash.");
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
As of fairly recently, you need to provide a full flash configuration to
be able to even build an archive for a board. This makes it annoying to
bring up new chips.

This change makes the build system tolerate this condition, and simply
doesn't include flashing instructions in the archive.