### PR TITLE
Improvements to IRQ tables

### DIFF
--- a/build/phash-gen/src/lib.rs
+++ b/build/phash-gen/src/lib.rs
@@ -57,12 +57,117 @@ where
                         assert!(out[index].is_none());
                         out[index] = Some(v);
                     }
-                    return Ok(OwnedPerfectHashMap { m, values: out });
+                    return Ok(Self { m, values: out });
                 }
             }
         }
 
         bail!("Could not generate perfect hash");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct OwnedNestedPerfectHashMap<K, V> {
+    pub m: u32,
+    pub g: Vec<u32>,
+    pub values: Vec<Vec<(K, V)>>,
+}
+
+impl<K, V> OwnedNestedPerfectHashMap<K, V>
+where
+    K: PerfectHash + Hash + Eq,
+{
+    fn id(key: &K, m: u32, g: &[u32]) -> (usize, usize) {
+        let i = key.phash(m) as usize % g.len();
+        let j = key.phash(g[i]) as usize;
+        (i, j)
+    }
+
+    /// Checks if `m` and `g` create a valid perfect hash
+    ///
+    /// If they work, returns a `Vec` of sub-table sizes (for each value
+    /// in `g`).  Otherwise, returns `None`
+    fn check(values: &[(K, V)], m: u32, g: &[u32]) -> Option<Vec<usize>> {
+        // Accumulate un-modded values
+        let mut seen: Vec<HashSet<usize>> = vec![HashSet::default(); g.len()];
+        for (i, j) in values.iter().map(|(k, _v)| Self::id(k, m, g)) {
+            if !seen[i].insert(j) {
+                return None;
+            }
+        }
+        // Every entry in the secondary table must be used
+        if seen.iter().any(|h| h.is_empty()) {
+            return None;
+        }
+        let mut out = vec![];
+        for h in &mut seen {
+            let mut vs = h.iter().map(|v| v % h.len()).collect::<Vec<usize>>();
+            vs.sort_unstable();
+            vs.dedup();
+            if vs.len() != h.len() {
+                return None;
+            }
+            out.push(h.len());
+        }
+        Some(out)
+    }
+
+    /// Attempt to generate a perfect hash for the given input data
+    pub fn build(values: Vec<(K, V)>) -> Result<Self> {
+        if values.iter().map(|v| &v.0).collect::<HashSet<_>>().len()
+            != values.len()
+        {
+            bail!("Cannot build a perfect hash with duplicate keys");
+        }
+
+        const TRY_COUNT: usize = 10_000;
+        let mut rng = ChaCha20Rng::seed_from_u64(0x1de);
+        for slots in 2..16 {
+            for _ in 0..TRY_COUNT {
+                let m: u32 = rng.gen();
+                let mut g = vec![0u32; slots];
+                for g in g.iter_mut() {
+                    *g = rng.gen();
+                }
+                if let Some(sizes) = Self::check(&values, m, &g) {
+                    let mut out = vec![];
+                    for s in &sizes {
+                        out.push((0..*s).map(|_| None).collect::<Vec<_>>());
+                    }
+                    for (k, v) in values.into_iter() {
+                        let (i, j) = Self::id(&k, m, &g);
+                        let j = j % sizes[i];
+                        assert!(out[i][j].is_none());
+                        out[i][j] = Some((k, v));
+                    }
+                    let out = out
+                        .into_iter()
+                        .map(|o| o.into_iter().map(|v| v.unwrap()).collect())
+                        .collect();
+                    return Ok(Self { g, m, values: out });
+                }
+            }
+        }
+
+        bail!("Could not generate perfect hash");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct OwnedSortedList<K, V> {
+    pub values: Vec<(K, V)>,
+}
+
+impl<K, V> OwnedSortedList<K, V>
+where
+    K: Eq + Ord,
+{
+    /// Attempt to generate a perfect hash for the given input data
+    pub fn build(mut values: Vec<(K, V)>) -> Result<Self> {
+        values.sort_by(|x, y| x.0.cmp(&y.0));
+        Ok(Self { values })
     }
 }
 
@@ -94,6 +199,11 @@ mod tests {
         OwnedPerfectHashMap::build(values).unwrap().values.len()
     }
 
+    fn nested_hash<K: PerfectHash + Hash + Eq>(values: Vec<K>) -> usize {
+        let values = values.into_iter().map(|v| (v, ())).collect();
+        OwnedNestedPerfectHashMap::build(values).unwrap().g.len()
+    }
+
     #[test]
     fn small_hash() {
         let values: Vec<U> = vec![36, 51, 13, 14].into_iter().map(U).collect();
@@ -111,6 +221,16 @@ mod tests {
     }
 
     #[test]
+    fn medium_hash_nested() {
+        let values: Vec<U> =
+            vec![36, 51, 85, 61, 31, 32, 33, 34, 72, 73, 95, 96]
+                .into_iter()
+                .map(U)
+                .collect();
+        assert_eq!(nested_hash(values), 2);
+    }
+
+    #[test]
     fn tuple_hash() {
         let values = vec![
             U2(2, 0b1),
@@ -125,6 +245,29 @@ mod tests {
             U2(9, 0b1000),
         ];
         assert!(values.len() + 1 >= hash_slots(values));
+    }
+
+    #[test]
+    fn tuple_hash_nested_smol() {
+        let values = vec![U2(2, 0b1), U2(3, 0b1)];
+        assert_eq!(nested_hash(values), 2);
+    }
+
+    #[test]
+    fn tuple_hash_nested() {
+        let values = vec![
+            U2(2, 0b1),
+            U2(3, 0b1),
+            U2(4, 0b1),
+            U2(5, 0b1),
+            U2(5, 0b11),
+            U2(8, 0b0),
+            U2(9, 0b1),
+            U2(9, 0b10),
+            U2(9, 0b100),
+            U2(9, 0b1000),
+        ];
+        assert_eq!(nested_hash(values), 2);
     }
 
     #[test]

--- a/lib/phash/src/lib.rs
+++ b/lib/phash/src/lib.rs
@@ -23,6 +23,9 @@ impl<'a, K: Copy + PerfectHash + PartialEq, V> PerfectHashMap<'a, K, V> {
     /// not stored in the table.
     #[inline(always)]
     pub fn get(&self, key: K) -> Option<&V> {
+        if self.values.is_empty() {
+            return None;
+        }
         let i = key.phash(self.m) % self.values.len();
         if key == self.values[i].0 {
             Some(&self.values[i].1)
@@ -49,7 +52,13 @@ impl<'a, K: Copy + PerfectHash + PartialEq, V> NestedPerfectHashMap<'a, K, V> {
     /// not stored in the table.
     #[inline(always)]
     pub fn get(&self, key: K) -> Option<&V> {
+        if self.g.is_empty() {
+            return None;
+        }
         let i = key.phash(self.m) % self.g.len();
+        if self.values[i].is_empty() {
+            return None;
+        }
         let j = key.phash(self.g[i]) % self.values[i].len();
         if key == self.values[i][j].0 {
             Some(&self.values[i][j].1)

--- a/lib/phash/src/lib.rs
+++ b/lib/phash/src/lib.rs
@@ -30,6 +30,10 @@ impl<'a, K: Copy + PerfectHash + PartialEq, V> PerfectHashMap<'a, K, V> {
             None
         }
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.values.iter()
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,6 +57,10 @@ impl<'a, K: Copy + PerfectHash + PartialEq, V> NestedPerfectHashMap<'a, K, V> {
             None
         }
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.values.iter().flat_map(|s| s.iter())
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,5 +78,9 @@ impl<'a, K: Copy + PerfectHash + PartialEq + Ord, V> SortedList<'a, K, V> {
             .binary_search_by_key(&key, |v| v.0)
             .ok()
             .map(|i| &self.values[i].1)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.values.iter()
     }
 }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -238,7 +238,17 @@ bitflags::bitflags! {
 
 /// Newtype wrapper for an interrupt index
 #[derive(
-    Copy, Clone, Debug, FromBytes, Serialize, Deserialize, Hash, Eq, PartialEq,
+    Copy,
+    Clone,
+    Debug,
+    FromBytes,
+    Serialize,
+    Deserialize,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
 )]
 #[repr(transparent)]
 pub struct InterruptNum(pub u32);
@@ -251,7 +261,17 @@ impl phash::PerfectHash for InterruptNum {
 /// Struct containing the task which waits for an interrupt, and the expected
 /// notification mask associated with the IRQ.
 #[derive(
-    Copy, Clone, Debug, FromBytes, Serialize, Deserialize, Hash, Eq, PartialEq,
+    Copy,
+    Clone,
+    Debug,
+    FromBytes,
+    Serialize,
+    Deserialize,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
 )]
 pub struct InterruptOwner {
     /// Which task to notify, by index.

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -257,6 +257,14 @@ impl phash::PerfectHash for InterruptNum {
         self.0.wrapping_mul(v) as usize
     }
 }
+impl InterruptNum {
+    pub const fn invalid() -> Self {
+        Self(u32::MAX)
+    }
+    pub fn is_valid(&self) -> bool {
+        self.0 != u32::MAX
+    }
+}
 
 /// Struct containing the task which waits for an interrupt, and the expected
 /// notification mask associated with the IRQ.
@@ -284,6 +292,17 @@ impl phash::PerfectHash for InterruptOwner {
         self.task
             .wrapping_mul(v)
             .wrapping_add(self.notification.wrapping_mul(!v)) as usize
+    }
+}
+impl InterruptOwner {
+    pub const fn invalid() -> Self {
+        Self {
+            task: u32::MAX,
+            notification: 0,
+        }
+    }
+    pub fn is_valid(&self) -> bool {
+        !(self.task == u32::MAX && self.notification == 0)
     }
 }
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -171,7 +171,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
                 "(abi::InterruptNum({}), abi::InterruptOwner {{ task: {}, notification: 0b{:b} }}),",
                 irq.0, owner.task, owner.notification
             ),
-            None => "(abi::InterruptNum(u32::MAX), abi::InterruptOwner { task: u32::MAX, notification: 0 }),"
+            None => "(abi::InterruptNum::invalid(), abi::InterruptOwner::invalid()),"
                 .to_string(),
         }
     };
@@ -186,7 +186,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
                     .join(", ")
             ),
             None => {
-                "(abi::InterruptOwner { task: u32::MAX, notification: 0}, &[]),"
+                "(abi::InterruptOwner::invalid(), &[]),"
                     .to_string()
             }
         }
@@ -261,7 +261,7 @@ pub const HUBRIS_TASK_IRQ_LOOKUP: PerfectHashMap::<abi::InterruptOwner, &'static
                     format!(
                         "&[\n            {}\n        ],",
                         v.iter()
-                            .map(|o| fmt_task_irq(Some(&o)))
+                            .map(|o| fmt_task_irq(o.as_ref()))
                             .collect::<Vec<String>>()
                             .join("\n            ")
                     )
@@ -317,7 +317,7 @@ pub const HUBRIS_IRQ_TASK_LOOKUP: PerfectHashMap::<abi::InterruptNum, abi::Inter
                     format!(
                         "&[\n            {}\n        ],",
                         v.iter()
-                            .map(|o| fmt_irq_task(Some(&o)))
+                            .map(|o| fmt_irq_task(o.as_ref()))
                             .collect::<Vec<String>>()
                             .join("\n            ")
                     )

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -77,12 +77,14 @@ pub unsafe fn start_kernel(tick_divisor: u32) -> ! {
 
     // Finally, check interrupts.
     for (irq, owner) in HUBRIS_IRQ_TASK_LOOKUP.iter() {
-        if irq.0 != u32::MAX {
+        if irq.is_valid() {
+            uassert!(owner.is_valid());
             uassert!(owner.task < tasks.len() as u32);
         }
     }
     for (owner, irqs) in HUBRIS_TASK_IRQ_LOOKUP.iter() {
         if !irqs.is_empty() {
+            uassert!(owner.is_valid());
             uassert!(owner.task < tasks.len() as u32);
         }
     }

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -76,12 +76,12 @@ pub unsafe fn start_kernel(tick_divisor: u32) -> ! {
     }
 
     // Finally, check interrupts.
-    for (irq, owner) in HUBRIS_IRQ_TASK_LOOKUP.values {
+    for (irq, owner) in HUBRIS_IRQ_TASK_LOOKUP.iter() {
         if irq.0 != u32::MAX {
             uassert!(owner.task < tasks.len() as u32);
         }
     }
-    for (owner, irqs) in HUBRIS_TASK_IRQ_LOOKUP.values {
+    for (owner, irqs) in HUBRIS_TASK_IRQ_LOOKUP.iter() {
         if !irqs.is_empty() {
             uassert!(owner.task < tasks.len() as u32);
         }

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -700,13 +700,15 @@ fn irq_control(
     };
 
     let caller = caller as u32;
-    let irqs = crate::arch::get_irqs_by_owner(abi::InterruptOwner {
-        task: caller,
-        notification: bitmask,
-    })
-    .ok_or(UserError::Unrecoverable(FaultInfo::SyscallUsage(
-        UsageError::NoIrq,
-    )))?;
+
+    let irqs = crate::startup::HUBRIS_TASK_IRQ_LOOKUP
+        .get(abi::InterruptOwner {
+            task: caller,
+            notification: bitmask,
+        })
+        .ok_or(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            UsageError::NoIrq,
+        )))?;
     for i in irqs.iter() {
         operation(i.0);
     }


### PR DESCRIPTION
This PR improves on IRQ perfect hashing in a few ways:

- Moves the choice of using a perfect hash table or a flat list to the build
  system, to reduce the amount of chip-specific logic in the kernel.
- Modifies the flat IRQ list to use binary search instead of iteration.
- Adds a fallback to two-level perfect hash tables if we fail to generate
  a single-level table.  This happens with large numbers of IRQs (> 50), which
  we may reach!
- Adds abstractions for invalid `InteruptNum` and `InteruptOwner`, then uses
  those abstractions instead of checking manually.
- Fixes a potential kernel crash if a task asks to reset an interrupt but the
  tables are completely empty.