### PR TITLE
Kernel klippy

### DIFF
--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -9,10 +9,6 @@
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, Unaligned};
 
-/// Magic number that appears at the start of an application header (`App`) to
-/// reassure the kernel that it is not reading uninitialized Flash.
-pub const CURRENT_APP_MAGIC: u32 = 0x1DE_fa7a1;
-
 /// Number of region slots in a `TaskDesc` record. Needs to be less or equal to
 /// than the number of regions in the MPU; may be less to improve context switch
 /// performance. (Though note that changing this alters the ABI.)

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -199,13 +199,13 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
         let irq_task_value = irq_task_map
             .values
             .iter()
-            .map(|o| fmt_irq_task(Some(&o)))
+            .map(|o| fmt_irq_task(Some(o)))
             .collect::<Vec<String>>()
             .join("\n        ");
         let task_irq_value = task_irq_map
             .values
             .iter()
-            .map(|o| fmt_task_irq(Some(&o)))
+            .map(|o| fmt_task_irq(Some(o)))
             .collect::<Vec<String>>()
             .join("\n        ");
 

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -476,7 +476,7 @@ pub fn apply_memory_protection(task: &task::Task) {
         };
 
         // RLAR = our upper bound
-        let rlar = region.base + region.size
+        let rlar = (region.base + region.size)
                 | (i as u32) << 1 // AttrIndx
                 | (1 << 0); // enable
 
@@ -492,11 +492,11 @@ pub fn apply_memory_protection(task: &task::Task) {
             // MAIR
             if rnr < 4 {
                 let mut mair0 = (0xe000_edc0 as *const u32).read_volatile();
-                mair0 = mair0 | (mair as u32) << (rnr * 8);
+                mair0 |= (mair as u32) << (rnr * 8);
                 core::ptr::write_volatile(0xe000_edc0 as *mut u32, mair0);
             } else {
                 let mut mair1 = (0xe000_edc4 as *const u32).read_volatile();
-                mair1 = mair1 | (mair as u32) << ((rnr - 4) * 8);
+                mair1 |= (mair as u32) << ((rnr - 4) * 8);
                 core::ptr::write_volatile(0xe000_edc4 as *mut u32, mair1);
             }
             // RBAR
@@ -928,6 +928,7 @@ pub fn now() -> Timestamp {
 ///
 /// `TICKS[0]` is the least significant part, `TICKS[1]` the most significant.
 static TICKS: [AtomicU32; 2] = {
+    #[allow(clippy::declare_interior_mutable_const)]
     const ZERO: AtomicU32 = AtomicU32::new(0);
     [ZERO; 2]
 };

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -25,9 +25,9 @@ pub fn handle_kernel_message(
         4 => read_image_id(tasks, caller, args.response?),
         _ => {
             // Task has sent an unknown message to the kernel. That's bad.
-            return Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(
                 UsageError::BadKernelMessage,
-            )));
+            )))
         }
     }
 }

--- a/sys/kern/src/profiling.rs
+++ b/sys/kern/src/profiling.rs
@@ -91,37 +91,53 @@ fn table() -> Option<&'static EventsTable> {
 }
 
 pub(crate) fn event_syscall_enter(nr: u32) {
-    table().map(|t| (t.syscall_enter)(nr));
+    if let Some(t) = table() {
+        (t.syscall_enter)(nr)
+    }
 }
 
 pub(crate) fn event_syscall_exit() {
-    table().map(|t| (t.syscall_exit)());
+    if let Some(t) = table() {
+        (t.syscall_exit)()
+    }
 }
 
 pub(crate) fn event_secondary_syscall_enter() {
-    table().map(|t| (t.secondary_syscall_enter)());
+    if let Some(t) = table() {
+        (t.secondary_syscall_enter)()
+    }
 }
 
 pub(crate) fn event_secondary_syscall_exit() {
-    table().map(|t| (t.secondary_syscall_exit)());
+    if let Some(t) = table() {
+        (t.secondary_syscall_exit)()
+    }
 }
 
 /// Signals entry to an ISR. This is `pub` in case you write your own
 /// non-kernel-managed ISR but you'd like to include it in ISR statistics.
 pub fn event_isr_enter() {
-    table().map(|t| (t.isr_enter)());
+    if let Some(t) = table() {
+        (t.isr_enter)()
+    }
 }
 
 /// Signals exit from an ISR. This is `pub` in case you write your own
 /// non-kernel-managed ISR but you'd like to include it in ISR statistics.
 pub fn event_isr_exit() {
-    table().map(|t| (t.isr_exit)());
+    if let Some(t) = table() {
+        (t.isr_exit)()
+    }
 }
 
 pub(crate) fn event_timer_isr_enter() {
-    table().map(|t| (t.timer_isr_enter)());
+    if let Some(t) = table() {
+        (t.timer_isr_enter)()
+    }
 }
 
 pub(crate) fn event_timer_isr_exit() {
-    table().map(|t| (t.timer_isr_exit)());
+    if let Some(t) = table() {
+        (t.timer_isr_exit)()
+    }
 }

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -183,7 +183,7 @@ fn send(tasks: &mut [Task], caller: usize) -> Result<NextTask, UserError> {
     tasks[caller].set_healthy_state(SchedState::InSend(callee_id));
     // We may not know what task to run next, but we're pretty sure it isn't the
     // caller.
-    return Ok(NextTask::Other.combine(next_task));
+    Ok(NextTask::Other.combine(next_task))
 }
 
 /// Implementation of the RECV IPC primitive.
