### PR TITLE
sidecar: hack to allow larger bitstreams for now

### DIFF
--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -1,7 +1,7 @@
 name = "sidecar"
 target = "thumbv7em-none-eabihf"
 board = "sidecar-1"
-chip = "../../chips/stm32h7"
+chip = "../../chips/stm32h7-nonredundant"
 stacksize = 896
 
 [kernel]
@@ -190,7 +190,6 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi1_driver"}]
 name = "drv-sidecar-seq-server"
 features = []
 priority = 4
-max-sizes = {flash = 262144, ram = 2048}
 stacksize = 1024
 start = true
 task-slots = [

--- a/chips/stm32h7-nonredundant/chip.toml
+++ b/chips/stm32h7-nonredundant/chip.toml
@@ -1,0 +1,144 @@
+[rcc]
+address = 0x58024400
+size = 1024
+
+[gpios1]
+address = 0x58020000
+size = 0x2000
+
+[gpios2]
+address = 0x58022000
+size = 0x0800
+
+[gpios3]
+address = 0x58022800
+size = 0x0400
+
+[spi1]
+address = 0x40013000
+size = 1024
+interrupts = { irq = 35 }
+
+[spi2]
+address = 0x40003800
+size = 1024
+interrupts = { irq = 36 }
+
+[spi3]
+address = 0x40003c00
+size = 1024
+interrupts = { irq = 51 }
+
+[spi4]
+address = 0x40013400
+size = 1024
+interrupts = { irq = 84 }
+
+[spi5]
+address = 0x40015000
+size = 1024
+interrupts = { irq = 85 }
+
+[spi6]
+address = 0x58001400
+size = 1024
+interrupts = { irq = 86 }
+
+[usart1]
+address = 0x40011000
+size = 1024
+interrupts = { irq = 37 }
+
+[usart2]
+address = 0x40004400
+size = 1024
+interrupts = { irq = 38 }
+
+[usart3]
+address = 0x40004800
+size = 1024
+interrupts = { irq = 39 }
+
+[uart4]
+address = 0x40004c00
+size = 1024
+interrupts = { irq = 52 }
+
+[uart5]
+address = 0x40005000
+size = 1024
+interrupts = { irq = 53 }
+
+[usart6]
+address = 0x40011400
+size = 1024
+interrupts = { irq = 71 }
+
+[uart7]
+address = 0x40007800
+size = 1024
+interrupts = { irq = 82 }
+
+[uart8]
+address = 0x40007c00
+size = 1024
+interrupts = { irq = 83 }
+
+[i2c1]
+address = 0x40005400
+size = 1024
+interrupts = { event = 31, error = 32 }
+
+[i2c2]
+address = 0x40005800
+size = 1024
+interrupts = { event = 33, error = 34 }
+
+[i2c3]
+address = 0x40005c00
+size = 1024
+interrupts = { event = 72, error = 73 }
+
+[i2c4]
+address = 0x58001c00
+size = 1024
+interrupts = { event = 95, error = 96 }
+
+[quadspi]
+address = 0x52005000
+size = 4096
+interrupts = { irq = 92 }
+
+[eth]
+address = 0x40028000
+size = 0x1000
+interrupts = { irq = 61 }
+
+[eth_dma]
+address = 0x40029000
+size = 0x400
+
+[hash]
+address = 0x48021400
+size = 4096
+interrupts = { irq = 80 }
+
+[system_flash]
+address = 0x1FF00000
+size = 0x20000
+
+[rng]
+address = 0x48021800
+size = 4096
+
+[flash_controller]
+address = 0x52002000
+size = 0x2000
+
+[bank2]
+address = 0x08100000
+size = 0x00100000
+
+#[cryp]
+#address = 0x48021000
+#size = 4096

--- a/chips/stm32h7-nonredundant/memory.toml
+++ b/chips/stm32h7-nonredundant/memory.toml
@@ -1,0 +1,24 @@
+# Flash sections are mapped into both flash banks, YOLO
+[[flash]]
+address = 0x08000000
+size = 2097152
+read = true
+execute = true
+
+# RAM sections are currently mapped into DTCM, a small but fast SRAM.
+[[ram]]
+address = 0x20000000
+size = 131072
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise
+
+# Network buffers are placed in sram1, which is directly accessible by the
+# Ethernet MAC.
+[[sram1]]
+address = 0x30000000
+size = 0x20000
+read = true
+write = true
+dma = true
+

--- a/chips/stm32h7-nonredundant/openocd.cfg
+++ b/chips/stm32h7-nonredundant/openocd.cfg
@@ -1,0 +1,43 @@
+gdb_port 3343
+telnet_port 4453
+
+source [find interface/stlink.cfg]
+source [find target/stm32h7x_dual_bank.cfg]
+
+#
+# Unfortunately, there exists a bug in OpenOCD's stm32h7x.cfg file whereby it
+# will set reserved bits in the STM32H7 DBGMCU CR:
+#
+#   https://sourceforge.net/p/openocd/tickets/266/
+#
+# The documentation is clear that these must be preserved at their reset
+# value (namely: zero) -- and setting them causes SWO to not function at all.
+# Making what feels like the reasonable assumption that this bug will never
+# actually be fixed by OpenOCD, we instead workaround it by overriding the
+# event in which the damage is done, replacing it with the correct
+# implementation.
+#
+$_CHIPNAME.cpu0 configure -event examine-end {
+	# Enable D3 and D1 DBG clocks
+	# DBGMCU_CR |= D3DBGCKEN | D1DBGCKEN
+	stm32h7x_dbgmcu_mmw 0x004 0x00600000 0
+
+	# Enable debug during low power modes (uses more power)
+	# DBGMCU_CR |= DBG_STANDBY | DBG_STOP | DBG_SLEEP
+	#
+	# Note that we do this ONLY for D1; setting this for D3 (a.k.a.
+	# SmartRun, a.k.a. SRD) and/or the reserved bits that may have once
+	# corresponded to D2 is what causes SWO to malfunction.  As an added
+	# precaution, we also take the step of explicitly clearing these bits,
+	# should a broken OpenOCD have already set them.
+	stm32h7x_dbgmcu_mmw 0x004 0x00000007 0x000001B8
+
+	# Stop watchdog counters during halt
+	# DBGMCU_APB3FZ1 |= WWDG1
+	stm32h7x_dbgmcu_mmw 0x034 0x00000040 0
+	# DBGMCU_APB1LFZ1 |= WWDG2
+	stm32h7x_dbgmcu_mmw 0x03C 0x00000800 0
+	# DBGMCU_APB4FZ1 |= WDGLSD1 | WDGLSD2
+	stm32h7x_dbgmcu_mmw 0x054 0x000C0000 0
+}
+

--- a/chips/stm32h7-nonredundant/openocd.gdb
+++ b/chips/stm32h7-nonredundant/openocd.gdb
@@ -1,0 +1,12 @@
+target extended-remote :3343
+
+# print demangled symbols
+set print asm-demangle on
+
+# set backtrace limit to not have infinite backtrace loops
+set backtrace limit 32
+
+# detect hard faults
+break HardFault
+
+monitor arm semihosting enable


### PR DESCRIPTION
This allows sidecar to use both banks of the STM32H7 flash for its
images, which in turn allows the use of FPGA bitstreams that are larger
than ~100kiB. I've tested this with up to 512 kiB of bitstreams and
there's space to spare.

Note that this destroys sidecar's ability to do online updates or have
redundant firmware images. So, this is explicitly intended as a
short-term hack to unblock bringup while we get the external flash
online.