### PR TITLE
Configure mux before locking the SPI device

### DIFF
--- a/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
+++ b/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
@@ -279,6 +279,9 @@ impl<'a> Ecp5Driver for DeviceInstance<'a> {
 
     fn configuration_lock(&self) -> Result<(), Self::Error> {
         self.driver
+            .select_device(self.device_id)
+            .map_err(Self::Error::from)?;
+        self.driver
             .config
             .configuration_port
             .lock(spi_api::CsState::Asserted)

--- a/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
+++ b/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
@@ -344,6 +344,9 @@ impl<'a> FpgaUserDesign for DeviceInstance<'a> {
 
     fn user_design_lock(&self) -> Result<(), FpgaError> {
         self.driver
+            .select_device(self.device_id)
+            .map_err(Error::from)?;
+        self.driver
             .config
             .user_design
             .lock(spi_api::CsState::Asserted)


### PR DESCRIPTION
Calling `SpiDevice::lock` asserts the chip select line.  Because the chip select line is passed through the SPI mux, we need to configure the mux beforehand; otherwise, the CS line will be pulsed for the _other_ FPGA when changing targets.

This fixes [hardware-qsfp-x32#36](https://github.com/oxidecomputer/hardware-qsfp-x32/issues/36) and [humility#191](https://github.com/oxidecomputer/humility/issues/191), tested on the `niles` Sidecar.