### PR TITLE
xtask: Add dice configuration options to 'Signing' table.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?rev=e1890a705e4fba8c4223af9fe9edad8be9d3ed98#e1890a705e4fba8c4223af9fe9edad8be9d3ed98"
+source = "git+https://github.com/oxidecomputer/lpc55_support?rev=edbc00749b708d5bc48c5fe0f1df0d1ed6f054c2#edbc00749b708d5bc48c5fe0f1df0d1ed6f054c2"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/app/gemini-bu-rot/stage0.toml
+++ b/app/gemini-bu-rot/stage0.toml
@@ -21,3 +21,7 @@ start = true
 [signing]
 priv-key = "../../support/fake_certs/fake_private_key.pem"
 root-cert = "../../support/fake_certs/fake_certificate.der.crt"
+enable-dice = true
+dice-inc-nxp-cfg = false
+dice-cust-cfg = false
+dice-inc-sec-epoch = false

--- a/app/gimlet-rot/stage0.toml
+++ b/app/gimlet-rot/stage0.toml
@@ -21,3 +21,7 @@ start = true
 [signing]
 priv-key = "../../support/fake_certs/fake_private_key.pem"
 root-cert = "../../support/fake_certs/fake_certificate.der.crt"
+enable-dice = true
+dice-inc-nxp-cfg = false
+dice-cust-cfg = false
+dice-inc-sec-epoch = false

--- a/app/lpc55xpresso/stage0.toml
+++ b/app/lpc55xpresso/stage0.toml
@@ -22,3 +22,7 @@ start = true
 [signing]
 priv-key = "../../support/fake_certs/fake_private_key.pem"
 root-cert = "../../support/fake_certs/fake_certificate.der.crt"
+enable-dice = true
+dice-inc-nxp-cfg = false
+dice-cust-cfg = false
+dice-inc-sec-epoch = false

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -38,4 +38,4 @@ zerocopy = "0.6.1"
 # For NXP signing
 [dependencies.lpc55_sign]
 git = "https://github.com/oxidecomputer/lpc55_support"
-rev = "e1890a705e4fba8c4223af9fe9edad8be9d3ed98"
+rev = "edbc00749b708d5bc48c5fe0f1df0d1ed6f054c2"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -430,6 +430,14 @@ impl std::fmt::Display for SigningMethod {
 pub struct Signing {
     pub priv_key: PathBuf,
     pub root_cert: PathBuf,
+    #[serde(default)]
+    pub enable_dice: bool,
+    #[serde(default)]
+    pub dice_inc_nxp_cfg: bool,
+    #[serde(default)]
+    pub dice_cust_cfg: bool,
+    #[serde(default)]
+    pub dice_inc_sec_epoch: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -344,13 +344,11 @@ pub fn package(
         if let Some(signing) = &cfg.toml.signing {
             let priv_key = &signing.priv_key;
             let root_cert = &signing.root_cert;
-            lpc55_sign::signed_image::sign_image(
-                false, // TODO add an option to enable DICE
+            let rkth = lpc55_sign::signed_image::sign_image(
                 &cfg.img_file("combined.bin", image_name),
                 &cfg.app_src_dir.join(&priv_key),
                 &cfg.app_src_dir.join(&root_cert),
                 &cfg.img_file("combined_rsa.bin", image_name),
-                &cfg.img_file("CMPA.bin", image_name),
             )?;
             std::fs::copy(
                 cfg.img_file("combined.bin", image_name),
@@ -375,6 +373,18 @@ pub fn package(
                 &cfg.img_file("final.srec", image_name),
             )?;
             translate_srec_to_other_formats(&cfg.img_dir(image_name), "final")?;
+
+            // The 'enable-dice' key causes the build to create a CMPA image
+            // with DICE enabled, however the CFPA & keystore must be setup too
+            // before the UDS can be created. See lpc55_support for details.
+            lpc55_sign::signed_image::create_cmpa(
+                signing.enable_dice,
+                signing.dice_inc_nxp_cfg,
+                signing.dice_cust_cfg,
+                signing.dice_inc_sec_epoch,
+                &rkth,
+                &cfg.img_file("CMPA.bin", image_name),
+            )?;
         } else {
             // If there's no bootloader, the "combined" and "final" images are
             // identical, so we copy from one to the other


### PR DESCRIPTION
Names of variables / parameters have been kept as similar to those from
the spec as possible. These names are pretty awkward but we preserve
them as best we can for consistency.

NOTE: This PR depends on API changes in the lpc55_support repo. There's an open PR with the required changes in lpc55_support that must be merged first: https://github.com/oxidecomputer/lpc55_support/pull/19

I've marked this PR as an RFC since it configures xtask to use a topic branch from my fork of the lpc55_support repo with the API changes required to set these bits. It should not be merged until the associated changes in lpc55_support have been reviewed & merged.