### PR TITLE
mgmt-gateway: add support for update and reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=5951498bbd60306bf8e73a382e6b5aaed67a7616#5951498bbd60306bf8e73a382e6b5aaed67a7616"
+source = "git+https://github.com/oxidecomputer/omicron?rev=45286415755d5ec7c0d3683addc9942832244eff#45286415755d5ec7c0d3683addc9942832244eff"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -2684,18 +2684,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "7af873f2c95b99fcb0bd0fe622a43e29514658873c8ceba88c4cb88833a22500"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "75743a150d003dd863b51dc809bcad0d73f2102c53632f1e954e738192a3413f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3070,11 +3070,14 @@ dependencies = [
  "cfg-if",
  "drv-stm32h7-usart",
  "drv-stm32xx-uid",
+ "drv-update-api",
  "gateway-messages",
+ "mutable-statics",
  "num-traits",
  "ringbuf",
  "serde",
  "ssmarshal",
+ "task-jefe-api",
  "task-net-api",
  "tinyvec",
  "userlib",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -121,7 +121,7 @@ name = "task-net"
 stacksize = 3800
 priority = 3
 features = ["h753", "vlan", "gimletlet-nic"]
-max-sizes = {flash = 65536, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 65536, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -147,7 +147,7 @@ uses = [
     "usart1",
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
 ]
-task-slots = ["net", "sys"]
+task-slots = ["jefe", "net", "update_server", "sys"]
 features = ["usart1", "vlan"]
 interrupts = {"usart1.irq" = 0b10}
 
@@ -262,5 +262,5 @@ rx = { packets = 3, bytes = 1024 }
 kind = "udp"
 owner = {name = "mgmt_gateway", notification = 0b01}
 port = 11111 # TODO do we have a documented port for MGS traffic?
-tx = { packets = 3, bytes = 1024 }
-rx = { packets = 3, bytes = 1024 }
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -9,6 +9,7 @@
 #![no_std]
 #![no_main]
 
+use drv_update_api::stm32h7::{BLOCK_SIZE_BYTES, FLASH_WORD_BYTES};
 use drv_update_api::UpdateError;
 use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
 use ringbuf::*;
@@ -32,17 +33,6 @@ const BANK_END: u32 = 0x08200000;
 // BANK_ADDR + FLASH_WORD_BYTES is word 1 etc.
 const BANK_WORD_LIMIT: usize =
     (BANK_END - BANK_ADDR) as usize / FLASH_WORD_BYTES;
-
-// RM0433 Rev 7 section 4.3.9
-// Flash word is defined as 256 bits
-const FLASH_WORD_BITS: usize = 256;
-
-// Total length of a word in bytes (i.e. our array size)
-const FLASH_WORD_BYTES: usize = FLASH_WORD_BITS / 8;
-
-// Block is an abstract concept here. It represents the size of data the
-// driver will process at a time.
-const BLOCK_SIZE_BYTES: usize = FLASH_WORD_BYTES * 32;
 
 // Must match app.toml!
 const FLASH_IRQ: u32 = 1 << 0;

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -26,4 +26,17 @@ pub enum UpdateError {
     WriteProtErr = 13,
 }
 
+pub mod stm32h7 {
+    // RM0433 Rev 7 section 4.3.9
+    // Flash word is defined as 256 bits
+    pub const FLASH_WORD_BITS: usize = 256;
+
+    // Total length of a word in bytes (i.e. our array size)
+    pub const FLASH_WORD_BYTES: usize = FLASH_WORD_BITS / 8;
+
+    // Block is an abstract concept here. It represents the size of data the
+    // driver will process at a time.
+    pub const BLOCK_SIZE_BYTES: usize = FLASH_WORD_BYTES * 32;
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -12,11 +12,14 @@ tinyvec = "1.6"
 
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"]}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
+drv-update-api = {path = "../../drv/update-api"}
+mutable-statics = {path = "../../lib/mutable-statics"}
 ringbuf = {path = "../../lib/ringbuf"}
+task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "5951498bbd60306bf8e73a382e6b5aaed67a7616"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "45286415755d5ec7c0d3683addc9942832244eff"}
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -242,10 +242,7 @@ impl NetHandler {
         }
     }
 
