### PR TITLE
Pseudorandom clippy fixes

### DIFF
--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -16,11 +16,14 @@ pub fn run(
 ) -> Result<()> {
     let toml = Config::from_file(&cfg)?;
 
+    let mut tasks = tasks.to_vec();
+
     if tasks.is_empty() {
-        bail!("Must provide one or more task names");
+        tasks.extend(toml.tasks.keys().cloned());
+        tasks.push("kernel".to_string());
     }
 
-    for name in tasks {
+    for name in &tasks {
         if !toml.tasks.contains_key(name) && name != "kernel" {
             bail!("{}", toml.task_name_suggestion(name));
         }

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -113,7 +113,6 @@ enum Xtask {
         cfg: PathBuf,
 
         /// Name of task(s) to check.
-        #[clap(min_values = 1)]
         tasks: Vec<String>,
 
         /// Extra options to pass to clippy

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -106,6 +106,7 @@ pub enum Controller {
 }
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[allow(clippy::unusual_byte_groupings)]
 pub enum ReservedAddress {
     GeneralCall = 0b0000_000,
     CBUSAddress = 0b0000_001,
@@ -257,11 +258,11 @@ impl I2cDevice {
         address: u8,
     ) -> Self {
         Self {
-            task: task,
-            controller: controller,
-            port: port,
-            segment: segment,
-            address: address,
+            task,
+            controller,
+            port,
+            segment,
+            address,
         }
     }
 }

--- a/drv/stm32g0-usart/src/main.rs
+++ b/drv/stm32g0-usart/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> ! {
                     #[cfg(any(feature = "g031", feature = "g070"))]
                     if usart.isr.read().txe().bit() {
                         // TX register empty. Do we need to send something?
-                        step_transmit(&usart, txref);
+                        step_transmit(usart, txref);
                     }
 
                     #[cfg(feature = "g0b1")]
@@ -215,7 +215,7 @@ fn step_transmit(
         usart
             .cr1_fifo_disabled()
             .modify(|_, w| w.txeie().clear_bit());
-        core::mem::replace(state, None).unwrap().caller
+        state.take().unwrap().caller
     }
 
     let txs = if let Some(txs) = tx { txs } else { return };

--- a/drv/stm32h7-eth/src/ring.rs
+++ b/drv/stm32h7-eth/src/ring.rs
@@ -13,16 +13,21 @@
 //! setting up the `static mut` data buffers required to call `new` on the
 //! respective ring types.
 
+// The ring APIs in general do not need to know if something is empty.
+#![allow(clippy::len_without_is_empty)]
+
 use core::cell::{Cell, UnsafeCell};
 use core::sync::atomic::{AtomicU32, Ordering};
 
 /// This can be used in an array initializer, while `AtomicU32::new(0)` cannot.
 /// Believe it!
+#[allow(clippy::declare_interior_mutable_const)]
 const ATOMIC_ZERO: AtomicU32 = AtomicU32::new(0);
 
 /// Similarly, we have to make this intermediate array to store an array of
 /// arrays of AtomicZero
 #[cfg(feature = "vlan")]
+#[allow(clippy::declare_interior_mutable_const)]
 const ATOMIC_ZERO_FOUR: [AtomicU32; 4] = [ATOMIC_ZERO; 4];
 
 /// Size of buffer used with the Ethernet DMA. This can be changed but must

--- a/drv/stm32h7-i2c/src/lib.rs
+++ b/drv/stm32h7-i2c/src/lib.rs
@@ -410,6 +410,7 @@ impl<'a> I2cController<'a> {
 
             laps += 1;
 
+            #[allow(clippy::comparison_chain)] // clippy misfire
             if laps == BUSY_SLEEP_THRESHOLD {
                 //
                 // If we have taken BUSY_SLEEP_THRESHOLD laps, we are going to

--- a/drv/stm32h7-i2c/src/ltc4306.rs
+++ b/drv/stm32h7-i2c/src/ltc4306.rs
@@ -37,6 +37,7 @@ bitfield! {
 }
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[allow(clippy::enum_variant_names)] // not great, TODO
 enum Timeout {
     TimeoutDisabled = 0b00,
     Timeout30ms = 0b01,

--- a/drv/stm32h7-i2c/src/max7358.rs
+++ b/drv/stm32h7-i2c/src/max7358.rs
@@ -89,8 +89,8 @@ fn read_regs(
     ) {
         Err(code) => Err(mux.error_code(code)),
         _ => {
-            for i in 0..rbuf.len() {
-                ringbuf_entry!(Trace::Read(Register::from(i as u8), rbuf[i]));
+            for (i, &byte) in rbuf.iter().enumerate() {
+                ringbuf_entry!(Trace::Read(Register::from(i as u8), byte));
             }
 
             Ok(())

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> ! {
     // with one of these activated.
     let current_mux_index = 0;
     for opt in &CONFIG.mux_options[1..] {
-        deactivate_mux_option(&opt, &sys);
+        deactivate_mux_option(opt, &sys);
     }
     activate_mux_option(&CONFIG.mux_options[current_mux_index], &sys, &spi);
 
@@ -270,14 +270,9 @@ impl ServerImpl {
         }
 
         // Get the required transfer lengths in the src and dest directions.
-        let src_len = data_src
-            .as_ref()
-            .map(|leased| LenLimit::len_as_u16(&leased))
-            .unwrap_or(0);
-        let dest_len = data_dest
-            .as_ref()
-            .map(|leased| LenLimit::len_as_u16(&leased))
-            .unwrap_or(0);
+        let src_len = data_src.as_ref().map(LenLimit::len_as_u16).unwrap_or(0);
+        let dest_len =
+            data_dest.as_ref().map(LenLimit::len_as_u16).unwrap_or(0);
         let overall_len = src_len.max(dest_len);
 
         // Zero-byte SPI transactions don't make sense and we'll

--- a/drv/stm32h7-spi/src/lib.rs
+++ b/drv/stm32h7-spi/src/lib.rs
@@ -73,7 +73,7 @@ impl Spi {
         // cannot presume to have either direct GPIO access _or_ IPC access.
         // - Clock on, reset off - again, we can't do this directly.
 
-        assert!(bits_per_frame >= 4 && bits_per_frame <= 32);
+        assert!((4..=32).contains(&bits_per_frame));
 
         // Write CFG1/CFG2 to configure
         self.reg

--- a/drv/stm32h7-startup/src/lib.rs
+++ b/drv/stm32h7-startup/src/lib.rs
@@ -293,11 +293,14 @@ pub fn system_init_custom(
             .wrhighfreq()
             .bits(config.flash_write_delay)
     });
-    while {
+    loop {
         let r = p.FLASH.acr.read();
-        r.latency().bits() != config.flash_latency
-            || r.wrhighfreq().bits() != config.flash_write_delay
-    } {}
+        if r.latency().bits() == config.flash_latency
+            && r.wrhighfreq().bits() == config.flash_write_delay
+        {
+            break;
+        }
+    }
     // Not that reordering is likely here, since we polled, but: we
     // really do need the Flash to be programmed with more wait states
     // before switching the clock.

--- a/lib/fixedmap/src/lib.rs
+++ b/lib/fixedmap/src/lib.rs
@@ -17,20 +17,20 @@
 /// type `V`.
 ///
 #[derive(Debug)]
-pub struct FixedMap<K: Copy + PartialEq, V: Copy, const N: usize> {
+pub struct FixedMap<K, V, const N: usize> {
     contents: [Option<(K, V)>; N],
 }
 
-impl<K: Copy + PartialEq, V: Copy, const N: usize> FixedMap<K, V, { N }> {
-    ///
-    /// Create a new `FixedMap`.
-    ///
-    pub fn new() -> Self {
+impl<K: Copy, V: Copy, const N: usize> Default for FixedMap<K, V, { N }> {
+    /// Create an empty `FixedMap`.
+    fn default() -> Self {
         Self {
             contents: [None; N],
         }
     }
+}
 
+impl<K: Copy + PartialEq, V: Copy, const N: usize> FixedMap<K, V, { N }> {
     ///
     /// Gets the value that corresponds to `key`, returning `None` if no
     /// such key is in the map.
@@ -93,10 +93,8 @@ impl<K: Copy + PartialEq, V: Copy, const N: usize> FixedMap<K, V, { N }> {
                 Some((k, _)) => {
                     if k == key {
                         found = Some(i);
-                    } else {
-                        if found.is_some() {
-                            swap = Some(i);
-                        }
+                    } else if found.is_some() {
+                        swap = Some(i);
                     }
                 }
             }

--- a/sys/num-tasks/build.rs
+++ b/sys/num-tasks/build.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut task_enum = vec![];
     if let Ok(task_names) = env::var("HUBRIS_TASKS") {
         println!("HUBRIS_TASKS = {}", task_names);
-        for (i, name) in task_names.split(",").enumerate() {
+        for (i, name) in task_names.split(',').enumerate() {
             task_enum.push(format!("    {} = {},", name, i));
         }
     } else {

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -24,7 +24,7 @@ pub fn restart_task(task: usize, start: bool) {
     let msg = (task as u32, start);
     let mut buf = [0; core::mem::size_of::<(u32, bool)>()];
     ssmarshal::serialize(&mut buf, &msg).unwrap_lite();
-    let (rc, _len) = sys_send(TaskId::KERNEL, 2, &mut buf, &mut [], &[]);
+    let (rc, _len) = sys_send(TaskId::KERNEL, 2, &buf, &mut [], &[]);
     assert_eq!(rc, 0);
 }
 

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -285,7 +285,7 @@ pub(crate) fn qspi_read_status(
 ) -> Result<usize, Failure> {
     use drv_gimlet_hf_api as hf;
 
-    if rval.len() < 1 {
+    if rval.is_empty() {
         return Err(Failure::Fault(Fault::ReturnValueOverflow));
     }
 
@@ -422,7 +422,7 @@ pub(crate) fn qspi_sector_erase(
 ) -> Result<usize, Failure> {
     use drv_gimlet_hf_api as hf;
 
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::MissingParameters));
     }
     let frame = &stack[stack.len() - 1..];
@@ -488,7 +488,7 @@ pub(crate) fn hash_digest_sha256(
         return Err(Failure::Fault(Fault::ReturnValueOverflow));
     }
 
-    if stack.len() < 1 {
+    if stack.is_empty() {
         // return Err(Failure::Fault(Fault::MissingParameters));
         return Err(Failure::Fault(Fault::BadParameter(0)));
     }
@@ -512,7 +512,7 @@ pub(crate) fn hash_update(
 ) -> Result<usize, Failure> {
     use drv_hash_api as hash;
 
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::BadParameter(0)));
     }
     let frame = &stack[stack.len() - 1..];
@@ -555,7 +555,7 @@ pub(crate) fn rng_fill(
 ) -> Result<usize, Failure> {
     use drv_rng_api::Rng;
 
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::MissingParameters));
     }
     if stack.len() > 1 {

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -32,7 +32,7 @@ pub(crate) fn sleep(
     _data: &[u8],
     _rval: &mut [u8],
 ) -> Result<usize, Failure> {
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::MissingParameters));
     }
 

--- a/task/hiffy/src/stm32g0.rs
+++ b/task/hiffy/src/stm32g0.rs
@@ -91,7 +91,7 @@ fn gpio_input(
     let task = SYS.get_task_id();
     let sys = drv_stm32xx_sys_api::Sys::from(task);
 
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::MissingParameters));
     }
 

--- a/task/jefe/src/external.rs
+++ b/task/jefe/src/external.rs
@@ -130,7 +130,7 @@ pub fn check(disposition: &mut [Disposition]) -> bool {
     }
 
     JEFE_EXTERNAL_ERRORS.fetch_add(1, Ordering::SeqCst);
-    return false;
+    false
 }
 
 ///

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -51,12 +51,12 @@ fn generate_net_config(
             generate_socket_state(name, socket, config.vlan.map(|v| v.count))?
         )?;
     }
-    writeln!(out, "{}", generate_state_struct(&config)?)?;
-    writeln!(out, "{}", generate_constructor(&config)?)?;
-    writeln!(out, "{}", generate_owner_info(&config)?)?;
-    writeln!(out, "{}", generate_port_table(&config)?)?;
+    writeln!(out, "{}", generate_state_struct(config)?)?;
+    writeln!(out, "{}", generate_constructor(config)?)?;
+    writeln!(out, "{}", generate_owner_info(config)?)?;
+    writeln!(out, "{}", generate_port_table(config)?)?;
 
-    build_net::generate_socket_enum(&config, &mut out)?;
+    build_net::generate_socket_enum(config, &mut out)?;
 
     drop(out);
 

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -151,7 +151,7 @@ impl<'a> ServerImpl<'a> {
     /// Calls the `wake` function on the BSP, which handles things like
     /// periodic logging and monitoring of ports.
     pub fn wake(&self) {
-        self.bsp.wake(&self.iface.device());
+        self.bsp.wake(self.iface.device());
     }
 }
 
@@ -256,7 +256,8 @@ impl idl::InOrderNetImpl for ServerImpl<'_> {
         value: u16,
     ) -> Result<(), RequestError<NetError>> {
         // TODO: this should not be open to all callers!
-        Ok(self.iface.device().smi_write(phy, register, value))
+        self.iface.device().smi_write(phy, register, value);
+        Ok(())
     }
 }
 

--- a/task/pong/src/main.rs
+++ b/task/pong/src/main.rs
@@ -39,7 +39,7 @@ pub fn main() -> ! {
             loop {
                 match user_leds.led_toggle(current >> 1) {
                     Ok(_) => {
-                        current = current + 1;
+                        current += 1;
                         break;
                     }
                     Err(drv_user_leds_api::LedError::NotPresent) => {


### PR DESCRIPTION
Been inspecting Clippy warnings as a background task. This PR gets the stm32g0 and stm32h743-nucleo builds to be Clippy clean, except for some warnings on h7 from Idol generated code.

None of the warnings seemed to signal lurking bugs, but there were a lot of good cleanup suggestions (and a few I suppressed).