### PR TITLE
New `net` APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,7 @@ dependencies = [
  "serde",
  "userlib",
  "vsc7448",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3205,8 +3206,10 @@ version = "0.1.0"
 dependencies = [
  "build-net",
  "derive-idol-err",
+ "drv-spi-api",
  "idol",
  "idol-runtime",
+ "ksz8463",
  "num-traits",
  "serde",
  "smoltcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ name = "ksz8463"
 version = "0.1.0"
 dependencies = [
  "drv-spi-api",
+ "num-traits",
  "ringbuf",
  "userlib",
 ]

--- a/drv/ksz8463/Cargo.toml
+++ b/drv/ksz8463/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib" }
-ringbuf = {path = "../../lib/ringbuf" }
 drv-spi-api = {path = "../../drv/spi-api"}
+ringbuf = {path = "../../lib/ringbuf" }
+userlib = {path = "../../sys/userlib" }
+
+num-traits = { version = "0.2.12", default-features = false }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -227,6 +227,13 @@ impl Ksz8463 {
         assert!(addr < 1024);
         self.write(Register::IACR, 0x1800 | addr)?;
         // Wait for the "not ready" bit to be cleared
+        //
+        // The IADR* registers together form a 72-bit value, which is packed
+        // into a set of u16 values; we use variables of the form `d_HI_LO`,
+        // where `HI` and `LO` are bit ranges in that value.
+        //
+        // Each `d_*` variable uses all 16 bits *except* `d_71_64`, which only
+        // uses the lower 8 bits.
         let d_71_64 = loop {
             let d = self.read(Register::IADR1)?;
             // Check bit 71 to see if the register is ready

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -84,21 +84,21 @@ pub enum SourcePort {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct KszMacTableEntry {
+pub struct KszRawMacTableEntry {
     /// Number of valid entries in the table
-    count: u32,
+    pub count: u32,
 
     /// Two-bit counter for internal aging
     timestamp: u8,
 
     /// Source port where the FID + MAC is learned
-    source: SourcePort,
+    pub source: SourcePort,
 
     /// Filter ID
     fid: u8,
 
     /// MAC address from the table
-    addr: [u8; 6],
+    pub addr: [u8; 6],
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -222,7 +222,7 @@ impl Ksz8463 {
     pub fn read_dynamic_mac_table(
         &self,
         addr: u16,
-    ) -> Result<Option<KszMacTableEntry>, Error> {
+    ) -> Result<Option<KszRawMacTableEntry>, Error> {
         assert!(addr < 1024);
         self.write(Register::IACR, 0x1800 | addr)?;
         // Wait for the "not ready" bit to be cleared
@@ -267,7 +267,7 @@ impl Ksz8463 {
             d_15_0 as u8,
         ];
 
-        Ok(Some(KszMacTableEntry {
+        Ok(Some(KszRawMacTableEntry {
             count: count + 1, // table is non-empty
             timestamp,
             source,

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -185,6 +185,7 @@ impl Ksz8463 {
         let b = match port {
             1 => 0x0,
             2 => 0x20,
+            3 => 0x40,
             _ => panic!("Invalid port {}", port),
         };
         // Request counter with given offset.

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -228,7 +228,8 @@ impl Ksz8463 {
         // Wait for the "not ready" bit to be cleared
         let d_71_64 = loop {
             let d = self.read(Register::IADR1)?;
-            if d & (1 << 15) == 0 {
+            // Check bit 71 to see if the register is ready
+            if d & (1 << 7) == 0 {
                 break d;
             }
         };
@@ -245,7 +246,8 @@ impl Ksz8463 {
         }
 
         // Awkwardly stradling the line between two words...
-        let count = (d_71_64 as u32 & 0b11) << 8 | (d_63_48 as u32 & 0xF0) >> 8;
+        let count =
+            (d_71_64 as u32 & 0b11) << 8 | (d_63_48 as u32 & 0xFF00) >> 8;
 
         let timestamp = (d_63_48 >> 6) as u8 & 0b11;
         let source = match (d_63_48 >> 4) & 0b11 {

--- a/drv/ksz8463/src/registers.rs
+++ b/drv/ksz8463/src/registers.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use userlib::FromPrimitive;
+
 /// Offsets used to access MIB counters
 /// (see Table 4-200 in the datasheet for details)
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -103,7 +105,7 @@ pub enum MIBCounter {
     TxMultipleCollision = 0x1F,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
 #[allow(non_camel_case_types)]
 pub enum Register {
     // Table 4-2

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -12,6 +12,7 @@ vsc7448 = {path = "../vsc7448"}
 
 num-traits = {version = "0.2", default-features = false}
 serde = { version = "1", features = ["derive"], default-features = false}
+zerocopy = "0.6.1"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -201,7 +201,7 @@ pub struct PhyStatus {
     pub media_link_up: LinkStatus,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, zerocopy::AsBytes, zerocopy::FromBytes)]
 #[repr(C)]
 pub struct MacTableEntry {
     pub mac: [u8; 6],

--- a/idl/monorail.idol
+++ b/idl/monorail.idol
@@ -175,7 +175,6 @@ Interface(
                 ok: "MacTableEntry",
                 err: CLike("MonorailError"),
             ),
-            encoding: Ssmarshal,
         ),
     },
 )

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -98,5 +98,22 @@ Interface(
                 err: CLike("KszError"),
             ),
         ),
+        "read_ksz8463_reg": (
+            doc: "Reads a register from the KSZ8463",
+            args: {
+                "reg": "u16",
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("KszError"),
+            ),
+        ),
+        "get_mac_address": (
+            doc: "Reports the MAC address of port 0",
+            reply: Result(
+                ok: "MacAddress",
+                err: ServerDeath,
+            ),
+        ),
     },
 )

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -115,5 +115,13 @@ Interface(
                 err: ServerDeath,
             ),
         ),
+        "management_link_status": (
+            doc: "Checks the client side management network status",
+            reply: Result(
+                ok: "ManagementLinkStatus",
+                err: CLike("MgmtError")
+            ),
+            encoding: Ssmarshal,
+        ),
     },
 )

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -123,5 +123,13 @@ Interface(
             ),
             encoding: Ssmarshal,
         ),
+        "management_counters": (
+            doc: "Returns management network counters",
+            reply: Result(
+                ok: "ManagementCounters",
+                err: CLike("MgmtError")
+            ),
+            encoding: Ssmarshal,
+        ),
     },
 )

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -81,5 +81,22 @@ Interface(
                 err: CLike("PhyError"),
             ),
         ),
+        "read_ksz8463_mac_count": (
+            doc: "Returns the number of entries in the KSZ8463 dynamic MAC table",
+            reply: Result(
+                ok: "usize",
+                err: CLike("KszError"),
+            ),
+        ),
+        "read_ksz8463_mac": (
+            doc: "Reads a particular MAC address from the KSZ8463 dynamic MAC table",
+            args: {
+                "i": "u16",
+            },
+            reply: Result(
+                ok: "KszMacTableEntry",
+                err: CLike("KszError"),
+            ),
+        ),
     },
 )

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [features]
 use-smoltcp = ["smoltcp"]
 vlan = ["build-net/vlan"]
+mgmt = ["ksz8463"]
+ksz8463 = ["drv-spi-api", "dep:ksz8463"]
 
 [dependencies]
 derive-idol-err = {path = "../../lib/derive-idol-err" }
@@ -15,6 +17,9 @@ serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 zerocopy = "0.6"
+
+ksz8463 = { path = "../../drv/ksz8463", optional = true }
+drv-spi-api = {path = "../../drv/spi-api", optional = true}
 
 [dependencies.smoltcp]
 version = "0.8.0"

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -9,6 +9,7 @@
 use derive_idol_err::IdolError;
 use serde::{Deserialize, Serialize};
 use userlib::*;
+use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
 #[repr(u32)]
@@ -86,7 +87,7 @@ impl From<ksz8463::Error> for KszError {
     }
 }
 
-#[derive(Copy, Clone, Debug, zerocopy::AsBytes, zerocopy::FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct KszMacTableEntry {
     pub mac: [u8; 6],
@@ -107,9 +108,22 @@ impl From<ksz8463::KszRawMacTableEntry> for KszMacTableEntry {
     }
 }
 
-#[derive(Copy, Clone, Debug, zerocopy::AsBytes, zerocopy::FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct MacAddress(pub [u8; 6]);
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagementLinkStatus {
+    ksz8463_100base_fx_link_up: [bool; 2],
+    vsc85x2_100base_fx_link_up: [bool; 2],
+    vsc85x2_sgmii_link_up: [bool; 2],
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
+#[repr(u32)]
+pub enum MgmtError {
+    NotAvailable,
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -112,17 +112,19 @@ impl From<ksz8463::KszRawMacTableEntry> for KszMacTableEntry {
 #[repr(C)]
 pub struct MacAddress(pub [u8; 6]);
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ManagementLinkStatus {
-    ksz8463_100base_fx_link_up: [bool; 2],
-    vsc85x2_100base_fx_link_up: [bool; 2],
-    vsc85x2_sgmii_link_up: [bool; 2],
+    pub ksz8463_100base_fx_link_up: [bool; 2],
+    pub vsc85x2_100base_fx_link_up: [bool; 2],
+    pub vsc85x2_sgmii_link_up: [bool; 2],
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
 #[repr(u32)]
 pub enum MgmtError {
     NotAvailable,
+    VscError,
+    KszError,
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -56,6 +56,8 @@ pub enum KszError {
     NotAvailable,
     /// The MAC table index is too large
     BadMacIndex,
+    /// The given address is not a valid register
+    BadRegister,
 
     WrongChipId,
 
@@ -104,6 +106,10 @@ impl From<ksz8463::KszRawMacTableEntry> for KszMacTableEntry {
         }
     }
 }
+
+#[derive(Copy, Clone, Debug, zerocopy::AsBytes, zerocopy::FromBytes)]
+#[repr(C)]
+pub struct MacAddress(pub [u8; 6]);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -113,10 +113,41 @@ impl From<ksz8463::KszRawMacTableEntry> for KszMacTableEntry {
 pub struct MacAddress(pub [u8; 6]);
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[repr(C)]
 pub struct ManagementLinkStatus {
     pub ksz8463_100base_fx_link_up: [bool; 2],
     pub vsc85x2_100base_fx_link_up: [bool; 2],
     pub vsc85x2_sgmii_link_up: [bool; 2],
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[repr(C)]
+pub struct ManagementCountersVsc85x2 {
+    pub mac_good: u16,
+    pub media_good: u16,
+    pub mac_bad: u16,
+    pub media_bad: u16,
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[repr(C)]
+pub struct ManagementCountersKsz8463 {
+    pub multicast: u32,
+    pub unicast: u32,
+    pub broadcast: u32,
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[repr(C)]
+pub struct ManagementCounters {
+    pub vsc85x2_tx: [ManagementCountersVsc85x2; 2],
+    pub vsc85x2_rx: [ManagementCountersVsc85x2; 2],
+
+    pub ksz8463_tx: [ManagementCountersKsz8463; 3],
+    pub ksz8463_rx: [ManagementCountersKsz8463; 3],
+
+    /// The MAC counters are only valid on the VSC8562
+    pub vsc85x2_mac_valid: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -42,13 +42,13 @@ features = [
 ]
 
 [features]
-mgmt = ["drv-spi-api", "ksz8463", "drv-user-leds-api"]
+mgmt = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/mgmt"]
 gimlet = ["drv-gimlet-seq-api"]
 sidecar = ["drv-sidecar-seq-api"]
 h743 = ["drv-stm32h7-eth/h743", "stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["drv-stm32h7-eth/h753", "stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
 vlan = ["task-net-api/vlan", "build-net/vlan", "drv-stm32h7-eth/vlan"]
-gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api"]
+gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/ksz8463"]
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -127,7 +127,7 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
-        Some(&self.0.ksz8463)
+    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+        &self.0.ksz8463
     }
 }

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -8,7 +8,7 @@ use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_jefe_api::Jefe;
-use task_net_api::PhyError;
+use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
 use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -129,5 +129,12 @@ impl Bsp {
 
     pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
+    }
+
+    pub fn management_link_status(
+        &self,
+        eth: &eth::Ethernet,
+    ) -> Result<ManagementLinkStatus, MgmtError> {
+        self.0.management_link_status(eth)
     }
 }

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -8,7 +8,9 @@ use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_jefe_api::Jefe;
-use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
+use task_net_api::{
+    ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
+};
 use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -136,5 +138,12 @@ impl Bsp {
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
+    }
+
+    pub fn management_counters(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<ManagementCounters, MgmtError> {
+        self.0.management_counters(eth)
     }
 }

--- a/task/net/src/bsp/gimlet_1.rs
+++ b/task/net/src/bsp/gimlet_1.rs
@@ -126,4 +126,8 @@ impl Bsp {
     ) -> Result<(), PhyError> {
         self.0.phy_write(port, reg, value, eth)
     }
+
+    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
+        Some(&self.0.ksz8463)
+    }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -272,7 +272,7 @@ impl Bsp {
         self.mgmt.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
-        Some(&self.mgmt.ksz8463)
+    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+        &self.mgmt.ksz8463
     }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -39,8 +39,6 @@ enum Trace {
         port: u8,
         counter: MIBCounterValue,
     },
-    Ksz8463EmptyMacTable,
-    Ksz8463MacTable(ksz8463::KszMacTableEntry),
 
     Vsc8552Status {
         port: u8,
@@ -179,13 +177,6 @@ impl Bsp {
                 Err(err) => Trace::KszErr { err },
             });
         }
-
-        // Read the MAC table for fun
-        ringbuf_entry!(match self.mgmt.ksz8463.read_dynamic_mac_table(0) {
-            Ok(Some(mac)) => Trace::Ksz8463MacTable(mac),
-            Ok(None) => Trace::Ksz8463EmptyMacTable,
-            Err(err) => Trace::KszErr { err },
-        });
 
         let mut any_comma = false;
         let mut any_link = false;

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -11,7 +11,7 @@ use ksz8463::{
     Error as KszError, MIBCounter, MIBCounterValue, Register as KszRegister,
 };
 use ringbuf::*;
-use task_net_api::PhyError;
+use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
 use userlib::task_slot;
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
 use vsc85xx::VscError;
@@ -274,5 +274,12 @@ impl Bsp {
 
     pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.mgmt.ksz8463
+    }
+
+    pub fn management_link_status(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<ManagementLinkStatus, MgmtError> {
+        self.mgmt.management_link_status(eth)
     }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -11,7 +11,9 @@ use ksz8463::{
     Error as KszError, MIBCounter, MIBCounterValue, Register as KszRegister,
 };
 use ringbuf::*;
-use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
+use task_net_api::{
+    ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
+};
 use userlib::task_slot;
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
 use vsc85xx::VscError;
@@ -281,5 +283,12 @@ impl Bsp {
         eth: &crate::eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.mgmt.management_link_status(eth)
+    }
+
+    pub fn management_counters(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<ManagementCounters, MgmtError> {
+        self.mgmt.management_counters(eth)
     }
 }

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -271,4 +271,8 @@ impl Bsp {
     ) -> Result<(), PhyError> {
         self.mgmt.phy_write(port, reg, value, eth)
     }
+
+    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
+        Some(&self.mgmt.ksz8463)
+    }
 }

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -125,7 +125,7 @@ impl Bsp {
         Err(PhyError::NotImplemented)
     }
 
-    pub fn ksz8463(&self) -> Option<&Ksz8463> {
-        Some(&self.ksz8463)
+    pub fn ksz8463(&self) -> &Ksz8463 {
+        &self.ksz8463
     }
 }

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -7,7 +7,7 @@ use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use ksz8463::{
-    Error as KszError, Ksz8463, MIBCounter, MIBCounterValue,
+    Error as RawKszError, Ksz8463, MIBCounter, MIBCounterValue,
     Register as KszRegister,
 };
 use ringbuf::*;
@@ -22,12 +22,10 @@ enum Trace {
     None,
     BspConfigured,
 
-    KszErr { err: KszError },
+    KszErr { err: RawKszError },
     Ksz8463Status { port: u8, status: u16 },
     Ksz8463Control { port: u8, control: u16 },
     Ksz8463Counter { port: u8, counter: MIBCounterValue },
-    Ksz8463MacTable(ksz8463::KszMacTableEntry),
-    Ksz8463EmptyMacTable,
 }
 ringbuf!(Trace, 32, Trace::None);
 
@@ -103,13 +101,6 @@ impl Bsp {
                 Ok(counter) => Trace::Ksz8463Counter { port, counter },
                 Err(err) => Trace::KszErr { err },
             });
-
-            // Read the MAC table for fun
-            ringbuf_entry!(match self.ksz8463.read_dynamic_mac_table(0) {
-                Ok(Some(mac)) => Trace::Ksz8463MacTable(mac),
-                Ok(None) => Trace::Ksz8463EmptyMacTable,
-                Err(err) => Trace::KszErr { err },
-            });
         }
     }
 
@@ -132,5 +123,9 @@ impl Bsp {
         _eth: &eth::Ethernet,
     ) -> Result<u16, PhyError> {
         Err(PhyError::NotImplemented)
+    }
+
+    pub fn ksz8463(&self) -> Option<&Ksz8463> {
+        Some(&self.ksz8463)
     }
 }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -99,4 +99,8 @@ impl Bsp {
             .map_err(|_| PhyError::Other)?;
         Ok(())
     }
+
+    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
+        None
+    }
 }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -99,8 +99,4 @@ impl Bsp {
             .map_err(|_| PhyError::Other)?;
         Ok(())
     }
-
-    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
-        None
-    }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -62,7 +62,7 @@ impl Bsp {
             ksz8463_spi: Spi::from(SPI.get_task_id()).device(0),
             ksz8463_nrst: Port::C.pin(2),
             ksz8463_rst_type: mgmt::Ksz8463ResetSpeed::Normal,
-            ksz8463_vlan_mode: ksz8463::VLanMode::Optional,
+            ksz8463_vlan_mode: ksz8463::VLanMode::Mandatory,
 
             // SP_TO_MGMT_PHY_COMA_MODE
             vsc85x2_coma_mode: Some(Port::D.pin(7)),

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -98,7 +98,7 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
-        Some(&self.0.ksz8463)
+    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+        &self.0.ksz8463
     }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -6,7 +6,7 @@ use crate::{mgmt, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
-use task_net_api::PhyError;
+use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
 use userlib::task_slot;
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -100,5 +100,12 @@ impl Bsp {
 
     pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
+    }
+
+    pub fn management_link_status(
+        &self,
+        eth: &eth::Ethernet,
+    ) -> Result<ManagementLinkStatus, MgmtError> {
+        self.0.management_link_status(eth)
     }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -97,4 +97,8 @@ impl Bsp {
     ) -> Result<(), PhyError> {
         self.0.phy_write(port, reg, value, eth)
     }
+
+    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
+        Some(&self.0.ksz8463)
+    }
 }

