### PR TITLE
Remove unused build metadata

### DIFF
--- a/drv/fpga-api/Cargo.toml
+++ b/drv/fpga-api/Cargo.toml
@@ -13,9 +13,5 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 num-traits = {version = "0.2.12", default-features = false}
 zerocopy = "0.6.1"
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -20,10 +20,6 @@ zerocopy = "0.6.1"
 build-util = {path = "../../build/util"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -10,9 +10,5 @@ num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 drv-gimlet-state = {path = "../gimlet-state"}
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/sidecar-mainboard-controller-api/Cargo.toml
+++ b/drv/sidecar-mainboard-controller-api/Cargo.toml
@@ -9,10 +9,6 @@ userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [build-dependencies]
 build-util = {path = "../../build/util"}
 serde = { version = "1.0.114", features = ["derive"] }

--- a/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
+++ b/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
@@ -8,12 +8,6 @@ ringbuf = {path = "../../lib/ringbuf"}
 userlib = {path = "../../sys/userlib"}
 drv-i2c-api = {path = "../i2c-api"}
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
-[build-dependencies]
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -11,9 +11,5 @@ zerocopy = "0.6.1"
 drv-fpga-api = {path = "../fpga-api"}
 drv-sidecar-mainboard-controller-api = {path = "../sidecar-mainboard-controller-api"}
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/sidecar-seq-server/Cargo.toml
+++ b/drv/sidecar-seq-server/Cargo.toml
@@ -28,10 +28,6 @@ build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/update-api/Cargo.toml
+++ b/drv/update-api/Cargo.toml
@@ -13,10 +13,6 @@ num-traits = { version = "0.2.12", default-features = false }
 default = ["standalone"]
 standalone = []
 
-# a target for `cargo xtask check`
-[package.metadata.build]
-target = "thumbv7em-none-eabihf"
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]


### PR DESCRIPTION
`cargo xtask check` does not exist, so we don't need special metadata to support it.