### PR TITLE
jefe system state API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,6 +2943,7 @@ name = "task-jefe"
 version = "0.1.0"
 dependencies = [
  "abi",
+ "anyhow",
  "armv6m-atomic-hack",
  "build-util",
  "cortex-m",
@@ -2950,6 +2951,7 @@ dependencies = [
  "hubris-num-tasks",
  "num-traits",
  "ringbuf",
+ "serde",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,9 +2949,23 @@ dependencies = [
  "cortex-m",
  "cortex-m-semihosting",
  "hubris-num-tasks",
+ "idol",
+ "idol-runtime",
  "num-traits",
  "ringbuf",
  "serde",
+ "task-jefe-api",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "task-jefe-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,6 +3009,7 @@ dependencies = [
  "ssmarshal",
  "stm32h7",
  "syn",
+ "task-jefe-api",
  "task-net-api",
  "userlib",
  "vsc7448-pac",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ name = "drv-gimlet-seq-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
+ "drv-gimlet-state",
  "idol",
  "num-traits",
  "userlib",
@@ -746,6 +747,15 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_json",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "drv-gimlet-state"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_json",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "task/template",
 
     "task/jefe",
+    "task/jefe-api",
     "task/ping",
     "task/pong",
     "task/idle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "drv/user-leds-api",
     "drv/ice40-spi-program",
     "drv/gimlet-seq-server",
+    "drv/gimlet-state",
     "drv/gimlet-hf-server",
     "drv/gimlet-hf-api",
     "drv/vsc7448",

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -54,6 +54,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+on-state-change = {net = {bit-number = 3}}
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h743"]

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -52,6 +52,7 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.jefe.config]
+state-owner = "gimlet_seq"
 on-state-change = {net = {bit-number = 3}}
 
 [tasks.sys]

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -124,7 +124,7 @@ priority = 5
 requires = {flash = 16384, ram = 8192 }
 stacksize = 4504
 start = true
-task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
+task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
 name = "task-power"
@@ -151,7 +151,7 @@ priority = 4
 requires = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
-task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga.bin"

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -51,6 +51,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+on-state-change = {net = {bit-number = 3}}
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]
@@ -178,9 +181,7 @@ sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
 interrupts = {"eth.irq" = 0b1}
-task-slots = ["sys",
-              { spi_driver = "spi2_driver" },
-              { seq = "gimlet_seq" }]
+task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sensor]
 name = "task-sensor"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -136,7 +136,7 @@ priority = 5
 requires = {flash = 32768, ram = 8192 }
 stacksize = 4504
 start = true
-task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
+task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
 name = "task-power"
@@ -163,7 +163,7 @@ priority = 4
 requires = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
-task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga-b.bin"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -52,6 +52,7 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.jefe.config]
+state-owner = "gimlet_seq"
 on-state-change = {net = {bit-number = 3}}
 
 [tasks.net]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -51,6 +51,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+on-state-change = {net = {bit-number = 3}}
+
 [tasks.net]
 name = "task-net"
 stacksize = 5400
@@ -61,7 +64,7 @@ sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
 interrupts = {"eth.irq" = 0b1}
-task-slots = ["sys", { spi_driver = "spi2_driver" }, { seq = "gimlet_seq" }]
+task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::de::DeserializeOwned;
 use std::env;
 
@@ -48,38 +48,53 @@ pub fn expose_target_board() {
 /// reflect that by having its member (or members) be an `Option` type.
 ///
 pub fn config<T: DeserializeOwned>() -> Result<T> {
-    toml_from_env("HUBRIS_APP_CONFIG", Some("[config]"))
+    toml_from_env("HUBRIS_APP_CONFIG")?.ok_or_else(|| {
+        anyhow!("app.toml missing global config section [config]")
+    })
 }
 
 /// Pulls the task configuration. See `config` for more details.
 pub fn task_config<T: DeserializeOwned>() -> Result<T> {
-    let section = match env::var("HUBRIS_TASK_NAME") {
-        Ok(task_name) => Some(format!("[tasks.{}.config]", task_name)),
-        _ => None,
-    };
-    toml_from_env("HUBRIS_TASK_CONFIG", section.as_deref())
+    let task_name =
+        env::var("HUBRIS_TASK_NAME").expect("missing HUBRIS_TASK_NAME");
+    task_maybe_config()?.ok_or_else(|| {
+        anyhow!(
+            "app.toml missing task config section [tasks.{}.config]",
+            task_name
+        )
+    })
 }
 
-/// Parse the contents of an environment variable as toml. `section_name_pattern` is a string
-/// indicating what section of original toml file the variable should have come from to improve error reporting. `{task}` in the pattern is replaced with HUBRIS_TASK_NAME.
-fn toml_from_env<T: DeserializeOwned>(
-    var: &str,
-    section_name: Option<&str>,
-) -> Result<T> {
-    let config = env::var(var).map_err(|err|
-        match err {
-            env::VarError::NotPresent =>
-                match section_name {
-                    Some(section_name) => anyhow!("{} environment variable is undefined, but it should contain toml. Are you missing the {} section in your app.toml?", var, section_name),
-                    None => anyhow!("{} environment variable should contain toml, but it's missing, and we don't know why. Something has gone horribly wrong.", var)
-                },
-            _ => anyhow!(err)
+/// Pulls the task configuration, or `None` if the configuration is not
+/// provided.
+pub fn task_maybe_config<T: DeserializeOwned>() -> Result<Option<T>> {
+    toml_from_env("HUBRIS_TASK_CONFIG")
+}
+
+/// Parse the contents of an environment variable as toml.
+///
+/// Returns:
+///
+/// - `Ok(Some(x))` if the environment variable is defined and the contents
+///   deserialized correctly.
+/// - `Ok(None)` if the environment variable is not defined.
+/// - `Err(e)` if deserialization failed or the environment variable did not
+///   contain UTF-8.
+fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
+    let config = match env::var(var) {
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("accessing environment variable {}", var)
+            })
         }
-    )?;
+        Ok(c) => c,
+    };
 
     println!("--- toml for ${} ---", var);
     println!("{}", config);
