### PR TITLE
Automatically size tasks

### DIFF
--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -35,7 +35,7 @@ execute = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -44,7 +44,7 @@ stacksize = 1536
 name = "drv-stm32fx-rcc"
 features = ["f3"]
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 uses = ["rcc"]
 start = true
 
@@ -52,7 +52,7 @@ start = true
 name = "drv-stm32fx-usart"
 features = ["stm32f3"]
 priority = 2
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["usart2", "gpioa"]
 start = true
 interrupts = {"usart2.irq" = 1}
@@ -62,7 +62,7 @@ task-slots = ["rcc_driver"]
 name = "drv-user-leds"
 features = ["stm32f3"]
 priority = 2
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["gpioe"]
 start = true
 task-slots = ["rcc_driver"]
@@ -71,7 +71,7 @@ task-slots = ["rcc_driver"]
 name = "task-ping"
 features = ["uart"]
 priority = 4
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 stacksize = 512
 start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
@@ -79,21 +79,21 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 3
-requires = {flash = 16384, ram = 16384 }
+max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 2048
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -35,7 +35,7 @@ execute = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -44,7 +44,7 @@ stacksize = 1536
 name = "drv-stm32fx-rcc"
 features = ["f4"]
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 uses = ["rcc"]
 start = true
 
@@ -52,7 +52,7 @@ start = true
 name = "drv-stm32fx-usart"
 features = ["stm32f4"]
 priority = 2
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["usart2", "gpioa"]
 start = true
 interrupts = {"usart2.irq" = 1}
@@ -62,7 +62,7 @@ task-slots = ["rcc_driver"]
 name = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["gpiod"]
 start = true
 task-slots = ["rcc_driver"]
@@ -71,7 +71,7 @@ task-slots = ["rcc_driver"]
 name = "task-ping"
 features = ["uart"]
 priority = 4
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 stacksize = 512
 start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
@@ -79,20 +79,20 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 3
-requires = {flash = 16384, ram = 16384 }
+max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 2048
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -25,7 +25,7 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 512}
 start = true
 features = ["log-null"]
 stacksize = 368
@@ -33,7 +33,7 @@ stacksize = 368
 [tasks.sys]
 name = "drv-stm32xx-sys"
 priority = 1
-requires = {flash = 2048, ram = 256}
+max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
 start = true
 features = ["g031"]
@@ -42,7 +42,7 @@ stacksize = 256
 [tasks.pong]
 name = "task-pong"
 priority = 4
-requires = {flash = 1024, ram = 256}
+max-sizes = {flash = 1024, ram = 256}
 start = true
 task-slots = ["user_leds"]
 stacksize = 256
@@ -51,7 +51,7 @@ stacksize = 256
 name = "drv-user-leds"
 features = ["stm32g0"]
 priority = 3
-requires = {flash = 2048, ram = 256}
+max-sizes = {flash = 2048, ram = 256}
 start = true
 task-slots = ["sys"]
 stacksize = 256
@@ -59,7 +59,7 @@ stacksize = 256
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 task-slots = ["sys"]
 stacksize = 912
@@ -68,6 +68,6 @@ features = ["stm32g0", "gpio", "micro"]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 64}
+max-sizes = {flash = 128, ram = 64}
 stacksize = 64
 start = true

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -26,7 +26,7 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 512}
 start = true
 features = ["log-null"]
 stacksize = 352
@@ -35,7 +35,7 @@ stacksize = 352
 name = "drv-stm32xx-sys"
 features = ["g070"]
 priority = 1
-requires = {flash = 2048, ram = 256}
+max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
 start = true
 stacksize = 256
@@ -44,7 +44,7 @@ stacksize = 256
 name = "drv-stm32g0-usart"
 features = ["g070"]
 priority = 2
-requires = {flash = 4096, ram = 256}
+max-sizes = {flash = 4096, ram = 256}
 uses = ["usart1"]
 start = true
 interrupts = {"usart1.irq" = 1}
@@ -55,7 +55,7 @@ stacksize = 256
 name = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
-requires = {flash = 2048, ram = 256}
+max-sizes = {flash = 2048, ram = 256}
 start = true
 task-slots = ["sys"]
 stacksize = 256
@@ -63,7 +63,7 @@ stacksize = 256
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 1024, ram = 256}
+max-sizes = {flash = 1024, ram = 256}
 start = true
 task-slots = ["user_leds"]
 stacksize = 256
@@ -72,7 +72,7 @@ stacksize = 256
 name = "task-ping"
 features = ["uart"]
 priority = 4
-requires = {flash = 8192, ram = 512}
+max-sizes = {flash = 8192, ram = 512}
 stacksize = 256
 start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
@@ -80,12 +80,12 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 3
-requires = {flash = 8192, ram = 8192 }
+max-sizes = {flash = 8192, ram = 8192 }
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 64}
+max-sizes = {flash = 128, ram = 64}
 stacksize = 64
 start = true

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -49,7 +49,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -61,7 +61,7 @@ on-state-change = {net = {bit-number = 3}}
 name = "drv-stm32xx-sys"
 features = ["h743"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -69,7 +69,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -81,7 +81,7 @@ task-slots = ["sys"]
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi1", "h743"]
 uses = ["spi1"]
 start = true
@@ -96,7 +96,7 @@ global_config = "spi1"
 name = "task-net"
 stacksize = 3800
 priority = 2
-requires = {flash = 65536, ram = 8192, sram1 = 32768}
+max-sizes = {flash = 65536, ram = 8192, sram1 = 32768}
 features = ["h743"]
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
@@ -108,7 +108,7 @@ task-slots = ["sys"]
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
@@ -116,14 +116,14 @@ task-slots = ["sys"]
 name = "task-ping"
 features = []
 priority = 4
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = [{peer = "pong"}]
 
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 1024, ram = 1024}
+max-sizes = {flash = 1024, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
@@ -133,7 +133,7 @@ features = ["stm32h743", "usart3"]
 uses = ["usart3"]
 interrupts = {"usart3.irq" = 1}
 priority = 3
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys"]
@@ -141,7 +141,7 @@ task-slots = ["sys"]
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 3
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -150,7 +150,7 @@ task-slots = ["net"]
 name = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "spi", "rng"]
 priority = 4