-    fn run_until_blocked(
-        &mut self,
-        mgs_handler: &mut MgsHandler,
-    ) {
+    fn run_until_blocked(&mut self, mgs_handler: &mut MgsHandler) {
         loop {
             // Try to send first.
             if let Some(meta) = self.packet_to_send.take() {

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -2,20 +2,33 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use core::convert::Infallible;
+
 use crate::{Log, MgsMessage, UsartHandler, __RINGBUF};
+use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
+use drv_update_api::Update;
 use gateway_messages::{
     sp_impl::SocketAddrV6,
     sp_impl::{SerialConsolePacketizer, SpHandler},
     BulkIgnitionState, DiscoverResponse, IgnitionCommand, IgnitionState,
-    ResponseError, SerialConsole, SpComponent, SpPort, SpState,
+    ResponseError, SerialConsole, SpComponent, SpPort, SpState, UpdateChunk,
+    UpdateStart,
 };
+use mutable_statics::mutable_statics;
 use ringbuf::ringbuf_entry;
+use tinyvec::ArrayVec;
 use userlib::UnwrapLite;
+
+// TODO How are we versioning SP images? This is a placeholder.
+const VERSION: u32 = 1;
 
 pub(crate) struct MgsHandler {
     pub(crate) usart: UsartHandler,
     attached_serial_console_mgs: Option<(SocketAddrV6, SpPort)>,
     serial_console_packetizer: SerialConsolePacketizer,
+    update_task: Update,
+    update_progress: Option<&'static mut UpdateBuffer>,
+    reset_requested: bool,
 }
 
 impl MgsHandler {
@@ -29,6 +42,9 @@ impl MgsHandler {
                 // console"s?
                 SpComponent::try_from("sp3").unwrap_lite(),
             ),
+            update_task: Update::from(crate::UPDATE_SERVER.get_task_id()),
+            update_progress: None,
+            reset_requested: false,
         }
     }
 
@@ -125,7 +141,60 @@ impl SpHandler for MgsHandler {
             *to = from;
         }
 
-        Ok(SpState { serial_number })
+        Ok(SpState {
+            serial_number,
+            version: VERSION,
+        })
+    }
+
+    fn update_start(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        update: UpdateStart,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStart {
+            length: update.total_size
+        }));
+
+        if let Some(progress) = self.update_progress.as_ref() {
+            return Err(ResponseError::UpdateInProgress {
+                bytes_received: progress.bytes_written as u32,
+            });
+        }
+
+        self.update_task
+            .prep_image_update()
+            .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+
+        // We can only call `claim_update_buffer_static` once; we bail out above
+        // if `self.update_progress` is already `Some(_)`, and after we claim it
+        // here, we store that into `self.update_progress` (and never clear it).
+        let update_buffer = claim_update_buffer_static();
+        update_buffer.total_length = update.total_size as usize;
+        self.update_progress = Some(update_buffer);
+
+        Ok(())
+    }
+
+    fn update_chunk(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        chunk: UpdateChunk,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+            offset: chunk.offset,
+        }));
+
+        let update_progress = self
+            .update_progress
+            .as_mut()
+            .ok_or(ResponseError::InvalidUpdateChunk)?;
+
+        update_progress.ingest_chunk(&self.update_task, &chunk)?;
+
+        Ok(())
     }
 
     fn serial_console_write(
@@ -152,4 +221,104 @@ impl SpHandler for MgsHandler {
             Err(ResponseError::Busy)
         }
     }
