### PR TITLE
Build crates by name instead of path

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -186,7 +186,6 @@ peripherals would read
 
 ```toml
 [tasks.name_for_task_in_this_image]
-path = "../my-task-directory"
 name = "my-task-target-name"
 priority = 1
 requires = {flash = 1024, ram = 1024}

--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32f3"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "demo-stm32f4-discovery"
 requires = {flash = 20000, ram = 3072}
 #
@@ -34,7 +33,6 @@ write = true
 execute = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -43,7 +41,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.rcc_driver]
-path = "../../drv/stm32fx-rcc"
 name = "drv-stm32fx-rcc"
 features = ["f3"]
 priority = 1
@@ -52,7 +49,6 @@ uses = ["rcc"]
 start = true
 
 [tasks.usart_driver]
-path = "../../drv/stm32fx-usart"
 name = "drv-stm32fx-usart"
 features = ["stm32f3"]
 priority = 2
@@ -63,7 +59,6 @@ interrupts = {"usart2.irq" = 1}
 task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32f3"]
 priority = 2
@@ -73,7 +68,6 @@ start = true
 task-slots = ["rcc_driver"]
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 4
@@ -83,7 +77,6 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
@@ -91,7 +84,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 3
 requires = {flash = 16384, ram = 16384 }
@@ -99,7 +91,6 @@ stacksize = 2048
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32f4"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "demo-stm32f4-discovery"
 requires = {flash = 20000, ram = 3072}
 #
@@ -34,7 +33,6 @@ write = true
 execute = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -43,7 +41,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.rcc_driver]
-path = "../../drv/stm32fx-rcc"
 name = "drv-stm32fx-rcc"
 features = ["f4"]
 priority = 1
@@ -52,7 +49,6 @@ uses = ["rcc"]
 start = true
 
 [tasks.usart_driver]
-path = "../../drv/stm32fx-usart"
 name = "drv-stm32fx-usart"
 features = ["stm32f4"]
 priority = 2
@@ -63,7 +59,6 @@ interrupts = {"usart2.irq" = 1}
 task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
@@ -73,7 +68,6 @@ start = true
 task-slots = ["rcc_driver"]
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 4
@@ -83,7 +77,6 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
@@ -91,7 +84,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 3
 requires = {flash = 16384, ram = 16384 }
@@ -99,7 +91,6 @@ stacksize = 2048
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}

--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -4,7 +4,6 @@ chip = "../../chips/stm32g0"
 board = "stm32g031"
 
 [kernel]
-path = "."
 name = "demo-stm32g0-nucleo"
 requires = {flash = 11702, ram = 1536}
 features = ["g031", "panic-halt"]
@@ -24,7 +23,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 4096, ram = 512}
@@ -33,7 +31,6 @@ features = ["log-null"]
 stacksize = 368
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 priority = 1
 requires = {flash = 2048, ram = 256}
@@ -43,7 +40,6 @@ features = ["g031"]
 stacksize = 256
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 4
 requires = {flash = 1024, ram = 256}
@@ -52,7 +48,6 @@ task-slots = ["user_leds"]
 stacksize = 256
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32g0"]
 priority = 3
@@ -62,7 +57,6 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 4
 requires = {flash = 8192, ram = 2048}
@@ -72,7 +66,6 @@ stacksize = 912
 features = ["stm32g0", "gpio", "micro"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 64}

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -5,7 +5,6 @@ board = "stm32g070"
 stacksize = 944
 
 [kernel]
-path = "."
 name = "demo-stm32g0-nucleo"
 requires = {flash = 12000, ram = 2000}
 features = ["g070", "panic-halt"]
@@ -25,7 +24,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 4096, ram = 512}
@@ -34,7 +32,6 @@ features = ["log-null"]
 stacksize = 352
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["g070"]
 priority = 1
@@ -44,7 +41,6 @@ start = true
 stacksize = 256
 
 [tasks.usart_driver]
-path = "../../drv/stm32g0-usart"
 name = "drv-stm32g0-usart"
 features = ["g070"]
 priority = 2
@@ -56,7 +52,6 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
@@ -66,7 +61,6 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 256}
@@ -75,7 +69,6 @@ task-slots = ["user_leds"]
 stacksize = 256
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 4
@@ -85,14 +78,12 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 3
 requires = {flash = 8192, ram = 8192 }
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 64}

--- a/app/demo-stm32g0-nucleo/app-g0b1.toml.noworky
+++ b/app/demo-stm32g0-nucleo/app-g0b1.toml.noworky
@@ -4,7 +4,6 @@ board = "stm32g0b1"
 stacksize = 944
 
 [kernel]
-path = "."
 name = "demo-stm32g0-nucleo"
 requires = {flash = 17872, ram = 1984}
 features = ["g0b1", "panic-halt"]
@@ -24,7 +23,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 4096, ram = 512}
@@ -33,7 +31,6 @@ features = ["log-null"]
 stacksize = 352
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["g0b1"]
 priority = 1
@@ -43,7 +40,6 @@ start = true
 stacksize = 256
 
 [tasks.usart_driver]
-path = "../../drv/stm32g0-usart"
 name = "drv-stm32g0-usart"
 features = ["g0b1"]
 priority = 2
@@ -55,7 +51,6 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
@@ -65,7 +60,6 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 256}
@@ -74,7 +68,6 @@ task-slots = ["user_leds"]
 stacksize = 256
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 4
@@ -84,14 +77,12 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 3
 requires = {flash = 8192, ram = 8192 }
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 64}

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "demo-stm32h7-nucleo"
 requires = {flash = 22000, ram = 4096}
 
@@ -48,7 +47,6 @@ dma = true
 
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -57,7 +55,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h743"]
 priority = 1
@@ -66,7 +63,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
@@ -80,7 +76,6 @@ task-slots = ["sys"]
 "i2c2.error" = 0b0000_0010
 
 [tasks.spi_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -95,7 +90,6 @@ task-slots = ["sys"]
 global_config = "spi1"
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 2
@@ -108,7 +102,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -117,7 +110,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = []
 priority = 4
@@ -126,7 +118,6 @@ start = true
 task-slots = [{peer = "pong"}]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
@@ -134,7 +125,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.uartecho]
-path = "../../task/uartecho"
 name = "task-uartecho"
 features = ["stm32h743", "usart3"]
 uses = ["usart3"]
@@ -146,7 +136,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 3
 requires = {flash = 16384, ram = 8192}
@@ -155,7 +144,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "spi", "rng"]
 priority = 4
@@ -165,7 +153,6 @@ start = true
 task-slots = ["sys", "i2c_driver", "rng_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
@@ -174,7 +161,6 @@ start = true
 
 [tasks.rng_driver]
 features = ["h743"]
-path = "../../drv/stm32h7-rng"
 priority = 3
 name = "drv-stm32h7-rng"
 requires = {flash = 8192, ram = 512}

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "demo-stm32h7-nucleo"
 requires = {flash = 22000, ram = 5120}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753"]
 priority = 2
@@ -77,7 +73,6 @@ task-slots = ["sys"]
 "i2c2.error" = 0b0000_0010
 
 [tasks.spi_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -92,7 +87,6 @@ task-slots = ["sys"]
 global_config = "spi1"
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 2
@@ -105,7 +99,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -114,7 +107,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = []
 priority = 4
@@ -123,7 +115,6 @@ start = true
 task-slots = [{peer = "pong"}]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
@@ -131,7 +122,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 3
 requires = {flash = 32768, ram = 8192}
@@ -140,7 +130,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
@@ -150,7 +139,6 @@ start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 
 [tasks.hf]
-path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
@@ -162,7 +150,6 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.hash_driver]
-path = "../../drv/stm32h7-hash-server"
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
@@ -174,7 +161,6 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 6
 requires = {flash = 128, ram = 256}
@@ -183,7 +169,6 @@ start = true
 
 [tasks.rng_driver]
 features = ["h753"]
-path = "../../drv/stm32h7-rng"
 priority = 3
 name = "drv-stm32h7-rng"
 requires = {flash = 8192, ram = 512}

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/lpc55"
 stacksize = 1024
 
 [kernel]
-path = "."
 name = "gemini-bu-rot"
 requires = {flash = 21504, ram = 4096}
 features = ["itm"]
@@ -20,7 +19,6 @@ priv-key = "../../support/fake_certs/fake_private_key.pem"
 root-cert = "../../support/fake_certs/fake_certificate.der.crt"
 
 [bootloader]
-path = "../../stage0"
 name = "stage0"
 # Currently we have the first 0x8000 of flash and first 0x4000 of RAM
 # dedicated for the stage0 bootloader and the rest for Hubris. Once we have
@@ -56,7 +54,6 @@ write = true
 execute = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -65,7 +62,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 7
 requires = {flash = 128, ram = 256}
@@ -73,7 +69,6 @@ stacksize = 256
 start = true
 
 [tasks.syscon_driver]
-path = "../../drv/lpc55-syscon"
 name = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 8192, ram = 2048}
@@ -81,7 +76,6 @@ uses = ["syscon", "anactrl", "pmc"]
 start = true
 
 [tasks.gpio_driver]
-path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -90,7 +84,6 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["lpc55"]
 priority = 4
@@ -99,7 +92,6 @@ start = true
 task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
-path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
 priority = 4
 requires = {flash = 8192, ram = 2048}
@@ -115,7 +107,6 @@ pins = [
 ]
 
 [tasks.rng_driver]
-path = "../../drv/lpc55-rng"
 name = "drv-lpc55-rng"
 priority = 3
 requires = {flash = 16384, ram = 4096}
@@ -125,7 +116,6 @@ stacksize = 2200
 task-slots = ["syscon_driver"]
 
 [tasks.spi0_driver]
-path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 4
 requires = {flash = 16384, ram = 2048}
@@ -149,7 +139,6 @@ pins = [
 ]
 
 [tasks.swd]
-path = "../../drv/lpc55-swd"
 name = "drv-lpc55-swd"
 priority = 4
 requires = {flash = 16384, ram = 4096}
@@ -182,7 +171,6 @@ pins = [
 spi_num = 3
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 6
@@ -191,7 +179,6 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 5
 requires = {flash = 8192, ram = 1024}
@@ -199,7 +186,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "spi", "spctrl"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gemini-bu"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -45,7 +43,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -54,7 +51,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -72,7 +68,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-path = "../../task/spd"
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 3
@@ -86,7 +81,6 @@ task-slots = ["sys", "i2c_driver"]
 "i2c2.error" = 0b0000_0010
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -101,7 +95,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.spi4_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -116,7 +109,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -125,7 +117,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
@@ -133,7 +124,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.hf]
-path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
@@ -145,7 +135,6 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.hash_driver]
-path = "../../drv/stm32h7-hash-server"
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
@@ -157,7 +146,6 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
@@ -167,7 +155,6 @@ start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 
 [tasks.validate]
-path = "../../task/validate"
 name = "task-validate"
 priority = 3
 requires = {flash = 8192, ram = 4096 }
@@ -176,7 +163,6 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 6
 requires = {flash = 128, ram = 256}

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/lpc55"
 stacksize = 1024
 
 [kernel]
-path = "."
 name = "gimlet-rot"
 requires = {flash = 32768, ram = 3072}
 features = ["itm"]
@@ -29,7 +28,6 @@ write = true
 execute = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -38,7 +36,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "spctrl"]
@@ -48,7 +45,6 @@ start = true
 task-slots = ["gpio_driver", "swd"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 6
 requires = {flash = 128, ram = 256}
@@ -56,7 +52,6 @@ stacksize = 256
 start = true
 
 [tasks.syscon_driver]
-path = "../../drv/lpc55-syscon"
 name = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 8192, ram = 2048}
@@ -64,7 +59,6 @@ uses = ["syscon", "anactrl", "pmc"]
 start = true
 
 [tasks.gpio_driver]
-path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -73,7 +67,6 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.usart_driver]
-path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
 priority = 4
 requires = {flash = 8192, ram = 2048}
@@ -89,7 +82,6 @@ pins = [
 ]
 
 [tasks.spi0_driver]
-path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 4
 requires = {flash = 16384, ram = 2048}
@@ -113,7 +105,6 @@ pins = [
 ]
 
 [tasks.swd]
-path = "../../drv/lpc55-swd"
 name = "drv-lpc55-swd"
 priority = 4
 requires = {flash = 16384, ram = 4096}

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -78,7 +74,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -93,7 +88,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -111,7 +105,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-path = "../../task/spd"
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 2
@@ -125,7 +118,6 @@ task-slots = ["sys", "i2c_driver"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-path = "../../task/thermal"
 name = "task-thermal"
 features = ["itm", "h753", "gimlet"]
 priority = 5
@@ -135,7 +127,6 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.power]
-path = "../../task/power"
 name = "task-power"
 features = ["itm", "h753"]
 priority = 5
@@ -145,7 +136,6 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 5
@@ -155,7 +145,6 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
-path = "../../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
@@ -169,7 +158,6 @@ fpga_image = "fpga.bin"
 register_defs = "gimlet_regs.json"
 
 [tasks.hf]
-path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
@@ -181,7 +169,6 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 5
@@ -196,7 +183,6 @@ task-slots = ["sys",
               { seq = "gimlet_seq" }]
 
 [tasks.sensor]
-path = "../../task/sensor"
 name = "task-sensor"
 features = ["itm"]
 priority = 3
@@ -205,7 +191,6 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 6
 requires = {flash = 16384, ram = 8192}
@@ -214,7 +199,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.udpbroadcast]
-path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
 priority = 6
 requires = {flash = 16384, ram = 8192}
@@ -223,7 +207,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.validate]
-path = "../../task/validate"
 name = "task-validate"
 priority = 3
 requires = {flash = 8192, ram = 4096 }
@@ -232,7 +215,6 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 7
 requires = {flash = 128, ram = 256}

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 5400
 priority = 5
@@ -67,7 +64,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, { seq = "gimlet_seq" }]
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -76,7 +72,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 3
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +86,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 3
 requires = {flash = 16384, ram = 2048}
@@ -106,7 +100,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 3
@@ -124,7 +117,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-path = "../../task/spd"
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 2
@@ -138,7 +130,6 @@ task-slots = ["sys", "i2c_driver"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-path = "../../task/thermal"
 name = "task-thermal"
 features = ["itm", "h753", "gimlet"]
 priority = 5
@@ -148,7 +139,6 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.power]
-path = "../../task/power"
 name = "task-power"
 features = ["itm", "h753"]
 priority = 6
@@ -158,7 +148,6 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 5
@@ -168,7 +157,6 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
-path = "../../drv/gimlet-seq-server"
 name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
@@ -182,7 +170,6 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet_regs.json"
 
 [tasks.hf]
-path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
@@ -194,7 +181,6 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.sensor]
-path = "../../task/sensor"
 name = "task-sensor"
 features = ["itm"]
 priority = 4
@@ -203,7 +189,6 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 6
 requires = {flash = 16384, ram = 8192}
@@ -213,7 +198,6 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
 priority = 6
 requires = {flash = 16384, ram = 8192}
@@ -223,7 +207,6 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.validate]
-path = "../../task/validate"
 name = "task-validate"
 priority = 5
 requires = {flash = 8192, ram = 4096 }
@@ -232,7 +215,6 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 7
 requires = {flash = 128, ram = 256}

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 1024
 
 [kernel]
-path = "."
 name = "gimletlet"
 requires = {flash = 32768, ram = 4096}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
@@ -78,7 +74,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -87,7 +82,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "gpio", "spi"]
 priority = 3
@@ -97,7 +91,6 @@ start = true
 task-slots = ["sys", "user_leds"]
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 3
@@ -110,7 +103,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", "user_leds", { spi_driver = "spi2_driver" }]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 4
 requires = {flash = 16384, ram = 8192}
@@ -119,7 +111,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gimletlet"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -45,7 +43,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -54,7 +51,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -70,7 +66,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spi4_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -85,7 +80,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -94,7 +88,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
@@ -104,7 +97,6 @@ start = true
 task-slots = ["sys", "i2c_driver", "user_leds"]
 
 [tasks.vsc7448]
-path = "../../task/vsc7448"
 name = "task-vsc7448"
 priority = 3
 requires = {flash = 131072, ram = 4096}
@@ -114,7 +106,6 @@ start = true
 task-slots = ["sys", "user_leds", { spi_driver = "spi4_driver" }]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gimletlet"
 requires = {flash = 32768, ram = 8192}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -81,7 +77,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spi_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -96,7 +91,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -105,7 +99,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
@@ -113,7 +106,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.uartecho]
-path = "../../task/uartecho"
 name = "task-uartecho"
 features = ["stm32h743", "usart2"]
 uses = ["usart2"]
@@ -125,7 +117,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "rng", "update"]
 priority = 4
@@ -135,7 +126,6 @@ start = true
 task-slots = ["hf", "sys", "i2c_driver", "user_leds", "rng_driver", "update_server"]
 
 [tasks.hf]
-path = "../../drv/gimlet-hf-server"
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
@@ -147,7 +137,6 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 4320
 priority = 3
@@ -160,7 +149,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", "spi_driver" ]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 4
 requires = {flash = 8192, ram = 8192}
@@ -170,7 +158,6 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.validate]
-path = "../../task/validate"
 name = "task-validate"
 priority = 3
 requires = {flash = 32768, ram = 4096}
@@ -179,7 +166,6 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
@@ -188,7 +174,6 @@ start = true
 
 [tasks.rng_driver]
 features = ["h753"]
-path = "../../drv/stm32h7-rng"
 name = "drv-stm32h7-rng"
 priority = 3
 requires = {flash = 8192, ram = 512}
@@ -198,7 +183,6 @@ stacksize = 256
 task-slots = ["sys", "user_leds"]
 
 [tasks.update_server]
-path = "../../drv/stm32h7-update-server"
 name = "stm32h7-update-server"
 priority = 3
 requires = {flash = 8192, ram = 4096}

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -6,7 +6,6 @@ stacksize = 1024
 secure-separation = true
 
 [kernel]
-path = "."
 name = "lpc55xpresso"
 requires = {flash = 32768, ram = 4096}
 features = ["itm"]
@@ -47,7 +46,6 @@ priv-key = "../../support/fake_certs/fake_private_key.pem"
 root-cert = "../../support/fake_certs/fake_certificate.der.crt"
 
 [bootloader]
-path = "../../stage0"
 name = "stage0"
 # Currently we have the first 0x8000 of flash and first 0x4000 of RAM
 # dedicated for the stage0 bootloader and the rest for Hubris. Once we have
@@ -59,7 +57,6 @@ imagea-ram-size = 0x18000
 features = ["tz_support"]
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -68,7 +65,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "rng"]
@@ -78,7 +74,6 @@ start = true
 task-slots = ["gpio_driver", "rng_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 7
 requires = {flash = 256, ram = 256}
@@ -86,7 +81,6 @@ stacksize = 256
 start = true
 
 [tasks.syscon_driver]
-path = "../../drv/lpc55-syscon"
 name = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 8192, ram = 2048}
@@ -95,7 +89,6 @@ start = true
 stacksize = 1000
 
 [tasks.gpio_driver]
-path = "../../drv/lpc55-gpio"
 name = "drv-lpc55-gpio"
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -105,7 +98,6 @@ stacksize = 1000
 task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["lpc55"]
 priority = 4
@@ -115,7 +107,6 @@ stacksize = 1000
 task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
-path = "../../drv/lpc55-usart"
 name = "drv-lpc55-usart"
 priority = 4
 requires = {flash = 8192, ram = 2048}
@@ -132,7 +123,6 @@ pins = [
 ]
 
 [tasks.i2c_driver]
-path = "../../drv/lpc55-i2c"
 name = "drv-lpc55-i2c"
 priority = 4
 requires = {flash = 8192, ram = 2048}
@@ -142,7 +132,6 @@ stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
-path = "../../drv/lpc55-rng"
 name = "drv-lpc55-rng"
 priority = 3
 requires = {flash = 16384, ram = 4096}
@@ -152,7 +141,6 @@ stacksize = 2200
 task-slots = ["syscon_driver"]
 
 [tasks.spi0_driver]
-path = "../../drv/lpc55-spi-server"
 name = "drv-lpc55-spi-server"
 priority = 4
 requires = {flash = 16384, ram = 2048}
@@ -176,7 +164,6 @@ pins = [
 ]
 
 [tasks.ping]
-path = "../../task/ping"
 name = "task-ping"
 features = ["uart"]
 priority = 6
@@ -186,7 +173,6 @@ stacksize = 512
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 5
 requires = {flash = 8192, ram = 2048}

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "psc"
 requires = {flash = 32768, ram = 4096}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -78,7 +74,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -93,7 +88,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -111,7 +105,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
@@ -121,7 +114,6 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 3
@@ -134,7 +126,6 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 4
 requires = {flash = 16384, ram = 8192}
@@ -143,7 +134,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.eeprom]
-path = "../../drv/eeprom"
 name = "drv-eeprom"
 priority = 3
 requires = {flash = 2048, ram = 256}
@@ -152,7 +142,6 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "sidecar"
 requires = {flash = 32768, ram = 4096}
 #
@@ -45,7 +44,6 @@ write = true
 dma = true
 
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
@@ -54,7 +52,6 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -63,7 +60,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi2_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -78,7 +74,6 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.spi3_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
@@ -93,7 +88,6 @@ task-slots = ["sys"]
 global_config = "spi3"
 
 [tasks.spi5_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -108,7 +102,6 @@ task-slots = ["sys"]
 global_config = "spi5"
 
 [tasks.net]
-path = "../../task/net"
 name = "task-net"
 stacksize = 3800
 priority = 4
@@ -123,7 +116,6 @@ task-slots = ["sys",
               { seq = "sidecar_seq" }]
 
 [tasks.udpecho]
-path = "../../task/udpecho"
 name = "task-udpecho"
 priority = 5
 requires = {flash = 16384, ram = 8192}
@@ -132,7 +124,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.udpbroadcast]
-path = "../../task/udpbroadcast"
 name = "task-udpbroadcast"
 priority = 5
 requires = {flash = 16384, ram = 8192}
@@ -141,7 +132,6 @@ start = true
 task-slots = ["net"]
 
 [tasks.vsc7448]
-path = "../../task/vsc7448"
 name = "task-vsc7448"
 priority = 5
 requires = {flash = 131072, ram = 8192}
@@ -153,7 +143,6 @@ task-slots = ["sys", "net",
               { seq = "sidecar_seq" }]
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -173,7 +162,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "spi", "stm32h7", "itm", "i2c", "gpio"]
 priority = 3
@@ -183,7 +171,6 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 
 [tasks.sensor]
-path = "../../task/sensor"
 name = "task-sensor"
 features = ["itm"]
 priority = 3
@@ -192,7 +179,6 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.sidecar_seq]
-path = "../../drv/sidecar-seq-server"
 name = "drv-sidecar-seq-server"
 features = ["h753"]
 priority = 3
@@ -202,7 +188,6 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 6
 requires = {flash = 128, ram = 256}

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -62,9 +62,10 @@ pub fn run(
                     ("HUBRIS_KCONFIG", &kconfig),
                     ("HUBRIS_IMAGE_ID", "1234"), // dummy image ID
                 ],
+                None,
             )
         } else {
-            toml.task_build_config(name, verbose).unwrap()
+            toml.task_build_config(name, verbose, None).unwrap()
         };
         let mut cmd = build_config.cmd("clippy");
 

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use crate::config::Config;
 
@@ -15,10 +15,6 @@ pub fn run(
     options: &[String],
 ) -> Result<()> {
     let toml = Config::from_file(&cfg)?;
-
-    let src_dir = cfg
-        .parent()
-        .ok_or_else(|| anyhow!("Could not get src dir"))?;
 
     if tasks.is_empty() {
         bail!("Must provide one or more task names");
@@ -31,11 +27,11 @@ pub fn run(
     }
 
     for (i, name) in tasks.iter().enumerate() {
-        let (task_name, path) = if name == "kernel" {
-            ("kernel", &toml.kernel.path)
+        let crate_name = if name == "kernel" {
+            "kernel"
         } else {
             let task_toml = &toml.tasks[name];
-            (task_toml.name.as_str(), &task_toml.path)
+            task_toml.name.as_str()
         };
         if tasks.len() > 1 {
             if i > 0 {
@@ -43,7 +39,7 @@ pub fn run(
             }
             println!(
                 "================== {} [{}] ==================",
-                name, task_name
+                name, crate_name
             );
         }
 
@@ -86,7 +82,6 @@ pub fn run(
             cmd.arg(opt);
         }
 
-        cmd.current_dir(&src_dir.join(&path));
         let status = cmd.status()?;
         if !status.success() {
             bail!("`cargo clippy` failed, see output for details");

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -182,10 +182,10 @@ impl Config {
             env.insert("HUBRIS_APP_CONFIG".to_string(), app_config);
         }
 
-        let mut out_path = Path::new("").to_path_buf();
-        out_path.push(&self.target);
-        out_path.push("release");
-        out_path.push(crate_name);
+        let out_path = Path::new("")
+            .join(&self.target)
+            .join("release")
+            .join(crate_name);
 
         BuildConfig {
             args,

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -506,7 +506,7 @@ fn check_rebuild(toml: &Config) -> Result<()> {
             // [tasks.jefe]
             // name = "task-jefe"
             //
-            // The "name" in the key is `jefei`, but the package (crate)
+            // The "name" in the key is `jefe`, but the package (crate)
             // name is in `tasks.jefe.name`, and that's what we need to
             // give to `cargo`.
             names.push(toml.tasks[name].name.as_str());

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -562,7 +562,7 @@ fn build_bootloader(
     )?;
 
     if let Some(signing) = cfg.toml.signing.get("bootloader") {
-        do_sign_file(&cfg, signing, "bootloader", 0)?;
+        do_sign_file(cfg, signing, "bootloader", 0)?;
     }
 
     // We need to get the absolute symbols for the non-secure application
@@ -1026,7 +1026,7 @@ fn build(
     name: impl AsRef<Path>,
     build_config: BuildConfig,
 ) -> Result<()> {
-    println!("building path {}", build_config.crate_path.display());
+    println!("building crate {}", build_config.crate_name);
 
     let mut cmd = build_config.cmd("rustc");
     cmd.arg("--release");
@@ -1060,9 +1060,8 @@ fn build(
         let mut tree = build_config.cmd("tree");
         tree.arg("--edges").arg("features").arg("--verbose");
         println!(
-            "Path: {}\nRunning cargo {:?}",
-            build_config.crate_path.display(),
-            tree
+            "Crate: {}\nRunning cargo {:?}",
+            build_config.crate_name, tree
         );
         let tree_status = tree
             .status()

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -4,7 +4,7 @@
 
 use std::convert::TryInto;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::bail;
 use goblin::Object;
@@ -45,9 +45,7 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
 
     let toml = Config::from_file(cfg)?;
 
-    let mut dist_dir = PathBuf::from("target");
-    dist_dir.push(&toml.name);
-    dist_dir.push("dist");
+    let dist_dir = Path::new("target").join(&toml.name).join("dist");
 
     let mut memories = IndexMap::new();
     for (name, out) in &toml.outputs {

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fpga_image = fs::read(&fpga_image_path)?;
     let compressed = compress(&fpga_image);
 
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let compressed_path = out.join(fpga_image_path.with_extension("bin.rle"));
     fs::write(&compressed_path, compressed)?;
     println!("cargo:rerun-if-changed={}", config.fpga_image);

--- a/lib/hypocalls/build.rs
+++ b/lib/hypocalls/build.rs
@@ -20,8 +20,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!()
     }
 
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let target_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let target_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let mut task_file = File::create(out.join("hypo.rs")).unwrap();
     // This contains the addresses of the secure entry points so make sure
     // this crate gets rebuilt if it changes

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
     println!("cargo:rerun-if-env-changed=HUBRIS_SECURE");
@@ -64,7 +64,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
         ron::de::from_str(&env::var("HUBRIS_KCONFIG")?)?;
     println!("cargo:rerun-if-env-changed=HUBRIS_KCONFIG");
 
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut file = File::create(out.join("kconfig.rs")).unwrap();
 
     writeln!(file, "// See build.rs for details")?;

--- a/sys/num-tasks/build.rs
+++ b/sys/num-tasks/build.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     println!("cargo:rerun-if-env-changed=HUBRIS_TASKS");
     let mut task_enum = vec![];

--- a/task/ping/build.rs
+++ b/task/ping/build.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
     // If hubris is non-secure (i.e. TZ is enabled) we need to use a

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
     // If hubris is non-secure (i.e. TZ is enabled) we need to use a

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/lpc55"
 stacksize = 1400
 
 [kernel]
-path = "../../app/gemini-bu-rot"
 name = "gemini-bu-rot"
 requires = {flash = 32768, ram = 4096}
 features = ["itm"]
@@ -47,7 +46,6 @@ root-cert = "../../support/fake_certs/fake_certificate.der.crt"
 
 
 [bootloader]
-path = "../../stage0"
 name = "stage0"
 # Currently we have the first 0x8000 of flash and first 0x4000 of RAM
 # dedicated for the stage0 bootloader and the rest for Hubris. Once we have
@@ -58,7 +56,6 @@ imagea-ram-start = 0x20004000
 imagea-ram-size = 0x3C000
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -66,7 +63,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -82,7 +78,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -90,7 +85,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -98,7 +92,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 2048
 
 [kernel]
-path = "../../app/gemini-bu"
 name = "gemini-bu"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -44,7 +42,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -60,7 +57,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -68,7 +64,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -76,7 +71,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-gimletlet/app.toml
+++ b/test/tests-gimletlet/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 2048
 
 [kernel]
-path = "../../app/gimletlet"
 name = "gimletlet"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -44,7 +42,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -60,7 +57,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -68,7 +64,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -76,7 +71,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -6,7 +6,6 @@ stacksize = 2048
 secure-separation = true
 
 [kernel]
-path = "../../app/lpc55xpresso"
 name = "lpc55xpresso"
 requires = {flash = 32768, ram = 4096}
 features = ["itm"]
@@ -48,7 +47,6 @@ root-cert = "../../support/fake_certs/fake_certificate.der.crt"
 
 
 [bootloader]
-path = "../../stage0"
 name = "stage0"
 sharedsyms = ["write_to_flash"]
 # Currently we have the first 0x8000 of flash and first 0x4000 of RAM
@@ -61,7 +59,6 @@ imagea-ram-size = 0x18000
 features = ["tz_support"]
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -69,7 +66,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -86,7 +82,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -94,7 +89,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -102,7 +96,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -5,7 +5,6 @@ board = "psc-1"
 stacksize = 896
 
 [kernel]
-path = "../../app/psc"
 name = "psc"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 2048}
@@ -44,7 +42,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -61,7 +58,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 1024}
@@ -69,7 +65,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -77,7 +72,6 @@ stacksize = 1024
 start = true
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -86,7 +80,6 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -104,7 +97,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 128, ram = 256}

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32f3"
 stacksize = 2048
 
 [kernel]
-path = "../../app/demo-stm32f4-discovery"
 name = "demo-stm32f4-discovery"
 requires = {flash = 65536, ram = 4096}
 features = ["itm", "stm32f3"]
@@ -24,7 +23,6 @@ write = true
 execute = false
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -32,7 +30,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -47,7 +44,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384 , ram = 4096}
@@ -55,7 +51,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -63,7 +58,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32f4"
 stacksize = 2048
 
 [kernel]
-path = "../../app/demo-stm32f4-discovery"
 name = "demo-stm32f4-discovery"
 requires = {flash = 65536, ram = 4096}
 features = ["itm", "stm32f4"]
@@ -24,7 +23,6 @@ write = true
 execute = false
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -32,7 +30,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -48,7 +45,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -56,7 +52,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -64,7 +59,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -4,7 +4,6 @@ board = "stm32g070"
 chip = "../../chips/stm32g0"
 
 [kernel]
-path = "../../app/demo-stm32g0-nucleo"
 name = "demo-stm32g0-nucleo"
 requires = {flash = 17148, ram = 2808}
 #
@@ -34,7 +33,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 2048}
@@ -43,7 +41,6 @@ features = ["semihosting"]
 stacksize = 1904
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 2048}
@@ -60,7 +57,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 2048}
@@ -69,7 +65,6 @@ features = ["semihosting"]
 stacksize = 1504
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -77,7 +72,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 128, ram = 64}

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 2048
 
 [kernel]
-path = "../../app/demo-stm32h7-nucleo"
 name = "demo-stm32h7-nucleo"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -44,7 +42,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -60,7 +57,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -68,7 +64,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -76,7 +71,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}

--- a/test/tests-stm32h7/app-h753.toml
+++ b/test/tests-stm32h7/app-h753.toml
@@ -5,7 +5,6 @@ chip = "../../chips/stm32h7"
 stacksize = 2048
 
 [kernel]
-path = "../../app/demo-stm32h7-nucleo"
 name = "demo-stm32h7-nucleo"
 requires = {flash = 32768, ram = 4096}
 #
@@ -36,7 +35,6 @@ write = true
 execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
-path = "../test-runner"
 name = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
@@ -44,7 +42,6 @@ start = true
 features = ["itm"]
 
 [tasks.suite]
-path = "../test-suite"
 name = "test-suite"
 priority = 2
 requires = {flash = 65536, ram = 4096}
@@ -60,7 +57,6 @@ baz = [1, 2, 3, 4]
 tup = [[1, true], [2, true], [3, false]]
 
 [tasks.assist]
-path = "../test-assist"
 name = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
@@ -68,7 +64,6 @@ start = true
 features = ["itm"]
 
 [tasks.idol]
-path = "../test-idol-server"
 name = "test-idol-server"
 priority = 1
 requires = {flash = 4096, ram = 1024}
@@ -76,7 +71,6 @@ stacksize = 1024
 start = true
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}


### PR DESCRIPTION
In our build system, we specify both crate names _and_ paths, and use the latter to run `cargo rustc ...` in the crate's directory.

However, crate names are guaranteed to be unique by dint of being in the same workspace.  This means we can instead use `cargo rustc -p ...` to run on that specific crate, saving a bunch of boilerplate in `app.toml`.

Other drive-by fixes:
- Added `sysroot` to `BuildConfig`, which speeds up a no-op Sidecar rebuild by 12% by skipping `rustup` façade (!)
- When doing `cargo clean` after changing apps, clean all the apps at once (`cargo clean -p hf -p spi_driver ...`).  This is _much faster_.