--- a/task/net/src/bsp/psc_1.rs
+++ b/task/net/src/bsp/psc_1.rs
@@ -6,7 +6,9 @@ use crate::{mgmt, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
-use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
+use task_net_api::{
+    ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
+};
 use userlib::task_slot;
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -107,5 +109,12 @@ impl Bsp {
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
+    }
+
+    pub fn management_counters(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<ManagementCounters, MgmtError> {
+        self.0.management_counters(eth)
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -7,7 +7,9 @@ use drv_sidecar_seq_api::Sequencer;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
-use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
+use task_net_api::{
+    ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
+};
 use userlib::{hl::sleep_for, task_slot};
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -116,5 +118,12 @@ impl Bsp {
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
+    }
+
+    pub fn management_counters(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<ManagementCounters, MgmtError> {
+        self.0.management_counters(eth)
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -7,7 +7,7 @@ use drv_sidecar_seq_api::Sequencer;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
-use task_net_api::PhyError;
+use task_net_api::{ManagementLinkStatus, MgmtError, PhyError};
 use userlib::{hl::sleep_for, task_slot};
 use vsc7448_pac::types::PhyRegisterAddress;
 
@@ -109,5 +109,12 @@ impl Bsp {
 
     pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
+    }
+
+    pub fn management_link_status(
+        &self,
+        eth: &eth::Ethernet,
+    ) -> Result<ManagementLinkStatus, MgmtError> {
+        self.0.management_link_status(eth)
     }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -106,4 +106,8 @@ impl Bsp {
     ) -> Result<(), PhyError> {
         self.0.phy_write(port, reg, value, eth)
     }
+
+    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
+        Some(&self.0.ksz8463)
+    }
 }

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -68,7 +68,7 @@ impl Bsp {
             // SP_TO_EPE_RESET_L
             ksz8463_nrst: Port::A.pin(0),
             ksz8463_rst_type: mgmt::Ksz8463ResetSpeed::Normal,
-            ksz8463_vlan_mode: ksz8463::VLanMode::Optional,
+            ksz8463_vlan_mode: ksz8463::VLanMode::Mandatory,
 
             // SP_TO_PHY2_COMA_MODE_3V3
             vsc85x2_coma_mode: Some(Port::I.pin(15)),

--- a/task/net/src/bsp/sidecar_1.rs
+++ b/task/net/src/bsp/sidecar_1.rs
@@ -107,7 +107,7 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> Option<&ksz8463::Ksz8463> {
-        Some(&self.0.ksz8463)
+    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+        &self.0.ksz8463
     }
 }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -31,8 +31,8 @@ cfg_if::cfg_if! {
 mod idl {
     use task_net_api::{
         KszError, KszMacTableEntry, LargePayloadBehavior, MacAddress,
-        ManagementLinkStatus, MgmtError, PhyError, RecvError, SendError,
-        SocketName, UdpMetadata,
+        ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
+        RecvError, SendError, SocketName, UdpMetadata,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -30,8 +30,8 @@ cfg_if::cfg_if! {
 
 mod idl {
     use task_net_api::{
-        LargePayloadBehavior, PhyError, RecvError, SendError, SocketName,
-        UdpMetadata,
+        KszError, KszMacTableEntry, LargePayloadBehavior, PhyError, RecvError,
+        SendError, SocketName, UdpMetadata,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -30,8 +30,9 @@ cfg_if::cfg_if! {
 
 mod idl {
     use task_net_api::{
-        KszError, KszMacTableEntry, LargePayloadBehavior, MacAddress, PhyError,
-        RecvError, SendError, SocketName, UdpMetadata,
+        KszError, KszMacTableEntry, LargePayloadBehavior, MacAddress,
+        ManagementLinkStatus, MgmtError, PhyError, RecvError, SendError,
+        SocketName, UdpMetadata,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -30,8 +30,8 @@ cfg_if::cfg_if! {
 
 mod idl {
     use task_net_api::{
-        KszError, KszMacTableEntry, LargePayloadBehavior, PhyError, RecvError,
-        SendError, SocketName, UdpMetadata,
+        KszError, KszMacTableEntry, LargePayloadBehavior, MacAddress, PhyError,
+        RecvError, SendError, SocketName, UdpMetadata,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -330,6 +330,10 @@ impl Bsp {
                 out.vsc85x2_rx[i].mac_bad = rx;
             }
         }
+
+        // Only the VSC8562 has valid MAC counters
+        out.vsc85x2_mac_valid = self.vsc85x2.has_mac_counters();
+
         Ok(out)
     }
 }

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -205,7 +205,7 @@ impl Bsp {
         }
     }
 
-    pub fn wake(&self, eth: &Ethernet) {
+    pub fn wake(&self, _eth: &Ethernet) {
         // Nothing to do here
     }
 

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -47,8 +47,6 @@ enum Trace {
     None,
     Ksz8463Err { port: u8, err: KszError },
     Vsc85x2Err { port: u8, err: VscError },
-    Ksz8463MacTable(ksz8463::KszMacTableEntry),
-    Ksz8463EmptyMacTable,
     Status(Status),
 }
 
@@ -292,13 +290,6 @@ impl Bsp {
                 Err(err) => ringbuf_entry!(Trace::Vsc85x2Err { port, err }),
             }
         }
-
-        // Read the MAC table for fun
-        ringbuf_entry!(match self.ksz8463.read_dynamic_mac_table(0) {
-            Ok(Some(mac)) => Trace::Ksz8463MacTable(mac),
-            Ok(None) => Trace::Ksz8463EmptyMacTable,
-            Err(err) => Trace::Ksz8463Err { port: 0, err },
-        });
 
         ringbuf_entry!(Trace::Status(s));
     }

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -217,6 +217,8 @@ impl<T: NetServer> idl::InOrderNetImpl for T {
         &mut self,
         _msg: &userlib::RecvMessage,
     ) -> Result<ManagementLinkStatus, RequestError<MgmtError>> {
-        unimplemented!()
+        let (eth, bsp) = self.eth_bsp();
+        let out = bsp.management_link_status(eth).map_err(MgmtError::from)?;
+        Ok(out)
     }
 }

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -49,6 +49,7 @@ pub struct ServerImpl<'a> {
     client_waiting_to_send: [bool; SOCKET_COUNT],
     iface: Interface<'static, &'a eth::Ethernet>,
     bsp: crate::bsp::Bsp,
+    mac: EthernetAddress,
 }
 
 impl<'a> ServerImpl<'a> {
@@ -95,6 +96,7 @@ impl<'a> ServerImpl<'a> {
             client_waiting_to_send: [false; SOCKET_COUNT],
             iface,
             bsp,
+            mac,
         }
     }
 
@@ -253,6 +255,10 @@ impl NetServer for ServerImpl<'_> {
 
     fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut crate::bsp::Bsp) {
         (self.iface.device(), &mut self.bsp)
+    }
+
+    fn base_mac_address(&self) -> &EthernetAddress {
+        &self.mac
     }
 }
 

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -121,6 +121,8 @@ pub struct ServerImpl<'a> {
     client_waiting_to_send: [bool; SOCKET_COUNT],
     ifaces: [Interface<'static, VLanEthernet<'a>>; VLAN_COUNT],
     bsp: crate::bsp::Bsp,
+
+    mac: EthernetAddress,
 }
 
 impl<'a> ServerImpl<'a> {
@@ -156,6 +158,7 @@ impl<'a> ServerImpl<'a> {
         let sockets = generated::construct_sockets();
         assert_eq!(sockets.0.len(), VLAN_COUNT);
 
+        let start_mac = mac.clone();
         for sockets in sockets.0.into_iter() {
             let neighbor_cache_storage = neighbor_cache_iter.next().unwrap();
             let neighbor_cache = smoltcp::iface::NeighborCache::new(
@@ -212,6 +215,7 @@ impl<'a> ServerImpl<'a> {
             socket_handles,
             ifaces,
             bsp,
+            mac: start_mac,
         }
     }
 
@@ -386,6 +390,10 @@ impl NetServer for ServerImpl<'_> {
 
     fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut crate::bsp::Bsp) {
         (self.eth, &mut self.bsp)
+    }
+
+    fn base_mac_address(&self) -> &EthernetAddress {
+        &self.mac
     }
 }
 


### PR DESCRIPTION
This PR implements a set of new APIs for the `net` task, which allow us to
- Read the KSZ8463 MAC table
- Read registers on the KSZ8463
- Get the system's MAC address (from which the IP address can be inferred)
- Get the management network link status (when applicable)
- Read management network counters status (when applicable)

This is all infrastructure for the upcoming `humility net` subcommand.