### PR TITLE
Add temperature sensing to DIMMs

### DIFF
--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -551,145 +551,161 @@ refdes = "U431"
 bus = "mid"
 address = 0x18
 device = "tse2004av"
-name = "A0"
+name = "DIMM_A0"
 description = "DIMM A0"
 sensors = { temperature = 1 }
 refdes = "M0"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x19
 device = "tse2004av"
-name = "A1"
+name = "DIMM_A1"
 description = "DIMM A1"
 sensors = { temperature = 1 }
 refdes = "M8"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1a
 device = "tse2004av"
-name = "B0"
+name = "DIMM_B0"
 description = "DIMM B0"
 sensors = { temperature = 1 }
 refdes = "M1"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1b
 device = "tse2004av"
-name = "B1"
+name = "DIMM_B1"
 description = "DIMM B1"
 sensors = { temperature = 1 }
 refdes = "M9"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1c
 device = "tse2004av"
-name = "C0"
+name = "DIMM_C0"
 description = "DIMM C0"
 sensors = { temperature = 1 }
 refdes = "M2"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1d
 device = "tse2004av"
-name = "C1"
+name = "DIMM_C1"
 description = "DIMM C1"
 sensors = { temperature = 1 }
 refdes = "M10"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1e
 device = "tse2004av"
-name = "D0"
+name = "DIMM_D0"
 description = "DIMM D0"
 sensors = { temperature = 1 }
 refdes = "M3"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1f
 device = "tse2004av"
-name = "D1"
+name = "DIMM_D1"
 description = "DIMM D1"
 sensors = { temperature = 1 }
 refdes = "M11"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x18
 device = "tse2004av"
-name = "E0"
+name = "DIMM_E0"
 description = "DIMM E0"
 sensors = { temperature = 1 }
 refdes = "M4"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x19
 device = "tse2004av"
-name = "E1"
+name = "DIMM_E1"
 description = "DIMM E1"
 sensors = { temperature = 1 }
 refdes = "M12"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1a
 device = "tse2004av"
-name = "F0"
+name = "DIMM_F0"
 description = "DIMM F0"
 sensors = { temperature = 1 }
 refdes = "M5"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1b
 device = "tse2004av"
-name = "F1"
+name = "DIMM_F1"
 description = "DIMM F1"
 sensors = { temperature = 1 }
 refdes = "M13"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1c
 device = "tse2004av"
-name = "G0"
+name = "DIMM_G0"
 description = "DIMM G0"
 sensors = { temperature = 1 }
 refdes = "M6"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1d
 device = "tse2004av"
-name = "G1"
+name = "DIMM_G1"
 description = "DIMM G1"
 sensors = { temperature = 1 }
 refdes = "M14"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1e
 device = "tse2004av"
-name = "H0"
+name = "DIMM_H0"
 description = "DIMM H0"
 sensors = { temperature = 1 }
 refdes = "M7"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1f
 device = "tse2004av"
-name = "H1"
+name = "DIMM_H1"
 description = "DIMM H1"
 sensors = { temperature = 1 }
 refdes = "M15"
+removable = true
 
 ################################################################################
 

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -132,8 +132,8 @@ path = "../../task/thermal"
 name = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
-requires = {flash = 8192, ram = 2048 }
-stacksize = 1920
+requires = {flash = 16384, ram = 4096 }
+stacksize = 3504
 start = true
 task-slots = ["i2c_driver", "sensor"]
 

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -545,6 +545,153 @@ pmbus = { rails = [ "V12_SYS_A2" ] }
 sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
 refdes = "U431"
 
