### PR TITLE
Add `net` PHY read/write API

### DIFF
--- a/drv/stm32h7-eth/src/lib.rs
+++ b/drv/stm32h7-eth/src/lib.rs
@@ -463,38 +463,6 @@ impl Ethernet {
     }
 }
 
-/// Standard MDIO registers laid out in IEEE 802.3 standard clause 22. Vendors
-/// often add to this set in the 16+ range.
-///
-/// If you are using the VSC7448 / VSC85xx / KSZ8463, then your task includes
-/// the `vsc7448-pac` crate.  This crate defines a more complete set of
-/// registers, including various extended pages, and has bitfield definitions;
-/// you may consider using them instead!
-pub enum SmiClause22Register {
-    Control = 0,
-    Status = 1,
-    PhyIdent2 = 2,
-    PhyIdent3 = 3,
-    AutoNegAdvertisement = 4,
-    AutoNegPartnerAbility = 5,
-    AutoNegExpansion = 6,
-    AutoNegNextPageTransmit = 7,
-    AutoNegPartnerReceivedNextPage = 8,
-    MasterSlaveControl = 9,
-    MasterSlaveStatus = 10,
-    PseControl = 11,
-    PseStatus = 12,
-    MmdAccessControl = 13,
-    MmdAccessAddressData = 14,
-    ExtendedStatus = 15,
-}
-
-impl From<SmiClause22Register> for u8 {
-    fn from(x: SmiClause22Register) -> Self {
-        x as u8
-    }
-}
-
 #[cfg(all(not(feature = "vlan"), feature = "with-smoltcp"))]
 mod tokens {
     use super::Ethernet;

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -55,5 +55,30 @@ Interface(
                 err: ServerDeath,
             ),
         ),
+        "read_phy_reg": (
+            doc: "Read a register from the PHY associated with a particular port",
+            args: {
+                "port": "u8",
+                "page": "u16",
+                "reg": "u8",
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("NetError"),
+            ),
+        ),
+        "write_phy_reg": (
+            doc: "Writes a register in the PHY associated with a particular port",
+            args: {
+                "port": "u8",
+                "page": "u16",
+                "reg": "u8",
+                "value": "u16",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("NetError"),
+            ),
+        ),
     },
 )

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -414,6 +414,34 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         }
     }
 
+    fn bounce_vsc7448(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), RequestError<MonorailError>> {
+        self.bsp
+            .bounce_vsc7448()
+            .map_err(MonorailError::from)
+            .map_err(RequestError::from)
+    }
+    fn bounce_vsc8504(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), RequestError<MonorailError>> {
+        self.bsp
+            .bounce_vsc8504()
+            .map_err(MonorailError::from)
+            .map_err(RequestError::from)
+    }
+    fn bounce_vsc8562(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), RequestError<MonorailError>> {
+        self.bsp
+            .bounce_vsc8562()
+            .map_err(MonorailError::from)
+            .map_err(RequestError::from)
+    }
+
     fn read_vsc7448_reg(
         &mut self,
         _msg: &userlib::RecvMessage,

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -414,34 +414,6 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         }
     }
 