-requires = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "rng_driver"]
@@ -158,7 +158,7 @@ task-slots = ["sys", "i2c_driver", "rng_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
@@ -166,7 +166,7 @@ start = true
 features = ["h743"]
 priority = 3
 name = "drv-stm32h7-rng"
-requires = {flash = 8192, ram = 512}
+max-sizes = {flash = 8192, ram = 512}
 stacksize = 256
 start = true
 task-slots = ["sys", "user_leds"]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -55,7 +55,7 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -63,7 +63,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h753"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -75,7 +75,7 @@ task-slots = ["sys"]
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi1", "h753"]
 uses = ["spi1"]
 start = true
@@ -90,7 +90,7 @@ global_config = "spi1"
 name = "task-net"
 stacksize = 3800
 priority = 2
-requires = {flash = 131072, ram = 8192, sram1 = 32768}
+max-sizes = {flash = 131072, ram = 8192, sram1 = 32768}
 features = ["h753"]
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
@@ -102,7 +102,7 @@ task-slots = ["sys"]
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
@@ -110,21 +110,21 @@ task-slots = ["sys"]
 name = "task-ping"
 features = []
 priority = 4
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = [{peer = "pong"}]
 
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 1024, ram = 1024}
+max-sizes = {flash = 1024, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 3
-requires = {flash = 32768, ram = 8192}
+max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -133,7 +133,7 @@ task-slots = ["net"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
-requires = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
@@ -142,7 +142,7 @@ task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
-requires = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 uses = ["quadspi"]
@@ -153,7 +153,7 @@ task-slots = ["sys", "hash_driver"]
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
-requires = {flash = 8192, ram=4096 }
+max-sizes = {flash = 8192, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]
@@ -163,7 +163,7 @@ task-slots = ["sys"]
 [tasks.idle]
 name = "task-idle"
 priority = 6
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
@@ -171,7 +171,7 @@ start = true
 features = ["h753"]
 priority = 3
 name = "drv-stm32h7-rng"
-requires = {flash = 8192, ram = 512}
+max-sizes = {flash = 8192, ram = 512}
 stacksize = 256
 start = true
 task-slots = ["sys", "user_leds"]

--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -56,7 +56,7 @@ execute = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -64,21 +64,21 @@ stacksize = 1536
 [tasks.idle]
 name = "task-idle"
 priority = 7
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
 priority = 2
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
 start = true
 
 [tasks.gpio_driver]
 name = "drv-lpc55-gpio"
 priority = 3
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
 task-slots = ["syscon_driver"]
@@ -87,14 +87,14 @@ task-slots = ["syscon_driver"]
 name = "drv-user-leds"
 features = ["lpc55"]
 priority = 4
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
 name = "drv-lpc55-usart"
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
 start = true
 interrupts = {"flexcomm0.irq" = 1}
@@ -109,7 +109,7 @@ pins = [
 [tasks.rng_driver]
 name = "drv-lpc55-rng"
 priority = 3
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
 start = true
 stacksize = 2200
@@ -118,7 +118,7 @@ task-slots = ["syscon_driver"]
 [tasks.spi0_driver]
 name = "drv-lpc55-spi-server"
 priority = 4
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi0"]
 uses = ["flexcomm3", "flexcomm8"]
 start = true
@@ -141,7 +141,7 @@ pins = [
 [tasks.swd]
 name = "drv-lpc55-swd"
 priority = 4
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm3"]
 start = true
 stacksize = 1000
@@ -174,14 +174,14 @@ spi_num = 3
 name = "task-ping"
 features = ["uart"]
 priority = 6
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 name = "task-pong"
 priority = 5
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
@@ -189,7 +189,7 @@ task-slots = ["user_leds"]
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "spi", "spctrl"]
-requires = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["gpio_driver", "swd"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -37,7 +37,7 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -46,7 +46,7 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -54,7 +54,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -71,7 +71,7 @@ task-slots = ["sys"]
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 3
-requires = {flash = 16384, ram = 16384 }
+max-sizes = {flash = 16384, ram = 16384 }
 uses = ["i2c2"]
 start = true
 task-slots = ["sys", "i2c_driver"]
@@ -83,7 +83,7 @@ task-slots = ["sys", "i2c_driver"]
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi2"]
 uses = ["spi2"]
 start = true
@@ -97,7 +97,7 @@ global_config = "spi2"
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi4"]
 uses = ["spi4"]
 start = true
@@ -112,14 +112,14 @@ global_config = "spi4"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 1024, ram = 1024}
+max-sizes = {flash = 1024, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
@@ -127,7 +127,7 @@ task-slots = ["user_leds"]
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
-requires = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 uses = ["quadspi"]
@@ -138,7 +138,7 @@ task-slots = ["sys", "hash_driver"]
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
-requires = {flash = 8192, ram=4096 }
+max-sizes = {flash = 8192, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]
@@ -149,7 +149,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
-requires = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
@@ -157,7 +157,7 @@ task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 [tasks.validate]
 name = "task-validate"
 priority = 3
-requires = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 8192, ram = 4096 }
 stacksize = 1000 
 start = true
 task-slots = ["i2c_driver"]
@@ -165,7 +165,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 6
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -30,7 +30,7 @@ execute = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -39,7 +39,7 @@ stacksize = 1536
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "spctrl"]
-requires = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["gpio_driver", "swd"]
@@ -47,21 +47,21 @@ task-slots = ["gpio_driver", "swd"]
 [tasks.idle]
 name = "task-idle"
 priority = 6
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
 priority = 2
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
 start = true
 
 [tasks.gpio_driver]
 name = "drv-lpc55-gpio"
 priority = 3
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
 task-slots = ["syscon_driver"]
@@ -69,7 +69,7 @@ task-slots = ["syscon_driver"]
 [tasks.usart_driver]
 name = "drv-lpc55-usart"
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["iocon", "flexcomm0"]
 start = true
 interrupts = {"flexcomm0.irq" = 1}
@@ -84,7 +84,7 @@ pins = [
 [tasks.spi0_driver]
 name = "drv-lpc55-spi-server"
 priority = 4
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["iocon", "flexcomm3", "flexcomm8"]
 features = ["spi0"]
 start = true
@@ -107,7 +107,7 @@ pins = [
 [tasks.swd]
 name = "drv-lpc55-swd"
 priority = 4
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm5"]
 start = false
 stacksize = 1000

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -59,14 +59,14 @@ on-state-change = {net = {bit-number = 3}}
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -80,7 +80,7 @@ global_config = "spi4"
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
 uses = ["spi2"]
 start = true
@@ -95,7 +95,7 @@ global_config = "spi2"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -112,7 +112,7 @@ task-slots = ["sys"]
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 16384}
+max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys", "i2c_driver"]
@@ -125,7 +125,7 @@ task-slots = ["sys", "i2c_driver"]
 name = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
-requires = {flash = 16384, ram = 8192 }
+max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 4504
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
@@ -134,7 +134,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 name = "task-power"
 features = ["itm", "gimlet"]
 priority = 5
-requires = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
@@ -143,7 +143,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 5
-requires = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "hf", "i2c_driver"]
@@ -152,7 +152,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
-requires = {flash = 65536, ram = 4096 }
+max-sizes = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
@@ -165,7 +165,7 @@ register_defs = "gimlet_regs.json"
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
-requires = {flash = 16384, ram = 2048 }
+max-sizes = {flash = 16384, ram = 2048 }
 stacksize = 1920
 start = true
 uses = ["quadspi"]
@@ -177,7 +177,7 @@ name = "task-net"
 stacksize = 3800
 priority = 5
 features = ["mgmt", "h753", "gimlet"]
-requires = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -188,14 +188,14 @@ task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 name = "task-sensor"
 features = ["itm"]
 priority = 3
-requires = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 8192, ram = 2048 }
 stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 6
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -203,7 +203,7 @@ task-slots = ["net"]
 [tasks.udpbroadcast]
 name = "task-udpbroadcast"
 priority = 6
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -211,7 +211,7 @@ task-slots = ["net"]
 [tasks.validate]
 name = "task-validate"
 priority = 3
-requires = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 8192, ram = 4096 }
 stacksize = 1000
 start = true
 task-slots = ["i2c_driver"]