+################################################################################
+# DIMM slots
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x18
+device = "tse2004av"
+name = "A0"
+description = "DIMM A0"
+sensors = { temperature = 1 }
+refdes = "M0"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x19
+device = "tse2004av"
+name = "A1"
+description = "DIMM A1"
+sensors = { temperature = 1 }
+refdes = "M8"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1a
+device = "tse2004av"
+name = "B0"
+description = "DIMM B0"
+sensors = { temperature = 1 }
+refdes = "M1"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1b
+device = "tse2004av"
+name = "B1"
+description = "DIMM B1"
+sensors = { temperature = 1 }
+refdes = "M9"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1c
+device = "tse2004av"
+name = "C0"
+description = "DIMM C0"
+sensors = { temperature = 1 }
+refdes = "M2"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1d
+device = "tse2004av"
+name = "C1"
+description = "DIMM C1"
+sensors = { temperature = 1 }
+refdes = "M10"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1e
+device = "tse2004av"
+name = "D0"
+description = "DIMM D0"
+sensors = { temperature = 1 }
+refdes = "M3"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1f
+device = "tse2004av"
+name = "D1"
+description = "DIMM D1"
+sensors = { temperature = 1 }
+refdes = "M11"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x18
+device = "tse2004av"
+name = "E0"
+description = "DIMM E0"
+sensors = { temperature = 1 }
+refdes = "M4"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x19
+device = "tse2004av"
+name = "E1"
+description = "DIMM E1"
+sensors = { temperature = 1 }
+refdes = "M12"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1a
+device = "tse2004av"
+name = "F0"
+description = "DIMM F0"
+sensors = { temperature = 1 }
+refdes = "M5"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1b
+device = "tse2004av"
+name = "F1"
+description = "DIMM F1"
+sensors = { temperature = 1 }
+refdes = "M13"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1c
+device = "tse2004av"
+name = "G0"
+description = "DIMM G0"
+sensors = { temperature = 1 }
+refdes = "M6"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1d
+device = "tse2004av"
+name = "G1"
+description = "DIMM G1"
+sensors = { temperature = 1 }
+refdes = "M14"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1e
+device = "tse2004av"
+name = "H0"
+description = "DIMM H0"
+sensors = { temperature = 1 }
+refdes = "M7"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1f
+device = "tse2004av"
+name = "H1"
+description = "DIMM H1"
+sensors = { temperature = 1 }
+refdes = "M15"
+
+################################################################################
 
 [config.spi.spi2]
 controller = 2

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -555,145 +555,161 @@ refdes = "U431"
 bus = "mid"
 address = 0x18
 device = "tse2004av"
-name = "A0"
+name = "DIMM_A0"
 description = "DIMM A0"
 sensors = { temperature = 1 }
 refdes = "M0"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x19
 device = "tse2004av"
-name = "A1"
+name = "DIMM_A1"
 description = "DIMM A1"
 sensors = { temperature = 1 }
 refdes = "M8"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1a
 device = "tse2004av"
-name = "B0"
+name = "DIMM_B0"
 description = "DIMM B0"
 sensors = { temperature = 1 }
 refdes = "M1"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1b
 device = "tse2004av"
-name = "B1"
+name = "DIMM_B1"
 description = "DIMM B1"
 sensors = { temperature = 1 }
 refdes = "M9"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1c
 device = "tse2004av"
-name = "C0"
+name = "DIMM_C0"
 description = "DIMM C0"
 sensors = { temperature = 1 }
 refdes = "M2"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1d
 device = "tse2004av"
-name = "C1"
+name = "DIMM_C1"
 description = "DIMM C1"
 sensors = { temperature = 1 }
 refdes = "M10"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1e
 device = "tse2004av"
-name = "D0"
+name = "DIMM_D0"
 description = "DIMM D0"
 sensors = { temperature = 1 }
 refdes = "M3"
+removable = true
 
 [[config.i2c.devices]]
 bus = "mid"
 address = 0x1f
 device = "tse2004av"
-name = "D1"
+name = "DIMM_D1"
 description = "DIMM D1"
 sensors = { temperature = 1 }
 refdes = "M11"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x18
 device = "tse2004av"
-name = "E0"
+name = "DIMM_E0"
 description = "DIMM E0"
 sensors = { temperature = 1 }
 refdes = "M4"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x19
 device = "tse2004av"
-name = "E1"
+name = "DIMM_E1"
 description = "DIMM E1"
 sensors = { temperature = 1 }
 refdes = "M12"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1a
 device = "tse2004av"
-name = "F0"
+name = "DIMM_F0"
 description = "DIMM F0"
 sensors = { temperature = 1 }
 refdes = "M5"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1b
 device = "tse2004av"
-name = "F1"
+name = "DIMM_F1"
 description = "DIMM F1"
 sensors = { temperature = 1 }
 refdes = "M13"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1c
 device = "tse2004av"
-name = "G0"
+name = "DIMM_G0"
 description = "DIMM G0"
 sensors = { temperature = 1 }
 refdes = "M6"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1d
 device = "tse2004av"
-name = "G1"
+name = "DIMM_G1"
 description = "DIMM G1"
 sensors = { temperature = 1 }
 refdes = "M14"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1e
 device = "tse2004av"
-name = "H0"
+name = "DIMM_H0"
 description = "DIMM H0"
 sensors = { temperature = 1 }
 refdes = "M7"
+removable = true
 
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x1f
 device = "tse2004av"
-name = "H1"
+name = "DIMM_H1"
 description = "DIMM H1"
 sensors = { temperature = 1 }
 refdes = "M15"
+removable = true
 
 ################################################################################
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -147,8 +147,8 @@ path = "../../task/thermal"
 name = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
-requires = {flash = 8192, ram = 2048 }
-stacksize = 1920
+requires = {flash = 16384, ram = 4096 }
+stacksize = 3504
 start = true
 task-slots = ["i2c_driver", "sensor"]
 
