### PR TITLE
Bump straggler still on stm32h7 0.13.0 to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -730,7 +730,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "smoltcp",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -1191,7 +1191,7 @@ name = "drv-stm32h7-hash"
 version = "0.1.0"
 dependencies = [
  "drv-hash-api",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "vcell",
  "zerocopy",
@@ -1210,7 +1210,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1225,7 +1225,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1245,7 +1245,7 @@ dependencies = [
  "fixedmap",
  "num-traits",
  "ringbuf",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -1253,7 +1253,7 @@ dependencies = [
 name = "drv-stm32h7-qspi"
 version = "0.1.0"
 dependencies = [
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "vcell",
  "zerocopy",
@@ -1268,7 +1268,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1279,7 +1279,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "ringbuf",
- "stm32h7 0.14.0",
+ "stm32h7",
  "vcell",
  "zerocopy",
 ]
@@ -1303,7 +1303,7 @@ dependencies = [
  "quote",
  "ringbuf",
  "serde",
- "stm32h7 0.14.0",
+ "stm32h7",
  "syn",
  "userlib",
  "zerocopy",
@@ -1315,7 +1315,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1323,7 +1323,7 @@ name = "drv-stm32h7-usart"
 version = "0.1.0"
 dependencies = [
  "drv-stm32xx-sys-api",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -1334,7 +1334,7 @@ dependencies = [
  "cfg-if",
  "num-traits",
  "stm32g0",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1350,7 +1350,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "stm32g0",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -1530,7 +1530,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ dependencies = [
  "kern",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -1612,7 +1612,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2408,7 +2408,7 @@ dependencies = [
  "kern",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -2888,18 +2888,6 @@ dependencies = [
 
 [[package]]
 name = "stm32h7"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b672c837e0ee8158ecc7fce0f9a948dd0693a9c588338e728d14b73307a0b7d"
-dependencies = [
- "bare-metal 0.2.5",
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "stm32h7"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0faa648e03579befdd7267ab5c669624729028001fcf3c973832f53e310a06"
@@ -2919,7 +2907,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "ringbuf",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
  "zerocopy",
 ]
@@ -3128,7 +3116,7 @@ dependencies = [
  "serde",
  "smoltcp",
  "ssmarshal",
- "stm32h7 0.14.0",
+ "stm32h7",
  "syn",
  "task-jefe-api",
  "task-net-api",
@@ -3240,7 +3228,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "spd",
- "stm32h7 0.14.0",
+ "stm32h7",
  "userlib",
 ]
 
@@ -3461,7 +3449,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -3490,7 +3478,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.13.0",
+ "stm32h7",
 ]
 
 [[package]]
@@ -3552,7 +3540,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32h7 0.14.0",
+ "stm32h7",
 ]
 
 [[package]]

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -16,7 +16,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "1"
-stm32h7 = { version = "0.13.0", default-features = false, features = ["rt"] }
+stm32h7 = { version = "0.14.0", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../sys/kern"


### PR DESCRIPTION
Noticed this was added as a side effect of https://github.com/oxidecomputer/hubris/pull/659#discussion_r930337746 (`tests-gimletlet` wasn't previously in the manifest, so `stm32h7 0.13.0` wasn't in `Cargo.lock`).