### PR TITLE
xtask: include kernel config in image ID

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -363,7 +363,6 @@ Did you mean to run `cargo xtask dist`?"
 
     let mut image_id = fnv::FnvHasher::default();
     all_output_sections.hash(&mut image_id);
-    let image_id = image_id.finish();
 
     // Format the descriptors for the kernel build.
     let kconfig = make_descriptors(
@@ -379,6 +378,9 @@ Did you mean to run `cargo xtask dist`?"
     )?;
     let kconfig = ron::ser::to_string(&kconfig)?;
 
+    kconfig.hash(&mut image_id);
+    allocs.hash(&mut image_id);
+
     generate_kernel_linker_script(
         "memory.x",
         &allocs.kernel,
@@ -386,6 +388,8 @@ Did you mean to run `cargo xtask dist`?"
     )?;
 
     fs::copy("build/kernel-link.x", "target/link.x")?;
+
+    let image_id = image_id.finish();
 
     // Build the kernel.
     let build_config = toml.kernel_build_config(
@@ -1056,7 +1060,7 @@ fn build(
     Ok(())
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Hash)]
 struct Allocations {
     /// Map from memory-name to address-range
     kernel: BTreeMap<String, Range<u32>>,


### PR DESCRIPTION
Noticed that Humility was saying I already had an image flashed when I
changed the start flag on a task. This fixes that.

The main thing left out of image ID generation now is the kernel build
itself, because we have a causality problem (the kernel build includes
the image ID). I'll fix this later.