@@ -548,6 +548,154 @@ description = "Intermediate bus converter"
 pmbus = { rails = [ "V12_SYS_A2" ] }
 sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
 refdes = "U431"
+
+################################################################################
+# DIMM slots
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x18
+device = "tse2004av"
+name = "A0"
+description = "DIMM A0"
+sensors = { temperature = 1 }
+refdes = "M0"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x19
+device = "tse2004av"
+name = "A1"
+description = "DIMM A1"
+sensors = { temperature = 1 }
+refdes = "M8"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1a
+device = "tse2004av"
+name = "B0"
+description = "DIMM B0"
+sensors = { temperature = 1 }
+refdes = "M1"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1b
+device = "tse2004av"
+name = "B1"
+description = "DIMM B1"
+sensors = { temperature = 1 }
+refdes = "M9"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1c
+device = "tse2004av"
+name = "C0"
+description = "DIMM C0"
+sensors = { temperature = 1 }
+refdes = "M2"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1d
+device = "tse2004av"
+name = "C1"
+description = "DIMM C1"
+sensors = { temperature = 1 }
+refdes = "M10"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1e
+device = "tse2004av"
+name = "D0"
+description = "DIMM D0"
+sensors = { temperature = 1 }
+refdes = "M3"
+
+[[config.i2c.devices]]
+bus = "mid"
+address = 0x1f
+device = "tse2004av"
+name = "D1"
+description = "DIMM D1"
+sensors = { temperature = 1 }
+refdes = "M11"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x18
+device = "tse2004av"
+name = "E0"
+description = "DIMM E0"
+sensors = { temperature = 1 }
+refdes = "M4"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x19
+device = "tse2004av"
+name = "E1"
+description = "DIMM E1"
+sensors = { temperature = 1 }
+refdes = "M12"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1a
+device = "tse2004av"
+name = "F0"
+description = "DIMM F0"
+sensors = { temperature = 1 }
+refdes = "M5"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1b
+device = "tse2004av"
+name = "F1"
+description = "DIMM F1"
+sensors = { temperature = 1 }
+refdes = "M13"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1c
+device = "tse2004av"
+name = "G0"
+description = "DIMM G0"
+sensors = { temperature = 1 }
+refdes = "M6"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1d
+device = "tse2004av"
+name = "G1"
+description = "DIMM G1"
+sensors = { temperature = 1 }
+refdes = "M14"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1e
+device = "tse2004av"
+name = "H0"
+description = "DIMM H0"
+sensors = { temperature = 1 }
+refdes = "M7"
+
+[[config.i2c.devices]]
+bus = "rear"
+address = 0x1f
+device = "tse2004av"
+name = "H1"
+description = "DIMM H1"
+sensors = { temperature = 1 }
+refdes = "M15"
+
+################################################################################
 
 [config.spi.spi2]
 controller = 2

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -20,6 +20,7 @@
 //! - [`tmp116`]: TMP116 temperature sensor
 //! - [`tmp451`]: TMP451 temperature sensor
 //! - [`tps546b24a`]: TPS546B24A buck converter
+//! - [`tse2004av`]: TSE2004av SPD EEPROM with temperature sensor
 
 #![no_std]
 
@@ -166,3 +167,4 @@ pub mod sbtsi;
 pub mod tmp117;
 pub mod tmp451;
 pub mod tps546b24a;
+pub mod tse2004av;

--- a/drv/i2c-devices/src/tse2004av.rs
+++ b/drv/i2c-devices/src/tse2004av.rs
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Driver for any chip implementing the TSE2004av specification, which is used
+//! for SPD (serial presence detection) and temperature sensing on DIMMs.
+
+use crate::TempSensor;
+use drv_i2c_api::*;
+use userlib::units::*;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Register {
+    Capabilities = 0x00,
+    Configuration = 0x01,
+    HighLimit = 0x02,
+    LowLimit = 0x03,
+    TcritLimit = 0x04,
+    AmbientTemp = 0x05,
+    ManufacturerId = 0x06,
+    DeviceRevision = 0x07,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    BadRegisterRead { reg: Register, code: ResponseCode },
+}
+
+impl From<Error> for ResponseCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::BadRegisterRead { code, .. } => code,
+        }
+    }
+}
+
+pub struct Tse2004av {
+    device: I2cDevice,
+}
+
+impl core::fmt::Display for Tse2004av {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "tmp451: {}", &self.device)
+    }
+}
+
+impl Tse2004av {
+    pub fn new(device: &I2cDevice) -> Self {
+        Self { device: *device }
+    }
+
+    fn read_reg(&self, reg: Register) -> Result<u16, Error> {
+        self.device
+            .read_reg::<u8, u16>(reg as u8)
+            .map_err(|code| Error::BadRegisterRead { reg, code })
+    }
+}
+
+impl TempSensor<Error> for Tse2004av {
+    fn read_temperature(&mut self) -> Result<Celsius, Error> {
+        let t: u16 = self.read_reg(Register::AmbientTemp)?;
+
+        // The actual temperature is a 13-bit two's complement value.
+        //
+        // We shift it so that the sign bit is in the right place, cast it
+        // to an i16 to make it signed, then scale it into a float.
+        let t = (u16::from_be(t) << 3) as i16;
+        Ok(Celsius(f32::from(t) * 0.0078125f32))
+    }
+}

