### PR TITLE
Support for Meanwell application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-meanwell"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cfg-if",
+ "drv-meanwell-api",
+ "drv-stm32xx-sys-api",
+ "drv-user-leds-api",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "drv-meanwell-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-onewire"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,8 @@ members = [
     "drv/stm32h7-hash-server",
     "drv/rng-api",
     "drv/sp-ctrl-api",
+    "drv/meanwell",
+    "drv/meanwell-api",
 
     "drv/sidecar-mainboard-controller-api",
     "drv/sidecar-mainboard-i2c-emulator",

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -109,14 +109,14 @@ task-slots = ["sys"]
 [tasks.ping]
 name = "task-ping"
 features = []
-priority = 4
+priority = 6 
 max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = [{peer = "pong"}]
 
 [tasks.pong]
 name = "task-pong"
-priority = 3
+priority = 6
 max-sizes = {flash = 1024, ram = 1024}
 start = true
 task-slots = ["user_leds"]
@@ -162,7 +162,7 @@ task-slots = ["sys"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 6
+priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -1,0 +1,84 @@
+name = "gimletlet"
+target = "thumbv7em-none-eabihf"
+board = "gimletlet-2"
+chip = "../../chips/stm32h7"
+stacksize = 896
+
+[kernel]
+name = "gimletlet"
+requires = {flash = 32768, ram = 8192}
+#
+# For the kernel (and for any task that logs), we are required to enable
+# either "itm" (denoting logging/panicking via ARM's Instrumentation Trace
+# Macrocell) or "semihosting" (denoting logging/panicking via ARM
+# semihosting).  We are biased to ITM because semihosting is excruciatingly
+# slow (it is breakpoint based) and has an undesirable failure mode if logging
+# output is generated and debugger is not attached (namely, the target stops).
+# If one does choose to change this to semihosting for purposes of
+# development, be sure to also change it in every task of interest.
+#
+features = ["itm"]
+
+# Flash sections are mapped into flash bank 1 (of 2).
+[outputs.flash]
+address = 0x08000000
+size = 1048576
+read = true
+execute = true
+
+# RAM sections are currently mapped into DTCM, a small but fast SRAM.
+[outputs.ram]
+address = 0x20000000
+size = 131072
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise
+
+[tasks.jefe]
+name = "task-jefe"
+priority = 0
+max-sizes = {flash = 8192, ram = 2048}
+start = true
+features = ["itm"]
+stacksize = 1536
+
+[tasks.sys]
+name = "drv-stm32xx-sys"
+features = ["h753"]
+priority = 1
+max-sizes = {flash = 2048, ram = 1024}
+uses = ["rcc", "gpios1", "gpios2", "gpios3"]
+start = true
+
+[tasks.user_leds]
+name = "drv-user-leds"
+features = ["stm32h7"]
+priority = 2
+max-sizes = {flash = 2048, ram = 1024}
+start = true
+task-slots = ["sys"]
+
+[tasks.meanwell]
+name = "drv-meanwell"
+features = ["stm32h7"]
+priority = 3
+max-sizes = {flash = 2048, ram = 1024}
+start = true
+task-slots = ["sys", "user_leds"]
+
+[tasks.hiffy]
+name = "task-hiffy"
+features = ["h753", "stm32h7", "itm", "gpio"] 
+priority = 4
+max-sizes = {flash = 32768, ram = 32768}
+stacksize = 2048
+start = true
+task-slots = ["sys", "user_leds"]
+
+[tasks.idle]
+name = "task-idle"
+priority = 5
+max-sizes = {flash = 128, ram = 256}
+stacksize = 256
+start = true
+

--- a/drv/meanwell-api/Cargo.toml
+++ b/drv/meanwell-api/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "drv-meanwell-api"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+

--- a/drv/meanwell-api/build.rs
+++ b/drv/meanwell-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/meanwell.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/meanwell-api/src/lib.rs
+++ b/drv/meanwell-api/src/lib.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Client API for the MeanWell driver.
+
+#![no_std]
+
+use derive_idol_err::IdolError;
+use userlib::*;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
+pub enum MeanwellError {
+    NotPresent = 1,
+}
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/meanwell-api/src/lib.rs
+++ b/drv/meanwell-api/src/lib.rs
@@ -12,6 +12,7 @@ use userlib::*;
 #[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
 pub enum MeanwellError {
     NotPresent = 1,
+    GpioError = 2,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/meanwell/Cargo.toml
+++ b/drv/meanwell/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "drv-meanwell"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+drv-user-leds-api = {path = "../../drv/user-leds-api"}
+drv-meanwell-api = {path = "../../drv/meanwell-api"}
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }
+drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", optional = true}
+cfg-if = "1"
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+[features]
+stm32g0 = ["drv-stm32xx-sys-api/family-stm32g0"]
+stm32h7 = ["drv-stm32xx-sys-api/family-stm32h7"]
+panic-messages = ["userlib/panic-messages"]
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-meanwell"
+test = false
+bench = false

--- a/drv/meanwell/build.rs
+++ b/drv/meanwell/build.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_util::expose_target_board();
+
+    idol::server::build_server_support(
+        "../../idl/meanwell.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/meanwell/src/main.rs
+++ b/drv/meanwell/src/main.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use drv_meanwell_api::MeanwellError;
+use idol_runtime::RequestError;
+use idol_runtime::NotificationHandler;
+use userlib::*;
+
+use drv_stm32xx_sys_api as sys_api;
+
+struct ServerImpl {
+    deadline: u64,
+    led_on: bool,
+}
+
+#[cfg(target_board = "gimletlet-2")]
+const MEANWELL_PINS: &[sys_api::PinSet] = &[
+    sys_api::Port::B.pin(14),
+    sys_api::Port::B.pin(15),
+    sys_api::Port::D.pin(8),
+    sys_api::Port::D.pin(9),
+    sys_api::Port::D.pin(10),
+    sys_api::Port::D.pin(11),
+    sys_api::Port::D.pin(12),
+];
+
+impl idl::InOrderMeanwellImpl for ServerImpl {
+    fn power_on(
+        &mut self,
+        _: &RecvMessage,
+        index: usize,
+    ) -> Result<(), RequestError<MeanwellError>> {
+        Ok(())
+    }
+
+    fn power_off(
+        &mut self,
+        _: &RecvMessage,
+        index: usize,
+    ) -> Result<(), RequestError<MeanwellError>> {
+        Ok(())
+    }
+
+    fn is_on(
+        &mut self,
+        _: &RecvMessage,
+        index: usize,
+    ) -> Result<bool, RequestError<MeanwellError>> {
+        Ok(false)
+    }
+}
+
+task_slot!(USER_LEDS, user_leds);
+task_slot!(SYS, sys);
+
+const TIMER_MASK: u32 = 1 << 0;
+const TIMER_INTERVAL_LONG: u64 = 900;
+const TIMER_INTERVAL_SHORT: u64 = 100;
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        TIMER_MASK
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        let user_leds = drv_user_leds_api::UserLeds::from(USER_LEDS.get_task_id());
+
+        if !self.led_on {
+            user_leds.led_on(3).unwrap();
+            self.led_on = true;
+            self.deadline += TIMER_INTERVAL_SHORT;
+        } else {
+            user_leds.led_off(3).unwrap();
+            self.led_on = false;
+            self.deadline += TIMER_INTERVAL_LONG;
+        }
+
+        sys_set_timer(Some(self.deadline), TIMER_MASK);
+    }
+}
+
+#[export_name = "main"]
+fn main() -> ! {
+    let deadline = sys_get_timer().now;
+
+    //
+    // This will put our timer in the past, and should immediately kick us.
+    //
+    sys_set_timer(Some(deadline), TIMER_MASK);
+
+    let mut serverimpl = ServerImpl {
+        led_on: false,
+        deadline,
+    };
+
+    use drv_stm32xx_sys_api::*;
+
+    let sys = SYS.get_task_id();
+    let sys = Sys::from(sys);
+
+    for pin in MEANWELL_PINS {
+        sys.gpio_configure_output(*pin, OutputType::PushPull, Speed::Low, Pull::None).unwrap();
+    }
+
+    // Handle messages.
+    let mut incoming = [0u8; idl::INCOMING_SIZE];
+    loop {
+        idol_runtime::dispatch_n(&mut incoming, &mut serverimpl);
+    }
+}
+
+mod idl {
+    use super::MeanwellError;
+
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}

--- a/idl/meanwell.idol
+++ b/idl/meanwell.idol
@@ -1,0 +1,37 @@
+// API for a Meanwell on a bench
+
+Interface(
+    name: "Meanwell",
+    ops: {
+        "power_on": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("MeanwellError"),
+            ),
+            idempotent: true,
+        ),
+        "power_off": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("MeanwellError"),
+            ),
+            idempotent: true,
+        ),
+        "is_on": (
+            args: {
+                "index": "usize",
+            },
+            reply: Result(
+                ok: "bool",
+                err: CLike("MeanwellError"),
+            ),
+            idempotent: true,
+        ),
+    },
+)


### PR DESCRIPTION
Draft commit message:

```
This adds support for a Meanwell application definition for Gimletlet,
which allows for a Gimletlet to be easily used to manage Meanwell
power supplies on a benchtop. There is nothing particularly
Meanwell-specific (or indeed even power-specific) here; this is really
just a thin veneer on the GPIOs present on the J16 header on the
Gimletlet, allowing them to be used to manage external power supplies
without forcing the user to wade into the intricacies of GPIO pin
configuration.  Note that the Meanwell application also indicates a
different LED pattern (a quick blue LED blink, once per second) to
make it clear from across a room that a particularly Gimletlet is
serving to manage Meanwell supplies.
```