-    let rval = toml::from_slice(config.as_bytes())?;
+    let rval = toml::from_slice(config.as_bytes())
+        .context("deserializing configuration")?;
     println!("cargo:rerun-if-env-changed={}", var);
-    Ok(rval)
+    Ok(Some(rval))
 }

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -8,6 +8,7 @@ derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
+drv-gimlet-state = {path = "../gimlet-state"}
 
 # a target for `cargo xtask check`
 [package.metadata.build]

--- a/drv/gimlet-seq-api/src/lib.rs
+++ b/drv/gimlet-seq-api/src/lib.rs
@@ -8,7 +8,9 @@
 
 use derive_idol_err::IdolError;
 use userlib::*;
-use zerocopy::AsBytes;
+
+// Re-export PowerState for client convenience.
+pub use drv_gimlet_state::PowerState;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum SeqError {
@@ -16,16 +18,6 @@ pub enum SeqError {
     MuxToHostCPUFailed = 2,
     MuxToSPFailed = 3,
     ClockConfigFailed = 4,
-}
-
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
-#[repr(u8)]
-pub enum PowerState {
-    A2 = 1,
-    A2PlusMono = 2,
-    A2PlusFans = 3,
-    A1 = 4,
-    A0 = 5,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -14,6 +14,7 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-spi-api = {path = "../spi-api"}
+task-jefe-api = {path = "../../task/jefe-api"}
 drv-ice40-spi-program = {path = "../ice40-spi-program"}
 drv-i2c-api = {path = "../i2c-api"}
 drv-i2c-devices = {path = "../i2c-devices"}

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -443,16 +443,6 @@ impl idl::InOrderSequencerImpl for ServerImpl {
             .unwrap();
         Ok(())
     }
-
-    //
-    // By the time we are hanging out the shingle, the clock config is loaded.
-    //
-    fn is_clock_config_loaded(
-        &mut self,
-        _: &RecvMessage,
-    ) -> Result<u8, RequestError<SeqError>> {
-        Ok(1)
-    }
 }
 
 fn reprogram_fpga(

--- a/drv/gimlet-state/Cargo.toml
+++ b/drv/gimlet-state/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "drv-gimlet-state"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }

--- a/drv/gimlet-state/src/lib.rs
+++ b/drv/gimlet-state/src/lib.rs
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Common definitions for dealing with system state on Gimlet, shared by the
+//! various tasks and IPC interfaces involved.
+
+#![no_std]
+
+use userlib::FromPrimitive;
+use zerocopy::AsBytes;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[repr(u8)]
+pub enum PowerState {
+    A2 = 1,
+    A2PlusMono = 2,
+    A2PlusFans = 3,
+    A1 = 4,
+    A0 = 5,
+}

--- a/idl/gimlet-seq.idol
+++ b/idl/gimlet-seq.idol
@@ -40,12 +40,5 @@ Interface(
                 err: CLike("SeqError"),
             ),
         ),
-        "is_clock_config_loaded": (
-            args: {},
-            reply: Result(
-                ok: "u8",
-                err: CLike("SeqError"),
-            ),
-        ),
     },
 )

--- a/idl/jefe.idol
+++ b/idl/jefe.idol
@@ -1,0 +1,18 @@
+// Jefe IPC API
+
+Interface(
+    name: "Jefe",
+    ops: {
+        "get_state": (
+            reply: Simple("u32"),
+            idempotent: true,
+        ),
+        "set_state": (
+            args: {
+                "state": "u32",
+            },
+            reply: Simple("()"),
+            idempotent: true,
+        ),
+    },
+)

--- a/task/jefe-api/Cargo.toml
+++ b/task/jefe-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "task-jefe-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+userlib = {path = "../../sys/userlib"}
+num-traits = {version = "0.2", default-features = false}
+zerocopy = "0.6"
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false