--- a/drv/i2c-devices/src/tse2004av.rs
+++ b/drv/i2c-devices/src/tse2004av.rs
@@ -41,7 +41,7 @@ pub struct Tse2004Av {
 
 impl core::fmt::Display for Tse2004Av {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "tmp451: {}", &self.device)
+        write!(f, "TSE2004av: {}", &self.device)
     }
 }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -45,7 +45,7 @@ enum Device {
     South(Zone, Tmp117),
     T6Nic(Tmp451),
     CPU(Sbtsi),
-    Dimm(Tse2004av),
+    Dimm(Tse2004Av),
 }
 
 struct Sensor {
@@ -144,67 +144,67 @@ fn temperature_sensors() -> [Sensor; NUM_TEMPERATURE_SENSORS] {
             id: sensors::TMP451_TEMPERATURE_SENSOR,
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[0])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[0])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[0],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[1])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[1])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[1],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[2])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[2])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[2],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[3])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[3])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[3],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[4])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[4])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[4],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[5])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[5])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[5],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[6])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[6])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[6],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[7])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[7])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[7],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[8])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[8])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[8],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[9])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[9])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[9],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[10])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[10])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[10],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[11])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[11])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[11],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[12])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[12])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[12],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[13])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[13])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[13],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[14])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[14])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[14],
         },
         Sensor {
-            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[15])),
+            device: Device::Dimm(Tse2004Av::new(&devices::tse2004av(task)[15])),
             id: sensors::TSE2004AV_TEMPERATURE_SENSORS[15],
         },
     ]

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -17,6 +17,7 @@ use drv_i2c_devices::max31790::*;
 use drv_i2c_devices::sbtsi::*;
 use drv_i2c_devices::tmp117::*;
 use drv_i2c_devices::tmp451::*;
+use drv_i2c_devices::tse2004av::*;
 use drv_i2c_devices::TempSensor;
 use idol_runtime::{NotificationHandler, RequestError};
 use task_sensor_api as sensor_api;
@@ -44,6 +45,7 @@ enum Device {
     South(Zone, Tmp117),
     T6Nic(Tmp451),
     CPU(Sbtsi),
+    Dimm(Tse2004av),
 }
 
 struct Sensor {
@@ -72,13 +74,15 @@ impl Sensor {
             Device::North(_, dev) | Device::South(_, dev) => temp_read(dev),
             Device::T6Nic(dev) => temp_read(dev),
             Device::CPU(dev) => temp_read(dev),
+            Device::Dimm(dev) => temp_read(dev),
         }
     }
 }
 
 const NUM_TEMPERATURE_SENSORS: usize = sensors::NUM_TMP117_TEMPERATURE_SENSORS
     + sensors::NUM_TMP451_TEMPERATURE_SENSORS
-    + sensors::NUM_SBTSI_TEMPERATURE_SENSORS;
+    + sensors::NUM_SBTSI_TEMPERATURE_SENSORS
+    + sensors::NUM_TSE2004AV_TEMPERATURE_SENSORS;
 
 fn temperature_sensors() -> [Sensor; NUM_TEMPERATURE_SENSORS] {
     let task = I2C.get_task_id();
@@ -138,6 +142,70 @@ fn temperature_sensors() -> [Sensor; NUM_TEMPERATURE_SENSORS] {
                 Target::Remote,
             )),
             id: sensors::TMP451_TEMPERATURE_SENSOR,
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[0])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[0],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[1])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[1],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[2])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[2],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[3])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[3],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[4])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[4],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[5])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[5],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[6])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[6],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[7])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[7],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[8])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[8],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[9])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[9],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[10])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[10],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[11])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[11],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[12])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[12],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[13])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[13],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[14])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[14],
+        },
+        Sensor {
+            device: Device::Dimm(Tse2004av::new(&devices::tse2004av(task)[15])),
+            id: sensors::TSE2004AV_TEMPERATURE_SENSORS[15],
         },
     ]
 }


### PR DESCRIPTION
This adds temperature sensing for all of the DIMMs in Gimlet, based on the TSE2004av standard.

(this is orthogonal to the existing `spd` task, because the temperature sensors have their own addresses and register sets, and are actively polled during operation)