### PR TITLE
Add `compress_to_vec` to Gnarle

### DIFF
--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -29,7 +29,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-fpga-regmap = {path = "../../build/fpga-regmap"}
 build-i2c = {path = "../../build/i2c"}
 build-util = {path = "../../build/util"}
-gnarle = {path = "../../lib/gnarle"}
+gnarle = {path = "../../lib/gnarle", features=["std"]}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0"

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let fpga_image = fs::read(&fpga_image_path)?;
-    let compressed = compress(&fpga_image);
+    let compressed = gnarle::compress_to_vec(&fpga_image);
 
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let compressed_path = out.join(fpga_image_path.with_extension("bin.rle"));
@@ -73,14 +73,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     Ok(())
-}
-
-fn compress(input: &[u8]) -> Vec<u8> {
-    let mut output = vec![];
-    gnarle::compress(input, |chunk| {
-        output.extend_from_slice(chunk);
-        Ok::<_, std::convert::Infallible>(())
-    })
-    .ok();
-    output
 }

--- a/drv/sidecar-front-io/Cargo.toml
+++ b/drv/sidecar-front-io/Cargo.toml
@@ -19,5 +19,5 @@ phy_smi = ["vsc85xx", "vsc7448-pac"]
 [build-dependencies]
 build-fpga-regmap = {path = "../../build/fpga-regmap"}
 build-util = {path = "../../build/util"}
-gnarle = {path = "../../lib/gnarle"}
+gnarle = {path = "../../lib/gnarle", features=["std"]}
 sha2 = { version = "0.9", default-features = false }

--- a/drv/sidecar-front-io/build.rs
+++ b/drv/sidecar-front-io/build.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
     let fpga_bitstream = fs::read(ecp5_bitstream_name)?;
-    let compressed_fpga_bitstream = compress(&fpga_bitstream);
+    let compressed_fpga_bitstream = gnarle::compress_to_vec(&fpga_bitstream);
 
     fs::write(out_dir.join("ecp5.bin.rle"), &compressed_fpga_bitstream)?;
 
@@ -46,16 +46,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={}", ecp5_bitstream_name);
 
     Ok(())
-}
-
-fn compress(input: &[u8]) -> Vec<u8> {
-    let mut output = vec![];
-
-    gnarle::compress(input, |chunk| {
-        output.extend_from_slice(chunk);
-        Ok::<_, std::convert::Infallible>(())
-    })
-    .ok();
-
-    output
 }

--- a/drv/sidecar-mainboard-controller/Cargo.toml
+++ b/drv/sidecar-mainboard-controller/Cargo.toml
@@ -14,4 +14,4 @@ build-fpga-regmap = {path = "../../build/fpga-regmap"}
 build-util = {path = "../../build/util"}
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0"
-gnarle = {path = "../../lib/gnarle"}
+gnarle = {path = "../../lib/gnarle", features=["std"]}

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
     let fpga_bitstream = fs::read(ecp5_bitstream_name)?;
-    let compressed_fpga_bitstream = compress(&fpga_bitstream);
+    let compressed_fpga_bitstream = gnarle::compress_to_vec(&fpga_bitstream);
 
     fs::write(out_dir.join("ecp5.bin.rle"), &compressed_fpga_bitstream)?;
 
@@ -33,16 +33,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={}", ecp5_bitstream_name);
 
     Ok(())
-}
-
-fn compress(input: &[u8]) -> Vec<u8> {
-    let mut output = vec![];
-
-    gnarle::compress(input, |chunk| {
-        output.extend_from_slice(chunk);
-        Ok::<_, std::convert::Infallible>(())
-    })
-    .ok();
-
-    output
 }

--- a/lib/gnarle/Cargo.toml
+++ b/lib/gnarle/Cargo.toml
@@ -5,4 +5,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+std = []
+
 [dependencies]

--- a/lib/gnarle/src/lib.rs
+++ b/lib/gnarle/src/lib.rs
@@ -9,7 +9,7 @@
 //! there don't appear to be any `no_std` lz4 crates out there, no matter what
 //! their READMEs claim.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use core::convert::TryFrom;
 
@@ -58,6 +58,20 @@ pub fn compress<E>(
     }
 
     Ok(())
+}
+
+/// Compresses the given data, returning a `Vec`
+#[cfg(feature = "std")]
+pub fn compress_to_vec(input: &[u8]) -> Vec<u8> {
+    let mut output = vec![];
+
+    compress(input, |chunk| {
+        output.extend_from_slice(chunk);
+        Ok::<_, std::convert::Infallible>(())
+    })
+    .ok();
+
+    output
 }
 
 fn generate_run<E>(


### PR DESCRIPTION
This removes a bit of duplicate code from FPGA `build.rs` files.

Closes #630