### PR TITLE
update-server bank erase: Wait for interrupt instead of polling

### DIFF
--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -179,6 +179,7 @@ max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 uses = ["flash_controller", "bank2"]
+interrupts = {"flash_controller.irq" = 0b1}
 
 [config]
 [[config.i2c.controllers]]

--- a/chips/stm32h7-nonredundant/chip.toml
+++ b/chips/stm32h7-nonredundant/chip.toml
@@ -134,6 +134,7 @@ size = 4096
 [flash_controller]
 address = 0x52002000
 size = 0x2000
+interrupts = { irq = 4 }
 
 [bank2]
 address = 0x08100000

--- a/chips/stm32h7/chip.toml
+++ b/chips/stm32h7/chip.toml
@@ -134,6 +134,7 @@ size = 4096
 [flash_controller]
 address = 0x52002000
 size = 0x2000
+interrupts = { irq = 4 }
 
 [bank2]
 address = 0x08100000


### PR DESCRIPTION
After switching from `cr.write(..)` to `cr.modify(..)` to get interrupts working, I noticed bank erasing was significantly faster. That doesn't make sense if the only change were switching from polling to an interrupt; after some poking at the cr register, I realized the previous `cr.write(..)` was clobbering the `psize()` field, setting the flash parallelism to 8 bits (as opposed to the value of `0b11`, 64 bits, when update server starts). 

With that realization, I changed the `cr.write(..)` call in `write_word(..)` to set `psize(0b11)` explicitly. Maybe changing that call to `.modify(..)` would be better? I'm not sure.

Prior to this change, my times to perform an update over UDP were ~13s for bank erase and then ~2.3s to write the new image. As of this branch, those times drop to ~5s for bank erase and ~1.1s to write the new image.