-    fn bounce_vsc7448(
-        &mut self,
-        _msg: &userlib::RecvMessage,
-    ) -> Result<(), RequestError<MonorailError>> {
-        self.bsp
-            .bounce_vsc7448()
-            .map_err(MonorailError::from)
-            .map_err(RequestError::from)
-    }
-    fn bounce_vsc8504(
-        &mut self,
-        _msg: &userlib::RecvMessage,
-    ) -> Result<(), RequestError<MonorailError>> {
-        self.bsp
-            .bounce_vsc8504()
-            .map_err(MonorailError::from)
-            .map_err(RequestError::from)
-    }
-    fn bounce_vsc8562(
-        &mut self,
-        _msg: &userlib::RecvMessage,
-    ) -> Result<(), RequestError<MonorailError>> {
-        self.bsp
-            .bounce_vsc8562()
-            .map_err(MonorailError::from)
-            .map_err(RequestError::from)
-    }
-
     fn read_vsc7448_reg(
         &mut self,
         _msg: &userlib::RecvMessage,

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -18,6 +18,9 @@ pub enum NetError {
     InvalidVLan = 3,
     QueueFull = 4,
     Other = 5,
+
+    /// The selected port is not valid
+    InvalidPort = 6,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -21,6 +21,9 @@ pub enum NetError {
 
     /// The selected port is not valid
     InvalidPort = 6,
+
+    /// This functionality isn't implemented
+    NotImplemented = 7,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -27,8 +27,8 @@ ringbuf = {path = "../../lib/ringbuf"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 task-jefe-api = {path = "../jefe-api"}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", optional = true}
-vsc85xx = { path = "../../drv/vsc85xx", optional = true }
+vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448"}
+vsc85xx = { path = "../../drv/vsc85xx"}
 
 [dependencies.smoltcp]
 version = "0.8.0"
@@ -41,7 +41,7 @@ features = [
 ]
 
 [features]
-mgmt = ["vsc85xx", "vsc7448-pac", "drv-spi-api", "ksz8463", "drv-user-leds-api"]
+mgmt = ["drv-spi-api", "ksz8463", "drv-user-leds-api"]
 gimlet = ["drv-gimlet-seq-api"]
 sidecar = ["drv-sidecar-seq-api"]
 h743 = ["drv-stm32h7-eth/h743", "stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{mgmt, miim_bridge::MiimBridge, pins};
+use crate::{mgmt, pins};
 use drv_gimlet_seq_api::PowerState;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
@@ -10,6 +10,7 @@ use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_jefe_api::Jefe;
 use task_net_api::NetError;
 use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
+use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 task_slot!(JEFE, jefe);
@@ -107,13 +108,22 @@ impl Bsp {
         self.0.wake(eth);
     }
 
-    /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+    pub fn phy_read(
         &mut self,
         port: u8,
-        callback: F,
+        reg: PhyRegisterAddress<u16>,
         eth: &eth::Ethernet,
-    ) -> Result<T, NetError> {
-        self.0.phy_fn(port, callback, eth)
+    ) -> Result<u16, NetError> {
+        self.0.phy_read(port, reg, eth)
+    }
+
+    pub fn phy_write(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        value: u16,
+        eth: &eth::Ethernet,
+    ) -> Result<(), NetError> {
+        self.0.phy_write(port, reg, value, eth)
     }
 }

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{mgmt, pins};
+use crate::{mgmt, miim_bridge::MiimBridge, pins};
 use drv_gimlet_seq_api::PowerState;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_jefe_api::Jefe;
+use task_net_api::NetError;
 use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
 
 task_slot!(SPI, spi_driver);
@@ -104,5 +105,15 @@ impl Bsp {
 
     pub fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
+    }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        self.0.phy_fn(port, callback, eth)
     }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -260,13 +260,22 @@ impl Bsp {
         }
     }
 
-    /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+    pub fn phy_read(
         &mut self,
         port: u8,
-        callback: F,
-        eth: &eth::Ethernet,
+        reg: PhyRegisterAddress<u16>,
+        eth: &Ethernet,
     ) -> Result<T, NetError> {
-        self.mgmt.phy_fn(port, callback, eth)
+        self.mgmt.phy_read(port, reg, eth)
+    }
+
+    pub fn phy_write(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        value: u16,
+        eth: &Ethernet,
+    ) -> Result<T, NetError> {
+        self.mgmt.phy_write(port, reg, eth, value)
     }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -259,4 +259,14 @@ impl Bsp {
             self.leds.led_off(2).unwrap();
         }
     }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        self.mgmt.phy_fn(port, callback, eth)
+    }
 }

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -11,7 +11,9 @@ use ksz8463::{
     Register as KszRegister,
 };
 use ringbuf::*;
+use task_net_api::NetError;
 use userlib::{hl::sleep_for, task_slot};
