### PR TITLE
Some work towards a sizing action

### DIFF
--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -77,6 +77,14 @@ enum Xtask {
         verbose: bool,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
+
+        /// Compare this to a previously saved file of sizes
+        #[clap(long)]
+        compare: bool,
+
+        /// Write JSON out to a file?
+        #[clap(long)]
+        save: bool,
     },
 
     /// Runs `humility`, passing any arguments
@@ -161,7 +169,7 @@ fn run(xtask: Xtask) -> Result<()> {
             cfg,
         } => {
             dist::package(verbose, edges, &cfg, None)?;
-            sizes::run(&cfg, true)?;
+            sizes::run(&cfg, true, false, false)?;
         }
         Xtask::Build {
             verbose,
@@ -178,9 +186,14 @@ fn run(xtask: Xtask) -> Result<()> {
             args.extra_options.push("--force".to_string());
             humility::run(&args, &chip, Some("flash"), false)?;
         }
-        Xtask::Sizes { verbose, cfg } => {
+        Xtask::Sizes {
+            verbose,
+            cfg,
+            compare,
+            save,
+        } => {
             dist::package(verbose, false, &cfg, None)?;
-            sizes::run(&cfg, false)?;
+            sizes::run(&cfg, false, compare, save)?;
         }
         Xtask::Humility { args } => {
             humility::run(&args, &[], None, true)?;

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -2,12 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::collections::HashSet;
 use std::convert::TryInto;
+use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::process;
 
 use anyhow::bail;
 use goblin::Object;
+use indexmap::map::Entry;
 use indexmap::IndexMap;
 use termcolor::{Color, ColorSpec, WriteColor};
 
@@ -25,7 +29,35 @@ fn armv8m_suggest(size: u64) -> u64 {
 /// When `only_suggest` is true, prints only the suggested improvements to
 /// stderr, rather than printing all sizes.  Suggestions are formatted to
 /// match compiler warnings.
-pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
+pub fn run(
+    cfg: &Path,
+    only_suggest: bool,
+    compare: bool,
+    save: bool,
+) -> anyhow::Result<()> {
+    let toml = Config::from_file(&cfg)?;
+
+    let sizes = create_sizes(cfg)?;
+
+    let filename = format!("{}.json", toml.name);
+
+    if save {
+        println!("Writing json to {}", filename);
+        fs::write(filename, serde_json::ser::to_string(&sizes)?)?;
+        process::exit(0);
+    } else if compare {
+        let compare = fs::read(filename)?;
+        let compare: (
+            IndexMap<String, IndexMap<String, u64>>,
+            IndexMap<String, Vec<Vec<(String, u32, u64)>>>,
+        ) = serde_json::from_slice(&compare)?;
+
+        compare_sizes(sizes, compare)?;
+        process::exit(0);
+    }
+
+    let (sizes, suggestions) = sizes;
+
     let s = if only_suggest {
         atty::Stream::Stderr
     } else {
@@ -44,6 +76,109 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
     let out = &mut out_stream;
 
     let toml = Config::from_file(cfg)?;
+    let mut print_task_sizes =
+        |name: &str, requires: &IndexMap<String, u32>| -> anyhow::Result<()> {
+            let sizes = &sizes[name];
+
+            if !only_suggest {
+                writeln!(out, "{}", name)?;
+            }
+
+            for (mem_name, &used) in sizes {
+                if let Some(&size) = requires.get(mem_name) {
+                    let percent = used * 100 / size as u64;
+                    if !only_suggest {
+                        write!(
+                            out,
+                            "  {:<6} {: >5} bytes",
+                            format!("{}:", mem_name),
+                            used,
+                        )?;
+                        let mut color = ColorSpec::new();
+                        color.set_fg(Some(if percent >= 50 {
+                            Color::Green
+                        } else if percent > 25 {
+                            Color::Yellow
+                        } else {
+                            Color::Red
+                        }));
+                        out.set_color(&color)?;
+                        write!(out, " ({}%)", percent,)?;
+                        out.reset()?;
+                        writeln!(out)?;
+                    }
+                } else {
+                    assert!(used == 0);
+                }
+            }
+
+            Ok(())
+        };
+
+    print_task_sizes("kernel", &toml.kernel.requires)?;
+
+    for (name, task) in &toml.tasks {
+        if !only_suggest {
+            println!();
+        }
+        print_task_sizes(&name, &task.requires)?;
+    }
+
+    if !suggestions.is_empty() {
+        let mut savings: IndexMap<String, u64> = IndexMap::new();
+
+        if only_suggest {
+            out.set_color(
+                ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)),
+            )?;
+            write!(out, "warning")?;
+            out.reset()?;
+            writeln!(out, ": memory allocation is sub-optimal")?;
+            out.set_color(ColorSpec::new().set_bold(true))?;
+            writeln!(out, "Suggested improvements:")?;
+            out.reset()?;
+        } else {
+            out.set_color(ColorSpec::new().set_bold(true))?;
+            writeln!(out, "\n========== Suggested changes ==========")?;
+            out.reset()?;
+        }
+
+        for (name, list) in suggestions {
+            if list.is_empty() {
+                continue;
+            }
+            writeln!(out, "{}:", name)?;
+            for list in list {
+                for (mem, prev, value) in list {
+                    write!(out, "  {:<6} {: >5}", format!("{}:", mem), value)?;
+                    out.set_color(ColorSpec::new().set_dimmed(true))?;
+                    writeln!(out, " (currently {})", prev)?;
+                    out.reset()?;
+                    *savings.entry(mem).or_default() += prev as u64 - value;
+                }
+            }
+        }
+
+        if !only_suggest {
+            out.set_color(ColorSpec::new().set_bold(true))?;
+            writeln!(out, "\n------------ Total savings ------------")?;
+            out.reset()?;
+            for (mem, savings) in &savings {
+                writeln!(out, "  {:<6} {}", format!("{}:", mem), savings)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn create_sizes(
+    cfg: &Path,
+) -> anyhow::Result<(
+    IndexMap<String, IndexMap<String, u64>>,
+    IndexMap<String, Vec<Vec<(String, u32, u64)>>>,
+)> {
+    let toml = Config::from_file(&cfg)?;
 
     let dist_dir = Path::new("target").join(&toml.name).join("dist");
 
@@ -71,124 +206,149 @@ pub fn run(cfg: &Path, only_suggest: bool) -> anyhow::Result<()> {
         panic!("Unknown target: {}", toml.target);
     };
 
-    let mut suggestions = Vec::new();
-    let mut check_task =
-        |name: &str, stacksize: u32, requires: &IndexMap<String, u32>| {
-            let mut elf_name = dist_dir.clone();
-            elf_name.push(name);
-            let buffer = std::fs::read(elf_name)?;
-            let elf = match Object::parse(&buffer)? {
-                Object::Elf(elf) => elf,
-                o => bail!("Invalid Object {:?}", o),
-            };
+    let check_task = move |name: &str,
+                           stacksize: u32,
+                           requires: &IndexMap<String, u32>|
+          -> anyhow::Result<(
+        IndexMap<String, u64>,
+        Vec<Vec<(String, u32, u64)>>,
+    )> {
+        let mut suggestions = Vec::new();
+        let mut sizes = IndexMap::new();
 
-            let mut memory_sizes = IndexMap::new();
-            for phdr in &elf.program_headers {
-                if let Some(vregion) = output_region(phdr.p_vaddr) {
-                    *memory_sizes.entry(vregion).or_default() += phdr.p_memsz;
-                }
-                // If the VirtAddr disagrees with the PhysAddr, then this is a
-                // section which is relocated into RAM, so we also accumulate
-                // its FileSiz in the physical address (which is presumably
-                // flash).
-                if phdr.p_vaddr != phdr.p_paddr {
-                    let region = output_region(phdr.p_paddr).unwrap();
-                    *memory_sizes.entry(region).or_default() += phdr.p_filesz;
-                }
-            }
-            *memory_sizes.entry("ram").or_default() += stacksize as u64;
-
-            if !only_suggest {
-                writeln!(out, "{}", name)?;
-            }
-            let mut my_suggestions = Vec::new();
-            for (mem_name, used) in memory_sizes {
-                if let Some(&size) = requires.get(mem_name) {
-                    let percent = used * 100 / size as u64;
-                    if !only_suggest {
-                        write!(
-                            out,
-                            "  {:<6} {: >5} bytes",
-                            format!("{}:", mem_name),
-                            used,
-                        )?;
-                        let mut color = ColorSpec::new();
-                        color.set_fg(Some(if percent >= 50 {
-                            Color::Green
-                        } else if percent > 25 {
-                            Color::Yellow
-                        } else {
-                            Color::Red
-                        }));
-                        out.set_color(&color)?;
-                        write!(out, " ({}%)", percent,)?;
-                        out.reset()?;
-                        writeln!(out)?;
-                    }
-                    let suggestion = suggest(used);
-                    if suggestion < size as u64 {
-                        my_suggestions.push((mem_name, size, suggestion));
-                    }
-                } else {
-                    assert!(used == 0);
-                }
-            }
-            if !my_suggestions.is_empty() {
-                suggestions.push((name.to_owned(), my_suggestions));
-            }
-            Ok(())
+        let mut elf_name = dist_dir.clone();
+        elf_name.push(name);
+        let buffer = std::fs::read(elf_name)?;
+        let elf = match Object::parse(&buffer)? {
+            Object::Elf(elf) => elf,
+            o => bail!("Invalid Object {:?}", o),
         };
 
-    check_task(
+        let mut memory_sizes = IndexMap::new();
+        for phdr in &elf.program_headers {
+            if let Some(vregion) = output_region(phdr.p_vaddr) {
+                *memory_sizes.entry(vregion).or_default() += phdr.p_memsz;
+            }
+            // If the VirtAddr disagrees with the PhysAddr, then this is a
+            // section which is relocated into RAM, so we also accumulate
+            // its FileSiz in the physical address (which is presumably
+            // flash).
+            if phdr.p_vaddr != phdr.p_paddr {
+                let region = output_region(phdr.p_paddr).unwrap();
+                *memory_sizes.entry(region).or_default() += phdr.p_filesz;
+            }
+        }
+        *memory_sizes.entry("ram").or_default() += stacksize as u64;
+
+        let mut my_suggestions = Vec::new();
+
+        for (mem_name, used) in memory_sizes {
+            if let Some(&size) = requires.get(mem_name) {
+                sizes.insert(mem_name.to_string(), used);
+                let suggestion = suggest(used);
+                if suggestion < size as u64 {
+                    my_suggestions.push((
+                        mem_name.to_string(),
+                        size,
+                        suggestion,
+                    ));
+                }
+            } else {
+                assert!(used == 0);
+            }
+        }
+        if !my_suggestions.is_empty() {
+            suggestions.push(my_suggestions);
+        }
+        Ok((sizes, suggestions))
+    };
+
+    let mut sizes: IndexMap<String, IndexMap<String, u64>> = IndexMap::new();
+    let mut suggestions: IndexMap<String, Vec<Vec<(String, u32, u64)>>> =
+        IndexMap::new();
+
+    let kernel_sizes = check_task(
         "kernel",
         toml.kernel.stacksize.unwrap_or(DEFAULT_KERNEL_STACK),
         &toml.kernel.requires,
     )?;
+    sizes.insert(String::from("kernel"), kernel_sizes.0);
+    suggestions.insert(String::from("kernel"), kernel_sizes.1);
+
     for (name, task) in &toml.tasks {
-        if !only_suggest {
-            println!();
-        }
-        check_task(
-            name,
+        let task_sizes = check_task(
+            &name,
             task.stacksize.or(toml.stacksize).unwrap(),
             &task.requires,
         )?;
+
+        sizes.insert(name.to_string(), task_sizes.0);
+        suggestions.insert(name.to_string(), task_sizes.1);
     }
 
-    if !suggestions.is_empty() {
-        let mut savings: IndexMap<_, u64> = IndexMap::new();
+    Ok((sizes, suggestions))
+}
 
-        if only_suggest {
-            out.set_color(
-                ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)),
-            )?;
-            write!(out, "warning")?;
-            out.reset()?;
-            writeln!(out, ": memory allocation is sub-optimal")?;
-            out.set_color(ColorSpec::new().set_bold(true))?;
-            writeln!(out, "Suggested improvements:")?;
-            out.reset()?;
-        } else {
-            out.set_color(ColorSpec::new().set_bold(true))?;
-            writeln!(out, "\n========== Suggested changes ==========")?;
-            out.reset()?;
-        }
-        for (name, list) in suggestions {
-            writeln!(out, "{}:", name)?;
-            for (mem, prev, value) in list {
-                write!(out, "  {:<6} {: >5}", format!("{}:", mem), value)?;
-                out.set_color(ColorSpec::new().set_dimmed(true))?;
-                writeln!(out, " (currently {})", prev)?;
-                out.reset()?;
-                *savings.entry(mem).or_default() += prev as u64 - value;
+fn compare_sizes(
+    current_sizes: (
+        IndexMap<String, IndexMap<String, u64>>,
+        IndexMap<String, Vec<Vec<(String, u32, u64)>>>,
+    ),
+    saved_sizes: (
+        IndexMap<String, IndexMap<String, u64>>,
+        IndexMap<String, Vec<Vec<(String, u32, u64)>>>,
+    ),
+) -> anyhow::Result<()> {
+    println!("Comparing against the previously saved sizes");
+
+    // 0 is sizes, 1 is suggestions
+    let mut current_sizes = current_sizes.0;
+    let mut saved_sizes = saved_sizes.0;
+
+    let mut names: HashSet<String> = current_sizes.keys().cloned().collect();
+    names.extend(saved_sizes.keys().cloned());
+
+    for name in names {
+        println!("Checking for differences in {}", name);
+
+        let current_size = current_sizes.entry(name.clone());
+        let saved_size = saved_sizes.entry(name.clone());
+
+        match (current_size, saved_size) {
+            // the common case; both are in both
+            (Entry::Occupied(current_entry), Entry::Occupied(saved_entry)) => {
+                let current = current_entry.get();
+                let saved = saved_entry.get();
+                for (key, &value) in current {
+                    let saved = saved.get(key).cloned().unwrap_or_default();
+                    let diff = value as i64 - saved as i64;
+
+                    if diff != 0 {
+                        println!("\t{}: {}", key, diff);
+                    }
+                }
             }
-        }
-        if !only_suggest {
-            out.set_color(ColorSpec::new().set_bold(true))?;
-            writeln!(out, "\n------------ Total savings ------------")?;
-            out.reset()?;
-            for (mem, savings) in &savings {
-                writeln!(out, "  {:<6} {}", format!("{}:", mem), savings)?;
+            // we have added something new
+            (Entry::Vacant(_), Entry::Occupied(saved_entry)) => {
+                println!(
+                    "This task was added since we last saved size information."
+                );
+                let saved = saved_entry.get();
+                for (key, value) in saved {
+                    println!("\t{}: {}", key, value);
+                }
+            }
+            // we have removed this entirely
+            (Entry::Occupied(current_entry), Entry::Vacant(_)) => {
+                println!("This task was removed since we last saved size information.");
+                let current = current_entry.get();
+                for (key, value) in current {
+                    println!("\t{}: {}", key, value);
+                }
+            }
+            // this should never happen
+            (Entry::Vacant(_), Entry::Vacant(_)) => {
+                bail!("{} doesn't exist, and this should never happen.", name)
             }
         }
     }


### PR DESCRIPTION
I talked with @mkeeter about this yesterday; rather than wait until I've figured out the actions stuff, here's a PR for just the code that calculates the sizes. The gist of it is:

This PR adds two new flags to `cargo xtask sizes`:

* --save, which writes out the sizes to a file
* --compare, which calculates sizes and then compares to a previously
  saved file

These files are named after the app, for example,
`demo-stm32f4-discovery.json`, and are written to the project root.

I am open to any and all suggestions about this code. I think it's... fine. I'm not sure what I don't like about it. Also happy to revise the overall strategy.

And one open question: should I put `*.json` in the `.gitignore`, or maybe include something a bit more recognizable in the filename so we could glob it?