### PR TITLE
Use -Zallow-features to ensure we don't add more

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -550,6 +550,18 @@ impl BuildConfig<'_> {
             Some(sysroot) => sysroot.join("bin").join("cargo"),
             None => PathBuf::from("cargo"),
         });
+
+        // nightly features that we use: asm_sym,named-profiles,naked_functions
+        // cmse_nonsecure_entry,array_methods,destructuring_assignment
+        // nightly features that our dependencies use: proc_macro_span,backtrace
+        // asm,llvm_asm
+
+        cmd.arg(
+            "-Zallow-features=asm,asm_sym,named-profiles,naked_functions,\
+cmse_nonsecure_entry,array_methods,destructuring_assignment,proc_macro_span,\
+backtrace,llvm_asm",
+        );
+
         cmd.arg(subcommand);
         cmd.arg("-p").arg(&self.crate_name);
         for a in &self.args {


### PR DESCRIPTION
This flag creates an allowlist of nightly features. By adding this to
the build, we'll get a failure if someone adds a new one, which gives us
the opportunity to really consider if we should be doing that.

Example output:

```
Caused by:
  the feature `foo_bar` is not in the list of allowed features:
  ["not_a_real_feature", "baz"]
  Error: failed to build jefe
```

Fixes #311

I only tried building one app here so we'll see if this breaks, if so I can push more commits.