### PR TITLE
Improve RoT -> SP SWD performance

### DIFF
--- a/app/gemini-bu-rot/app.toml
+++ b/app/gemini-bu-rot/app.toml
@@ -99,7 +99,7 @@ pins = [
 name = "drv-lpc55-swd"
 priority = 4
 max-sizes = {flash = 16384, ram = 4096}
-uses = ["flexcomm3"]
+uses = ["flexcomm3", "iocon"]
 start = true
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]

--- a/app/gimlet-rot/app.toml
+++ b/app/gimlet-rot/app.toml
@@ -91,7 +91,7 @@ pins = [
 name = "drv-lpc55-swd"
 priority = 4
 max-sizes = {flash = 16384, ram = 4096}
-uses = ["flexcomm5"]
+uses = ["flexcomm5", "iocon"]
 start = false
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -377,12 +377,12 @@ impl idl::InOrderSpCtrlImpl for ServerImpl {
 impl ServerImpl {
     fn io_out(&mut self) {
         self.wait_for_mstidle();
-        switch_io_out(self.gpio);
+        switch_io_out();
     }
 
     fn io_in(&mut self) {
         self.wait_for_mstidle();
-        switch_io_in(self.gpio);
+        switch_io_in();
     }
 
     fn read_ack(&mut self) -> Result<(), Ack> {

--- a/drv/lpc55-syscon/src/main.rs
+++ b/drv/lpc55-syscon/src/main.rs
@@ -207,9 +207,10 @@ fn main() -> ! {
     syscon.fcclksel0().modify(|_, w| w.sel().enum_0x2());
     // Flexcom4 (the DAC i2c) is also set to 12Mhz
     syscon.fcclksel4().modify(|_, w| w.sel().enum_0x2());
-    // Flexcom 3/5 is the the SPI for use with SWD, set to 1Mhz
-    syscon.fcclksel3().modify(|_, w| w.sel().enum_0x4());
-    syscon.fcclksel5().modify(|_, w| w.sel().enum_0x4());
+    // Flexcom 3/5 is the the SPI for use with SWD, set to 12Mhz
+    // (Set this lower if you are debugging with an analyzer!)
+    syscon.fcclksel3().modify(|_, w| w.sel().enum_0x2());
+    syscon.fcclksel5().modify(|_, w| w.sel().enum_0x2());
     // The high speed SPI AKA Flexcomm8 is also set to 12Mhz
     // Note this can definitely go higher but that involves
     // turning on PLLs and such


### PR DESCRIPTION
Drastically improved from ~10 minutes to closer to 30 seconds

Ticks before:
```
    0   68        1        1 Start(0xc)
   1  130        1        1 End(0x9cb18)
```

Ticks after
```
    0   68        1        1 Start(0x3)
   1  130        1        1 End(0x54ae)
```