--- a/task/jefe-api/build.rs
+++ b/task/jefe-api/build.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub("../../idl/jefe.idol", "client_stub.rs")?;
+
+    Ok(())
+}

--- a/task/jefe-api/src/lib.rs
+++ b/task/jefe-api/src/lib.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Client API for El Jefe
+
+#![no_std]
+
+use userlib::*;
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 abi = {path = "../../sys/abi"}
 userlib = {path = "../../sys/userlib"}
-hubris-num-tasks = {path = "../../sys/num-tasks"}
+hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
 ringbuf = {path = "../../lib/ringbuf" }
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
@@ -16,6 +16,8 @@ armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+serde = {version = "1", features = ["derive"]}
+anyhow = "1"
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -13,11 +13,14 @@ zerocopy = "0.6.1"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.3.7", features = ["inline-asm"], optional = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+task-jefe-api = {path = "../jefe-api"}
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
 serde = {version = "1", features = ["derive"]}
 anyhow = "1"
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -2,6 +2,49 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() {
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::io::Write;
+
+fn main() -> Result<()> {
     build_util::expose_m_profile();
+
+    let cfg = build_util::task_maybe_config::<Config>()?.unwrap_or_default();
+    let out_dir = std::env::var("OUT_DIR")?;
+    let dest_path = std::path::Path::new(&out_dir).join("jefe_config.rs");
+    let mut out =
+        std::fs::File::create(&dest_path).context("creating jefe_config.rs")?;
+
+    let count = cfg.on_state_change.len();
+
+    let task = "hubris_num_tasks::Task";
+    writeln!(
+        out,
+        "const MAILING_LIST: [({}, usize); {}] = [",
+        task, count
+    )?;
+    for (name, rec) in cfg.on_state_change {
+        writeln!(out, "    ({}::{}, 1 << {})", task, name, rec.bit_number)?;
+    }
+    writeln!(out, "];")?;
+
+    Ok(())
+}
+
+/// Jefe task-level configuration.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+struct Config {
+    /// Task requests to be notified on state change, as a map from task name to
+    /// `StateChange` record.
+    on_state_change: BTreeMap<String, StateChange>,
+}
+
+/// Description of something a task wants done on state change.
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct StateChange {
+    /// Number of notification bit to signal (_not_ mask).
+    bit_number: u8,
 }

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -36,6 +36,13 @@ fn main() -> Result<()> {
     }
     writeln!(out, "];")?;
 
+    write!(out, "pub(crate) const STATE_OWNER: Option<{}> = ", task)?;
+    if let Some(owner) = cfg.state_owner {
+        writeln!(out, "Some({}::{});", task, owner)?;
+    } else {
+        writeln!(out, "None;")?;
+    }
+
     Ok(())
 }
 
@@ -46,6 +53,10 @@ struct Config {
     /// Task requests to be notified on state change, as a map from task name to
     /// `StateChange` record.
     on_state_change: BTreeMap<String, StateChange>,
+    /// Name of task responsible for state changes. If provided, a state change
+    /// request from any other task will result in that task being faulted.
+    #[serde(default)]
+    state_owner: Option<String>,
 }
 
 /// Description of something a task wants done on state change.

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -8,6 +8,13 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 fn main() -> Result<()> {
+    idol::server::build_server_support(
+        "../../idl/jefe.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )
+    .unwrap();
+
     build_util::expose_m_profile();
 
     let cfg = build_util::task_maybe_config::<Config>()?.unwrap_or_default();
@@ -21,7 +28,7 @@ fn main() -> Result<()> {
     let task = "hubris_num_tasks::Task";
     writeln!(
         out,
-        "const MAILING_LIST: [({}, usize); {}] = [",
+        "pub(crate) const MAILING_LIST: [({}, u32); {}] = [",
         task, count
     )?;
     for (name, rec) in cfg.on_state_change {

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -179,3 +179,6 @@ fn main() -> ! {
         }
     }
 }
+
+// Pull in generated notification data.
+include!(concat!(env!("OUT_DIR"), "/jefe_config.rs"));

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -25,6 +25,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 ksz8463 = { path = "../../drv/ksz8463", optional = true }
 ringbuf = {path = "../../lib/ringbuf"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
+task-jefe-api = {path = "../jefe-api"}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", optional = true}
 vsc85xx = { path = "../../drv/vsc85xx", optional = true }


### PR DESCRIPTION
This adds a system state tracking API to Jefe. Currently the only things that can be done with that API are:
- Read the current state
- Alter the state
- Get notified if someone alters the state.

In support of that third one, Jefe now has configuration: it can be asked to poke tasks when the state changes.

This PR also includes `gimlet-seq-server` support for posting sequencing state to Jefe, and corresponding client code in `net` to use Jefe's state instead of directly contacting the sequencer task.