+use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 
@@ -112,12 +114,23 @@ impl Bsp {
     }
 
     /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+    pub fn phy_read(
         &mut self,
-        port: u8,
-        callback: F,
-        eth: &eth::Ethernet,
-    ) -> Result<T, NetError> {
+        _port: u8,
+        _reg: PhyRegisterAddress<u16>,
+        _eth: &eth::Ethernet,
+    ) -> Result<u16, NetError> {
+        Err(NetError::NotImplemented)
+    }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_write(
+        &mut self,
+        _port: u8,
+        _reg: PhyRegisterAddress<u16>,
+        _value: u16,
+        _eth: &eth::Ethernet,
+    ) -> Result<u16, NetError> {
         Err(NetError::NotImplemented)
     }
 }

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -110,4 +110,14 @@ impl Bsp {
             });
         }
     }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        Err(NetError::NotImplemented)
+    }
 }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -12,7 +12,7 @@ use vsc7448_pac::phy;
 /// Address used on the MDIO link by our Ethernet PHY. Different
 /// vendors have different defaults for this, it will likely need to
 /// become configurable.
-const PHYADDR: u8 = 0x01;
+const PHYADDR: u8 = 0x0;
 
 // The Nucleo dev board doesn't do any periodic logging
 pub const WAKE_INTERVAL: Option<u64> = None;
@@ -55,12 +55,6 @@ impl Bsp {
             r.set_restart_auto_neg(1);
         })
         .unwrap();
-
-        // Wait for link-up
-        while phy.read(phy::STANDARD::MODE_STATUS()).unwrap().0 & (1 << 2) == 0
-        {
-            userlib::hl::sleep_for(1);
-        }
 
         Self {}
     }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -5,6 +5,7 @@
 use crate::pins;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
+use task_net_api::NetError;
 
 /// Address used on the MDIO link by our Ethernet PHY. Different
 /// vendors have different defaults for this, it will likely need to
@@ -68,5 +69,15 @@ impl Bsp {
 
     pub fn wake(&self, _eth: &eth::Ethernet) {
         panic!("Wake should never be called, because WAKE_INTERVAL is None");
+    }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        Err(NetError::NotImplemented)
     }
 }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::miim_bridge::MiimBridge;
 use crate::pins;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_net_api::NetError;
+use vsc7448_pac::phy;
 
 /// Address used on the MDIO link by our Ethernet PHY. Different
 /// vendors have different defaults for this, it will likely need to
