### PR TITLE
Apply serde(deny_unknown_fields) to all config structs

### DIFF
--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -18,12 +18,13 @@ use std::path::Path;
 // build-specific types; we must not set `deny_unknown_fields` here.
 //
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct Config {
     i2c: I2cConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct I2cConfig {
     controllers: Vec<I2cController>,
     devices: Option<Vec<I2cDevice>>,
@@ -44,7 +45,7 @@ struct I2cConfig {
 // ordering.
 //
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct I2cController {
     controller: u8,
     ports: BTreeMap<String, I2cPort>,
@@ -63,7 +64,7 @@ struct I2cController {
 // additional lengths to assure that these mistakes are caught in compilation.
 //
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[allow(dead_code)]
 struct I2cDevice {
     /// device part name
@@ -108,7 +109,7 @@ struct I2cDevice {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct I2cPort {
     name: Option<String>,
     #[allow(dead_code)]
@@ -127,7 +128,7 @@ struct I2cPinSet {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct I2cMux {
     driver: String,
     address: u8,
@@ -135,14 +136,14 @@ struct I2cMux {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(dead_code)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct I2cPmbus {
     rails: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[allow(dead_code)]
 struct I2cSensors {
     #[serde(default)]

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use std::io::Write;
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Pin {
     port: usize,
     pin: usize,
@@ -35,7 +36,7 @@ impl ToTokens for Pin {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PinConfig {
     pin: Pin,
     alt: usize,

--- a/build/net/src/lib.rs
+++ b/build/net/src/lib.rs
@@ -9,12 +9,16 @@ use std::collections::BTreeMap;
 // Network config schema definition.
 //
 
+/// This represents our _subset_ of global config and _must not_ be marked with
+/// `deny_unknown_fields`!
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct GlobalConfig {
     pub net: NetConfig,
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct NetConfig {
     /// Sockets known to the system, indexed by name.
     pub sockets: BTreeMap<String, SocketConfig>,
@@ -29,6 +33,7 @@ pub struct NetConfig {
 /// handling is really, really fragile, and currently it would be an enum with a
 /// single variant anyway.
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SocketConfig {
     pub kind: String,
     pub owner: TaskNote,
@@ -38,6 +43,7 @@ pub struct SocketConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct VLanConfig {
     /// Address of the 0-index VLAN
     pub start: usize,
@@ -46,12 +52,14 @@ pub struct VLanConfig {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BufSize {
     pub packets: usize,
     pub bytes: usize,
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TaskNote {
     pub name: String,
     pub notification: u32,

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -7,6 +7,7 @@ use std::fmt::Write;
 use std::{env, fs, path::PathBuf};
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Config {
     fpga_image: String,
     register_defs: String,

--- a/drv/lpc55-spi-server/build.rs
+++ b/drv/lpc55-spi-server/build.rs
@@ -5,6 +5,7 @@ use build_lpc55pins::PinConfig;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct TaskConfig {
     pins: Vec<PinConfig>,
 }

--- a/drv/lpc55-swd/build.rs
+++ b/drv/lpc55-swd/build.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use std::io::Write;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct TaskConfig {
     in_cfg: Vec<PinConfig>,
     out_cfg: Vec<PinConfig>,

--- a/drv/lpc55-usart/build.rs
+++ b/drv/lpc55-usart/build.rs
@@ -5,6 +5,7 @@ use build_lpc55pins::PinConfig;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct TaskConfig {
     pins: Vec<PinConfig>,
 }

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -38,21 +38,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Global starts at `GlobalConfig`.
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct TaskConfig {
     spi: SpiTaskConfig,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SpiTaskConfig {
     global_config: String,
 }
 
+/// This represents our _subset_ of global config and _must not_ be marked with
+/// `deny_unknown_fields`!
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct GlobalConfig {
     spi: BTreeMap<String, SpiConfig>,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SpiConfig {
     controller: usize,
     fifo_depth: Option<usize>,
@@ -61,6 +67,7 @@ struct SpiConfig {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SpiMuxOptionConfig {
     outputs: Vec<AfPinSetConfig>,
     input: AfPinConfig,
@@ -84,6 +91,7 @@ enum ConfigPort {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct AfPinSetConfig {
     port: ConfigPort,
     pins: Vec<usize>,
@@ -91,6 +99,7 @@ struct AfPinSetConfig {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct AfPinConfig {
     #[serde(flatten)]
     pc: GpioPinConfig,
@@ -98,6 +107,7 @@ struct AfPinConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct GpioPinConfig {
     port: ConfigPort,
     pin: usize,
@@ -108,6 +118,7 @@ struct GpioPinConfig {
 struct Af(usize);
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DeviceDescriptorConfig {
     mux: String,
     #[serde(default)]

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
 
 /// Jefe task-level configuration.
 #[derive(Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     /// Task requests to be notified on state change, as a map from task name to
     /// `StateChange` record.
@@ -61,7 +61,7 @@ struct Config {
 
 /// Description of something a task wants done on state change.
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct StateChange {
     /// Number of notification bit to signal (_not_ mask).
     bit_number: u8,


### PR DESCRIPTION
serde+toml by default will tolerate arbitrary unknown fields, producing
ground fertile for errors such as typos or pasting in the wrong section.
While fixing serde+toml to not do this by default is _awfully tempting_
this change instead goes through and decorates all of our config structs
with annotations to suppress the behavior.

While I was at it, I have applied rename_all = kebab-case to all config
structs that (1) were missing it and (2) don't have underscores in any
field names, so it's a no-op. This is to prepare for the addition of
other field names in the future. I'll be going through and kebabing the
rest in a bit.