### PR TITLE
Remove `LargePayloadBehavior::Fail`

### DIFF
--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -288,11 +288,7 @@ impl NetHandler {
                 Err(RecvError::QueueEmpty) => {
                     return;
                 }
-                Err(
-                    RecvError::NotYours
-                    | RecvError::PayloadTooLarge
-                    | RecvError::Other,
-                ) => panic!(),
+                Err(RecvError::NotYours | RecvError::Other) => panic!(),
             }
         }
     }

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -34,11 +34,7 @@ pub enum RecvError {
     /// The incoming rx queue is empty
     QueueEmpty = 2,
 
-    /// The provided buffer was too small for the payload of the recieved
-    /// packet. Only returned if `LargePayloadBehavior::Fail` was passed.
-    PayloadTooLarge = 3,
-
-    Other = 4,
+    Other = 3,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
@@ -54,13 +50,18 @@ pub enum PhyError {
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[repr(u32)]
 pub enum LargePayloadBehavior {
     /// If we have a packet with a payload larger than the buffer provided to
     /// `recv()`, discard it.
     Discard,
-    /// If we have a packet with a payload larger than the buffer provided to
-    /// `recv()`, return `RecvError::PayloadTooLarge`.
-    Fail,
+    // We could add a `Fail` case here allowing callers to retry with a
+    // larger payload buffer, but
+    //
+    // a) we have no callers that want to do this today, and
+    // b) it complicates the net implementation
+    //
+    // so we omit it for now.
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -191,9 +191,10 @@ impl NetServer for ServerImpl<'_> {
                     if payload.len() < body.len() {
                         match large_payload_behavior {
                             LargePayloadBehavior::Discard => continue,
-                            LargePayloadBehavior::Fail => {
-                                return Err(RecvError::PayloadTooLarge.into());
-                            }
+
+                            // If we add a `::Fail` case, we will need to
+                            // allow for caller retries (possibly by peeking
+                            // on the socket instead of recving)
                         }
                     }
                     payload

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -191,7 +191,6 @@ impl NetServer for ServerImpl<'_> {
                     if payload.len() < body.len() {
                         match large_payload_behavior {
                             LargePayloadBehavior::Discard => continue,
-
                             // If we add a `::Fail` case, we will need to
                             // allow for caller retries (possibly by peeking
                             // on the socket instead of recving)

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -308,7 +308,6 @@ impl NetServer for ServerImpl<'_> {
                         if payload.len() < body.len() {
                             match large_payload_behavior {
                                 LargePayloadBehavior::Discard => continue,
-
                                 // If we add a `::Fail` case, we will need to
                                 // allow for caller retries (possibly by peeking
                                 // on the socket instead of recving)

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -308,11 +308,10 @@ impl NetServer for ServerImpl<'_> {
                         if payload.len() < body.len() {
                             match large_payload_behavior {
                                 LargePayloadBehavior::Discard => continue,
-                                LargePayloadBehavior::Fail => {
-                                    return Err(
-                                        RecvError::PayloadTooLarge.into()
-                                    );
-                                }
+
+                                // If we add a `::Fail` case, we will need to
+                                // allow for caller retries (possibly by peeking
+                                // on the socket instead of recving)
                             }
                         }
                         payload

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -53,9 +53,6 @@ fn main() -> ! {
             }
             Err(RecvError::NotYours) => panic!(),
             Err(RecvError::Other) => panic!(),
-            // We passed `LargePayloadBehavior::Discard`, so we should never get
-            // this error.
-            Err(RecvError::PayloadTooLarge) => unreachable!(),
         }
 
         // Try again.


### PR DESCRIPTION
This fixes the bug (or at least undocumented, surprising behavior) that
if a caller passed `LargePayloadBehavior::Fail` and the net task
returned `RecvError::PayloadTooLarge`, the overlarge packet was
_discarded_ in the process, and the caller could not retry with a larger
buffer.