### PR TITLE
Clean net features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#add88a535411bd98254b193887e39150d4bb500c"
+source = "git+https://github.com/oxidecomputer/idolatry.git#994077e3ecff3ec6df15c082fc4f810cf27c97f2"
 dependencies = [
  "indexmap",
  "quote",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#add88a535411bd98254b193887e39150d4bb500c"
+source = "git+https://github.com/oxidecomputer/idolatry.git#994077e3ecff3ec6df15c082fc4f810cf27c97f2"
 dependencies = [
  "userlib",
  "zerocopy",
@@ -3024,6 +3024,7 @@ dependencies = [
  "build-net",
  "derive-idol-err",
  "idol",
+ "idol-runtime",
  "num-traits",
  "serde",
  "smoltcp",
@@ -3582,6 +3583,7 @@ name = "vsc-err"
 version = "0.1.0"
 dependencies = [
  "drv-spi-api",
+ "idol-runtime",
  "task-net-api",
 ]
 

--- a/drv/vsc-err/Cargo.toml
+++ b/drv/vsc-err/Cargo.toml
@@ -8,9 +8,6 @@ drv-spi-api = {path = "../spi-api"}
 task-net-api = {path = "../../task/net-api", optional = true }
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
-[features]
-mgmt = ["task-net-api"]
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]

--- a/drv/vsc-err/Cargo.toml
+++ b/drv/vsc-err/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 drv-spi-api = {path = "../spi-api"}
 task-net-api = {path = "../../task/net-api", optional = true }
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 mgmt = ["task-net-api"]

--- a/drv/vsc-err/src/lib.rs
+++ b/drv/vsc-err/src/lib.rs
@@ -10,16 +10,13 @@
 #![no_std]
 
 use drv_spi_api::SpiError;
-
-#[cfg(feature = "mgmt")]
-use task_net_api::NetError;
+use idol_runtime::ServerDeath;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum VscError {
     SpiError(SpiError),
 
-    #[cfg(feature = "mgmt")]
-    NetError(NetError),
+    ServerDied,
 
     BadChipId(u32),
     Serdes1gReadTimeout {
@@ -103,9 +100,8 @@ impl From<SpiError> for VscError {
     }
 }
 
-#[cfg(feature = "mgmt")]
-impl From<NetError> for VscError {
-    fn from(s: NetError) -> Self {
-        Self::NetError(s)
+impl From<ServerDeath> for VscError {
+    fn from(_s: ServerDeath) -> Self {
+        Self::ServerDied
     }
 }

--- a/drv/vsc7448/Cargo.toml
+++ b/drv/vsc7448/Cargo.toml
@@ -13,9 +13,6 @@ vsc-err = { path = "../vsc-err" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
 vsc85xx = { path = "../vsc85xx" }
 
-[features]
-mgmt = ["vsc-err/mgmt"]
-
 [build-dependencies]
 build-util = {path = "../../build/util"}
 

--- a/drv/vsc85xx/Cargo.toml
+++ b/drv/vsc85xx/Cargo.toml
@@ -9,9 +9,6 @@ ringbuf = {path = "../../lib/ringbuf" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
 vsc-err = { path = "../vsc-err" }
 
-[features]
-mgmt = ["vsc-err/mgmt"]
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -40,7 +40,7 @@ Interface(
             },
             reply: Result(
                 ok: "u16",
-                err: CLike("NetError"),
+                err: ServerDeath,
             ),
         ),
         "smi_write": (
@@ -52,7 +52,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("NetError"),
+                err: ServerDeath,
             ),
         ),
     },

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -9,6 +9,7 @@ vlan = ["build-net/vlan"]
 
 [dependencies]
 derive-idol-err = {path = "../../lib/derive-idol-err" }
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 userlib = {path = "../../sys/userlib"}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -41,7 +41,7 @@ features = [
 ]
 
 [features]
-mgmt = ["vsc85xx/mgmt", "vsc7448-pac", "drv-spi-api", "ksz8463", "drv-user-leds-api"]
+mgmt = ["vsc85xx", "vsc7448-pac", "drv-spi-api", "ksz8463", "drv-user-leds-api"]
 gimlet = ["drv-gimlet-seq-api"]
 sidecar = ["drv-sidecar-seq-api"]
 h743 = ["drv-stm32h7-eth/h743", "stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -243,7 +243,8 @@ impl idl::InOrderNetImpl for ServerImpl<'_> {
         _msg: &userlib::RecvMessage,
         phy: u8,
         register: u8,
-    ) -> Result<u16, RequestError<NetError>> {
+    ) -> Result<u16, idol_runtime::RequestError<core::convert::Infallible>>
+    {
         // TODO: this should not be open to all callers!
         Ok(self.iface.device().smi_read(phy, register))
     }
@@ -254,10 +255,9 @@ impl idl::InOrderNetImpl for ServerImpl<'_> {
         phy: u8,
         register: u8,
         value: u16,
-    ) -> Result<(), RequestError<NetError>> {
+    ) -> Result<(), idol_runtime::RequestError<core::convert::Infallible>> {
         // TODO: this should not be open to all callers!
-        self.iface.device().smi_write(phy, register, value);
-        Ok(())
+        Ok(self.iface.device().smi_write(phy, register, value))
     }
 }
 

--- a/task/net/src/vlan.rs
+++ b/task/net/src/vlan.rs
@@ -371,7 +371,8 @@ impl idl::InOrderNetImpl for ServerImpl<'_> {
         _msg: &userlib::RecvMessage,
         phy: u8,
         register: u8,
-    ) -> Result<u16, RequestError<NetError>> {
+    ) -> Result<u16, idol_runtime::RequestError<core::convert::Infallible>>
+    {
         // TODO: this should not be open to all callers!
         Ok(self.eth.smi_read(phy, register))
     }
@@ -382,7 +383,7 @@ impl idl::InOrderNetImpl for ServerImpl<'_> {
         phy: u8,
         register: u8,
         value: u16,
-    ) -> Result<(), RequestError<NetError>> {
+    ) -> Result<(), idol_runtime::RequestError<core::convert::Infallible>> {
         // TODO: this should not be open to all callers!
         Ok(self.eth.smi_write(phy, register, value))
     }

--- a/task/vsc7448/Cargo.toml
+++ b/task/vsc7448/Cargo.toml
@@ -18,7 +18,7 @@ vsc85xx = {path = "../../drv/vsc85xx" }
 
 [features]
 leds = ["drv-user-leds-api"]
-mgmt = ["task-net-api", "vsc85xx/mgmt", "vsc7448/mgmt"]
+mgmt = ["task-net-api"]
 sidecar = ["drv-sidecar-seq-api"]
 
 [build-dependencies]


### PR DESCRIPTION
This simplifies the return type of the (infallible) `smi_read/write` functions. Once they're no longer returning a `NetError`, we can simplify the `VscError` type as well, then prune unused features!