@@ -219,7 +219,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 7
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -60,7 +60,7 @@ name = "task-net"
 stacksize = 5400
 priority = 5
 features = ["mgmt", "h753", "gimlet", "h7-vlan"]
-requires = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -71,14 +71,14 @@ task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"
 priority = 3
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -92,7 +92,7 @@ global_config = "spi4"
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 3
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
 uses = ["spi2"]
 start = true
@@ -107,7 +107,7 @@ global_config = "spi2"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 3
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -124,7 +124,7 @@ task-slots = ["sys"]
 name = "task-spd"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 16384}
+max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys", "i2c_driver"]
@@ -137,7 +137,7 @@ task-slots = ["sys", "i2c_driver"]
 name = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
-requires = {flash = 32768, ram = 8192 }
+max-sizes = {flash = 32768, ram = 8192 }
 stacksize = 4504
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
@@ -146,7 +146,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
-requires = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
@@ -155,7 +155,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 5
-requires = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "hf", "i2c_driver"]
@@ -164,7 +164,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
-requires = {flash = 65536, ram = 4096 }
+max-sizes = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
@@ -177,7 +177,7 @@ register_defs = "gimlet_regs.json"
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
-requires = {flash = 16384, ram = 2048 }
+max-sizes = {flash = 16384, ram = 2048 }
 stacksize = 1920
 start = true
 uses = ["quadspi"]
@@ -188,14 +188,14 @@ task-slots = ["sys"]
 name = "task-sensor"
 features = ["itm"]
 priority = 4
-requires = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 8192, ram = 2048 }
 stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 6
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -204,7 +204,7 @@ features = ["vlan"]
 [tasks.udpbroadcast]
 name = "task-udpbroadcast"
 priority = 6
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
 start = true
 task-slots = ["net"]
@@ -213,7 +213,7 @@ features = ["vlan"]
 [tasks.validate]
 name = "task-validate"
 priority = 5
-requires = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 8192, ram = 4096 }
 stacksize = 1000 
 start = true
 task-slots = ["i2c_driver"]
@@ -221,7 +221,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 7
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -55,14 +55,14 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
 uses = ["spi2"]
 start = true
@@ -77,7 +77,7 @@ global_config = "spi2"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
@@ -85,7 +85,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "gpio", "spi"]
 priority = 3
-requires = {flash = 16384, ram = 16384 }
+max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "user_leds"]
@@ -95,7 +95,7 @@ name = "task-net"
 stacksize = 3800
 priority = 3
 features = ["mgmt", "h753"]
-requires = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -105,7 +105,7 @@ task-slots = ["sys", "user_leds", { spi_driver = "spi2_driver" }]
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 4
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -113,7 +113,7 @@ task-slots = ["net"]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -51,7 +51,7 @@ dma = true
 path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -61,7 +61,7 @@ path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -70,7 +70,7 @@ path = "../../drv/stm32h7-i2c-server"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -85,7 +85,7 @@ task-slots = ["sys"]
 path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -101,7 +101,7 @@ path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["sys"]
 
