### PR TITLE
Simplify color printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,10 +3737,10 @@ version = "1.0.0"
 dependencies = [
  "abi",
  "anyhow",
- "atty",
  "byteorder",
  "cargo_metadata",
  "clap 3.0.14",
+ "colored",
  "ctrlc",
  "dunce",
  "filetime",
@@ -3745,7 +3756,6 @@ dependencies = [
  "serde_json",
  "srec",
  "strsim 0.10.0",
- "termcolor",
  "toml",
  "walkdir",
  "zerocopy",

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -6,13 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2"
+colored = "2.0"
 clap = { version = "3.0.14", features = ["derive"] }
 anyhow = "1.0.32"
 cargo_metadata = "0.12.0"
 ordered-toml = {git = "https://github.com/oxidecomputer/ordered-toml"}
 strsim = "0.10.0"
-termcolor = "1.1.2"
 
 # for dist
 serde = { version = "1.0.114", features = ["derive"] }


### PR DESCRIPTION
This is a minor QoL improvement: it turns out that `colored` already checks whether the output should have colors enabled, so we can remove a bunch of boilerplate.