### PR TITLE
Reduce stack usage in `net` task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutable-statics"
+version = "0.1.0"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3181,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "ksz8463",
+ "mutable-statics",
  "num-traits",
  "proc-macro2",
  "quote",

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -68,7 +68,7 @@ global_config = "spi1"
 
 [tasks.net]
 name = "task-net"
-stacksize = 3800
+stacksize = 3000
 priority = 2
 max-sizes = {flash = 65536, ram = 8192, sram1 = 32768}
 features = ["h743"]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -64,7 +64,7 @@ global_config = "spi1"
 
 [tasks.net]
 name = "task-net"
-stacksize = 3800
+stacksize = 3000
 priority = 2
 max-sizes = {flash = 131072, ram = 8192, sram1 = 32768}
 features = ["h753"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -33,7 +33,7 @@ on-state-change = {net = {bit-number = 3}}
 
 [tasks.net]
 name = "task-net"
-stacksize = 5400
+stacksize = 4400
 priority = 5
 features = ["mgmt", "h753", "gimlet", "h7-vlan"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -33,7 +33,7 @@ on-state-change = {net = {bit-number = 3}}
 
 [tasks.net]
 name = "task-net"
-stacksize = 4400
+stacksize = 4600
 priority = 5
 features = ["mgmt", "h753", "gimlet", "h7-vlan"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -68,7 +68,7 @@ task-slots = ["sys", "user_leds"]
 
 [tasks.net]
 name = "task-net"
-stacksize = 3800
+stacksize = 3000
 priority = 3
 features = ["mgmt", "h753"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -114,7 +114,7 @@ task-slots = ["sys"]
 
 [tasks.net]
 name = "task-net"
-stacksize = 4800
+stacksize = 3800
 priority = 3
 features = ["h753", "h7-vlan", "gimletlet-nic"]
 max-sizes = {flash = 65536, ram = 16384, sram1 = 16384}

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -91,7 +91,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.net]
 name = "task-net"
-stacksize = 3800
+stacksize = 3000
 priority = 3
 features = ["mgmt", "h753"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -93,7 +93,7 @@ global_config = "spi5"
 
 [tasks.net]
 name = "task-net"
-stacksize = 5400
+stacksize = 4400
 priority = 5
 features = ["mgmt", "h753", "sidecar"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}

--- a/lib/mutable-statics/Cargo.toml
+++ b/lib/mutable-statics/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mutable-statics"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/lib/mutable-statics/src/lib.rs
+++ b/lib/mutable-statics/src/lib.rs
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#![no_std]
+
+/// A macro to facilitate declaring mutable statics safely using the
+/// "first-mover" pattern.
+///
+/// Any given use of this macro can only execute once. If execution reaches it
+/// again, it will panic. It uses this behavior to ensure that it can hand out
+/// &mut references to statics, which are declared within the macro.
+///
+/// The macro accepts definitions of one or more mutable static arrays. It will
+/// arrange for them to be initialized, and return a tuple containing mutable
+/// references to each, in the order they're declared.
+#[macro_export]
+macro_rules! mutable_statics {
+    (
+        $(
+            $(#[$attr:meta])*
+            static mut $name:ident: [$t:ty; $n:expr] = [$init:expr; _];
+        )*
+    ) => {{
+        static TAKEN: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+        if TAKEN.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            panic!()
+        }
+        (
+            $(
+                {
+                    $(#[$attr])*
+                    static mut $name: core::mem::MaybeUninit<[$t; $n]> =
+                        core::mem::MaybeUninit::uninit();
+                    // Safety: unsafe because of reference to mutable static;
+                    // safe because the AtomicBool swap above, combined with the
+                    // lexical scoping of $name, means that this reference can't
+                    // be aliased by any other reference in the program.
+                    let __ref = unsafe {
+                        &mut $name
+                    };
+                    // Safety: unsafe because of dereference of a raw pointer
+                    // (after we cast it) -- safe because we are casting here
+                    // from MaybeUninit<[$t; $n]> to [MaybeUninit<$t>; $n],
+                    // which is safe by definition.
+                    let __ref: &'static mut [core::mem::MaybeUninit<$t>; $n] =
+                        unsafe {
+                            &mut *(__ref as *mut _ as *mut _)
+                        };
+                    for __u in __ref.iter_mut() {
+                        *__u = core::mem::MaybeUninit::new($init);
+                    }
+                    // Safety: unsafe because of dereference of a raw pointer
+                    // (after we cast it) -- safe because we are casting here
+                    // from [MaybeUninit<$t>; $n] to [$t; $n] after
+                    // initializing.
+                    let __ref: &'static mut [$t; $n] = unsafe {
+                        &mut *(__ref as *mut _ as *mut _)
+                    };
+                    __ref
+                }
+            ),*
+        )
+    }};
+}

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -23,9 +23,10 @@ drv-user-leds-api = {path = "../../drv/user-leds-api", optional = true}
 hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 ksz8463 = { path = "../../drv/ksz8463", optional = true }
+mutable-statics = {path = "../../lib/mutable-statics"}
 ringbuf = {path = "../../lib/ringbuf"}
-task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 task-jefe-api = {path = "../jefe-api"}
+task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448"}
 vsc85xx = { path = "../../drv/vsc85xx"}

--- a/task/net/src/buf.rs
+++ b/task/net/src/buf.rs
@@ -103,3 +103,5 @@ pub fn claim_mac_address() -> &'static mut [u8; 6] {
         static mut MAC_ADDRESS: [u8; 6] = [0; _];
     }
 }
+
+pub(crate) use mutable_statics;

--- a/task/net/src/buf.rs
+++ b/task/net/src/buf.rs
@@ -4,68 +4,8 @@
 
 use drv_stm32h7_eth as eth;
 
-use core::mem::MaybeUninit;
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use crate::{RX_RING_SZ, TX_RING_SZ};
-
-/// A macro to facilitate declaring mutable statics safely using the
-/// "first-mover" pattern.
-///
-/// Any given use of this macro can only execute once. If execution reaches it
-/// again, it will panic. It uses this behavior to ensure that it can hand out
-/// &mut references to statics, which are declared within the macro.
-///
-/// The macro accepts definitions of one or more mutable static arrays. It will
-/// arrange for them to be initialized, and return a tuple containing mutable
-/// references to each, in the order they're declared.
-macro_rules! mutable_statics {
-    (
-        $(
-            $(#[$attr:meta])*
-            static mut $name:ident: [$t:ty; $n:expr] = [$init:expr; _];
-        )*
-    ) => {{
-        static TAKEN: AtomicBool = AtomicBool::new(false);
-        if TAKEN.swap(true, Ordering::Relaxed) {
-            panic!()
-        }
-        (
-            $(
-                {
-                    $(#[$attr])*
-                    static mut $name: MaybeUninit<[$t; $n]> =
-                        MaybeUninit::uninit();
-                    // Safety: unsafe because of reference to mutable static;
-                    // safe because the AtomicBool swap above, combined with the
-                    // lexical scoping of $name, means that this reference can't
-                    // be aliased by any other reference in the program.
-                    let __ref = unsafe {
-                        &mut $name
-                    };
-                    // Safety: unsafe because of dereference of a raw pointer
-                    // (after we cast it) -- safe because we are casting here
-                    // from MaybeUninit<[$t; $n]> to [MaybeUninit<$t>; $n],
-                    // which is safe by definition.
-                    let __ref: &'static mut [MaybeUninit<$t>; $n] = unsafe {
-                        &mut *(__ref as *mut _ as *mut _)
-                    };
-                    for __u in __ref.iter_mut() {
-                        *__u = MaybeUninit::new($init);
-                    }
-                    // Safety: unsafe because of dereference of a raw pointer
-                    // (after we cast it) -- safe because we are casting here
-                    // from [MaybeUninit<$t>; $n] to [$t; $n] after
-                    // initializing.
-                    let __ref: &'static mut [$t; $n] = unsafe {
-                        &mut *(__ref as *mut _ as *mut _)
-                    };
-                    __ref
-                }
-            ),*
-        )
-    }};
-}
+use mutable_statics::mutable_statics;
 
 /// Grabs references to the static descriptor/buffer transmit rings. Can only be
 /// called once.
@@ -103,5 +43,3 @@ pub fn claim_mac_address() -> &'static mut [u8; 6] {
         static mut MAC_ADDRESS: [u8; 6] = [0; _];
     }
 }
