### PR TITLE
Fix SPD priority inversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,9 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_json",
+ "spd",
  "task-jefe-api",
+ "task-spd-api",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,11 +3115,26 @@ dependencies = [
  "drv-i2c-api",
  "drv-stm32h7-i2c",
  "drv-stm32xx-sys-api",
+ "idol",
+ "idol-runtime",
  "num-traits",
  "ringbuf",
  "spd",
  "stm32h7",
+ "task-spd-api",
  "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "task-spd-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
+ "userlib",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "task/sensor",
     "task/sensor-api",
     "task/spd",
+    "task/spd-api",
     "task/thermal",
     "task/thermal-api",
     "task/uartecho",

--- a/app/gimlet/rev-a.toml
+++ b/app/gimlet/rev-a.toml
@@ -115,7 +115,7 @@ priority = 2
 max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
-task-slots = ["sys", "i2c_driver"]
+task-slots = ["sys"]
 
 [tasks.spd.interrupts]
 "i2c1.event" = 0b0000_0001
@@ -155,7 +155,8 @@ priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
-task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe",
+"spd"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga.bin"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -127,7 +127,7 @@ priority = 2
 max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
-task-slots = ["sys", "i2c_driver"]
+task-slots = ["sys"]
 
 [tasks.spd.interrupts]
 "i2c1.event" = 0b0000_0001
@@ -167,7 +167,8 @@ priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
 stacksize = 1600
 start = true
-task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe"]
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe",
+"spd"]
 
 [tasks.gimlet_seq.config]
 fpga_image = "fpga-b.bin"

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -1144,6 +1144,7 @@ pub fn codegen(disposition: Disposition) -> Result<()> {
 
         Disposition::Devices => {
             g.generate_devices()?;
+            g.generate_ports()?;
             g.generate_pmbus()?;
         }
 

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -24,6 +24,8 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "1"
 gnarle = {path = "../../lib/gnarle"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+spd = { git = "https://github.com/oxidecomputer/spd" }
+task-spd-api = {path = "../../task/spd-api"}
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/drv/stm32h7-i2c/src/ltc4306.rs
+++ b/drv/stm32h7-i2c/src/ltc4306.rs
@@ -88,7 +88,7 @@ fn read_reg_u8(
     mux: &I2cMux,
     controller: &I2cController,
     reg: u8,
-    ctrl: &I2cControl,
+    ctrl: &mut dyn I2cControl,
 ) -> Result<u8, ResponseCode> {
     let mut rval = 0u8;
     let wlen = 1;
@@ -114,7 +114,7 @@ fn write_reg_u8(
     controller: &I2cController,
     reg: u8,
     val: u8,
-    ctrl: &I2cControl,
+    ctrl: &mut dyn I2cControl,
 ) -> Result<(), ResponseCode> {
     match controller.write_read(
         mux.address,
@@ -135,7 +135,7 @@ impl I2cMuxDriver for Ltc4306 {
         mux: &I2cMux,
         _controller: &I2cController,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
+        _ctrl: &mut dyn I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -145,7 +145,7 @@ impl I2cMuxDriver for Ltc4306 {
         mux: &I2cMux,
         controller: &I2cController,
         segment: Segment,
-        ctrl: &I2cControl,
+        ctrl: &mut dyn I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg3 = Register3(0);
 

--- a/drv/stm32h7-i2c/src/max7358.rs
+++ b/drv/stm32h7-i2c/src/max7358.rs
@@ -74,7 +74,7 @@ fn read_regs(
     mux: &I2cMux,
     controller: &I2cController,
     rbuf: &mut [u8],
-    ctrl: &I2cControl,
+    ctrl: &mut dyn I2cControl,
 ) -> Result<(), ResponseCode> {
     match controller.write_read(
         mux.address,
@@ -103,7 +103,7 @@ fn write_reg(
     controller: &I2cController,
     reg: Register,
     val: u8,
-    ctrl: &I2cControl,
+    ctrl: &mut dyn I2cControl,
 ) -> Result<(), ResponseCode> {
     let mut wbuf = [0u8; 3];
 
@@ -142,7 +142,7 @@ impl I2cMuxDriver for Max7358 {
         mux: &I2cMux,
         controller: &I2cController,
         gpio: &sys_api::Sys,
-        ctrl: &I2cControl,
+        ctrl: &mut dyn I2cControl,
     ) -> Result<(), ResponseCode> {
         mux.configure(gpio)?;
 
@@ -196,7 +196,7 @@ impl I2cMuxDriver for Max7358 {
         mux: &I2cMux,
         controller: &I2cController,
         segment: Segment,
-        ctrl: &I2cControl,
+        ctrl: &mut dyn I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = SwitchControl(0);
 

--- a/drv/stm32h7-i2c/src/pca9548.rs
+++ b/drv/stm32h7-i2c/src/pca9548.rs
@@ -29,7 +29,7 @@ impl I2cMuxDriver for Pca9548 {
         mux: &I2cMux,
         _controller: &I2cController,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
+        _ctrl: &mut dyn I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -39,7 +39,7 @@ impl I2cMuxDriver for Pca9548 {
         mux: &I2cMux,
         controller: &I2cController,
         segment: Segment,
-        ctrl: &I2cControl,
+        ctrl: &mut dyn I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = ControlRegister(0);
 

--- a/idl/spd.idol
+++ b/idl/spd.idol
@@ -1,0 +1,19 @@
+// SPD Proxy IPC API
+
+Interface(
+    name: "Spd",
+    ops: {
+        "eeprom_update": (
+            args: {
+                "index": "u8",
+                "page1": "bool",
+                "offset": "u8",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(256)),
+            },
+            reply: Simple("()"),
+            idempotent: true,
+        ),
+    },
+)

--- a/task/spd-api/Cargo.toml
+++ b/task/spd-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "task-spd-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+userlib = {path = "../../sys/userlib"}
+num-traits = {version = "0.2", default-features = false}
+zerocopy = "0.6"
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false

--- a/task/spd-api/build.rs
+++ b/task/spd-api/build.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub("../../idl/spd.idol", "client_stub.rs")?;
+
+    Ok(())
+}

--- a/task/spd-api/src/lib.rs
+++ b/task/spd-api/src/lib.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Client API for the SPD Proxy.
+
+#![no_std]
+
+use userlib::*;
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -14,12 +14,16 @@ drv-i2c-api = {path = "../../drv/i2c-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "1"
 stm32h7 = { version = "0.14", default-features = false }
+task-spd-api = {path = "../spd-api"}
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+zerocopy = "0.6.1"
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
 cfg-if = "1"
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-i2c/h743", "drv-stm32xx-sys-api/h743", "build-i2c/h743"]

--- a/task/spd/build.rs
+++ b/task/spd/build.rs
@@ -3,6 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() {
+    idol::server::build_server_support(
+        "../../idl/spd.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )
+    .unwrap();
+
     build_util::expose_target_board();
 
     let disposition = build_i2c::Disposition::Target;

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -395,14 +395,10 @@ fn main() -> ! {
         rval
     };
 
-    let ctrl = I2cControl {
-        enable: |notification| {
-            sys_irq_control(notification, true);
-        },
-        wfi: |notification| {
-            let _ = sys_recv_closed(&mut [], notification, TaskId::KERNEL);
-        },
-    };
-
-    controller.operate_as_target(&ctrl, &mut initiate, &mut rx, &mut tx);
+    controller.operate_as_target(
+        &mut DefaultControl,
+        &mut initiate,
+        &mut rx,
+        &mut tx,
+    );
 }


### PR DESCRIPTION
This finishes implementing the design outlined in #599, which should in turn fix #545 and #562.