@@ -44,22 +46,18 @@ pub fn preinit() {
 pub struct Bsp;
 impl Bsp {
     pub fn new(eth: &eth::Ethernet, _sys: &Sys) -> Self {
+        let mut bridge = MiimBridge::new(eth);
+        let phy = vsc85xx::Phy::new(PHYADDR, &mut bridge);
+
         // Set up the PHY.
-        let mii_basic_control =
-            eth.smi_read(PHYADDR, eth::SmiClause22Register::Control);
-        let mii_basic_control = mii_basic_control
-        | 1 << 12 // AN enable
-        | 1 << 9 // restart autoneg
-        ;
-        eth.smi_write(
-            PHYADDR,
-            eth::SmiClause22Register::Control,
-            mii_basic_control,
-        );
+        phy.modify(phy::STANDARD::MODE_CONTROL(), |r| {
+            r.set_auto_neg_ena(1);
+            r.set_restart_auto_neg(1);
+        })
+        .unwrap();
 
         // Wait for link-up
-        while eth.smi_read(PHYADDR, eth::SmiClause22Register::Status) & (1 << 2)
-            == 0
+        while phy.read(phy::STANDARD::MODE_STATUS()).unwrap().0 & (1 << 2) == 0
         {
             userlib::hl::sleep_for(1);
         }
@@ -78,6 +76,11 @@ impl Bsp {
         callback: F,
         eth: &eth::Ethernet,
     ) -> Result<T, NetError> {
-        Err(NetError::NotImplemented)
+        if port > 0 {
+            return Err(NetError::InvalidPort);
+        }
+        let mut bridge = MiimBridge::new(eth);
+        let phy = vsc85xx::Phy::new(PHYADDR, &mut bridge);
+        Ok(callback(phy))
     }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -8,6 +8,7 @@ use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_net_api::NetError;
 use userlib::task_slot;
+use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 
@@ -78,13 +79,22 @@ impl Bsp {
         self.0.wake(eth);
     }
 
-    /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+    pub fn phy_read(
         &mut self,
         port: u8,
-        callback: F,
+        reg: PhyRegisterAddress<u16>,
         eth: &eth::Ethernet,
-    ) -> Result<T, NetError> {
-        self.0.phy_fn(port, callback, eth)
+    ) -> Result<u16, NetError> {
+        self.0.phy_read(port, reg, eth)
+    }
+
+    pub fn phy_write(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        value: u16,
+        eth: &eth::Ethernet,
+    ) -> Result<(), NetError> {
+        self.0.phy_write(port, reg, value, eth)
     }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -6,6 +6,7 @@ use crate::{mgmt, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
+use task_net_api::NetError;
 use userlib::task_slot;
 
 task_slot!(SPI, spi_driver);
@@ -75,5 +76,15 @@ impl Bsp {
 
     pub fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
+    }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        self.0.phy_fn(port, callback, eth)
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -9,6 +9,7 @@ use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_net_api::NetError;
 use userlib::{hl::sleep_for, task_slot};
+use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 task_slot!(SEQ, seq);
@@ -87,13 +88,22 @@ impl Bsp {
         self.0.wake(eth);
     }
 
-    /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+    pub fn phy_read(
         &mut self,
         port: u8,
-        callback: F,
+        reg: PhyRegisterAddress<u16>,
         eth: &eth::Ethernet,
-    ) -> Result<T, NetError> {
-        self.0.phy_fn(port, callback, eth)
+    ) -> Result<u16, NetError> {
+        self.0.phy_read(port, reg, eth)
+    }
+
+    pub fn phy_write(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        value: u16,
+        eth: &eth::Ethernet,
+    ) -> Result<(), NetError> {
+        self.0.phy_write(port, reg, value, eth)
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -7,6 +7,7 @@ use drv_sidecar_seq_api::Sequencer;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
+use task_net_api::NetError;
 use userlib::{hl::sleep_for, task_slot};
 
 task_slot!(SPI, spi_driver);
@@ -84,5 +85,15 @@ impl Bsp {
 
     pub fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
+    }
+
+    /// Calls a function on a `Phy` associated with the given port.
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<MiimBridge>) -> T>(
+        &mut self,
+        port: u8,
+        callback: F,
+        eth: &eth::Ethernet,
+    ) -> Result<T, NetError> {
+        self.0.phy_fn(port, callback, eth)
     }
 }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -7,16 +7,17 @@
 
 mod bsp;
 mod buf;
+mod server;
 
 pub mod pins;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "vlan")] {
-        mod vlan;
-        use vlan::{ServerImpl, ServerStorage};
+        mod server_vlan;
+        use server_vlan::{ServerImpl, ServerStorage};
     } else {
-        mod server;
-        use server::{ServerImpl, ServerStorage};
+        mod server_basic;
+        use server_basic::{ServerImpl, ServerStorage};
     }
 }
 

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -7,6 +7,7 @@
 
 mod bsp;
 mod buf;
+mod miim_bridge;
 mod server;
 
 pub mod pins;
