### PR TITLE
Clean up taskdesc and index handling

### DIFF
--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -364,7 +364,7 @@ pub struct Task {
     pub path: PathBuf,
     pub name: String,
     pub requires: IndexMap<String, u32>,
-    pub priority: u32,
+    pub priority: u8,
     pub stacksize: Option<u32>,
     #[serde(default)]
     pub uses: Vec<String>,

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1327,7 +1327,6 @@ pub fn make_kconfig(
         base: 0,
         size: 32, // smallest legal size on ARMv7-M
         attributes: abi::RegionAttributes::empty(), // no rights
-        reserved_zero: 0,
     });
 
     // Regions 1.. are the fixed peripheral regions, shared by tasks that
@@ -1373,7 +1372,6 @@ pub fn make_kconfig(
             base: p.address,
             size: p.size,
             attributes,
-            reserved_zero: 0,
         });
     }
 
@@ -1392,7 +1390,6 @@ pub fn make_kconfig(
             base: p.address,
             size: p.size,
             attributes,
-            reserved_zero: 0,
         });
     }
 
@@ -1447,7 +1444,6 @@ pub fn make_kconfig(
                 base: range.start,
                 size: range.end - range.start,
                 attributes,
-                reserved_zero: 0,
             });
         }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1474,6 +1474,7 @@ pub fn make_kconfig(
                 + task.stacksize.or(toml.stacksize).unwrap(),
             priority: task.priority,
             flags,
+            index: u16::try_from(i).expect("more than 2**16 tasks?"),
         });
 
         // Interrupts.

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -146,12 +146,24 @@ pub struct TaskDesc {
     pub priority: u8,
     /// Collection of boolean flags controlling task behavior.
     pub flags: TaskFlags,
+    /// Index of this task within the task table.
+    ///
+    /// This field is here as an optimization for the kernel entry sequences. It
+    /// can contain an invalid index if you create an arbitrary invalid
+    /// `TaskDesc`; this will cause the kernel to behave strangely (if the index
+    /// is in range for the task table) or panic predictably (if not), but won't
+    /// violate safety. The build system is careful to generate correct indices
+    /// here.
+    ///
+    /// The index is a u16 to save space in the `TaskDesc` struct; in practice
+    /// other factors limit us to fewer than `2**16` tasks.
+    pub index: u16,
 }
 
 bitflags::bitflags! {
     #[derive(FromBytes, Serialize, Deserialize)]
     #[repr(transparent)]
-    pub struct TaskFlags: u16 {
+    pub struct TaskFlags: u8 {
         const START_AT_BOOT = 1 << 0;
         const RESERVED = !1;
     }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -123,36 +123,8 @@ impl Priority {
     }
 }
 
-/// Application header, read by the kernel to load the application.
-///
-/// One copy of this appears in Flash next to the kernel, with the other types
-/// of records following immediately.
-#[derive(Clone, Debug, FromBytes)]
-#[repr(C)]
-pub struct App {
-    /// Reassures the kernel that it is dealing with this kind of an app struct.
-    /// Should have the value `CURRENT_APP_MAGIC`.
-    pub magic: u32,
-    /// Number of tasks. This many `TaskDesc` records will immediately follow
-    /// the `RegionDesc` records that follow the app header.
-    pub task_count: u32,
-    /// Number of memory regions in the address space layout. This many
-    /// `RegionDesc` records will immediately follow the app header.
-    pub region_count: u32,
-    /// Number of interrupt response records that will follow the `RegionDesc`
-    /// records.
-    pub irq_count: u32,
-    /// Bitmask to post to task 0 when any task faults.
-    pub fault_notification: u32,
-
-    /// Reserved expansion space; pads this structure out to 32 bytes. You will
-    /// need to adjust this when you add fields above.
-    pub zeroed_expansion_space: [u8; 32 - (5 * 4)],
-}
-
 /// Record describing a single task.
 #[derive(Clone, Debug, FromBytes, Serialize, Deserialize)]
-#[repr(C)]
 pub struct TaskDesc {
     /// Identifies memory regions this task has access to, by index in the
     /// `RegionDesc` table. If the task needs fewer than `REGIONS_PER_TASK`
@@ -171,7 +143,7 @@ pub struct TaskDesc {
     /// regions (the kernel *will* check this).
     pub initial_stack: u32,
     /// Initial priority of this task.
-    pub priority: u32,
+    pub priority: u8,
     /// Collection of boolean flags controlling task behavior.
     pub flags: TaskFlags,
 }
@@ -179,7 +151,7 @@ pub struct TaskDesc {
 bitflags::bitflags! {
     #[derive(FromBytes, Serialize, Deserialize)]
     #[repr(transparent)]
-    pub struct TaskFlags: u32 {
+    pub struct TaskFlags: u16 {
         const START_AT_BOOT = 1 << 0;
         const RESERVED = !1;
     }
@@ -195,7 +167,6 @@ bitflags::bitflags! {
 /// two regions pointing to the same area of the address space, but one
 /// read-only and the other read-write.
 #[derive(Clone, Debug, FromBytes, Serialize, Deserialize)]
-#[repr(C)]
 pub struct RegionDesc {
     /// Address of start of region. The platform likely has alignment
     /// requirements for this; it must meet them. (For example, on ARMv7-M, it
@@ -207,8 +178,6 @@ pub struct RegionDesc {
     pub size: u32,
     /// Flags describing what can be done with this region.
     pub attributes: RegionAttributes,
-    /// Reserved word, must be zero.
-    pub reserved_zero: u32,
 }
 
 bitflags::bitflags! {

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -91,6 +91,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
         writeln!(file, "        entry_point: {:#010x},", task.entry_point)?;
         writeln!(file, "        initial_stack: {:#010x},", task.initial_stack)?;
         writeln!(file, "        priority: {},", task.priority)?;
+        writeln!(file, "        index: {},", task.index)?;
         writeln!(
             file,
             "        flags: unsafe {{ \

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -131,7 +131,6 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
             abi::RegionAttributes::from_bits_unchecked({}) }},",
             region.attributes.bits()
         )?;
-        writeln!(file, "        reserved_zero: 0,")?;
         writeln!(file, "    }},")?;
     }
     writeln!(file, "];")?;

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1164,11 +1164,13 @@ unsafe extern "C" fn pendsv_entry() {
     let current = unsafe { CURRENT_TASK_PTR }
         .expect("irq before kernel started?")
         .as_ptr();
-    with_task_table(|tasks| {
-        let idx = (current as usize - tasks.as_ptr() as usize)
-            / core::mem::size_of::<task::Task>();
 
-        let next = task::select(idx, tasks);
+    // Safety: we're dereferencing the current task pointer, which we're
+    // trusting the rest of this module to maintain correctly.
+    let current = usize::from(unsafe { (*current).descriptor().index });
+
+    with_task_table(|tasks| {
+        let next = task::select(current, tasks);
         let next = &mut tasks[next];
         apply_memory_protection(next);
         // Safety: next comes from the task table and we don't use it again
@@ -1474,10 +1476,17 @@ bitflags::bitflags! {
 #[cfg(armv6m)]
 unsafe extern "C" fn handle_fault(task: *mut task::Task) {
     // Who faulted?
-    // Safety: we're dereferencing the task pointer, because we trust the
-    // assembly fault handler to pass us a legitimate one. We use it immediately
-    // and discard it because otherwise it would alias the task table below.
-    let from_thread_mode = unsafe { (*task).save().exc_return & 0b1000 != 0 };
+    let (from_thread_mode, idx) = {
+        // Safety: we're dereferencing the task pointer, because we trust the
+        // assembly fault handler to pass us a legitimate one. We use it
+        // immediately and discard it because otherwise it would alias the task
+        // table below.
+        let t = unsafe { &(*task) };
+        (
+            t.save().exc_return & 0b1000 != 0,
+            usize::from(t.descriptor().index),
+        )
+    };
 
     if !from_thread_mode {
         // Uh. This fault originates from the kernel. We don't get fault
@@ -1491,9 +1500,6 @@ unsafe extern "C" fn handle_fault(task: *mut task::Task) {
     // We are now going to force a fault on our current task and directly
     // switch to a task to run.
     with_task_table(|tasks| {
-        let idx = (task as usize - tasks.as_ptr() as usize)
-            / core::mem::size_of::<task::Task>();
-
         let next = match task::force_fault(tasks, idx, fault) {
             task::NextTask::Specific(i) => i,
             task::NextTask::Other => task::select(idx, tasks),
@@ -1550,9 +1556,13 @@ unsafe extern "C" fn handle_fault(
     // contract requires that it be valid. We immediately throw away the result
     // of dereferencing it, as it would otherwise alias the task table obtained
     // later.
-    let (exc_return, psp) = unsafe {
-        let s = (*task).save();
-        (s.exc_return, s.psp)
+    let (exc_return, psp, idx) = unsafe {
+        let t = &(*task);
+        (
+            t.save().exc_return,
+            t.save().psp,
+            usize::from(t.descriptor().index),
+        )
     };
     let from_thread_mode = exc_return & 0b1000 != 0;
 
@@ -1663,9 +1673,6 @@ unsafe extern "C" fn handle_fault(
     // when returning from an exception with a PSP that generates an MPU
     // fault!)
     with_task_table(|tasks| {
-        let idx = (task as usize - tasks.as_ptr() as usize)
-            / core::mem::size_of::<task::Task>();
-
         let next = match task::force_fault(tasks, idx, fault) {
             task::NextTask::Specific(i) => i,
             task::NextTask::Other => task::select(idx, tasks),

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -836,15 +836,16 @@ pub unsafe extern "C" fn SVCall() {
                     ldr r0, =CURRENT_TASK_PTR
                     ldr r1, [r0]
                     @ now, store volatile registers, plus the PSP, plus LR.
-                    stm r1!, {{r4-r7}}
+                    movs r2, r1
+                    stm r2!, {{r4-r7}}
                     mov r4, r8
                     mov r5, r9
                     mov r6, r10
                     mov r7, r11
-                    stm r1!, {{r4-r7}}
+                    stm r2!, {{r4-r7}}
                     mrs r4, PSP
                     mov r5, lr
-                    stm r1!, {{r4, r5}}
+                    stm r2!, {{r4, r5}}
 
                     @ syscall number is passed in r11. Move it into r0 to pass
                     @ it as an argument to the handler, then call the handler.
@@ -909,12 +910,13 @@ pub unsafe extern "C" fn SVCall() {
                     movw r0, #:lower16:CURRENT_TASK_PTR
                     movt r0, #:upper16:CURRENT_TASK_PTR
                     ldr r1, [r0]
+                    movs r2, r1
                     @ fetch the process-mode stack pointer.
                     @ fetching into r12 means the order in the stm below is right.
                     mrs r12, PSP
                     @ now, store volatile registers, plus the PSP in r12, plus LR.
-                    stm r1!, {{r4-r12, lr}}
-                    vstm r1, {{s16-s31}}
+                    stm r2!, {{r4-r12, lr}}
+                    vstm r2, {{s16-s31}}
 
                     @ syscall number is passed in r11. Move it into r0 to pass it as
                     @ an argument to the handler, then call the handler.
@@ -1389,9 +1391,6 @@ pub unsafe extern "C" fn HardFault() {
             mrs r4, PSP
             mov r5, lr
             stm r2!, {{r4, r5}}
-
-            @ armv6m only has one fault, and it's number three.
-            movs r1, #3
 
             bl handle_fault
 

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -59,7 +59,7 @@ impl Task {
         region_table: &'static [&'static RegionDesc],
     ) -> Self {
         Task {
-            priority: abi::Priority(descriptor.priority as u8),
+            priority: abi::Priority(descriptor.priority),
             state: if descriptor.flags.contains(TaskFlags::START_AT_BOOT) {
                 TaskState::Healthy(SchedState::Runnable)
             } else {


### PR DESCRIPTION
This cleans up some cruft in the abi crate, but the biggest part of the change is best summarized by the message of the top commit:

---

    kern: add task index to TaskDesc instead of computing
    
    From time immemorial, the kernel has computed the task index of the
    current task during the syscall/ISR entry sequences using a subtraction
    and a division. This is problematic on ARMv6-M, where hardware division
    is unavailable.
    
    This commit applies mkeeter's idea of just stashing a task index in the
    TaskDesc. By adjusting the size of some existing fields that had room to
    spare, this doesn't even make the TaskDesc larger.
    
    This knocks 6% or 600+ bytes off the STM32G0 kernel by removing the last
    use of division, and should take hundreds of cycles off the Cortex-M0
    syscall and interrupt latency.
    
    Interestingly it also makes the M7 kernel smaller, by removing a panic
    path: the old index computation code could panic on subtraction
    underflow if the task address was lower than the start of the task
    table, and contained code to handle this case at runtime.
