### PR TITLE
Add `large_payload_behavior` arg to `net::recv_packet()`

### DIFF
--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -127,7 +127,7 @@ task-slots = ["sys", "spi_driver" ]
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 4
-max-sizes = {flash = 8192, ram = 8192}
+max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -8,6 +8,7 @@ Interface(
             doc: "Unqueues an incoming packet from a socket.",
             args: {
                 "socket": "SocketName",
+                "large_payload_behavior": "LargePayloadBehavior",
             },
             leases: {
                 "payload": (type: "[u8]", write: true),

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -24,6 +24,18 @@ pub enum NetError {
 
     /// This functionality isn't implemented
     NotImplemented = 7,
+
+    PayloadTooLarge = 8,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LargePayloadBehavior {
+    /// If we have a packet with a payload larger than the buffer provided to
+    /// `recv()`, discard it.
+    Discard,
+    /// If we have a packet with a payload larger than the buffer provided to
+    /// `recv()`, return `NetError::PayloadTooLarge`.
+    Fail,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -29,7 +29,9 @@ cfg_if::cfg_if! {
 }
 
 mod idl {
-    use task_net_api::{NetError, SocketName, UdpMetadata};
+    use task_net_api::{
+        LargePayloadBehavior, NetError, SocketName, UdpMetadata,
+    };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
 

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -6,7 +6,7 @@ use drv_stm32h7_eth as eth;
 
 use crate::idl;
 use idol_runtime::RequestError;
-use task_net_api::{NetError, SocketName, UdpMetadata};
+use task_net_api::{LargePayloadBehavior, NetError, SocketName, UdpMetadata};
 
 /// Abstraction trait to reduce code duplication between VLAN and non-VLAN
 /// server implementations.
@@ -15,6 +15,7 @@ pub trait NetServer {
         &mut self,
         msg: &userlib::RecvMessage,
         socket: SocketName,
+        large_payload_behavior: LargePayloadBehavior,
         payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
     ) -> Result<UdpMetadata, RequestError<NetError>>;
 
@@ -35,9 +36,10 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         &mut self,
         msg: &userlib::RecvMessage,
         socket: SocketName,
+        large_payload_behavior: LargePayloadBehavior,
         payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
     ) -> Result<UdpMetadata, RequestError<NetError>> {
-        self.net_recv_packet(msg, socket, payload)
+        self.net_recv_packet(msg, socket, large_payload_behavior, payload)
     }
 
     fn send_packet(

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -14,7 +14,7 @@ use smoltcp::socket::UdpSocket;
 use smoltcp::wire::{
     EthernetAddress, IpAddress, IpCidr, Ipv6Address, Ipv6Cidr,
 };
-use task_net_api::{NetError, SocketName, UdpMetadata};
+use task_net_api::{LargePayloadBehavior, NetError, SocketName, UdpMetadata};
 use userlib::{sys_post, sys_refresh_task_id};
 
 use crate::generated::{self, SOCKET_COUNT};

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -171,6 +171,7 @@ impl NetServer for ServerImpl<'_> {
         &mut self,
         msg: &userlib::RecvMessage,
         socket: SocketName,
+        large_payload_behavior: LargePayloadBehavior,
         payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
     ) -> Result<UdpMetadata, RequestError<NetError>> {
         let socket_index = socket as usize;
@@ -183,25 +184,34 @@ impl NetServer for ServerImpl<'_> {
         }
 
         let socket = self.get_socket_mut(socket_index)?;
-        match socket.recv() {
-            Ok((body, endp)) => {
-                if payload.len() < body.len() {
-                    return Err(RequestError::Fail(ClientError::BadLease));
-                }
-                payload
-                    .write_range(0..body.len(), body)
-                    .map_err(|_| RequestError::went_away())?;
+        loop {
+            match socket.recv() {
+                Ok((body, endp)) => {
+                    if payload.len() < body.len() {
+                        match large_payload_behavior {
+                            LargePayloadBehavior::Discard => continue,
+                            LargePayloadBehavior::Fail => {
+                                return Err(NetError::PayloadTooLarge.into());
+                            }
+                        }
+                    }
+                    payload
+                        .write_range(0..body.len(), body)
+                        .map_err(|_| RequestError::went_away())?;
 
-                Ok(UdpMetadata {
-                    port: endp.port,
-                    size: body.len() as u32,
-                    addr: endp.addr.try_into().map_err(|_| ()).unwrap(),
-                })
-            }
-            Err(smoltcp::Error::Exhausted) => Err(NetError::QueueEmpty.into()),
-            Err(_) => {
-                // uhhhh TODO
-                Err(NetError::QueueEmpty.into())
+                    return Ok(UdpMetadata {
+                        port: endp.port,
+                        size: body.len() as u32,
+                        addr: endp.addr.try_into().map_err(|_| ()).unwrap(),
+                    });
+                }
+                Err(smoltcp::Error::Exhausted) => {
+                    return Err(NetError::QueueEmpty.into());
+                }
+                Err(_) => {
+                    // uhhhh TODO
+                    return Err(NetError::QueueEmpty.into());
+                }
             }
         }
     }

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> ! {
     loop {
         // Tiiiiiny payload buffer
         let mut rx_data_buf = [0u8; 64];
-        match net.recv_packet(SOCKET, &mut rx_data_buf) {
+        match net.recv_packet(
+            SOCKET,
+            LargePayloadBehavior::Discard,
+            &mut rx_data_buf,
+        ) {
             Ok(meta) => {
                 // A packet! We want to turn it right around. Deserialize the
                 // packet header; unwrap because we trust the server.
@@ -44,6 +48,7 @@ fn main() -> ! {
                         Err(NetError::QueueEmpty) => unreachable!(),
                         Err(NetError::InvalidPort) => unreachable!(),
                         Err(NetError::NotImplemented) => unreachable!(),
+                        Err(NetError::PayloadTooLarge) => unreachable!(),
                     }
                 }
             }
@@ -58,6 +63,9 @@ fn main() -> ! {
             Err(NetError::QueueFull) => unreachable!(),
             Err(NetError::InvalidPort) => unreachable!(),
             Err(NetError::NotImplemented) => unreachable!(),
+            // We passed `LargePayloadBehavior::Discard`, so we should never get
+            // this error.
+            Err(NetError::PayloadTooLarge) => unreachable!(),
         }
 
         // Try again.


### PR DESCRIPTION
This fixes the ability of an external UDP source crashing `net` clients with `ClientError::BadLease` by sending packets in between their lease size and the max size allowed by the `net` task.

Unfortunately it continues to pour fuel on the fire of `server.rs` + `vlan.rs`.