### PR TITLE
idle: add insomniac mode

### DIFF
--- a/task/idle/Cargo.toml
+++ b/task/idle/Cargo.toml
@@ -3,6 +3,10 @@ name = "task-idle"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+default = []
+insomniac = []
+
 [dependencies]
 # The idle task cannot panic, so we deliberately don't request panic-messages
 # to keep the binary tiny.

--- a/task/idle/src/main.rs
+++ b/task/idle/src/main.rs
@@ -12,8 +12,20 @@ extern crate userlib;
 #[export_name = "main"]
 fn main() -> ! {
     loop {
-        // Wait For Interrupt to pause the processor until an ISR arrives,
-        // which could wake some higher-priority task.
-        cortex_m::asm::wfi();
+        if cfg!(feature = "insomniac") {
+            // In insomniac-mode, we just spinloop to absorb idle cycles. This
+            // is useful on certain processors where entering a low-power state
+            // interrupts debugging.
+            //
+            // Note that this is an explicit nop rather than an empty block
+            // because an empty `loop {}` is technically UB and will be replaced
+            // by a trap, bringing the system to a halt with no tasks runnable.
+            // So, do not get clever and remove this.
+            cortex_m::asm::nop();
+        } else {
+            // Wait For Interrupt to pause the processor until an ISR arrives,
+            // which could wake some higher-priority task.
+            cortex_m::asm::wfi();
+        }
     }
 }


### PR DESCRIPTION
This avoids using WFI to enter a lower power state. This appears to be important to be able to debug the stm32g030.