### PR TITLE
QSFP x32 FPGA driver, server multiple device from fpga-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,8 @@ dependencies = [
  "bitfield",
  "cfg-if",
  "drv-fpga-api",
+ "drv-i2c-api",
+ "drv-i2c-devices",
  "drv-spi-api",
  "drv-stm32xx-sys-api",
  "num-traits",
@@ -676,10 +678,13 @@ dependencies = [
 name = "drv-fpga-server"
 version = "0.1.0"
 dependencies = [
+ "build-i2c",
  "build-util",
  "cfg-if",
  "drv-fpga-api",
  "drv-fpga-devices",
+ "drv-i2c-api",
+ "drv-i2c-devices",
  "drv-spi-api",
  "drv-stm32xx-sys-api",
  "gnarle",

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -59,6 +59,20 @@ max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
+[tasks.spi1_driver]
+name = "drv-stm32h7-spi-server"
+priority = 2
+max-sizes = {flash = 16384, ram = 2048}
+features = ["h753", "spi1"]
+uses = ["spi1"]
+start = true
+interrupts = {"spi1.irq" = 1}
+stacksize = 880
+task-slots = ["sys"]
+
+[tasks.spi1_driver.config.spi]
+global_config = "spi1"
+
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
@@ -180,11 +194,21 @@ start = true
 
 [tasks.ecp5_mainboard]
 name = "drv-fpga-server"
+features = ["mainboard"]
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 stacksize = 2048
 start = true
 task-slots = ["sys", {spi_driver = "spi5_driver"}]
+
+[tasks.ecp5_front_io]
+name = "drv-fpga-server"
+features = ["front_io"]
+priority = 3
+max-sizes = {flash = 32768, ram = 4096}
+stacksize = 2048
+start = true
+task-slots = ["sys", "i2c_driver", {spi_driver = "spi1_driver"}]
 
 [tasks.sequencer]
 name = "drv-sidecar-seq-server"
@@ -266,7 +290,7 @@ controller = 2
 # I2C_FRONT_IO0_SDA
 #
 [config.i2c.controllers.ports.F]
-name = "frontio"
+name = "front_io"
 description = "Front I/O Board"
 pins = [ { pins = [ 0, 1 ], af = 4 } ]
 
@@ -613,11 +637,12 @@ refdes = "U65"
 # device = "at24csw080"
 # description = ""
 
-# [[config.i2c.devices]]
-# bus = "south2"
-# address = 0b1010_0**
-# device = "at24csw080"
-# description = ""
+[[config.i2c.devices]]
+bus = "south2"
+address = 0b1010_000
+device = "at24csw080"
+description = "Mainboard FRUID"
+refdes = "U91"
 
 # [[config.i2c.devices]]
 # device = "tf2"
@@ -625,6 +650,37 @@ refdes = "U65"
 # address = 0b1011_011
 # description = ""
 
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b1010_000
+device = "at24csw080"
+description = "Front IO board FRUID"
+removable = true
+
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b1110_011
+device = "pca9538"
+description = "Front IO GPIO expander"
+removable = true
+
+[config.spi.spi1]
+controller = 1
+
+[config.spi.spi1.mux_options.port_adg]
+outputs = [
+    {port = "A", pins = [5], af = 5}, # FRONT_IO_SCK
+    {port = "D", pins = [7], af = 5}, # FRONT_IO_COPI
+]
+input = {port = "G", pin = 9, af = 5} # FRONT_IO_CIPO
+
+[config.spi.spi1.devices.ecp5_front_io_fpga]
+mux = "port_adg"
+cs = [{port = "G", pin = 10}] # FRONT_IO_CS0
+
+[config.spi.spi1.devices.ecp5_front_io_user_design]
+mux = "port_adg"
+cs = [{port = "A", pin = 15}] # FRONT_IO_CS1
 
 [config.spi.spi2]
 controller = 2

--- a/drv/fpga-devices/Cargo.toml
+++ b/drv/fpga-devices/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 [dependencies]
 userlib = {path = "../../sys/userlib"}
 ringbuf = {path = "../../lib/ringbuf"}
+drv-i2c-api = {path = "../../drv/i2c-api"}
+drv-i2c-devices = {path = "../../drv/i2c-devices"}
+drv-fpga-api = {path = "../../drv/fpga-api"}
 drv-spi-api = {path = "../../drv/spi-api"}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}
-drv-fpga-api = {path = "../../drv/fpga-api"}
-num-traits = { version = "0.2.12", default-features = false }
+num-traits = {version = "0.2.12", default-features = false}
 cfg-if = "1"
 bitfield = "0.13"
 zerocopy = "0.6.1"

--- a/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
+++ b/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
@@ -1,0 +1,362 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::ecp5::{Command, Ecp5, Ecp5Driver};
+use crate::FpgaUserDesign;
+use drv_fpga_api::FpgaError;
+use drv_i2c_api::ResponseCode;
+use drv_i2c_devices::pca9538;
+use drv_spi_api::{self as spi_api, SpiDevice, SpiError};
+use drv_stm32xx_sys_api::{self as sys_api, GpioError, Sys};
+
+/// This module implements an ECP5 driver which exposes two physical devices,
+/// which share a single SPI bus using a mux and are controlled through a shared
+/// PCA9538 GPIO expander.
+
+/// Impl Error type, with conversion from `GpioError`, `SpiError` and
+/// `ResponseCode`.
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    GpioError(GpioError),
+    SpiError(SpiError),
+    I2cError(ResponseCode),
+}
+
+impl From<GpioError> for Error {
+    fn from(e: GpioError) -> Self {
+        Self::GpioError(e)
+    }
+}
+
+impl From<SpiError> for Error {
+    fn from(e: SpiError) -> Self {
+        Self::SpiError(e)
+    }
+}
+
+impl From<ResponseCode> for Error {
+    fn from(e: ResponseCode) -> Self {
+        Self::I2cError(e)
+    }
+}
+
+impl From<Error> for u8 {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::GpioError(e) => match e {
+                GpioError::BadArg => 2,
+            },
+            Error::SpiError(e) => match e {
+                SpiError::BadTransferSize => 3,
+                SpiError::ServerRestarted => 4,
+                SpiError::NothingToRelease => 5,
+                SpiError::BadDevice => 6,
+                SpiError::DataOverrun => 7,
+            },
+            Error::I2cError(e) => 8 + (e as u8),
+        }
+    }
+}
+
+impl From<Error> for FpgaError {
+    fn from(e: Error) -> Self {
+        FpgaError::ImplError(u8::from(e))
+    }
+}
+
+pub struct DriverConfig {
+    pub sys: Sys,
+    pub configuration_port: SpiDevice,
+    pub user_design: SpiDevice,
+    pub spi_mux_select: sys_api::PinSet,
+    pub gpio: pca9538::Pca9538,
+    pub user_design_reset_duration: u64,
+}
+
+pub struct DevicePins {
+    pub done: pca9538::PinSet,
+    pub init_n: pca9538::PinSet,
+    pub program_n: pca9538::PinSet,
+    pub user_design_reset_n: pca9538::PinSet,
+}
+
+pub struct DeviceInstance<'a> {
+    pub driver: &'a Driver,
+    pub device_id: usize,
+    pub pins: DevicePins,
+}
+
+pub struct Driver {
+    config: DriverConfig,
+    device_selected: core::cell::Cell<Option<usize>>,
+}
+
+impl Driver {
+    pub fn new(config: DriverConfig) -> Self {
+        Self {
+            config,
+            device_selected: core::cell::Cell::new(None),
+        }
+    }
+
+    pub fn init(&self) -> Result<(), Error> {
+        use sys_api::*;
+
+        self.config.sys.gpio_set(self.config.spi_mux_select)?;
+        self.config
+            .sys
+            .gpio_configure_output(
+                self.config.spi_mux_select,
+                OutputType::PushPull,
+                Speed::Low,
+                Pull::None,
+            )
+            .map_err(Error::from)?;
+        self.device_selected.set(Some(0));
+        Ok(())
+    }
+
+    fn init_device(
+        &self,
+        device_id: usize,
+        pins: DevicePins,
+    ) -> Result<DeviceInstance, Error> {
+        let output_pins =
+            pins.init_n | pins.program_n | pins.user_design_reset_n;
+
+        self.config
+            .gpio
+            .set_mode(
+                output_pins,
+                pca9538::Mode::Output,
+                pca9538::Polarity::Normal,
+            )
+            .unwrap();
+
+        self.config
+            .gpio
+            .set_mode(
+                pins.done,
+                pca9538::Mode::Input,
+                pca9538::Polarity::Normal,
+            )
+            .unwrap();
+
+        Ok(DeviceInstance {
+            driver: self,
+            device_id,
+            pins,
+        })
+    }
+
+    pub fn init_devices(
+        &self,
+        device0_pins: DevicePins,
+        device1_pins: DevicePins,
+    ) -> Result<[Ecp5<DeviceInstance>; 2], Error> {
+        Ok([
+            Ecp5::new(self.init_device(0, device0_pins)?),
+            Ecp5::new(self.init_device(1, device1_pins)?),
+        ])
+    }
+
+    pub fn select_device(&self, device_id: usize) -> Result<(), GpioError> {
+        let set_gpio = || match self
+            .config
+            .sys
+            .gpio_set_to(self.config.spi_mux_select, device_id == 0)
+        {
+            Err(e) => {
+                self.device_selected.set(None);
+                Err(e)
+            }
+            Ok(()) => {
+                self.device_selected.set(Some(device_id));
+                userlib::hl::sleep_for(1);
+                Ok(())
+            }
+        };
+
+        match self.device_selected.get() {
+            None => set_gpio(),
+            Some(selected_id) if selected_id != device_id => set_gpio(),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl<'a> Ecp5Driver for DeviceInstance<'a> {
+    type Error = Error;
+
+    fn program_n(&self) -> Result<bool, Self::Error> {
+        Ok(self.driver.config.gpio.read(self.pins.program_n)? != 0)
+    }
+
+    fn set_program_n(&self, asserted: bool) -> Result<(), Self::Error> {
+        self.driver
+            .config
+            .gpio
+            .set_to(self.pins.program_n, asserted)
+            .map_err(Self::Error::from)
+    }
+
+    fn init_n(&self) -> Result<bool, Self::Error> {
+        Ok(self.driver.config.gpio.read(self.pins.init_n)? != 0)
+    }
+
+    fn set_init_n(&self, asserted: bool) -> Result<(), Self::Error> {
+        self.driver
+            .config
+            .gpio
+            .set_to(self.pins.init_n, asserted)
+            .map_err(Self::Error::from)
+    }
+
+    fn done(&self) -> Result<bool, Self::Error> {
+        Ok(self.driver.config.gpio.read(self.pins.done)? != 0)
+    }
+
+    fn set_done(&self, asserted: bool) -> Result<(), Self::Error> {
+        self.driver
+            .config
+            .gpio
+            .set_to(self.pins.done, asserted)
+            .map_err(Self::Error::from)
+    }
+
+    fn user_design_reset_n(&self) -> Result<bool, Self::Error> {
+        Ok(self
+            .driver
+            .config
+            .gpio
+            .read(self.pins.user_design_reset_n)?
+            != 0)
+    }
+
+    fn set_user_design_reset_n(&self, val: bool) -> Result<(), Self::Error> {
+        Ok(self
+            .driver
+            .config
+            .gpio
+            .set_to(self.pins.user_design_reset_n, val)?)
+    }
+
+    fn user_design_reset_duration(&self) -> u64 {
+        self.driver.config.user_design_reset_duration
+    }
+
+    fn configuration_read(&self, data: &mut [u8]) -> Result<(), Self::Error> {
+        self.driver
+            .select_device(self.device_id)
+            .map_err(Self::Error::from)?;
+        self.driver
+            .config
+            .configuration_port
+            .read(data)
+            .map_err(Self::Error::from)
+    }
+
+    fn configuration_write(&self, data: &[u8]) -> Result<(), Self::Error> {
+        self.driver
+            .select_device(self.device_id)
+            .map_err(Self::Error::from)?;
+        self.driver
+            .config
+            .configuration_port
+            .write(data)
+            .map_err(Self::Error::from)
+    }
+
+    fn configuration_write_command(
+        &self,
+        c: Command,
+    ) -> Result<(), Self::Error> {
+        let buffer: [u8; 4] = [c as u8, 0, 0, 0];
+        self.driver
+            .select_device(self.device_id)
+            .map_err(Self::Error::from)?;
+        self.driver
+            .config
+            .configuration_port
+            .write(&buffer)
+            .map_err(Self::Error::from)
+    }
+
+    fn configuration_lock(&self) -> Result<(), Self::Error> {
+        self.driver
+            .config
+            .configuration_port
+            .lock(spi_api::CsState::Asserted)
+            .map_err(Self::Error::from)
+    }
+
+    fn configuration_release(&self) -> Result<(), Self::Error> {
+        self.driver
+            .config
+            .configuration_port
+            .release()
+            .map_err(Self::Error::from)
+    }
+}
+
+impl<'a> FpgaUserDesign for DeviceInstance<'a> {
+    fn user_design_enabled(&self) -> Result<bool, FpgaError> {
+        Ok(self.user_design_reset_n()?)
+    }
+
+    fn set_user_design_enabled(&self, enabled: bool) -> Result<(), FpgaError> {
+        use crate::ecp5::{ecp5_trace, Trace};
+
+        self.set_user_design_reset_n(enabled)?;
+
+        ecp5_trace(if enabled {
+            Trace::UserDesignResetDeasserted
+        } else {
+            Trace::UserDesignResetAsserted
+        });
+
+        Ok(())
+    }
+
+    fn reset_user_design(&self) -> Result<(), FpgaError> {
+        self.set_user_design_enabled(false)?;
+        userlib::hl::sleep_for(self.user_design_reset_duration());
+        self.set_user_design_enabled(true)?;
+        Ok(())
+    }
+
+    fn user_design_read(&self, data: &mut [u8]) -> Result<(), FpgaError> {
+        self.driver
+            .select_device(self.device_id)
+            .map_err(Error::from)?;
+        self.driver
+            .config
+            .user_design
+            .read(data)
+            .map_err(Into::into)
+    }
+
+    fn user_design_write(&self, data: &[u8]) -> Result<(), FpgaError> {
+        self.driver
+            .select_device(self.device_id)
+            .map_err(Error::from)?;
+        self.driver
+            .config
+            .user_design
+            .write(data)
+            .map_err(Into::into)
+    }
+
+    fn user_design_lock(&self) -> Result<(), FpgaError> {
+        self.driver
+            .config
+            .user_design
+            .lock(spi_api::CsState::Asserted)
+            .map_err(Into::into)
+    }
+
+    fn user_design_release(&self) -> Result<(), FpgaError> {
+        self.driver.config.user_design.release().map_err(Into::into)
+    }
+}

--- a/drv/fpga-devices/src/lib.rs
+++ b/drv/fpga-devices/src/lib.rs
@@ -10,6 +10,7 @@ use drv_fpga_api::{DeviceState, FpgaError};
 
 pub mod ecp5;
 pub mod ecp5_spi;
+pub mod ecp5_spi_mux_pca9538;
 
 /// Trait to be implemented by FPGA device drivers in order to be exposed using
 /// the FPGA server. This trait allows managing the FPGA device itself as well

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -7,18 +7,25 @@ edition = "2021"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 gnarle = {path = "../../lib/gnarle"}
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"]}
 drv-fpga-api = {path = "../../drv/fpga-api"}
 drv-fpga-devices = {path = "../../drv/fpga-devices"}
+drv-i2c-api = {path = "../../drv/i2c-api", optional = true}
+drv-i2c-devices = {path = "../../drv/i2c-devices", optional = true}
+drv-spi-api = {path = "../../drv/spi-api"}
+drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"]}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 
 [build-dependencies]
+build-i2c = {path = "../../build/i2c"}
 build-util = {path = "../../build/util"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+[features]
+mainboard = []
+front_io = ["drv-i2c-api", "drv-i2c-devices"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/fpga-server/build.rs
+++ b/drv/fpga-server/build.rs
@@ -5,6 +5,15 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
 
+    if cfg!(feature = "front_io") {
+        let disposition = build_i2c::Disposition::Devices;
+
+        if let Err(e) = build_i2c::codegen(disposition) {
+            println!("code generation failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+
     idol::server::build_server_support(
         "../../idl/fpga.idol",
         "server_stub.rs",

--- a/drv/sidecar-mainboard-controller-api/src/lib.rs
+++ b/drv/sidecar-mainboard-controller-api/src/lib.rs
@@ -22,12 +22,13 @@ pub struct MainboardController {
 }
 
 impl MainboardController {
+    pub const DEVICE_INDEX: u8 = 0;
     pub const EXPECTED_IDENT: u32 = 0x1DE_AA55;
 
     pub fn new(task_id: userlib::TaskId) -> Self {
         Self {
-            fpga: Fpga::new(task_id),
-            user_design: FpgaUserDesign::new(task_id),
+            fpga: Fpga::new(task_id, Self::DEVICE_INDEX),
+            user_design: FpgaUserDesign::new(task_id, Self::DEVICE_INDEX),
         }
     }
 

--- a/drv/sidecar-mainboard-controller-api/src/tofino2.rs
+++ b/drv/sidecar-mainboard-controller-api/src/tofino2.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{Addr, Reg};
+use crate::{Addr, MainboardController, Reg};
 use drv_fpga_api::{FpgaError, FpgaUserDesign, WriteOp};
 use userlib::FromPrimitive;
 use zerocopy::AsBytes;
@@ -69,7 +69,10 @@ pub enum TofinoPcieReset {
 impl Sequencer {
     pub fn new(task_id: userlib::TaskId) -> Self {
         Self {
-            fpga: FpgaUserDesign::new(task_id),
+            fpga: FpgaUserDesign::new(
+                task_id,
+                MainboardController::DEVICE_INDEX,
+            ),
         }
     }
 

--- a/idl/fpga.idol
+++ b/idl/fpga.idol
@@ -5,6 +5,9 @@ Interface(
     ops: {
         "device_enabled": (
             doc: "Return true if the FPGA is enabled, false otherwise",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "bool",
                 err: CLike("FpgaError"),
@@ -13,6 +16,7 @@ Interface(
         "set_device_enabled": (
             doc: "Enable or disable the FPGA",
             args: {
+                "device_index": "u8",
                 "enabled": "bool",
             },
             reply: Result(
@@ -22,6 +26,9 @@ Interface(
         ),
         "reset_device": (
             doc: "Reset the FPGA",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "()",
                 err: CLike("FpgaError"),
@@ -29,6 +36,9 @@ Interface(
         ),
         "device_state": (
             doc: "Return the current device state",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: (
                     type: "DeviceState",
@@ -39,6 +49,9 @@ Interface(
         ),
         "device_id": (
             doc: "Return the device id, if applicable",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "u32",
                 err: CLike("FpgaError"),
@@ -47,6 +60,7 @@ Interface(
         "start_bitstream_load": (
             doc: "Prepare the device to load a bitstream",
             args: {
+                "device_index": "u8",
                 "bitstream_type": (
                     type: "BitstreamType",
                     recv: FromPrimitive("u8"),
@@ -59,6 +73,7 @@ Interface(
         ),
         "continue_bitstream_load": (
             doc: "Load the next chunk of the bitstream",
+            args: {},
             leases: {
                 "data": (type: "[u8]", read: true, max_len: Some(128)),
             },
@@ -69,6 +84,7 @@ Interface(
         ),
         "finish_bitstream_load": (
             doc: "Finish loading a bitstream",
+            args: {},
             reply: Result(
                 ok: "()",
                 err: CLike("FpgaError"),
@@ -77,6 +93,9 @@ Interface(
 
         "user_design_enabled": (
             doc: "Return true if the user design reset is released, false otherwise",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "bool",
                 err: CLike("FpgaError"),
@@ -85,6 +104,7 @@ Interface(
         "set_user_design_enabled": (
             doc: "Set the reset state for the user_design",
             args: {
+                "device_index": "u8",
                 "enabled": "bool",
             },
             reply: Result(
@@ -94,6 +114,9 @@ Interface(
         ),
         "reset_user_design": (
             doc: "Reset the user_design",
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "()",
                 err: CLike("FpgaError"),
@@ -102,6 +125,7 @@ Interface(
         "user_design_read": (
             doc: "Read N bytes from the user design, starting at the given address",
             args: {
+                "device_index": "u8",
                 "addr": "u16",
             },
             leases: {
@@ -115,6 +139,7 @@ Interface(
         "user_design_write": (
             doc: "Write N bytes to the user design, starting at the given address",
             args: {
+                "device_index": "u8",
                 "op": (
                     type: "WriteOp",
                     recv: FromPrimitive("u8"),
@@ -131,7 +156,9 @@ Interface(
         ),
         "lock": (
             doc: "Take exclusive control of this FPGA or the user design.",
-            args: {},
+            args: {
+                "device_index": "u8",
+            },
             reply: Result(
                 ok: "()",
                 err: CLike("FpgaError"),


### PR DESCRIPTION
This diff implements the following:

- Allow a `fpga-server` task to server requests for multiple FPGA devices
- Add a driver for hardware found on the QSFP x32 board, where multiple ECP5
  devices are controlled using a mux'd SPI link and an I2C GPIO expander