### PR TITLE
Reduce priority of ping

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -115,7 +115,7 @@ task-slots = ["sys"]
 [tasks.ping]
 name = "task-ping"
 features = []
-priority = 4
+priority = 5
 max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = [{peer = "pong"}]
@@ -157,7 +157,7 @@ task-slots = ["sys", "i2c_driver", "rng_driver"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 5
+priority = 6
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -109,7 +109,7 @@ task-slots = ["sys"]
 [tasks.ping]
 name = "task-ping"
 features = []
-priority = 4
+priority = 5
 max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = [{peer = "pong"}]
@@ -162,7 +162,7 @@ task-slots = ["sys"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 6
+priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true


### PR DESCRIPTION
The `ping` task crashes (intentionally).  If it's a higher priority than other tasks, it can preempt them forever (which is unintentional).