+
+    fn sys_reset_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SysResetPrepare));
+        self.reset_requested = true;
+        Ok(())
+    }
+
+    fn sys_reset_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<Infallible, ResponseError> {
+        if !self.reset_requested {
+            return Err(ResponseError::SysResetTriggerWithoutPrepare);
+        }
+
+        let jefe = task_jefe_api::Jefe::from(crate::JEFE.get_task_id());
+        jefe.request_reset();
+
+        // If `request_reset()` returns, something has gone very wrong.
+        panic!()
+    }
+}
+
+#[derive(Default)]
+struct UpdateBuffer {
+    total_length: usize,
+    bytes_written: usize,
+    current_block: ArrayVec<[u8; BLOCK_SIZE_BYTES]>,
+}
+
+impl UpdateBuffer {
+    fn ingest_chunk(
+        &mut self,
+        update_task: &Update,
+        chunk: &UpdateChunk,
+    ) -> Result<(), ResponseError> {
+        // Reject chunks that don't match our current progress.
+        if chunk.offset as usize != self.bytes_written {
+            return Err(ResponseError::UpdateInProgress {
+                bytes_received: self.bytes_written as u32,
+            });
+        }
+
+        // Reject chunks that would go past the total size we're expecting.
+        if self.bytes_written + chunk.chunk_length as usize > self.total_length
+        {
+            return Err(ResponseError::InvalidUpdateChunk);
+        }
+
+        let mut data = &chunk.data[..chunk.chunk_length as usize];
+        while !data.is_empty() {
+            let cap = self.current_block.capacity() - self.current_block.len();
+            assert!(cap > 0);
+            let to_copy = usize::min(cap, data.len());
+
+            let current_block_index = self.bytes_written / BLOCK_SIZE_BYTES;
+            self.current_block.extend_from_slice(&data[..to_copy]);
+            data = &data[to_copy..];
+            self.bytes_written += to_copy;
+
+            // If the block is full or this is the final block, send it to the
+            // update task.
+            if self.current_block.len() == self.current_block.capacity()
+                || self.bytes_written == self.total_length
+            {
+                update_task
+                    .write_one_block(current_block_index, &self.current_block)
+                    .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+                self.current_block.clear();
+            }
+        }
+
+        // Finalizing the update is implicit (we finalize if we just wrote the
+        // last block). Should we make it explict somehow? Maybe that comes with
+        // adding auth / code signing?
+        if self.bytes_written == self.total_length {
+            update_task
+                .finish_image_update()
+                .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+            ringbuf_entry!(Log::UpdateComplete);
+        } else {
+            ringbuf_entry!(Log::UpdatePartial {
+                bytes_written: self.bytes_written
+            });
+        }
+
+        Ok(())
+    }
+}
+
+fn claim_update_buffer_static() -> &'static mut UpdateBuffer {
+    let update_buffer_array = mutable_statics! {
+        static mut BUF: [UpdateBuffer; 1] = [Default::default(); _];
+    };
+    &mut update_buffer_array[0]
 }

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -227,6 +227,8 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), ResponseError> {
+        // TODO: Add some kind of auth check before performing a reset.
+        // https://github.com/oxidecomputer/hubris/issues/723
         ringbuf_entry!(Log::MgsMessage(MgsMessage::SysResetPrepare));
         self.reset_requested = true;
         Ok(())
@@ -237,6 +239,8 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<Infallible, ResponseError> {
+        // TODO: Add some kind of auth check before performing a reset.
+        // https://github.com/oxidecomputer/hubris/issues/723
         if !self.reset_requested {
             return Err(ResponseError::SysResetTriggerWithoutPrepare);
         }
@@ -327,7 +331,12 @@ impl UpdateBuffer {
     }
 }
 
+/// Grabs reference to a static `UpdateBuffer`. Can only be called once!
 fn claim_update_buffer_static() -> &'static mut UpdateBuffer {
+    // TODO: `mutable_statics!` is currently limited in what inputs it accepts,
+    // and in particular only accepts static mut arrays. We only want a single
+    // `UpdateBuffer`, so we create an array of length 1 and grab its only
+    // element.
     let update_buffer_array = mutable_statics! {
         static mut BUF: [UpdateBuffer; 1] = [Default::default(); _];
     };


### PR DESCRIPTION
This also includes a change to move the update server block size into `update_api` (underneath a chip-specific module). I did not remove the `block_size` runtime API call, although it's no longer necessary for clients, since they can grab the constant directly from `update_api`.