@@ -23,7 +24,6 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "mgmt")] {
-        mod miim_bridge;
         pub(crate) mod mgmt;
     }
 }

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -190,7 +190,7 @@ impl Bsp {
         eth: &Ethernet,
     ) -> Result<T, NetError> {
         if port >= 2 {
-            Err(NetError::InvalidPort.into());
+            Err(NetError::InvalidPort.into())
         } else {
             let rw = &mut MiimBridge::new(eth);
             Ok(callback(self.vsc85x2.phy(port, rw).phy))

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -189,9 +189,12 @@ impl Bsp {
         callback: F,
         eth: &Ethernet,
     ) -> Result<T, NetError> {
-        // Build handle for the VSC85x2 PHY, then initialize it
-        let rw = &mut MiimBridge::new(eth);
-        Ok(callback(self.vsc85x2.phy(port, rw).phy))
+        if port >= 2 {
+            Err(NetError::InvalidPort.into());
+        } else {
+            let rw = &mut MiimBridge::new(eth);
+            Ok(callback(self.vsc85x2.phy(port, rw).phy))
+        }
     }
 
     pub fn wake(&self, eth: &Ethernet) {

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -80,9 +80,6 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         page: u16,
         reg: u8,
     ) -> Result<u16, RequestError<NetError>> {
-        if port >= 2 {
-            return Err(NetError::InvalidPort.into());
-        }
         use vsc7448_pac::types::PhyRegisterAddress;
         let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
         let (eth, bsp) = self.eth_bsp();
@@ -100,9 +97,6 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         reg: u8,
         value: u16,
     ) -> Result<(), RequestError<NetError>> {
-        if port > 2 {
-            return Err(NetError::InvalidPort.into());
-        }
         use vsc7448_pac::types::PhyRegisterAddress;
         let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
         let (eth, bsp) = self.eth_bsp();

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -1,0 +1,113 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use drv_stm32h7_eth as eth;
+
+use crate::idl;
+use idol_runtime::RequestError;
+use task_net_api::{NetError, SocketName, UdpMetadata};
+
+/// Abstraction trait to reduce code duplication between VLAN and non-VLAN
+/// server implementations.
+pub trait NetServer {
+    fn net_recv_packet(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        socket: SocketName,
+        payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
+    ) -> Result<UdpMetadata, RequestError<NetError>>;
+
+    fn net_send_packet(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        socket: SocketName,
+        metadata: UdpMetadata,
+        payload: idol_runtime::Leased<idol_runtime::R, [u8]>,
+    ) -> Result<(), RequestError<NetError>>;
+
+    fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut crate::bsp::Bsp);
+}
+
+/// Implementation of the Net Idol interface.
+impl<T: NetServer> idl::InOrderNetImpl for T {
+    fn recv_packet(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        socket: SocketName,
+        payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
+    ) -> Result<UdpMetadata, RequestError<NetError>> {
+        self.net_recv_packet(msg, socket, payload)
+    }
+
+    fn send_packet(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        socket: SocketName,
+        metadata: UdpMetadata,
+        payload: idol_runtime::Leased<idol_runtime::R, [u8]>,
+    ) -> Result<(), RequestError<NetError>> {
+        self.net_send_packet(msg, socket, metadata, payload)
+    }
+
+    fn smi_read(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        phy: u8,
+        register: u8,
+    ) -> Result<u16, idol_runtime::RequestError<core::convert::Infallible>>
+    {
+        // TODO: this should not be open to all callers!
+        Ok(self.eth_bsp().0.smi_read(phy, register))
+    }
+
+    fn smi_write(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        phy: u8,
+        register: u8,
+        value: u16,
+    ) -> Result<(), idol_runtime::RequestError<core::convert::Infallible>> {
+        // TODO: this should not be open to all callers!
+        self.eth_bsp().0.smi_write(phy, register, value);
+        Ok(())
+    }
+
+    fn read_phy_reg(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        port: u8,
+        page: u16,
+        reg: u8,
+    ) -> Result<u16, RequestError<NetError>> {
+        if port > 2 {
+            return Err(NetError::InvalidPort.into());
+        }
+        use vsc7448_pac::types::PhyRegisterAddress;
+        let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
+        let (eth, bsp) = self.eth_bsp();
+        let out = bsp
+            .phy_fn(port, |phy| phy.read(addr), eth)?
+            .map_err(|_| NetError::Other)?;
+        Ok(out)
+    }
+
+    fn write_phy_reg(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        port: u8,
+        page: u16,
+        reg: u8,
+        value: u16,
+    ) -> Result<(), RequestError<NetError>> {
+        if port > 2 {
+            return Err(NetError::InvalidPort.into());
+        }
+        use vsc7448_pac::types::PhyRegisterAddress;
+        let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
+        let (eth, bsp) = self.eth_bsp();
+        bsp.phy_fn(port, |phy| phy.write(addr, value), eth)?
+            .map_err(|_| NetError::Other)?;
+        Ok(())
+    }
+}

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -83,9 +83,7 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         use vsc7448_pac::types::PhyRegisterAddress;
         let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
         let (eth, bsp) = self.eth_bsp();
-        let out = bsp
-            .phy_fn(port, |phy| phy.read(addr), eth)?
-            .map_err(|_| NetError::Other)?;
+        let out = bsp.phy_read(port, addr, eth)?;
         Ok(out)
     }
 
@@ -100,8 +98,7 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         use vsc7448_pac::types::PhyRegisterAddress;
         let addr = PhyRegisterAddress::from_page_and_addr_unchecked(page, reg);
         let (eth, bsp) = self.eth_bsp();
-        bsp.phy_fn(port, |phy| phy.write(addr, value), eth)?
-            .map_err(|_| NetError::Other)?;
+        bsp.phy_write(port, addr, value, eth)?;
         Ok(())
     }
 }

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -80,7 +80,7 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         page: u16,
         reg: u8,
     ) -> Result<u16, RequestError<NetError>> {
-        if port > 2 {
+        if port >= 2 {
             return Err(NetError::InvalidPort.into());
         }
         use vsc7448_pac::types::PhyRegisterAddress;

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -40,8 +40,10 @@ fn main() -> ! {
                         Err(NetError::NotYours) => panic!(),
                         Err(NetError::InvalidVLan) => panic!(),
                         Err(NetError::Other) => panic!(),
-                        // `send_packet()` can't return QueueEmpty
+                        // `send_packet()` can't return QueueEmpty or
+                        // InvalidPort
                         Err(NetError::QueueEmpty) => unreachable!(),
+                        Err(NetError::InvalidPort) => unreachable!(),
                     }
                 }
             }