@@ -384,7 +384,7 @@ fn reply(tasks: &mut [Task], caller: usize) -> Result<NextTask, FaultInfo> {
     // KEY ASSUMPTION: sends go from less important tasks to more important
     // tasks. As a result, Reply doesn't have scheduling implications unless
     // the task using it faults.
-    return Ok(NextTask::Same);
+    Ok(NextTask::Same)
 }
 
 /// Implementation of the `SET_TIMER` syscall.
@@ -447,12 +447,12 @@ fn borrow_read(
             tasks[caller]
                 .save_mut()
                 .set_borrow_response_and_length(0, n);
-            return Ok(NextTask::Same);
+            Ok(NextTask::Same)
         }
         Err(interact) => {
             let wake_hint = interact.apply_to_src(tasks, lender)?;
             // Copy failed but not our side, report defecting lender.
-            return Err(UserError::Recoverable(abi::DEFECT, wake_hint));
+            Err(UserError::Recoverable(abi::DEFECT, wake_hint))
         }
     }
 }
@@ -490,12 +490,12 @@ fn borrow_write(
             tasks[caller]
                 .save_mut()
                 .set_borrow_response_and_length(0, n);
-            return Ok(NextTask::Same);
+            Ok(NextTask::Same)
         }
         Err(interact) => {
             let wake_hint = interact.apply_to_dst(tasks, lender)?;
             // Copy failed but not our side, report defecting lender.
-            return Err(UserError::Recoverable(abi::DEFECT, wake_hint));
+            Err(UserError::Recoverable(abi::DEFECT, wake_hint))
         }
     }
 }
@@ -514,7 +514,7 @@ fn borrow_info(
     tasks[caller]
         .save_mut()
         .set_borrow_info(lease.attributes.bits(), lease.length as usize);
-    return Ok(NextTask::Same);
+    Ok(NextTask::Same)
 }
 
 fn borrow_lease(
@@ -817,5 +817,5 @@ fn reply_fault(
     // KEY ASSUMPTION: sends go from less important tasks to more important
     // tasks. As a result, Reply doesn't have scheduling implications unless
     // the task using it faults.
-    return Ok(NextTask::Same);
+    Ok(NextTask::Same)
 }

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -758,7 +758,7 @@ pub fn check_task_id_against_table(
         return Err(UserError::Recoverable(code, NextTask::Same));
     }
 
-    return Ok(id.index());
+    Ok(id.index())
 }
 
 /// Selects a new task to run after `previous`. Tries to be fair, kind of.

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -318,6 +318,7 @@ pub fn safe_copy(
 
 /// Utility routine for getting `&mut` to _two_ elements of a slice, at indexes
 /// `i` and `j`. `i` and `j` must be distinct, or this will panic.
+#[allow(clippy::comparison_chain)]
 fn index2_distinct<T>(
     elements: &mut [T],
     i: usize,


### PR DESCRIPTION
This makes the kernel (and abi crate) clippy-clean on armv6/7/8m.