### PR TITLE
Add "reason for most recent reset"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
 name = "drv-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "drv-stm32xx-gpio-common",
  "drv-stm32xx-sys-api",
@@ -1360,6 +1361,7 @@ dependencies = [
  "num-traits",
  "stm32g0",
  "stm32h7",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]
@@ -1795,7 +1797,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#994077e3ecff3ec6df15c082fc4f810cf27c97f2"
+source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
 dependencies = [
  "indexmap",
  "quote",
@@ -1807,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#994077e3ecff3ec6df15c082fc4f810cf27c97f2"
+source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
 dependencies = [
  "userlib",
  "zerocopy",
@@ -3105,6 +3107,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "serde",
+ "ssmarshal",
  "task-jefe-api",
  "userlib",
  "zerocopy",
@@ -3117,6 +3120,8 @@ dependencies = [
  "derive-idol-err",
  "idol",
  "num-traits",
+ "serde",
+ "ssmarshal",
  "userlib",
  "zerocopy",
 ]

--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -26,6 +26,7 @@ uses = ["rcc", "gpio"]
 start = true
 features = ["g031"]
 stacksize = 256
+task-slots = ["jefe"]
 
 [tasks.pong]
 name = "task-pong"

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -27,6 +27,7 @@ max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
 start = true
 stacksize = 256
+task-slots = ["jefe"]
 
 [tasks.usart_driver]
 name = "drv-stm32g0-usart"

--- a/app/demo-stm32g0-nucleo/app-g0b1.toml.noworky
+++ b/app/demo-stm32g0-nucleo/app-g0b1.toml.noworky
@@ -38,6 +38,7 @@ requires = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
 start = true
 stacksize = 256
+task-slots = ["jefe"]
 
 [tasks.usart_driver]
 name = "drv-stm32g0-usart"

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -39,6 +39,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32h7-i2c-server"

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -30,6 +30,7 @@ stacksize = 1536
 
 [tasks.jefe.config]
 on-state-change = {net = {bit-number = 3}}
+reset-reason-owner = "sys"
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32h7-i2c-server"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32h7-i2c-server"

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -30,6 +30,7 @@ stacksize = 1536
 [tasks.jefe.config]
 state-owner = "gimlet_seq"
 on-state-change = {net = {bit-number = 3}}
+reset-reason-owner = "sys"
 
 [tasks.net]
 name = "task-net"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -51,6 +51,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.user_leds]
 name = "drv-user-leds"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -32,6 +32,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -43,6 +43,7 @@ priority = 1
 max-sizes = {flash = 8192, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32h7-i2c-server"

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -34,6 +34,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32h7-i2c-server"

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.spi4_driver]
 name = "drv-stm32h7-spi-server"

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -27,6 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+reset-reason-owner = "sys"
+
 [tasks.sys]
 name = "drv-stm32xx-sys"
 features = ["h753"]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -37,6 +37,7 @@ priority = 1
 max-sizes = {flash = 2048, ram = 1024}
 uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
+task-slots = ["jefe"]
 
 [tasks.spi1_driver]
 name = "drv-stm32h7-spi-server"

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitflags = "1.2.1"
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
@@ -12,6 +13,7 @@ stm32h7 = {version = "0.14", default-features = false, optional = true}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}
 drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["server-support"]}
+task-jefe-api = {path="../../task/jefe-api"}
 cfg-if = "1"
 
 [build-dependencies]

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -294,6 +294,13 @@ cfg_if::cfg_if! {
             }
         }
 
+        fn try_read_reset_reason(
+            rcc: &device::rcc::RegisterBlock,
+        ) -> Option<ResetReason> {
+            // TODO map to ResetReason cases
+            let bits = rcc.csr.read().bits();
+            Some(ResetReason::Other(bits))
+        }
     } else if #[cfg(feature = "family-stm32h7")] {
         fn enable_clock(
             rcc: &device::rcc::RegisterBlock,

--- a/idl/jefe.idol
+++ b/idl/jefe.idol
@@ -18,5 +18,20 @@ Interface(
             reply: Simple("()"),
             idempotent: true,
         ),
+        "get_reset_reason": (
+            encoding: Ssmarshal,
+            doc: "Get the reason for the most recent reset",
+            reply: Simple("ResetReason"),
+            idempotent: true,
+        ),
+        "set_reset_reason": (
+            encoding: Ssmarshal,
+            doc: "Set the reason for the most recent reset",
+            args: {
+                "reason": "ResetReason",
+            },
+            reply: Simple("()"),
+            idempotent: true,
+        ),
     },
 )

--- a/task/jefe-api/Cargo.toml
+++ b/task/jefe-api/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = {version = "0.2", default-features = false}
+serde = {version = "1", default-features = false, features = ["derive"]}
+ssmarshal = {version = "1", default-features = false}
 zerocopy = "0.6"
 
 [build-dependencies]

--- a/task/jefe-api/src/lib.rs
+++ b/task/jefe-api/src/lib.rs
@@ -6,6 +6,23 @@
 
 #![no_std]
 
+use serde::{Deserialize, Serialize};
 use userlib::*;
+
+/// Platform-agnostic (but heavily influenced) reset status bits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(C)]
+pub enum ResetReason {
+    PowerOn,
+    Pin,
+    SystemCall,
+    Brownout,
+    SystemWatchdog,
+    IndependentWatchdog,
+    LowPowerSecurity,
+    ExitStandby,
+    Other(u32),
+    Unknown, // TODO remove and use `Option<ResetReason>` once we switch to hubpack
+}
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -9,6 +9,8 @@ userlib = {path = "../../sys/userlib"}
 hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
 ringbuf = {path = "../../lib/ringbuf" }
 num-traits = { version = "0.2.12", default-features = false }