@@ -52,8 +54,9 @@ fn main() -> ! {
             Err(NetError::NotYours) => panic!(),
             Err(NetError::InvalidVLan) => panic!(),
             Err(NetError::Other) => panic!(),
-            // `recv_packet()` can't return QueueFull
+            // `recv_packet()` can't return QueueFull or InvalidPort
             Err(NetError::QueueFull) => unreachable!(),
+            Err(NetError::InvalidPort) => unreachable!(),
         }
 
         // Try again.

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -40,10 +40,10 @@ fn main() -> ! {
                         Err(NetError::NotYours) => panic!(),
                         Err(NetError::InvalidVLan) => panic!(),
                         Err(NetError::Other) => panic!(),
-                        // `send_packet()` can't return QueueEmpty or
-                        // InvalidPort
+                        // `send_packet()` can't return these errors
                         Err(NetError::QueueEmpty) => unreachable!(),
                         Err(NetError::InvalidPort) => unreachable!(),
+                        Err(NetError::NotImplemented) => unreachable!(),
                     }
                 }
             }
@@ -54,9 +54,10 @@ fn main() -> ! {
             Err(NetError::NotYours) => panic!(),
             Err(NetError::InvalidVLan) => panic!(),
             Err(NetError::Other) => panic!(),
-            // `recv_packet()` can't return QueueFull or InvalidPort
+            // `recv_packet()` can't return these errors
             Err(NetError::QueueFull) => unreachable!(),
             Err(NetError::InvalidPort) => unreachable!(),
+            Err(NetError::NotImplemented) => unreachable!(),
         }
 
         // Try again.


### PR DESCRIPTION
This is initial infrastructure for a `humility net` subcommand, to query the SP's perspective on the management network.

These functions are distinct from the `smi_read/write` commands, since we need to
- change the page
- do a read/write
without anything else interrupting us.

In passing, I refactored the "VLAN Server" vs "Basic Server" distinction, moving them into better-named files, then added `server.rs` for a common trait.  This removes duplicate code from the two Idol implementations.  Unfortunately, moving `server.rs -> server_basic.rs`, then re-adding `server.rs` makes the diff unhappy; sorry about that!

In addition, the new API uses register types from the `vsc7448_pac` crates, so that crate is now non-optional.  This means I finally removed the `enum SmiClause22Register`, which duplicated some of that code (but was previously saved us an extra import).  The new dependency is only new for the STM32H7-Nucleo task; everyone else was already using it.

Finally, I noticed that the STM32H7-Nucleo `net` BSP was wrong: the PHY is at address 0, rather than 1.  I fixed this, then removed the loop-until-link-up block, because none of the other boards have that kind of blocking behavior in their BSP constructor.  Previously, the loop-until-link-up was accidentally returning right away, because the PHY address was wrong and MDIO returned `0xFFFF`.