@@ -109,7 +109,7 @@ task-slots = ["sys"]
 path = "../../task/pong"
 name = "task-pong"
 priority = 3
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
@@ -118,7 +118,7 @@ path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
-requires = {flash = 32768, ram = 32768}
+max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "user_leds"]
@@ -127,7 +127,7 @@ task-slots = ["sys", "i2c_driver", "user_leds"]
 path = "../../drv/fpga-server"
 name = "drv-fpga-server"
 priority = 3
-requires = {flash = 32768, ram = 4096}
+max-sizes = {flash = 32768, ram = 4096}
 #features = ["leds"]
 stacksize = 2048
 start = true
@@ -137,7 +137,7 @@ task-slots = ["sys", "spi_driver"]
 path = "../../drv/sidecar-mainboard-i2c-emulator"
 name = "drv-sidecar-mainboard-i2c-emulator"
 priority = 2
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 
 [tasks.sequencer]
@@ -145,7 +145,7 @@ path = "../../drv/sidecar-seq-server"
 name = "drv-sidecar-seq-server"
 features = []
 priority = 4
-requires = {flash = 262144, ram = 2048}
+max-sizes = {flash = 262144, ram = 2048}
 stacksize = 1024
 start = true
 task-slots = ["sys", {i2c_driver = "i2c_emulator"}, "fpga", "spi_driver"]
@@ -154,7 +154,7 @@ task-slots = ["sys", {i2c_driver = "i2c_emulator"}, "fpga", "spi_driver"]
 path = "../../task/idle"
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -37,7 +37,7 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -46,7 +46,7 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -54,7 +54,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -68,7 +68,7 @@ task-slots = ["sys"]
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -83,7 +83,7 @@ global_config = "spi4"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
@@ -91,7 +91,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
-requires = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "user_leds"]
@@ -99,7 +99,7 @@ task-slots = ["sys", "i2c_driver", "user_leds"]
 [tasks.vsc7448]
 name = "task-vsc7448"
 priority = 3
-requires = {flash = 131072, ram = 4096}
+max-sizes = {flash = 131072, ram = 4096}
 features = ["leds"]
 stacksize = 2048
 start = true
@@ -108,7 +108,7 @@ task-slots = ["sys", "user_leds", { spi_driver = "spi4_driver" }]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -55,7 +55,7 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -63,7 +63,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -79,7 +79,7 @@ task-slots = ["sys"]
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -94,14 +94,14 @@ global_config = "spi4"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
 [tasks.pong]
 name = "task-pong"
 priority = 3
-requires = {flash = 1024, ram = 1024}
+max-sizes = {flash = 1024, ram = 1024}
 start = true
 task-slots = ["user_leds"]
 
@@ -111,7 +111,7 @@ features = ["stm32h753", "usart2"]
 uses = ["usart2"]
 interrupts = {"usart2.irq" = 1}
 priority = 3
-requires = {flash = 8192, ram = 4096}
+max-sizes = {flash = 8192, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys"]
@@ -120,7 +120,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "rng", "update"]
 priority = 4