+serde = {version = "1", default-features = false, features = ["derive"]}
+ssmarshal = {version = "1", default-features = false}
 zerocopy = "0.6.1"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.5.0", optional = true }

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -43,7 +43,11 @@ fn main() -> Result<()> {
         writeln!(out, "None;")?;
     }
 
-    write!(out, "pub(crate) const RESET_REASON_OWNER: Option<{}> = ", task)?;
+    write!(
+        out,
+        "pub(crate) const RESET_REASON_OWNER: Option<{}> = ",
+        task
+    )?;
     if let Some(owner) = cfg.reset_reason_owner {
         writeln!(out, "Some({}::{});", task, owner)?;
     } else {

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -43,6 +43,13 @@ fn main() -> Result<()> {
         writeln!(out, "None;")?;
     }
 
+    write!(out, "pub(crate) const RESET_REASON_OWNER: Option<{}> = ", task)?;
+    if let Some(owner) = cfg.reset_reason_owner {
+        writeln!(out, "Some({}::{});", task, owner)?;
+    } else {
+        writeln!(out, "None;")?;
+    }
+
     Ok(())
 }
 
@@ -52,11 +59,17 @@ fn main() -> Result<()> {
 struct Config {
     /// Task requests to be notified on state change, as a map from task name to
     /// `StateChange` record.
+    #[serde(default)]
     on_state_change: BTreeMap<String, StateChange>,
     /// Name of task responsible for state changes. If provided, a state change
     /// request from any other task will result in that task being faulted.
     #[serde(default)]
     state_owner: Option<String>,
+    /// Name of task responsible for setting the reset reason. If provided, a
+    /// request to set the reset reason from any other task will result in that
+    /// task being faulted.
+    #[serde(default)]
+    reset_reason_owner: Option<String>,
 }
 
 /// Description of something a task wants done on state change.

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -28,7 +28,10 @@
 
 mod external;
 
+use core::convert::Infallible;
+
 use hubris_num_tasks::NUM_TASKS;
+use task_jefe_api::ResetReason;
 use userlib::*;
 
 fn log_fault(t: usize, fault: &abi::FaultInfo) {
@@ -132,6 +135,7 @@ fn main() -> ! {
         deadline,
         disposition: &mut disposition,
         logged: &mut logged,
+        reset_reason: ResetReason::Unknown,
     };
     let mut buf = [0u8; idl::INCOMING_SIZE];
 
@@ -145,23 +149,40 @@ struct ServerImpl<'s> {
     disposition: &'s mut [Disposition; NUM_TASKS],
     logged: &'s mut [bool; NUM_TASKS],
     deadline: u64,
+    reset_reason: ResetReason,
 }
 
 impl idl::InOrderJefeImpl for ServerImpl<'_> {
     fn request_reset(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<(), idol_runtime::RequestError<core::convert::Infallible>> {
+    ) -> Result<(), idol_runtime::RequestError<Infallible>> {
         // If we wanted to broadcast to other tasks that a restart is occuring
         // here is where we would do so!
         kipc::system_restart();
     }
 
+    fn get_reset_reason(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<ResetReason, idol_runtime::RequestError<Infallible>> {
+        Ok(self.reset_reason)
+    }
+
+    fn set_reset_reason(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        reason: ResetReason,
+    ) -> Result<(), idol_runtime::RequestError<Infallible>> {
+        // TODO check sender
+        self.reset_reason = reason;
+        Ok(())
+    }
+
     fn get_state(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<u32, idol_runtime::RequestError<core::convert::Infallible>>
-    {
+    ) -> Result<u32, idol_runtime::RequestError<Infallible>> {
         Ok(self.state)
     }
 
@@ -169,7 +190,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
         &mut self,
         msg: &userlib::RecvMessage,
         state: u32,
-    ) -> Result<(), idol_runtime::RequestError<core::convert::Infallible>> {
+    ) -> Result<(), idol_runtime::RequestError<Infallible>> {
         // If a task is designated as state owner, ensure that this RPC came
         // from that task.
         if let Some(owner) = generated::STATE_OWNER {
@@ -252,5 +273,6 @@ mod generated {
 
 // And the Idol bits
 mod idl {
+    use task_jefe_api::ResetReason;
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -171,10 +171,19 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
     fn set_reset_reason(
         &mut self,
-        _msg: &userlib::RecvMessage,
+        msg: &userlib::RecvMessage,
         reason: ResetReason,
     ) -> Result<(), idol_runtime::RequestError<Infallible>> {
-        // TODO check sender
+        // If a task is designated as the reset reason owner, ensure that this
+        // RPC came from that task.
+        if let Some(owner) = generated::RESET_REASON_OWNER {
+            if msg.sender.index() != owner as usize {
+                // We'll pretend this operation doesn't exist.
+                // TODO this should be AccessViolation but that isn't exposed in
+                // the current version of idol.
+                return Err(idol_runtime::ClientError::UnknownOperation.fail());
+            }
+        }
         self.reset_reason = reason;
         Ok(())
     }


### PR DESCRIPTION
The stm32h7 branch is fully implemented. stm32g0 has primitive support (the raw reset register is reported, but it is not mapped to one of the logical `ResetReason`s).

`set_reset_reason` is (optionally) restricted to a single task using the same style as `Jefe.set_state()`, until something like #710 is available.