### PR TITLE
Bump cfg-if everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
  "anyhow",
  "build-util",
  "cargo_metadata",
- "cfg-if 0.1.10",
+ "cfg-if",
  "convert_case 0.4.0",
  "indexmap",
  "multimap",
@@ -175,7 +175,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "convert_case 0.4.0",
  "indexmap",
  "multimap",
@@ -262,12 +262,6 @@ name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -414,7 +408,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -424,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cortex-m",
  "riscv",
 ]
@@ -537,7 +531,7 @@ name = "demo-stm32g0-nucleo"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -552,7 +546,7 @@ name = "demo-stm32h7-nucleo"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "drv-stm32h7-startup",
@@ -657,7 +651,7 @@ name = "drv-fpga-devices"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-fpga-api",
  "drv-spi-api",
  "drv-stm32xx-sys-api",
@@ -672,7 +666,7 @@ name = "drv-fpga-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-fpga-api",
  "drv-fpga-devices",
  "drv-spi-api",
@@ -703,7 +697,7 @@ name = "drv-gimlet-hf-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-hf-api",
  "drv-hash-api",
@@ -735,7 +729,7 @@ dependencies = [
  "build-i2c",
  "build-util",
  "byteorder",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",
@@ -821,7 +815,7 @@ name = "drv-lpc55-gpio-api"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "derive-idol-err",
  "idol",
  "num-traits",
@@ -845,7 +839,7 @@ dependencies = [
 name = "drv-lpc55-rng"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-lpc55-syscon-api",
  "drv-rng-api",
  "idol",
@@ -1001,7 +995,7 @@ dependencies = [
  "build-i2c",
  "build-util",
  "byteorder",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-i2c-devices",
@@ -1077,7 +1071,7 @@ dependencies = [
 name = "drv-stm32h7-eth"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cortex-m",
  "smoltcp",
  "stm32h7",
@@ -1100,7 +1094,7 @@ name = "drv-stm32h7-hash-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-hash-api",
  "drv-stm32h7-hash",
@@ -1118,7 +1112,7 @@ name = "drv-stm32h7-i2c"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "cfg-if 0.1.10",
+ "cfg-if",
  "drv-i2c-api",
  "drv-stm32xx-sys-api",
  "num-traits",
@@ -1135,7 +1129,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-stm32h7-i2c",
@@ -1188,7 +1182,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "call_rustfmt",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-spi-api",
  "drv-stm32h7-spi",
@@ -1229,7 +1223,7 @@ dependencies = [
 name = "drv-stm32xx-gpio-common"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num-traits",
  "stm32g0",
  "stm32h7",
@@ -1241,7 +1235,7 @@ dependencies = [
 name = "drv-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-stm32xx-gpio-common",
  "drv-stm32xx-sys-api",
  "idol",
@@ -1258,7 +1252,7 @@ name = "drv-stm32xx-sys-api"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derive-idol-err",
  "drv-stm32xx-gpio-common",
  "idol",
@@ -1271,7 +1265,7 @@ dependencies = [
 name = "drv-stm32xx-uid"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1290,7 +1284,7 @@ name = "drv-user-leds"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "drv-lpc55-gpio-api",
  "drv-stm32xx-sys-api",
  "drv-user-leds-api",
@@ -1381,7 +1375,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi",
@@ -1397,7 +1391,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -1420,7 +1414,7 @@ name = "gemini-bu"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "drv-stm32h7-startup",
@@ -1436,7 +1430,7 @@ name = "gemini-bu-rot"
 version = "0.1.0"
 dependencies = [
  "abi",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -1462,7 +1456,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -1472,7 +1466,7 @@ name = "gimlet"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "drv-stm32h7-startup",
@@ -1487,7 +1481,7 @@ name = "gimlet-rot"
 version = "0.1.0"
 dependencies = [
  "abi",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -1502,7 +1496,7 @@ name = "gimletlet"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "drv-stm32h7-startup",
@@ -1696,7 +1690,7 @@ dependencies = [
  "bitflags",
  "build-util",
  "byteorder",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "phash",
  "phash-gen",
@@ -1752,7 +1746,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1760,7 +1754,7 @@ name = "lpc55-iocon-gen"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "zerocopy",
@@ -1781,7 +1775,7 @@ dependencies = [
 name = "lpc55_romapi"
 version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "lpc55-pac",
  "num-derive",
  "num-traits",
@@ -1812,7 +1806,7 @@ name = "lpc55xpresso"
 version = "0.1.0"
 dependencies = [
  "abi",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -1891,7 +1885,7 @@ checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -2615,7 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2626,7 +2620,7 @@ name = "sidecar"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "drv-stm32h7-startup",
@@ -2724,7 +2718,7 @@ name = "stage0"
 version = "0.1.0"
 dependencies = [
  "abi",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "ecdsa",
@@ -2890,7 +2884,7 @@ dependencies = [
  "build-i2c",
  "build-util",
  "byteorder",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-hf-api",
  "drv-hash-api",
@@ -2941,7 +2935,7 @@ version = "0.1.0"
 dependencies = [
  "build-net",
  "build-util",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-seq-api",
  "drv-sidecar-seq-api",
@@ -3011,7 +3005,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-seq-api",
  "drv-i2c-api",
@@ -3030,7 +3024,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-i2c-devices",
@@ -3062,7 +3056,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-stm32h7-i2c",
@@ -3088,7 +3082,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-gimlet-seq-api",
  "drv-i2c-api",
@@ -3121,7 +3115,7 @@ name = "task-uartecho"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cortex-m",
  "drv-stm32h7-usart",
  "ringbuf",
@@ -3158,7 +3152,7 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-i2c-devices",
@@ -3188,7 +3182,7 @@ name = "task-vsc7448"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-sidecar-seq-api",
  "drv-spi-api",
  "drv-stm32xx-sys-api",
@@ -3266,7 +3260,7 @@ version = "0.1.0"
 dependencies = [
  "armv6m-atomic-hack",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-semihosting",
  "hubris-num-tasks",
@@ -3282,7 +3276,7 @@ version = "0.1.0"
 dependencies = [
  "build-i2c",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "drv-i2c-api",
  "drv-i2c-devices",
@@ -3301,7 +3295,7 @@ name = "tests-gemini-bu"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -3315,7 +3309,7 @@ dependencies = [
 name = "tests-gemini-bu-rot"
 version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -3329,7 +3323,7 @@ dependencies = [
 name = "tests-lpc55xpresso"
 version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -3358,7 +3352,7 @@ name = "tests-stm32g0"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -3373,7 +3367,7 @@ name = "tests-stm32h7"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "kern",
@@ -3485,7 +3479,7 @@ dependencies = [
  "armv6m-atomic-hack",
  "bstringify",
  "build-util",
- "cfg-if 0.1.10",
+ "cfg-if",
  "num-derive",
  "num-traits",
  "paste",
@@ -3541,7 +3535,7 @@ name = "vsc7448"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if 1.0.0",
+ "cfg-if",
  "drv-spi-api",
  "ringbuf",
  "userlib",

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -17,7 +17,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false, features = ["rt"] }
 
 [dependencies.kern]

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup"}
 

--- a/app/gemini-bu-rot/Cargo.toml
+++ b/app/gemini-bu-rot/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = {version = "0.3.0", features = ["rt"]}
-cfg-if = "0.1.10"
+cfg-if = "1"
 abi = { path = "../../sys/abi"}
 
 [dependencies.kern]

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = {version = "0.3.0", features = ["rt"]}
-cfg-if = "0.1.10"
+cfg-if = "1"
 abi = { path = "../../sys/abi"}
 
 [dependencies.kern]

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -15,7 +15,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = {version = "0.3.0", features = ["rt"]}
-cfg-if = "0.1.10"
+cfg-if = "1"
 abi = { path = "../../sys/abi"}
 
 [dependencies.kern]

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
 

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -8,7 +8,7 @@ build-util = {path = "../util"}
 serde = { version = "1.0.114", features = ["derive"] }
 indexmap = { version = "1.4.0", features = ["serde-1"] }
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 multimap = "0.8.3"
 convert_case = "0.4"
 cargo_metadata = "0.12.0"

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -8,7 +8,7 @@ build-util = {path = "../util"}
 serde = { version = "1", features = ["derive"] }
 indexmap = { version = "1.4.0", features = ["serde-1"] }
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 multimap = "0.8.3"
 convert_case = "0.4"
 syn = {version = "1", features = ["parsing"]}

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -10,7 +10,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32h7 = { version = "0.14", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
-cfg-if = "0.1.10"
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
 drv-hash-api = {path = "../hash-api", default-features = false}

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -20,7 +20,7 @@ drv-i2c-devices = {path = "../i2c-devices"}
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
 drv-gimlet-seq-api = {path = "../gimlet-seq-api"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "0.1.10"
+cfg-if = "1"
 gnarle = {path = "../../lib/gnarle"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 

--- a/drv/lpc55-gpio-api/Cargo.toml
+++ b/drv/lpc55-gpio-api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
-cfg-if = "0.1.10"
+cfg-if = "1"
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 
 [build-dependencies]

--- a/drv/lpc55-iocon-gen/Cargo.toml
+++ b/drv/lpc55-iocon-gen/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 zerocopy = "0.6.1"
 quote = "1.0.9"
-cfg-if = "0.1.10"
+cfg-if = "1"
 proc-macro2 = "1.0.9"
 
 [build-dependencies]

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 zerocopy = "0.6.1"
 lpc55-pac = "0.3.0"
 num-traits = { version = "0.2.12", default-features = false }
-cfg-if = { version = "1.0" }
+cfg-if = "1"
 drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
 drv-rng-api = { path = "../rng-api" }
 rand_chacha = { version = "0.3", default-features = false }

--- a/drv/lpc55-romapi/Cargo.toml
+++ b/drv/lpc55-romapi/Cargo.toml
@@ -13,7 +13,7 @@ log-semihosting = []
 lpc55-pac = "0.3.0"
 num-derive = "0.3.3"
 num-traits = { version = "0.2", default-features = false }
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [lib]
 test = false

--- a/drv/sidecar-seq-server/Cargo.toml
+++ b/drv/sidecar-seq-server/Cargo.toml
@@ -17,7 +17,7 @@ drv-i2c-api = {path = "../i2c-api"}
 drv-i2c-devices = {path = "../i2c-devices"}
 drv-sidecar-seq-api = {path = "../sidecar-seq-api"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -10,7 +10,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32h7 = { version = "0.14", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-hash = {path = "../stm32h7-hash", default-features = false, optional = true}
-cfg-if = "0.1.10"
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-hash-api = {path = "../hash-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }

--- a/drv/stm32h7-i2c-server/Cargo.toml
+++ b/drv/stm32h7-i2c-server/Cargo.toml
@@ -12,14 +12,14 @@ drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-i2c = {path = "../stm32h7-i2c", default-features = false }
 drv-i2c-api = {path = "../i2c-api"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32xx-sys-api/h743", "build-i2c/h743"]

--- a/drv/stm32h7-i2c/Cargo.toml
+++ b/drv/stm32h7-i2c/Cargo.toml
@@ -10,7 +10,7 @@ zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-i2c-api = {path = "../i2c-api"}
-cfg-if = "0.1.10"
+cfg-if = "1"
 bitfield = "0.13"
 stm32h7 = { version = "0.14", default-features = false }
 

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -13,7 +13,7 @@ drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-spi-api = {path = "../spi-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 stm32h7 = { version = "0.14", default-features = false }
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -13,7 +13,7 @@ zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", optional = true}
 drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", optional = true}
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -18,7 +18,7 @@ p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecds
 hmac = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }
 zerocopy = "0.6.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 abi = { path = "../sys/abi" }
 
 [[bin]]

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -8,7 +8,7 @@ abi = {path = "../abi"}
 zerocopy = "0.6.1"
 byteorder = { version = "1.3.4", default-features = false }
 bitflags = "1.2.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 serde = { version = "1.0.114", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -18,7 +18,7 @@ ssmarshal = { version = "1.0.0", default-features = false }
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
-cfg-if = "0.1.10"
+cfg-if = "1"
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 
 #

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -16,7 +16,7 @@ drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
 drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false, optional = true}
 drv-hash-api = {path = "../../drv/hash-api", optional = true}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "0.1.10"
+cfg-if = "1"
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 hif = { git = "https://github.com/oxidecomputer/hif" }
@@ -30,7 +30,7 @@ drv-update-api = {path = "../../drv/update-api", optional = true}
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -9,7 +9,7 @@ ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api"}
 task-sensor-api = {path = "../sensor-api"}
@@ -19,7 +19,7 @@ paste = "1.0.6"
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/sensor/Cargo.toml
+++ b/task/sensor/Cargo.toml
@@ -12,7 +12,7 @@ ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 task-sensor-api = {path = "../sensor-api"}
@@ -22,7 +22,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -12,14 +12,14 @@ drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = fa
 drv-stm32h7-i2c = {path = "../../drv/stm32h7-i2c", features = ["amd_erratum_1394"]}
 drv-i2c-api = {path = "../../drv/i2c-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32xx-sys-api/h743", "build-i2c/h743"]

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -9,7 +9,7 @@ ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
@@ -23,7 +23,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]

--- a/task/validate/Cargo.toml
+++ b/task/validate/Cargo.toml
@@ -12,7 +12,7 @@ ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
-cfg-if = "0.1.10"
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 task-validate-api = {path = "../validate-api"}
@@ -22,7 +22,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "0.1.10"
+cfg-if = "1"
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -12,7 +12,7 @@ zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"], optional = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -13,7 +13,7 @@ test-api = {path = "../test-api"}
 test-idol-api = {path = "../test-idol-api"}
 task-config = { path = "../../lib/task-config" }
 hypocalls = {path = "../../lib/hypocalls", default-features = false, optional = true }
-cfg-if = "0.1"
+cfg-if = "1"
 
 # Some tests require talking to I2C devices on the target board
 drv-i2c-api = {path = "../../drv/i2c-api", optional = true}

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -17,7 +17,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.3.0"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [dependencies.kern]
 path = "../../sys/kern"

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 
 [dependencies.kern]

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
 
 [dependencies.kern]

--- a/test/tests-lpc55xpresso/Cargo.toml
+++ b/test/tests-lpc55xpresso/Cargo.toml
@@ -17,7 +17,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 lpc55-pac = "0.3.0"
-cfg-if = "0.1.10"
+cfg-if = "1"
 
 [dependencies.kern]
 path = "../../sys/kern"

--- a/test/tests-stm32g0/Cargo.toml
+++ b/test/tests-stm32g0/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
 
 [dependencies.kern]

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-rt = "0.6.12"
 panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "0.1.10"
+cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
 
 [dependencies.kern]


### PR DESCRIPTION
This consolidates to using `cfg_if = "1"` everywhere (previously we had a mix of `1` and `0.1.10`).

The only change in `cfg_if` is to make the macro somewhat stricter, which would cause compilation failures if we were using the non-strict form.  We aren't, so it doesn't.