### PR TITLE
WIP: Generic task restriction support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
 dependencies = [
  "indexmap",
  "quote",
@@ -1792,7 +1791,6 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
 dependencies = [
  "userlib",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,9 @@ path = "sys/userlib"
 
 [patch."https://github.com/oxidecomputer/hubris".abi]
 path = "sys/abi"
+
+# TODO REMOVE!
+[patch."https://github.com/oxidecomputer/idolatry".idol]
+path = "../idolatry"
+[patch."https://github.com/oxidecomputer/idolatry".idol-runtime]
+path = "../idolatry/runtime"

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -28,9 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-on-state-change = {net = {bit-number = 3}}
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -29,9 +29,12 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.jefe.config]
-state-owner = "gimlet_seq"
 on-state-change = {net = {bit-number = 3}}
-reset-reason-owner = "sys"
+
+[tasks.jefe.config.allowed-callers]
+set_state = ["gimlet_seq"]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.net]
 name = "task-net"

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -32,8 +32,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy", "mgmt_gateway"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -28,8 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -10,11 +10,14 @@ use std::io::Write;
 fn main() -> Result<()> {
     let cfg = build_util::task_maybe_config::<Config>()?.unwrap_or_default();
 
+    let allowed_callers = build_util::task_ids()
+        .remap_allowed_caller_names_to_ids(&cfg.allowed_callers)?;
+
     idol::server::build_restricted_server_support(
         "../../idl/jefe.idol",
         "server_stub.rs",
         idol::server::ServerStyle::InOrder,
-        &cfg.allowed_callers,
+        &allowed_callers,
     )
     .unwrap();
 

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -171,19 +171,9 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
     fn set_reset_reason(
         &mut self,
-        msg: &userlib::RecvMessage,
+        _msg: &userlib::RecvMessage,
         reason: ResetReason,
     ) -> Result<(), idol_runtime::RequestError<Infallible>> {
-        // If a task is designated as the reset reason owner, ensure that this
-        // RPC came from that task.
-        if let Some(owner) = generated::RESET_REASON_OWNER {
-            if msg.sender.index() != owner as usize {
-                // We'll pretend this operation doesn't exist.
-                // TODO this should be AccessViolation but that isn't exposed in
-                // the current version of idol.
-                return Err(idol_runtime::ClientError::UnknownOperation.fail());
-            }
-        }
         self.reset_reason = reason;
         Ok(())
     }
@@ -197,20 +187,9 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
     fn set_state(
         &mut self,
-        msg: &userlib::RecvMessage,
+        _msg: &userlib::RecvMessage,
         state: u32,
     ) -> Result<(), idol_runtime::RequestError<Infallible>> {
-        // If a task is designated as state owner, ensure that this RPC came
-        // from that task.
-        if let Some(owner) = generated::STATE_OWNER {
-            if msg.sender.index() != owner as usize {
-                // We'll pretend this operation doesn't exist.
-                // TODO this should be AccessViolation but that isn't exposed in
-                // the current version of idol.
-                return Err(idol_runtime::ClientError::UnknownOperation.fail());
-            }
-        }
-
         if self.state != state {
             self.state = state;
 


### PR DESCRIPTION
This is a draft of support for generic support to restrict idol calls to specific tasks. The relevant change to idolatry is at https://github.com/jgallagher/idolatry/commit/2de1d7127998201a4bc741f254b7a2ec017ac64f, but I'm opening the PR here because I think it's more relevant. The specific changes are:

1. `idol::server::build_server_support()` now takes an extra arg of type `BTreeMap<String, Vec<String>>` which maps operation names to lists of tasks allowed to call them. If an operation name isn't present in the map (e.g., if the map is empty), there are no restrictions. Having to pass an empty map on every server stub is kind of annoying. Maybe this should be a separate function in idolatry, so callers that don't want to restrict ops don't need the extra arg?
2. For `jefe.get_state` (the only operation on master that currently has task restrictions, I think?), the explicit checks are removed in favor of adding the map for 1 to `jefe.config` in `app.toml`. The generated code looks like this:

```rust
    fn handle(
        &mut self,
        op: JefeOperation,
        incoming: &[u8],
        rm: &userlib::RecvMessage,
    ) -> Result<(), idol_runtime::RequestError<u16>> {
        // ... snip ...
        match op {
            // ... snip ...
            JefeOperation::request_reset => {
                if ![::hubris_num_tasks::Task::hiffy as usize,::hubris_num_tasks::Task::mgmt_gateway as usize,].contains(&rm.sender.index()) {
                    return Err(idol_runtime::RequestError::Fail(idol_runtime::ClientError::AccessViolation));
                }
```

which requires crates using this to depend on `hubris_num_tasks` with the `task-enum` feature.