### PR TITLE
Sidecar flash image size improvements

### DIFF
--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "sidecar"
-requires = {flash = 32768, ram = 8192}
+requires = {flash = 22776, ram = 5232}
 #
 # For the kernel (and for any task that logs), we are required to enable
 # either "itm" (denoting logging/panicking via ARM's Instrumentation Trace

--- a/drv/vsc-err/src/lib.rs
+++ b/drv/vsc-err/src/lib.rs
@@ -91,7 +91,6 @@ pub enum VscError {
     MiimReadErr {
         miim: u8,
         phy: u8,
-        page: u16,
         addr: u8,
     },
     MiimIdleTimeout,

--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -16,7 +16,7 @@ mod serdes10g;
 mod serdes1g;
 
 use crate::config::{PortConfig, PortDev, PortMap, PortMode, PortSerdes};
-use userlib::hl::sleep_for;
+use userlib::{hl::sleep_for, UnwrapLite};
 use vsc7448_pac::{types::RegisterAddress, *};
 
 pub use config::Speed;
@@ -311,8 +311,8 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
             serdes10g::Config::new(serdes10g::Mode::Sgmii)?;
 
         assert_eq!(cfg.dev.0, PortDev::Dev2g5);
-        let d2g5 = DevGeneric::new_2g5(cfg.dev.1).unwrap();
-        let d10g = Dev10g::new(p - 49).unwrap();
+        let d2g5 = DevGeneric::new_2g5(cfg.dev.1).unwrap_lite();
+        let d10g = Dev10g::new(p - 49).unwrap_lite();
         assert_eq!(d2g5.port(), d10g.port());
         assert_eq!(d2g5.port(), p);
 

--- a/drv/vsc7448/src/spi.rs
+++ b/drv/vsc7448/src/spi.rs
@@ -31,23 +31,16 @@ impl Vsc7448Spi {
     pub fn new(spi: SpiDevice) -> Self {
         Self(spi)
     }
-}
 
-impl Vsc7448Rw for Vsc7448Spi {
-    /// Reads from a VSC7448 register.  The register must be in the switch
-    /// core register block, i.e. having an address in the range
-    /// 0x71000000-0x72000000; otherwise, this return an error.
-    fn read<T>(&self, reg: RegisterAddress<T>) -> Result<T, VscError>
-    where
-        T: From<u32>,
-    {
-        if reg.addr < 0x71000000 || reg.addr >= 0x72000000 {
-            return Err(VscError::BadRegAddr(reg.addr));
+    #[inline(never)]
+    fn read_core(&self, orig_addr: u32) -> Result<u32, VscError> {
+        if orig_addr < 0x71000000 || orig_addr >= 0x72000000 {
+            return Err(VscError::BadRegAddr(orig_addr));
         }
 
         // Section 5.5.2 of the VSC7448 datasheet specifies how to convert
         // a register address to a request over SPI.
-        let addr = (reg.addr & 0x00FFFFFF) >> 2;
+        let addr = (orig_addr & 0x00FFFFFF) >> 2;
         let data: &[u8] = &addr.to_be_bytes()[1..];
 
         // We read back 7 + padding bytes in total:
@@ -61,7 +54,7 @@ impl Vsc7448Rw for Vsc7448Spi {
             u32::from_be_bytes(out[SIZE - 4..].try_into().unwrap_lite());
 
         ringbuf_entry!(Trace::Read {
-            addr: reg.addr,
+            addr: orig_addr,
             value
         });
         // The VSC7448 is configured to return 0x88888888 if a register is
@@ -88,7 +81,7 @@ impl Vsc7448Rw for Vsc7448Spi {
             // gone very deeply wrong.  This check also protects us from a
             // stack overflow.
             let if_cfgstat = DEVCPU_ORG().DEVCPU_ORG().IF_CFGSTAT();
-            if reg.addr == if_cfgstat.addr {
+            if orig_addr == if_cfgstat.addr {
                 panic!("Invalid nested read sentinel");
             }
             // This read should _never_ fail for timing reasons because the
@@ -96,10 +89,43 @@ impl Vsc7448Rw for Vsc7448Spi {
             // registers (section 5.3.2 of the datasheet).
             let v = self.read(if_cfgstat)?;
             if v.if_stat() == 1 {
-                return Err(VscError::InvalidRegisterRead(reg.addr));
+                return Err(VscError::InvalidRegisterRead(orig_addr));
             }
         }
-        Ok(value.into())
+        Ok(value)
+    }
+
+    #[inline(never)]
+    fn write_core(&self, reg_addr: u32, value: u32) -> Result<(), VscError> {
+        if reg_addr < 0x71000000 || reg_addr >= 0x72000000 {
+            return Err(VscError::BadRegAddr(reg_addr));
+        }
+
+        let addr = (reg_addr & 0x00FFFFFF) >> 2;
+        let mut data: [u8; 7] = [0; 7];
+        data[..3].copy_from_slice(&addr.to_be_bytes()[1..]);
+        data[3..].copy_from_slice(&value.to_be_bytes());
+        data[0] |= 0x80; // Indicates that this is a write
+
+        ringbuf_entry!(Trace::Write {
+            addr: reg_addr,
+            value,
+        });
+        self.0.write(&data[..])?;
+        Ok(())
+    }
+}
+
+impl Vsc7448Rw for Vsc7448Spi {
+    /// Reads from a VSC7448 register.  The register must be in the switch
+    /// core register block, i.e. having an address in the range
+    /// 0x71000000-0x72000000; otherwise, this return an error.
+    #[inline(always)]
+    fn read<T>(&self, reg: RegisterAddress<T>) -> Result<T, VscError>
+    where
+        T: From<u32>,
+    {
+        Ok(self.read_core(reg.addr)?.into())
     }
 
     /// Writes to a VSC7448 register.  This will overwrite the entire register;
@@ -108,6 +134,7 @@ impl Vsc7448Rw for Vsc7448Spi {
     /// The register must be in the switch core register block, i.e. having an
     /// address in the range 0x71000000-0x72000000; otherwise, this will
     /// return an error.
+    #[inline(always)]
     fn write<T>(
         &self,
         reg: RegisterAddress<T>,
@@ -116,22 +143,6 @@ impl Vsc7448Rw for Vsc7448Spi {
     where
         u32: From<T>,
     {
-        if reg.addr < 0x71000000 || reg.addr >= 0x72000000 {
-            return Err(VscError::BadRegAddr(reg.addr));
-        }
-
-        let addr = (reg.addr & 0x00FFFFFF) >> 2;
-        let value = u32::from(value);
-        let mut data: [u8; 7] = [0; 7];
-        data[..3].copy_from_slice(&addr.to_be_bytes()[1..]);
-        data[3..].copy_from_slice(&value.to_be_bytes());
-        data[0] |= 0x80; // Indicates that this is a write
-
-        ringbuf_entry!(Trace::Write {
-            addr: reg.addr,
-            value
-        });
-        self.0.write(&data[..])?;
-        Ok(())
+        self.write_core(reg.addr, u32::from(value))
     }
 }

--- a/drv/vsc7448/src/spi.rs
+++ b/drv/vsc7448/src/spi.rs
@@ -5,6 +5,7 @@
 use crate::{Vsc7448Rw, VscError};
 use drv_spi_api::SpiDevice;
 use ringbuf::*;
+use userlib::UnwrapLite;
 use vsc7448_pac::{types::RegisterAddress, *};
 
 #[derive(Copy, Clone, PartialEq)]
@@ -56,7 +57,8 @@ impl Vsc7448Rw for Vsc7448Spi {
         const SIZE: usize = 7 + SPI_NUM_PAD_BYTES as usize;
         let mut out = [0; SIZE];
         self.0.exchange(data, &mut out[..])?;
-        let value = u32::from_be_bytes(out[SIZE - 4..].try_into().unwrap());
+        let value =
+            u32::from_be_bytes(out[SIZE - 4..].try_into().unwrap_lite());
 
         ringbuf_entry!(Trace::Read {
             addr: reg.addr,

--- a/drv/vsc85xx/src/viper.rs
+++ b/drv/vsc85xx/src/viper.rs
@@ -47,7 +47,7 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
                 *r = (u16::from(*r) & !1).into();
             })?;
 
-        for ((page, addr), value) in VIPER_TR_CONFIG {
+        for &((page, addr), value) in &VIPER_TR_CONFIG {
             self.phy.write(
                 PhyRegisterAddress::from_page_and_addr_unchecked(page, addr),
                 value,
@@ -58,8 +58,8 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
         // `viper_revB_8051_patch` in the SDK
 
         const FIRMWARE_START_ADDR: u16 = 0xE800;
-        const PATCH_CRC_LEN: u16 = (VIPER_PATCH.len() + 1) as u16;
         const EXPECTED_CRC: u16 = 0xFB48;
+        let patch_crc_len = (VIPER_PATCH.len() + 1) as u16;
         // This patch can only be applied to Port 0 of the PHY, so we'll check
         // the address here.
         let phy_port =
@@ -68,7 +68,7 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
             return Err(VscError::BadPhyPatchPort(phy_port));
         }
 
-        let crc = self.phy.read_8051_crc(FIRMWARE_START_ADDR, PATCH_CRC_LEN)?;
+        let crc = self.phy.read_8051_crc(FIRMWARE_START_ADDR, patch_crc_len)?;
         if crc == EXPECTED_CRC {
             return Ok(());
         }
@@ -80,7 +80,7 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
         self.phy.write(phy::GPIO::GPIO_0(), 0xc018.into())?;
 
         // Reread the CRC to make sure the download succeeded
-        let crc = self.phy.read_8051_crc(FIRMWARE_START_ADDR, PATCH_CRC_LEN)?;
+        let crc = self.phy.read_8051_crc(FIRMWARE_START_ADDR, patch_crc_len)?;
         if crc != EXPECTED_CRC {
             return Err(VscError::PhyPatchFailedCrc);
         }
@@ -104,7 +104,7 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
 }
 
 /// Raw patch for 8051 microcode, from `viper_revB_8051_patch` in the SDK
-const VIPER_PATCH: [u8; 92] = [
+static VIPER_PATCH: [u8; 92] = [
     0xe8, 0x59, 0x02, 0xe8, 0x12, 0x02, 0xe8, 0x42, 0x02, 0xe8, 0x5a, 0x02,
     0xe8, 0x5b, 0x02, 0xe8, 0x5c, 0xe5, 0x69, 0x54, 0x0f, 0x24, 0xf7, 0x60,
     0x27, 0x24, 0xfc, 0x60, 0x23, 0x24, 0x08, 0x70, 0x14, 0xe5, 0x69, 0xae,
@@ -115,7 +115,7 @@ const VIPER_PATCH: [u8; 92] = [
     0x04, 0x40, 0xed, 0x22, 0x22, 0x22, 0x22, 0x22,
 ];
 
-const VIPER_TR_CONFIG: [((u16, u8), u16); 77] = [
+static VIPER_TR_CONFIG: [((u16, u8), u16); 77] = [
     (detype(phy::TR::TR_16()), 0x8fa4),
     (detype(phy::TR::TR_18()), 0x0050),
     (detype(phy::TR::TR_17()), 0x100f),

--- a/drv/vsc85xx/src/viper.rs
+++ b/drv/vsc85xx/src/viper.rs
@@ -18,6 +18,7 @@ impl<'a, 'b, P: PhyRw> ViperPhy<'a, 'b, P> {
     /// Applies a patch to the 8051 microcode inside the PHY, based on
     /// `vtss_phy_pre_init_seq_viper` in the SDK, which calls
     /// `vtss_phy_pre_init_seq_viper_rev_b`
+    #[inline(never)]
     pub(crate) fn patch(&mut self) -> Result<(), VscError> {
         ringbuf_entry!(Trace::ViperPatch(self.phy.port));
 

--- a/lib/unwrap-lite/src/lib.rs
+++ b/lib/unwrap-lite/src/lib.rs
@@ -19,7 +19,7 @@ impl<T, E> UnwrapLite for Result<T, E> {
     type Output = T;
 
     #[track_caller]
-    #[inline]
+    #[inline(always)]
     fn unwrap_lite(self) -> Self::Output {
         match self {
             Ok(x) => x,
@@ -32,7 +32,7 @@ impl<T> UnwrapLite for Option<T> {
     type Output = T;
 
     #[track_caller]
-    #[inline]
+    #[inline(always)]
     fn unwrap_lite(self) -> Self::Output {
         match self {
             Some(x) => x,

--- a/task/monorail-server/src/bsp/sidecar_1.rs
+++ b/task/monorail-server/src/bsp/sidecar_1.rs
@@ -135,32 +135,12 @@ pub use map::PORT_MAP;
 /// which owns the ethernet peripheral containing the MDIO block.
 pub struct NetPhyRw<'a>(&'a mut task_net_api::Net);
 impl<'a> PhyRw for NetPhyRw<'a> {
-    #[inline(always)]
-    fn read_raw<T: From<u16>>(
-        &self,
-        port: u8,
-        reg: PhyRegisterAddress<T>,
-    ) -> Result<T, VscError> {
-        self.0
-            .smi_read(port, reg.addr)
-            .map(|r| r.into())
-            .map_err(|e| e.into())
+    fn read_raw(&self, port: u8, reg: u8) -> Result<u16, VscError> {
+        Ok(self.0.smi_read(port, reg)?)
     }
 
-    #[inline(always)]
-    fn write_raw<T>(
-        &self,
-        port: u8,
-        reg: PhyRegisterAddress<T>,
-        value: T,
-    ) -> Result<(), VscError>
-    where
-        u16: From<T>,
-        T: From<u16> + Clone,
-    {
-        self.0
-            .smi_write(port, reg.addr, value.into())
-            .map_err(|e| e.into())
+    fn write_raw(&self, port: u8, reg: u8, value: u16) -> Result<(), VscError> {
+        Ok(self.0.smi_write(port, reg, value)?)
     }
 }
 
@@ -511,27 +491,14 @@ pub enum GenericPhyRw<'a> {
 
 impl<'a> PhyRw for GenericPhyRw<'a> {
     #[inline(always)]
-    fn read_raw<T: From<u16>>(
-        &self,
-        port: u8,
-        reg: PhyRegisterAddress<T>,
-    ) -> Result<T, VscError> {
+    fn read_raw(&self, port: u8, reg: u8) -> Result<u16, VscError> {
         match self {
             GenericPhyRw::Net(n) => n.read_raw(port, reg),
             GenericPhyRw::FrontIo(n) => n.read_raw(port, reg),
         }
     }
     #[inline(always)]
-    fn write_raw<T>(
-        &self,
-        port: u8,
-        reg: PhyRegisterAddress<T>,
-        value: T,
-    ) -> Result<(), VscError>
-    where
-        u16: From<T>,
-        T: From<u16> + Clone,
-    {
+    fn write_raw(&self, port: u8, reg: u8, value: u16) -> Result<(), VscError> {
         match self {
             GenericPhyRw::Net(n) => n.write_raw(port, reg, value),
             GenericPhyRw::FrontIo(n) => n.write_raw(port, reg, value),

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -52,12 +52,13 @@ impl Bsp {
         // This means that we use the _raw read and write functions, since the
         // higher-level funtions assume page switching.
         let phy = MiimBridge::new(eth);
-        let mut r = phy
-            .read_raw(PHYADDR, phy::STANDARD::MODE_CONTROL())
-            .unwrap();
+        let mut r = phy::standard::MODE_CONTROL::from(
+            phy.read_raw(PHYADDR, phy::STANDARD::MODE_CONTROL().addr)
+                .unwrap(),
+        );
         r.set_auto_neg_ena(1);
         r.set_restart_auto_neg(1);
-        phy.write_raw(PHYADDR, phy::STANDARD::MODE_CONTROL(), r)
+        phy.write_raw(PHYADDR, phy::STANDARD::MODE_CONTROL().addr, r.into())
             .unwrap();
 
         Self {}
@@ -77,7 +78,9 @@ impl Bsp {
             return Err(PhyError::InvalidPort);
         }
         let phy = MiimBridge::new(eth);
-        let out = phy.read_raw(PHYADDR, reg).map_err(|_| PhyError::Other)?;
+        let out = phy
+            .read_raw(PHYADDR, reg.addr)
+            .map_err(|_| PhyError::Other)?;
         Ok(out)
     }
 
@@ -92,7 +95,7 @@ impl Bsp {
             return Err(PhyError::InvalidPort);
         }
         let phy = MiimBridge::new(eth);
-        phy.write_raw(PHYADDR, reg, value)
+        phy.write_raw(PHYADDR, reg.addr, value)
             .map_err(|_| PhyError::Other)?;
         Ok(())
     }

--- a/task/net/src/miim_bridge.rs
+++ b/task/net/src/miim_bridge.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 use drv_stm32h7_eth as eth;
-use vsc7448_pac::types::PhyRegisterAddress;
 use vsc85xx::{PhyRw, VscError};
 
 /// Helper struct to implement the `PhyRw` trait using direct access through
@@ -21,26 +20,13 @@ impl<'a> MiimBridge<'a> {
 
 impl PhyRw for MiimBridge<'_> {
     #[inline(always)]
-    fn read_raw<T: From<u16>>(
-        &self,
-        phy: u8,
-        reg: PhyRegisterAddress<T>,
-    ) -> Result<T, VscError> {
-        Ok(self.eth.smi_read(phy, reg.addr).into())
+    fn read_raw(&self, phy: u8, reg: u8) -> Result<u16, VscError> {
+        Ok(self.eth.smi_read(phy, reg))
     }
 
     #[inline(always)]
-    fn write_raw<T>(
-        &self,
-        phy: u8,
-        reg: PhyRegisterAddress<T>,
-        value: T,
-    ) -> Result<(), VscError>
-    where
-        u16: From<T>,
-        T: From<u16> + Clone,
-    {
-        self.eth.smi_write(phy, reg.addr, value.into());
+    fn write_raw(&self, phy: u8, reg: u8, value: u16) -> Result<(), VscError> {
+        self.eth.smi_write(phy, reg, value);
         Ok(())
     }
 }


### PR DESCRIPTION
These changes, all together, free up
- 133,248 bytes of Flash
- 1,280 bytes of RAM

The bulk of the savings is from the monomorphization-control pattern I applied to the vsc crates, a change which should be stable across compiler revs and reduce the rate of code growth as more logic is added.