### PR TITLE
Derive PartialOrd for userlib units

### DIFF
--- a/sys/userlib/src/units.rs
+++ b/sys/userlib/src/units.rs
@@ -7,25 +7,25 @@
 //!
 
 /// Degrees Celsius
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Celsius(pub f32);
 
 /// Rotations per minute
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Rpm(pub u16);
 
 /// Volts of potential
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Volts(pub f32);
 
 /// Amperes of current
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Amperes(pub f32);
 
 /// Ohms of resistence
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Ohms(pub f32);
 
 /// Watts of power
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct Watts(pub f32);


### PR DESCRIPTION
Derive `PartialOrd` for units to allow expressions such as `if some_value < Volts(0.8)...`. This was suggested in https://github.com/oxidecomputer/hubris/pull/453.