-
-pub(crate) use mutable_statics;

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -15,10 +15,10 @@ pub mod pins;
 cfg_if::cfg_if! {
     if #[cfg(feature = "vlan")] {
         mod server_vlan;
-        use server_vlan::{ServerImpl, ServerStorage};
+        use server_vlan::ServerImpl;
     } else {
         mod server_basic;
-        use server_basic::{ServerImpl, ServerStorage};
+        use server_basic::ServerImpl;
     }
 }
 
@@ -143,12 +143,11 @@ fn main() -> ! {
 
     // Configure the server and its local storage arrays (on the stack)
     let ipv6_addr = link_local_iface_addr(mac);
-    let mut storage = ServerStorage::new(eth);
 
     // Board-dependant initialization (e.g. bringing up the PHYs)
-    let bsp = bsp::Bsp::new(&storage.eth, &sys);
+    let bsp = bsp::Bsp::new(&eth, &sys);
 
-    let mut server = ServerImpl::new(&mut storage, ipv6_addr, mac, bsp);
+    let mut server = ServerImpl::new(&eth, ipv6_addr, mac, bsp);
 
     // Turn on our IRQ.
     userlib::sys_irq_control(ETH_IRQ, true);

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -7,6 +7,11 @@
 //! This module implements a server which listens on multiple (incrementing)
 //! IPv6 addresses and supports some number of VLANs.
 
+use core::{
+    mem::MaybeUninit,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
 use drv_stm32h7_eth as eth;
 
 use idol_runtime::{ClientError, NotificationHandler, RequestError};
@@ -28,21 +33,32 @@ type NeighborStorage = Option<(IpAddress, Neighbor)>;
 
 /// Storage required to run a single [ServerImpl]. This should be allocated
 /// on the stack and passed into the constructor for the [ServerImpl].
-pub struct ServerStorage<'a> {
+pub struct ServerStorage {
     pub eth: eth::Ethernet,
-    neighbor_cache_storage: [[NeighborStorage; NEIGHBORS]; VLAN_COUNT],
-    socket_storage: [[SocketStorage<'a>; SOCKET_COUNT]; VLAN_COUNT],
-    ipv6_net: [IpCidr; VLAN_COUNT],
 }
 
-impl<'a> ServerStorage<'a> {
+/// Grabs references to the static descriptor/buffer receive rings. Can only be
+/// called once.
+pub fn claim_server_storage_statics() -> (
+    &'static mut [[NeighborStorage; NEIGHBORS]; VLAN_COUNT],
+    &'static mut [[SocketStorage<'static>; SOCKET_COUNT]; VLAN_COUNT],
+    &'static mut [IpCidr; VLAN_COUNT],
+) {
+    crate::buf::mutable_statics! {
+        static mut NEIGHBOR_CACHE_STORAGE:
+            [[NeighborStorage; NEIGHBORS]; VLAN_COUNT] =
+            [Default::default(); _];
+        static mut SOCKET_STORAGE:
+            [[SocketStorage<'static>; SOCKET_COUNT]; VLAN_COUNT] =
+            [Default::default(); _];
+        static mut IPV6_NET: [IpCidr; VLAN_COUNT] =
+            [Ipv6Cidr::default().into(); _];
+    }
+}
+
+impl ServerStorage {
     pub fn new(eth: eth::Ethernet) -> Self {
-        Self {
-            eth,
-            neighbor_cache_storage: Default::default(),
-            socket_storage: Default::default(),
-            ipv6_net: [Ipv6Cidr::default().into(); VLAN_COUNT],
-        }
+        Self { eth }
     }
 }
 
@@ -120,7 +136,7 @@ pub struct ServerImpl<'a> {
 
     socket_handles: [[SocketHandle; SOCKET_COUNT]; VLAN_COUNT],
     client_waiting_to_send: [bool; SOCKET_COUNT],
-    ifaces: [Interface<'a, VLanEthernet<'a>>; VLAN_COUNT],
+    ifaces: [Interface<'static, VLanEthernet<'a>>; VLAN_COUNT],
     bsp: crate::bsp::Bsp,
 }
 
@@ -130,7 +146,7 @@ impl<'a> ServerImpl<'a> {
 
     /// Builds a new `ServerImpl`, using the provided storage space.
     pub fn new(
-        storage: &'a mut ServerStorage<'a>,
+        storage: &'a mut ServerStorage,
         mut ipv6_addr: Ipv6Address,
         mut mac: EthernetAddress,
         bsp: crate::bsp::Bsp,
@@ -138,18 +154,20 @@ impl<'a> ServerImpl<'a> {
         // Local storage; this will end up owned by the returned ServerImpl.
         let mut socket_handles = [[Default::default(); generated::SOCKET_COUNT];
             generated::VLAN_COUNT];
-        let mut ifaces: [Option<Interface<'a, VLanEthernet<'a>>>; VLAN_COUNT] =
-            Default::default();
+        let mut ifaces: [Option<Interface<'static, VLanEthernet<'static>>>;
+            VLAN_COUNT] = Default::default();
+
+        let (n, s, i) = claim_server_storage_statics();
 
         // We're iterating over a bunch of things together.  The standard
         // library doesn't have a great multi-element zip, so we'll just
         // manually use mutable iterators.
-        let mut neighbor_cache_iter = storage.neighbor_cache_storage.iter_mut();
-        let mut socket_storage_iter = storage.socket_storage.iter_mut();
+        let mut neighbor_cache_iter = n.iter_mut();
+        let mut socket_storage_iter = s.iter_mut();
         let mut socket_handles_iter = socket_handles.iter_mut();
         let mut vid_iter = generated::VLAN_RANGE;
         let mut ifaces_iter = ifaces.iter_mut();
-        let mut ip_addr_iter = storage.ipv6_net.chunks_mut(1);
+        let mut ip_addr_iter = i.chunks_mut(1);
 
         // Create a VLAN_COUNT x SOCKET_COUNT nested array of sockets
         let sockets = generated::construct_sockets();
@@ -267,7 +285,7 @@ impl<'a> ServerImpl<'a> {
         &mut self,
         index: usize,
         vlan_index: usize,
-    ) -> Result<&mut UdpSocket<'a>, ClientError> {
+    ) -> Result<&mut UdpSocket<'static>, ClientError> {
         Ok(self.ifaces[vlan_index]
             .get_socket::<UdpSocket>(self.get_handle(index, vlan_index)?))
     }


### PR DESCRIPTION
Eliminates `ServerStorage`, moving its buffers to `static` storage.

As a drive-by, also moves the `mutable_statics` macro to its own crate.