-requires = {flash = 32768, ram = 32768}
+max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["hf", "sys", "i2c_driver", "user_leds", "rng_driver", "update_server"]
@@ -129,7 +129,7 @@ task-slots = ["hf", "sys", "i2c_driver", "user_leds", "rng_driver", "update_serv
 name = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 stacksize = 1920
 start = true
 uses = ["quadspi"]
@@ -141,7 +141,7 @@ name = "task-net"
 stacksize = 4320
 priority = 3
 features = ["h753", "h7-vlan", "gimletlet-nic"]
-requires = {flash = 65536, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 65536, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -151,7 +151,7 @@ task-slots = ["sys", "spi_driver" ]
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 4
-requires = {flash = 8192, ram = 8192}
+max-sizes = {flash = 8192, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -160,7 +160,7 @@ features = ["vlan"]
 [tasks.validate]
 name = "task-validate"
 priority = 3
-requires = {flash = 32768, ram = 4096}
+max-sizes = {flash = 32768, ram = 4096}
 stacksize = 1024
 start = true
 task-slots = ["i2c_driver"]
@@ -168,7 +168,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
@@ -176,7 +176,7 @@ start = true
 features = ["h753"]
 name = "drv-stm32h7-rng"
 priority = 3
-requires = {flash = 8192, ram = 512}
+max-sizes = {flash = 8192, ram = 512}
 uses = ["rng"]
 start = true
 stacksize = 256
@@ -185,7 +185,7 @@ task-slots = ["sys", "user_leds"]
 [tasks.update_server]
 name = "stm32h7-update-server"
 priority = 3
-requires = {flash = 8192, ram = 4096}
+max-sizes = {flash = 8192, ram = 4096}
 stacksize = 2048
 start = true
 uses = ["flash_controller", "bank2"]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -59,7 +59,7 @@ features = ["tz_support"]
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -68,7 +68,7 @@ stacksize = 1536
 name = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio", "rng"]
-requires = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
 task-slots = ["gpio_driver", "rng_driver"]
@@ -76,14 +76,14 @@ task-slots = ["gpio_driver", "rng_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 7
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
 priority = 2
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
 start = true
 stacksize = 1000
@@ -91,7 +91,7 @@ stacksize = 1000
 [tasks.gpio_driver]
 name = "drv-lpc55-gpio"
 priority = 3
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
 start = true
 stacksize = 1000
@@ -101,7 +101,7 @@ task-slots = ["syscon_driver"]
 name = "drv-user-leds"
 features = ["lpc55"]
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["gpio_driver"]
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver"]
 [tasks.usart_driver]
 name = "drv-lpc55-usart"
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
 start = true
 interrupts = {"flexcomm0.irq" = 1}
@@ -125,7 +125,7 @@ pins = [
 [tasks.i2c_driver]
 name = "drv-lpc55-i2c"
 priority = 4
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm4"]
 start = true
 stacksize = 1000
@@ -134,7 +134,7 @@ task-slots = ["gpio_driver", "syscon_driver"]
 [tasks.rng_driver]
 name = "drv-lpc55-rng"
 priority = 3
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
 start = true
 stacksize = 2200
@@ -143,7 +143,7 @@ task-slots = ["syscon_driver"]
 [tasks.spi0_driver]
 name = "drv-lpc55-spi-server"
 priority = 4
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi0"]
 uses = ["flexcomm8"]
 start = true
@@ -167,7 +167,7 @@ pins = [
 name = "task-ping"
 features = ["uart"]
 priority = 6
-requires = {flash = 8192, ram = 1024}
+max-sizes = {flash = 8192, ram = 1024}
 start = true
 stacksize = 512
 task-slots = [{peer = "pong"}, "usart_driver"]
@@ -175,7 +175,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 [tasks.pong]
 name = "task-pong"
 priority = 5
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 stacksize = 1000
 task-slots = ["user_leds"]

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -55,14 +55,14 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
 uses = ["spi4"]
 start = true
@@ -76,7 +76,7 @@ global_config = "spi4"
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
 uses = ["spi2"]
 start = true
@@ -91,7 +91,7 @@ global_config = "spi2"
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -108,7 +108,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
-requires = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "i2c_driver"]
@@ -118,7 +118,7 @@ name = "task-net"
 stacksize = 3800
 priority = 3
 features = ["mgmt", "h753"]
-requires = {flash = 131072, ram = 8192, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 8192, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -128,7 +128,7 @@ task-slots = ["sys", { spi_driver = "spi2_driver" }]
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 4
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -136,7 +136,7 @@ task-slots = ["net"]
 [tasks.eeprom]
 name = "drv-eeprom"
 priority = 3
-requires = {flash = 2048, ram = 256}
+max-sizes = {flash = 2048, ram = 256}
 stacksize = 256
 start = true
 task-slots = ["i2c_driver"]
@@ -144,7 +144,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 5
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -181,7 +181,7 @@ start = true
 [tasks.ecp5_mainboard]
 name = "drv-fpga-server"
 priority = 3
-requires = {flash = 32768, ram = 4096}
+max-sizes = {flash = 32768, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys", {spi_driver = "spi5_driver"}]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -46,7 +46,7 @@ dma = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-requires = {flash = 8192, ram = 2048}
+max-sizes = {flash = 8192, ram = 2048}
 start = true
 features = ["itm"]
 stacksize = 1536
@@ -55,14 +55,14 @@ stacksize = 1536
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi2"]
 uses = ["spi2"]
 start = true
@@ -76,7 +76,7 @@ global_config = "spi2"
 [tasks.spi3_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 features = ["h753", "spi3"]
 uses = ["spi3"]
 start = true
@@ -90,7 +90,7 @@ global_config = "spi3"
 [tasks.spi5_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi5"]
 uses = ["spi5"]
 start = true
@@ -106,7 +106,7 @@ name = "task-net"
 stacksize = 3800
 priority = 4
 features = ["mgmt", "h753", "sidecar"]
-requires = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -118,7 +118,7 @@ task-slots = ["sys",
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 5
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -126,7 +126,7 @@ task-slots = ["net"]
 [tasks.udpbroadcast]
 name = "task-udpbroadcast"
 priority = 5
-requires = {flash = 16384, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -134,7 +134,7 @@ task-slots = ["net"]
 [tasks.vsc7448]
 name = "task-vsc7448"
 priority = 5
-requires = {flash = 131072, ram = 8192}
+max-sizes = {flash = 131072, ram = 8192}
 features = ["mgmt", "sidecar"]
 stacksize = 4096
 start = true
@@ -146,7 +146,7 @@ task-slots = ["sys", "net",
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -164,8 +164,8 @@ task-slots = ["sys"]
 [tasks.hiffy]
 name = "task-hiffy"
 features = ["h753", "spi", "stm32h7", "itm", "i2c", "gpio"]
-priority = 5 
-requires = {flash = 32768, ram = 16384 }
+priority = 5
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "i2c_driver"]
@@ -174,7 +174,7 @@ task-slots = ["sys", "i2c_driver"]
 name = "task-sensor"
 features = ["itm"]
 priority = 4
-requires = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 8192, ram = 2048 }
 stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
@@ -190,7 +190,7 @@ task-slots = ["sys", {spi_driver = "spi5_driver"}]
 name = "drv-sidecar-seq-server"
 features = []
 priority = 3
-requires = {flash = 131072, ram = 2048}
+max-sizes = {flash = 131072, ram = 2048}
 stacksize = 1024
 start = true
 task-slots = ["sys", "i2c_driver", {fpga = "ecp5_mainboard"}]
@@ -224,7 +224,7 @@ task-slots = ["i2c_driver"]
 [tasks.idle]
 name = "task-idle"
 priority = 7
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -199,7 +199,7 @@ task-slots = ["sys", "i2c_driver", {fpga = "ecp5_mainboard"}]
 name = "task-thermal"
 features = ["itm", "sidecar"]
 priority = 5
-requires = {flash = 32768, ram = 8192 }
+max-sizes = {flash = 32768, ram = 8192 }
 stacksize = 4504
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]
@@ -208,7 +208,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 name = "task-power"
 features = ["itm", "sidecar"]
 priority = 6
-requires = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]
@@ -216,7 +216,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 [tasks.validate]
 name = "task-validate"
 priority = 5
-requires = {flash = 8192, ram = 4096 }
+max-sizes = {flash = 8192, ram = 4096 }
 stacksize = 1000
 start = true
 task-slots = ["i2c_driver"]

--- a/build/task-tlink.x
+++ b/build/task-tlink.x
@@ -1,0 +1,108 @@
+/* Linker script for a temporary link operation, used to measure task size
+ * (but without flash fill) */
+INCLUDE memory.x
+
+ENTRY(_start);
+
+SECTIONS
+{
+  PROVIDE(_stack_start = ORIGIN(STACK) + LENGTH(STACK));
+
+  /* ### .text */
+  .text : {
+    _stext = .;
+    *(.text.start*); /* try and pull start symbol to beginning */
+    *(.text .text.*);
+    . = ALIGN(4);
+    __etext = .;
+  } > FLASH =0xdededede
+
+  /* ### .rodata */
+  .rodata : ALIGN(4)
+  {
+    *(.rodata .rodata.*);
+
+    /* 4-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(4);
+    __erodata = .;
+  } > FLASH
+
+  /*
+   * Table of entry points for Hubris to get into the bootloader.
+   * table.ld containing the actual bytes is generated at runtime.
+   * Note the ALIGN requirement comes from TrustZone requirements.
+   */
+  .addr_table : ALIGN(32) {
+    __bootloader_fn_table = .;
+    INCLUDE table.ld
+    __end_flash = .;
+  } > FLASH
+
+  /*
+   * Sections in RAM
+   *
+   * NOTE: the userlib runtime assumes that these sections
+   * are 4-byte aligned and padded to 4-byte boundaries.
+   */
+  .data : ALIGN(4) {
+    . = ALIGN(4);
+    __sdata = .;
+    *(.data .data.*);
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+    __edata = .;
+  } > RAM AT>FLASH
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
+
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __sbss = .;
+    *(.bss .bss.*);
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+    __ebss = .;
+  } > RAM
+
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+    /* Place the heap right after `.uninit` */
+    __sheap = .;
+  } > RAM
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  /* ## .task_slot_table */
+  /* Table of TaskSlot instances and their names. Used to resolve task
+     dependencies during packaging. */
+  .task_slot_table (INFO) : {
+    . = .;
+    KEEP(*(.task_slot_table));
+  }
+
+  /* ## .idolatry */
+  .idolatry (INFO) : {
+    . = .;
+    KEEP(*(.idolatry));
+  }
+
+  /* ## Discarded sections */
+  /DISCARD/ :
+  {
+    /* Unused exception related info that only wastes space */
+    *(.ARM.exidx);
+    *(.ARM.exidx.*);
+    *(.ARM.extab.*);
+  }
+}

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -47,7 +48,10 @@ pub fn run(
         }
 
         let build_config = if name == "kernel" {
-            let (allocs, _) = crate::dist::allocate_all(&toml)?;
+            // Build dummy allocations for each task
+            let mut task_sizes = HashMap::new();
+
+            let (allocs, _) = crate::dist::allocate_all(&toml, &task_sizes)?;
             // Pick dummy entry points for each task
             let entry_points = allocs
                 .tasks

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -49,7 +48,14 @@ pub fn run(
 
         let build_config = if name == "kernel" {
             // Build dummy allocations for each task
-            let mut task_sizes = HashMap::new();
+            let task_sizes = toml
+                .tasks
+                .keys()
+                .map(|name| name.as_str())
+                .zip(std::iter::repeat_with(|| {
+                    [("flash", 64), ("ram", 64)].into_iter().collect()
+                }))
+                .collect();
 
             let (allocs, _) = crate::dist::allocate_all(&toml, &task_sizes)?;
             // Pick dummy entry points for each task

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
+use indexmap::IndexMap;
 
 use crate::config::Config;
 
@@ -48,13 +49,12 @@ pub fn run(
 
         let build_config = if name == "kernel" {
             // Build dummy allocations for each task
+            let fake_sizes: IndexMap<_, _> =
+                [("flash", 64), ("ram", 64)].into_iter().collect();
             let task_sizes = toml
                 .tasks
                 .keys()
-                .map(|name| name.as_str())
-                .zip(std::iter::repeat_with(|| {
-                    [("flash", 64), ("ram", 64)].into_iter().collect()
-                }))
+                .map(|name| (name.as_str(), fake_sizes.clone()))
                 .collect();
 
             let (allocs, _) = crate::dist::allocate_all(&toml, &task_sizes)?;

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -319,17 +319,6 @@ impl Config {
         self.mpu_alignment() == MpuAlignment::PowerOfTwo
     }
 
-    /// Looks up the sizing array for the given task or the kernel.  For tasks,
-    /// this is the `max_sizes` array establishing upper bounds on autosizing;
-    /// for the kernel, this is the `requires` array which defines its size
-    /// (there is no kernel autosizing).
-    pub fn requires(&self, name: &str) -> &IndexMap<String, u32> {
-        match name {
-            "kernel" => &self.kernel.requires,
-            name => &self.tasks[name].max_sizes,
-        }
-    }
-
     /// Suggests an appropriate size for the given task (or "kernel"), given
     /// its true size.  The size depends on MMU implementation, dispatched
     /// based on the `target` in the config file.

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -374,6 +374,7 @@ pub struct Output {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Task {
     pub name: String,
+    #[serde(default)]
     pub requires: IndexMap<String, u32>,
     pub priority: u8,
     pub stacksize: Option<u32>,

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -287,6 +287,20 @@ impl Config {
             })
             .collect()
     }
+
+    /// Calculates the output region which contains the given address
+    pub fn output_region(&self, vaddr: u64) -> Option<&str> {
+        let vaddr: u32 = match vaddr.try_into() {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        self.outputs
+            .iter()
+            .find(|(_name, out)| {
+                vaddr >= out.address && vaddr < out.address + out.size
+            })
+            .map(|(name, _out)| name.as_str())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -74,6 +74,7 @@ impl Config {
             toml::from_slice(&chip_contents)?
         };
 
+        assert!(!toml.tasks.contains_key("kernel"));
         let buildhash = hasher.finish();
 
         Ok(Config {
@@ -300,6 +301,14 @@ impl Config {
                 vaddr >= out.address && vaddr < out.address + out.size
             })
             .map(|(name, _out)| name.as_str())
+    }
+
+    /// Looks up the `requires` array for the given task or the kernel
+    pub fn requires(&self, name: &str) -> &IndexMap<String, u32> {
+        match name {
+            "kernel" => &self.kernel.requires,
+            name => &self.tasks[name].requires,
+        }
     }
 }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1491,7 +1491,7 @@ fn allocate_one(
     align: u32,
     avail: &mut Range<u32>,
 ) -> Result<Range<u32>> {
-    assert!(size.is_power_of_two());
+    assert!(align.is_power_of_two());
 
     let size_mask = align - 1;
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -690,6 +690,7 @@ fn link_task(
     name: &str,
     allocs: &Allocations,
 ) -> Result<()> {
+    println!("linking task '{}'", name);
     let task_toml = &cfg.toml.tasks[name];
     generate_task_linker_script(
         "memory.x",

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -167,7 +167,7 @@ pub fn package(
     edges: bool,
     app_toml: &Path,
     tasks_to_build: Option<Vec<String>>,
-) -> Result<()> {
+) -> Result<Allocations> {
     let cfg = PackageConfig::new(app_toml, verbose, edges)?;
 
     // If we're using filters, we change behavior at the end. Record this in a
@@ -278,7 +278,7 @@ pub fn package(
     // If we've done a partial build (which may have included the kernel), bail
     // out here before linking stuff.
     if partial_build {
-        return Ok(());
+        return Ok(allocs);
     }
 
     // Print stats on memory usage
@@ -363,7 +363,7 @@ pub fn package(
 
     write_gdb_script(&cfg)?;
     build_archive(&cfg)?;
-    Ok(())
+    Ok(allocs)
 }
 
 /// Convert SREC to other formats for convenience.
@@ -1299,7 +1299,7 @@ fn link(
 #[derive(Debug, Clone, Default, Hash)]
 pub struct Allocations {
     /// Map from memory-name to address-range
-    kernel: BTreeMap<String, Range<u32>>,
+    pub kernel: BTreeMap<String, Range<u32>>,
     /// Map from task-name to memory-name to address-range
     pub tasks: BTreeMap<String, BTreeMap<String, Range<u32>>>,
 }

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1365,8 +1365,8 @@ pub fn allocate_all(
             if let Some(r) = tasks[name].max_sizes.get(&mem.to_string()) {
                 if bytes > *r as u64 {
                     bail!(
-                        "task {}, memory region {}: requirement {} is too small (needs {}).",
-                        name, name, r, bytes);
+                        "task {}: needs {} bytes of {} but max-sizes limits it to {}",
+                        name, bytes, mem, r);
                 }
             }
             task_requests
@@ -1491,6 +1491,8 @@ fn allocate_one(
     align: u32,
     avail: &mut Range<u32>,
 ) -> Result<Range<u32>> {
+    assert!(size.is_power_of_two());
+
     let size_mask = align - 1;
 
     // Our base address will be larger than avail.start if it doesn't meet our

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1589,7 +1589,7 @@ pub fn make_kconfig(
 
     for (name, p) in toml.extratext.iter() {
         if power_of_two_required && !p.size.is_power_of_two() {
-            panic!("Memory region for peripheral '{}' is required to be a power of two, but has size {}", name, p.size);
+            panic!("Memory region for extratext '{}' is required to be a power of two, but has size {}", name, p.size);
         }
 
         peripheral_index.insert(name, regions.len());
@@ -1606,24 +1606,10 @@ pub fn make_kconfig(
     }
 
     // The remaining regions are allocated to tasks on a first-come first-serve
-    // basis.
+    // basis. We don't check power-of-two requirements in task_allocations
+    // because it's the result of autosizing, which already takes the MPU into
+    // account.
     for (i, (name, task)) in toml.tasks.iter().enumerate() {
-        if power_of_two_required
-            && !task_allocations[name]["flash"].len().is_power_of_two()
-        {
-            panic!(
-                "Flash for task '{}' is required to be a power of two, but has size {}",
-                task.name, task_allocations[name]["flash"].len());
-        }
-
-        if power_of_two_required
-            && !task_allocations[name]["ram"].len().is_power_of_two()
-        {
-            panic!(
-                "Ram for task '{}' is required to be a power of two, but has size {}",
-                task.name, task_allocations[name]["ram"].len());
-        }
-
         // Regions are referenced by index into the table we just generated.
         // Each task has up to 8, chosen from its 'requires' and 'uses' keys.
         let mut task_regions = [0; 8];

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -223,9 +223,6 @@ pub fn package(
         .keys()
         .map(|name| {
             let size = if tasks_to_build.contains(name.as_str()) {
-                // Link tasks regardless of whether they have changed, because
-                // we don't want to track changes in the other linker input
-                // (task-link.x, memory.x, table.ld, etc)
                 link_dummy_task(&cfg, name)?;
                 task_size(&cfg, name)
             } else {

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -167,8 +167,8 @@ fn run(xtask: Xtask) -> Result<()> {
             edges,
             cfg,
         } => {
-            dist::package(verbose, edges, &cfg, None)?;
-            sizes::run(&cfg, true, false, false)?;
+            let allocs = dist::package(verbose, edges, &cfg, None)?;
+            sizes::run(&cfg, &allocs, true, false, false)?;
         }
         Xtask::Build {
             verbose,
@@ -191,8 +191,8 @@ fn run(xtask: Xtask) -> Result<()> {
             compare,
             save,
         } => {
-            dist::package(verbose, false, &cfg, None)?;
-            sizes::run(&cfg, false, compare, save)?;
+            let allocs = dist::package(verbose, false, &cfg, None)?;
+            sizes::run(&cfg, &allocs, false, compare, save)?;
         }
         Xtask::Humility { args } => {
             humility::run(&args, &[], None, true)?;

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -12,12 +12,11 @@ use anyhow::{bail, Result};
 use goblin::Object;
 use indexmap::map::Entry;
 use indexmap::IndexMap;
-use serde::Serialize;
 use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::{dist::DEFAULT_KERNEL_STACK, Config};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 struct TaskSizes<'a> {
     /// Represents a map of task name -> memory region -> bytes used
     sizes: IndexMap<&'a str, IndexMap<&'a str, u64>>,
@@ -39,7 +38,7 @@ pub fn run(
 
     if save {
         println!("Writing json to {}", filename);
-        fs::write(filename, serde_json::ser::to_string(&sizes)?)?;
+        fs::write(filename, serde_json::ser::to_string(&sizes.sizes)?)?;
         process::exit(0);
     } else if compare {
         let compare = fs::read(filename)?;

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -304,13 +304,23 @@ fn print_memory_map(
                     print!("    {:#010x} | ", start + chunk.total_size);
                     println!(
                         "{:<size$} | {:>mem$} | {:>mem$} | ",
-                        "[padding]",
+                        "-padding-",
                         "--",
                         next - (start + chunk.total_size),
                         size = task_pad,
                         mem = mem_pad,
                     );
                 }
+            } else {
+                print!("    {:#010x} | ", start + chunk.total_size);
+                println!(
+                    "{:<size$} | {:>mem$} | {:>mem$} | ",
+                    "--end--",
+                    "",
+                    "",
+                    size = task_pad,
+                    mem = mem_pad,
+                );
             }
         }
     }

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -22,9 +22,9 @@ use crate::{dist::DEFAULT_KERNEL_STACK, Config};
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Default)]
 pub struct MemoryUsage {
     /// Actual memory usage
-    bytes: u64,
+    pub bytes: u64,
     /// Amount of memory requested in the TOML file, or `None`
-    required: Option<u64>,
+    pub required: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/test/tests-gemini-bu-rot/app.toml
+++ b/test/tests-gemini-bu-rot/app.toml
@@ -58,14 +58,14 @@ imagea-ram-size = 0x3C000
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 stacksize = 2048
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -80,21 +80,21 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true
 

--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -37,14 +37,14 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -59,20 +59,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-gimletlet/app.toml
+++ b/test/tests-gimletlet/app.toml
@@ -37,14 +37,14 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -59,20 +59,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -60,14 +60,14 @@ features = ["tz_support"]
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 stacksize = 2048
@@ -83,20 +83,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -37,14 +37,14 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 stacksize = 2048
 features = ["itm", "fru-id-eeprom"]
@@ -60,14 +60,14 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 1024}
+max-sizes = {flash = 16384, ram = 1024}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
@@ -75,7 +75,7 @@ start = true
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
-requires = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
@@ -83,7 +83,7 @@ start = true
 name = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]
@@ -99,7 +99,7 @@ task-slots = ["sys"]
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 128, ram = 256}
+max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -25,14 +25,14 @@ execute = false
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
 
@@ -46,20 +46,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384 , ram = 4096}
+max-sizes = {flash = 16384 , ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -25,14 +25,14 @@ execute = false
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -47,20 +47,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -35,7 +35,7 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 start = true
 features = ["semihosting"]
 stacksize = 1904
@@ -43,7 +43,7 @@ stacksize = 1904
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 2048}
+max-sizes = {flash = 65536, ram = 2048}
 start = true
 features = ["semihosting"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -59,7 +59,7 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 start = true
 features = ["semihosting"]
 stacksize = 1504
@@ -67,13 +67,13 @@ stacksize = 1504
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 128, ram = 64}
+max-sizes = {flash = 128, ram = 64}
 stacksize = 64
 start = true

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -37,14 +37,14 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -59,20 +59,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-stm32h7/app-h753.toml
+++ b/test/tests-stm32h7/app-h753.toml
@@ -37,14 +37,14 @@ execute = false  # let's assume XN until proven otherwise
 [tasks.runner]
 name = "test-runner"
 priority = 0
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.suite]
 name = "test-suite"
 priority = 2
-requires = {flash = 65536, ram = 4096}
+max-sizes = {flash = 65536, ram = 4096}
 start = true
 features = ["itm"]
 task-slots = ["assist", "idol", "suite", "runner"]
@@ -59,20 +59,20 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-requires = {flash = 16384, ram = 4096}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["itm"]
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-requires = {flash = 4096, ram = 1024}
+max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.idle]
 name = "task-idle"
 priority = 3
-requires = {flash = 256, ram = 256}
+max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true


### PR DESCRIPTION
This PR implements task autosizing, at long last!

It builds on the previous work with relocatable task builds (#584). After
building the relocatable task ELF file, it runs a "dummy link" against a
linker script with "infinite" memory (in practice, the entirety of memory
available on the chip). It then parses the resulting (static) binary to extract
sizes.

After finding sizes for every task, it runs the same memory packer as before,
then relinks each task with the resulting memory.

Task sizes are based on the target microcontroller, with a new `alignment`
parameter passed to `allocate_one`.

There are extensive changes to `cargo xtask sizes` to make it more generically
useful, decoupling the suggestions from the "find the size of a static ELF".

WARNING: this changes the format of the exported JSON files!

In addition, there are a bunch of new helper functions in `Config` to help with
task and memory sizing / alignment.

This fixes #474 and maybe #439, and deprecates #476
