### PR TITLE
Fix priority inversions in existing code

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -161,7 +161,7 @@ task-slots = ["net"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "spi", "rng"]
-priority = 3
+priority = 4
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
@@ -178,7 +178,7 @@ start = true
 [tasks.rng_driver]
 features = ["h743"]
 path = "../../drv/stm32h7-rng"
-priority = 2
+priority = 3
 name = "drv-stm32h7-rng"
 requires = {flash = 8192, ram = 512}
 stacksize = 256

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -146,7 +146,7 @@ task-slots = ["net"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
-priority = 3
+priority = 5
 requires = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
@@ -156,7 +156,7 @@ task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
-priority = 3
+priority = 4
 requires = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 6
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
@@ -187,7 +187,7 @@ start = true
 [tasks.rng_driver]
 features = ["h753"]
 path = "../../drv/stm32h7-rng"
-priority = 2
+priority = 3
 name = "drv-stm32h7-rng"
 requires = {flash = 8192, ram = 512}
 stacksize = 256

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -70,7 +70,7 @@ stacksize = 1536
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 7
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
@@ -86,7 +86,7 @@ start = true
 [tasks.gpio_driver]
 path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
-priority = 2
+priority = 3
 requires = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
@@ -96,7 +96,7 @@ task-slots = ["syscon_driver"]
 path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["lpc55"]
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["gpio_driver"]
@@ -104,7 +104,7 @@ task-slots = ["gpio_driver"]
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
 start = true
@@ -120,7 +120,7 @@ pins = [
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
 name = "drv-lpc55-rng"
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
 start = true
@@ -130,7 +130,7 @@ task-slots = ["syscon_driver"]
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
-priority = 2
+priority = 4
 requires = {flash = 16384, ram = 2048}
 features = ["spi0"]
 uses = ["flexcomm3", "flexcomm8"]
@@ -154,7 +154,7 @@ pins = [
 [tasks.swd]
 path = "../../drv/lpc55-swd"
 name = "drv-lpc55-swd"
-priority = 2
+priority = 4
 requires = {flash = 16384, ram = 4096}
 uses = ["flexcomm3"]
 start = true
@@ -188,7 +188,7 @@ spi_num = 3
 path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
-priority = 4
+priority = 6
 requires = {flash = 8192, ram = 2048}
 start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
@@ -196,7 +196,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.pong]
 path = "../../task/pong"
 name = "task-pong"
-priority = 3
+priority = 5
 requires = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
@@ -204,7 +204,7 @@ task-slots = ["user_leds"]
 [tasks.hiffy]
 path = "../../task/hiffy"
 name = "task-hiffy"
-priority = 3
+priority = 5
 features = ["lpc55", "gpio", "spi", "spctrl"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -78,7 +78,7 @@ task-slots = ["sys"]
 path = "../../task/spd"
 name = "task-spd"
 features = ["h753", "itm"]
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 16384 }
 uses = ["i2c2"]
 start = true
@@ -139,7 +139,7 @@ task-slots = ["user_leds"]
 path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
-priority = 3
+priority = 4
 requires = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
@@ -163,7 +163,7 @@ task-slots = ["sys"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
-priority = 3
+priority = 5
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
@@ -181,7 +181,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 6
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -43,7 +43,7 @@ stacksize = 1536
 [tasks.hiffy]
 path = "../../task/hiffy"
 name = "task-hiffy"
-priority = 3
+priority = 5
 features = ["lpc55", "gpio", "spctrl"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
@@ -53,7 +53,7 @@ task-slots = ["gpio_driver", "swd"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 6
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true
@@ -69,7 +69,7 @@ start = true
 [tasks.gpio_driver]
 path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
-priority = 2
+priority = 3
 requires = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
@@ -78,7 +78,7 @@ task-slots = ["syscon_driver"]
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 2048}
 uses = ["iocon", "flexcomm0"]
 start = true
@@ -94,7 +94,7 @@ pins = [
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
-priority = 2
+priority = 4
 requires = {flash = 16384, ram = 2048}
 uses = ["iocon", "flexcomm3", "flexcomm8"]
 features = ["spi0"]
@@ -118,7 +118,7 @@ pins = [
 [tasks.swd]
 path = "../../drv/lpc55-swd"
 name = "drv-lpc55-swd"
-priority = 2
+priority = 4
 requires = {flash = 16384, ram = 4096}
 uses = ["flexcomm5"]
 start = false

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -131,7 +131,7 @@ task-slots = ["sys", "i2c_driver"]
 path = "../../task/thermal"
 name = "task-thermal"
 features = ["itm", "h753"]
-priority = 3
+priority = 5
 requires = {flash = 16384, ram = 4096 }
 stacksize = 3504
 start = true
@@ -141,7 +141,7 @@ task-slots = ["i2c_driver", "sensor"]
 path = "../../task/power"
 name = "task-power"
 features = ["itm", "h753"]
-priority = 3
+priority = 5
 requires = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
@@ -151,7 +151,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
-priority = 3
+priority = 5
 requires = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
@@ -161,7 +161,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 path = "../../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
 features = ["h753"]
-priority = 3
+priority = 4
 requires = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
@@ -187,7 +187,7 @@ task-slots = ["sys"]
 path = "../../task/net"
 name = "task-net"
 stacksize = 3800
-priority = 2
+priority = 5
 features = ["mgmt", "h753", "gimlet"]
 requires = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -210,7 +210,7 @@ start = true
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 6
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -219,7 +219,7 @@ task-slots = ["net"]
 [tasks.udpbroadcast]
 path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
-priority = 3
+priority = 6
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -237,7 +237,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 7
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -143,10 +143,10 @@ task-slots = ["sys", "i2c_driver"]
 [tasks.thermal]
 path = "../../task/thermal"
 name = "task-thermal"
-features = ["itm", "h753", "gimlet"]
+features = ["itm", "h753"]
 priority = 5
-requires = {flash = 32768, ram = 8192 }
-stacksize = 4504
+requires = {flash = 16384, ram = 4096 }
+stacksize = 3504
 start = true
 task-slots = ["i2c_driver", "sensor"]
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -60,7 +60,7 @@ stacksize = 1536
 path = "../../task/net"
 name = "task-net"
 stacksize = 5400
-priority = 2
+priority = 5
 features = ["mgmt", "h753", "gimlet", "h7-vlan"]
 requires = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -81,7 +81,7 @@ start = true
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
@@ -96,7 +96,7 @@ global_config = "spi4"
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
 uses = ["spi2"]
@@ -112,7 +112,7 @@ global_config = "spi2"
 path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
@@ -143,10 +143,10 @@ task-slots = ["sys", "i2c_driver"]
 [tasks.thermal]
 path = "../../task/thermal"
 name = "task-thermal"
-features = ["itm", "h753"]
-priority = 3
-requires = {flash = 16384, ram = 4096 }
-stacksize = 3504
+features = ["itm", "h753", "gimlet"]
+priority = 5
+requires = {flash = 32768, ram = 8192 }
+stacksize = 4504
 start = true
 task-slots = ["i2c_driver", "sensor"]
 
@@ -154,7 +154,7 @@ task-slots = ["i2c_driver", "sensor"]
 path = "../../task/power"
 name = "task-power"
 features = ["itm", "h753"]
-priority = 3
+priority = 6
 requires = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
@@ -164,7 +164,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
-priority = 3
+priority = 5
 requires = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
@@ -174,7 +174,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 path = "../../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
 features = ["h753"]
-priority = 3
+priority = 4
 requires = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
@@ -200,7 +200,7 @@ task-slots = ["sys"]
 path = "../../task/sensor"
 name = "task-sensor"
 features = ["itm"]
-priority = 3
+priority = 4
 requires = {flash = 8192, ram = 2048 }
 stacksize = 1920        # Sensor data is stored on the stack
 start = true
@@ -208,7 +208,7 @@ start = true
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 6
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -218,7 +218,7 @@ features = ["vlan"]
 [tasks.udpbroadcast]
 path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
-priority = 3
+priority = 6
 requires = {flash = 16384, ram = 8192}
 stacksize = 2048
 start = true
@@ -228,7 +228,7 @@ features = ["vlan"]
 [tasks.validate]
 path = "../../task/validate"
 name = "task-validate"
-priority = 3
+priority = 5
 requires = {flash = 8192, ram = 4096 }
 stacksize = 1000 
 start = true
@@ -237,7 +237,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 7
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -103,7 +103,7 @@ task-slots = ["sys", "user_leds"]
 path = "../../task/net"
 name = "task-net"
 stacksize = 3800
-priority = 2
+priority = 3
 features = ["mgmt", "h753"]
 requires = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -115,7 +115,7 @@ task-slots = ["sys", "user_leds", { spi_driver = "spi2_driver" }]
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 4
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -131,7 +131,7 @@ task-slots = ["sys"]
 path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "rng", "update"]
-priority = 3
+priority = 4
 requires = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
@@ -153,7 +153,7 @@ task-slots = ["sys"]
 path = "../../task/net"
 name = "task-net"
 stacksize = 4320
-priority = 2
+priority = 3
 features = ["h753", "h7-vlan", "gimletlet-nic"]
 requires = {flash = 65536, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -165,7 +165,7 @@ task-slots = ["sys", "spi_driver" ]
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 4
 requires = {flash = 8192, ram = 8192}
 stacksize = 4096
 start = true
@@ -193,7 +193,7 @@ start = true
 features = ["h753"]
 path = "../../drv/stm32h7-rng"
 name = "drv-stm32h7-rng"
-priority = 2
+priority = 3
 requires = {flash = 8192, ram = 512}
 uses = ["rng"]
 start = true

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -73,7 +73,7 @@ stacksize = 1536
 [tasks.hiffy]
 path = "../../task/hiffy"
 name = "task-hiffy"
-priority = 3
+priority = 5
 features = ["lpc55", "gpio", "rng"]
 requires = {flash = 32768, ram = 16384 }
 stacksize = 2048
@@ -83,7 +83,7 @@ task-slots = ["gpio_driver", "rng_driver"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 7
 requires = {flash = 256, ram = 256}
 stacksize = 256
 start = true
@@ -100,7 +100,7 @@ stacksize = 1000
 [tasks.gpio_driver]
 path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
-priority = 2
+priority = 3
 requires = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
@@ -111,7 +111,7 @@ task-slots = ["syscon_driver"]
 path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["lpc55"]
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
@@ -120,7 +120,7 @@ task-slots = ["gpio_driver"]
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
 start = true
@@ -137,7 +137,7 @@ pins = [
 [tasks.i2c_driver]
 path = "../../drv/lpc55-i2c"
 name = "drv-lpc55-i2c"
-priority = 2
+priority = 4
 requires = {flash = 8192, ram = 2048}
 uses = ["flexcomm4"]
 start = true
@@ -147,7 +147,7 @@ task-slots = ["gpio_driver", "syscon_driver"]
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
 name = "drv-lpc55-rng"
-priority = 2
+priority = 3
 requires = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
 start = true
@@ -157,7 +157,7 @@ task-slots = ["syscon_driver"]
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
-priority = 2
+priority = 4
 requires = {flash = 16384, ram = 2048}
 features = ["spi0"]
 uses = ["flexcomm8"]
@@ -182,7 +182,7 @@ pins = [
 path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
-priority = 4
+priority = 6
 requires = {flash = 8192, ram = 1024}
 start = true
 stacksize = 512
@@ -191,7 +191,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.pong]
 path = "../../task/pong"
 name = "task-pong"
-priority = 3
+priority = 5
 requires = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -127,7 +127,7 @@ task-slots = ["sys", "i2c_driver"]
 path = "../../task/net"
 name = "task-net"
 stacksize = 3800
-priority = 2
+priority = 3
 features = ["mgmt", "h753"]
 requires = {flash = 131072, ram = 8192, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -139,7 +139,7 @@ task-slots = ["sys", { spi_driver = "spi2_driver" }]
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 4
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -114,7 +114,7 @@ global_config = "spi5"
 path = "../../task/net"
 name = "task-net"
 stacksize = 3800
-priority = 2
+priority = 4
 features = ["mgmt", "h753", "sidecar"]
 requires = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
@@ -128,7 +128,7 @@ task-slots = ["sys",
 [tasks.udpecho]
 path = "../../task/udpecho"
 name = "task-udpecho"
-priority = 3
+priority = 5
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -137,7 +137,7 @@ task-slots = ["net"]
 [tasks.udpbroadcast]
 path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
-priority = 3
+priority = 5
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -146,7 +146,7 @@ task-slots = ["net"]
 [tasks.vsc7448]
 path = "../../task/vsc7448"
 name = "task-vsc7448"
-priority = 3
+priority = 5
 requires = {flash = 131072, ram = 8192}
 features = ["mgmt", "sidecar"]
 stacksize = 4096
@@ -207,7 +207,7 @@ task-slots = ["sys", "i2c_driver"]
 [tasks.idle]
 path = "../../task/idle"
 name = "task-idle"
-priority = 5
+priority = 6
 requires = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -684,7 +684,7 @@ fn check_task_priorities(toml: &Config) -> Result<()> {
                 .get(callee)
                 .ok_or_else(|| anyhow!("Invalid task-slot: {}", callee))?
                 .priority;
-            if p >= task.priority {
+            if p >= task.priority && name != callee {
                 // TODO: once all priority inversions are fixed, return an
                 // error so no more can be introduced
                 let mut color = ColorSpec::new();

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -676,6 +676,7 @@ fn check_task_priorities(toml: &Config) -> Result<()> {
     let mut out_stream = termcolor::StandardStream::stderr(color_choice);
     let out = &mut out_stream;
 
+    let idle_priority = toml.tasks["idle"].priority;
     for (name, task) in &toml.tasks {
         for callee in task.task_slots.values() {
             let p = toml
@@ -696,6 +697,8 @@ fn check_task_priorities(toml: &Config) -> Result<()> {
                     "task {} (priority {}) calls into {} (priority {})",
                     name, task.priority, callee, p
                 )?;
+            } else if task.priority >= idle_priority && name != "idle" {
+                bail!("task {} has priority that's >= idle priority", name);
             }
         }
     }


### PR DESCRIPTION
This fixes _nearly_ all priority inversions, with the exception that `spd` still messages the lower-priority `i2c_driver` on Gimlet images.