### PR TITLE
Add Hubris ID to stage0

### DIFF
--- a/build/kernel-link.x
+++ b/build/kernel-link.x
@@ -101,7 +101,9 @@ SECTIONS
   {
     __srodata = .;
     *(.rodata .rodata.*);
-
+    /* We move this into a special section so we can ensure it is always
+       included in the build */
+    KEEP(*(.hubris_id));
     /* 4-byte align the end (VMA) of this section.
        This is required by LLD to ensure the LMA of the following .data
        section will have the correct alignment. */

--- a/stage0/build.rs
+++ b/stage0/build.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let mut const_file = File::create(out.join("consts.rs")).unwrap();
+
+    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
+    println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
+
+    writeln!(const_file, "// See build.rs for details")?;
+
+    writeln!(const_file, "#[used]")?;
+    writeln!(const_file, "#[no_mangle]")?;
+    writeln!(const_file, "#[link_section = \".hubris_id\"]")?;
+    writeln!(
+        const_file,
+        "pub static HUBRIS_IMAGE_ID: u64 = {};",
+        image_id
+    )?;
+
+    Ok(())
+}

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -182,3 +182,5 @@ fn main() -> ! {
         branch_to_image(imagea);
     }
 }
+
+include!(concat!(env!("OUT_DIR"), "/consts.rs"));


### PR DESCRIPTION
While not a true 'hubris' image, adding a hubris ID to stage0 lets
it be used with some humility commands.