### PR TITLE
supress a warning about an unused result

### DIFF
--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -186,7 +186,7 @@ impl<'a, B: BspT> NotificationHandler for ServerImpl<'a, B> {
             ThermalMode::Auto => {
                 if self.counter % CONTROL_RATE == 0 {
                     // TODO: what to do with errors here?
-                    self.control.run_control();
+                    let _ = self.control.run_control();
                 } else {
                     let _ = self.control.read_sensors();
                 }


### PR DESCRIPTION
We've got a couple of warnings in the build that are leaving comments on PRs. This is the simplest one; while this TODO is being figured out, at least we can stop all of this:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/27786/172241675-cb0557d3-a016-4bb8-b19c-126963f4d275.png">
