### PR TITLE
UDP RPC task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-udprpc"
+version = "0.1.0"
+dependencies = [
+ "task-net-api",
+ "userlib",
+]
+
+[[package]]
 name = "task-validate"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,7 @@ dependencies = [
  "ssmarshal",
  "task-net-api",
  "userlib",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,6 +3336,7 @@ version = "0.1.0"
 dependencies = [
  "task-net-api",
  "userlib",
+ "zerocopy",
 ]
 
 [[package]]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -70,7 +70,7 @@ global_config = "spi1"
 name = "task-net"
 stacksize = 3000
 priority = 2
-max-sizes = {flash = 131072, ram = 8192, sram1 = 32768}
+max-sizes = {flash = 131072, ram = 16384, sram1 = 32768}
 features = ["h753"]
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
@@ -103,6 +103,22 @@ task-slots = ["user_leds"]
 
 [tasks.udpecho]
 name = "task-udpecho"
+priority = 3
+max-sizes = {flash = 32768, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+
+[tasks.udpbroadcast]
+name = "task-udpbroadcast"
+priority = 3
+max-sizes = {flash = 16384, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+
+[tasks.udprpc]
+name = "task-udprpc"
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -194,5 +210,19 @@ clock_divider = "DIV32"
 kind = "udp"
 owner = {name = "udpecho", notification = 1}
 port = 7
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.broadcast]
+kind = "udp"
+owner = {name = "udpbroadcast", notification = 1}
+port = 997
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.rpc]
+kind = "udp"
+owner = {name = "udprpc", notification = 1}
+port = 8
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -223,6 +223,6 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.rpc]
 kind = "udp"
 owner = {name = "udprpc", notification = 1}
-port = 8
+port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -38,7 +38,7 @@ name = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
-max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -196,6 +196,15 @@ name = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
+start = true
+task-slots = ["net"]
+features = ["vlan"]
+
+[tasks.udprpc]
+name = "task-udprpc"
+priority = 6
+max-sizes = {flash = 32768, ram = 8192}
+stacksize = 4096
 start = true
 task-slots = ["net"]
 features = ["vlan"]
@@ -756,5 +765,12 @@ rx = { packets = 3, bytes = 1024 }
 kind = "udp"
 owner = {name = "udpbroadcast", notification = 1}
 port = 997
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.rpc]
+kind = "udp"
+owner = {name = "udprpc", notification = 1}
+port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -98,7 +98,7 @@ name = "task-net"
 stacksize = 4640
 priority = 3
 features = ["mgmt", "h753", "vlan"]
-max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -118,6 +118,15 @@ features = ["vlan"]
 name = "task-udpbroadcast"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+features = ["vlan"]
+
+[tasks.udprpc]
+name = "task-udprpc"
+priority = 4
+max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -340,5 +349,12 @@ rx = { packets = 3, bytes = 1024 }
 kind = "udp"
 owner = {name = "udpbroadcast", notification = 1}
 port = 997
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.rpc]
+kind = "udp"
+owner = {name = "udprpc", notification = 1}
+port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -7,7 +7,7 @@ memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"
-requires = {flash = 22776, ram = 5232}
+requires = {flash = 22776, ram = 5424}
 #
 # For the kernel (and for any task that logs), we are required to enable
 # either "itm" (denoting logging/panicking via ARM's Instrumentation Trace

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -100,7 +100,7 @@ name = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan"]
-max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash"]
 start = true
@@ -122,6 +122,15 @@ features = ["vlan"]
 name = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+features = ["vlan"]
+
+[tasks.udprpc]
+name = "task-udprpc"
+priority = 6
+max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -726,5 +735,12 @@ rx = { packets = 3, bytes = 1024 }
 kind = "udp"
 owner = {name = "udpbroadcast", notification = 1}
 port = 997
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.rpc]
+kind = "udp"
+owner = {name = "udprpc", notification = 1}
+port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -3,6 +3,7 @@ target = "thumbv7em-none-eabihf"
 board = "sidecar-1"
 chip = "../../chips/stm32h7-nonredundant"
 stacksize = 896
+memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -7,7 +7,7 @@ use std::hash::Hasher;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -88,7 +88,8 @@ impl Config {
                 "memory.toml".to_string()
             };
             let chip_file = cfg.parent().unwrap().join(&toml.chip).join(fname);
-            let chip_contents = std::fs::read(chip_file)?;
+            let chip_contents = std::fs::read(chip_file)
+                .context("Could not read memory file")?;
             hasher.write(&chip_contents);
             toml::from_slice::<IndexMap<String, Vec<Output>>>(&chip_contents)?
         };

--- a/chips/stm32h7-nonredundant/memory-large.toml
+++ b/chips/stm32h7-nonredundant/memory-large.toml
@@ -1,0 +1,25 @@
+# Flash sections are mapped into both flash banks, YOLO
+[[flash]]
+address = 0x08000000
+size = 2097152
+read = true
+execute = true
+
+# This maps RAM into AXI SRAM, a 512 kiB bank. This is turned on by default by
+# the stm32h7 startup code.
+[[ram]]
+address = 0x24000000
+size = 524288
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise
+
+# Network buffers are placed in sram1, which is directly accessible by the
+# Ethernet MAC.
+[[sram1]]
+address = 0x30000000
+size = 0x20000
+read = true
+write = true
+dma = true
+

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -56,3 +56,17 @@ pub fn system_restart() -> ! {
     let _ = sys_send(TaskId::KERNEL, Kipcnum::Reset as u16, &[], &mut [], &[]);
     panic!();
 }
+
+pub fn read_image_id() -> u64 {
+    let mut response = [0; core::mem::size_of::<u64>()];
+    let (rc, len) = sys_send(
+        TaskId::KERNEL,
+        Kipcnum::ReadImageId as u16,
+        &[],
+        &mut response,
+        &[],
+    );
+    assert_eq!(rc, 0);
+    assert_eq!(len, 8); // we *really* expect this to be a u64
+    ssmarshal::deserialize(&response[..len]).unwrap_lite().0
+}

--- a/task/udpbroadcast/Cargo.toml
+++ b/task/udpbroadcast/Cargo.toml
@@ -12,6 +12,7 @@ serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
 num-traits = {version = "0.2", default-features = false}
 task-net-api = {path = "../net-api"}
+zerocopy = "0.6.1"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/udpbroadcast/src/main.rs
+++ b/task/udpbroadcast/src/main.rs
@@ -7,6 +7,7 @@
 
 use task_net_api::*;
 use userlib::*;
+use zerocopy::AsBytes;
 
 task_slot!(NET, net);
 
@@ -22,21 +23,24 @@ fn main() -> ! {
     #[cfg(feature = "vlan")]
     let mut vid_iter = VLAN_RANGE.cycle();
 
+    // We broadcast the HUBRIS_IMAGE_ID repeatedly, because we have to broadcast
+    // *something*, and this allows `humility rpc` to detect valid targets.
+    let image_id = kipc::read_image_id();
+
     loop {
-        let tx_bytes: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
         let meta = UdpMetadata {
             // IPv6 multicast address for "all nodes"
             addr: Address::Ipv6(Ipv6Address([
                 0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
             ])),
             port: 8,
-            size: tx_bytes.len() as u32,
+            size: core::mem::size_of_val(&image_id) as u32,
             #[cfg(feature = "vlan")]
             vid: vid_iter.next().unwrap(),
         };
 
         hl::sleep_for(500);
-        match net.send_packet(SOCKET, meta, &tx_bytes) {
+        match net.send_packet(SOCKET, meta, &image_id.as_bytes()) {
             Ok(()) => UDP_BROADCAST_COUNT
                 .fetch_add(1, core::sync::atomic::Ordering::Relaxed),
             Err(_) => UDP_ERROR_COUNT

--- a/task/udpbroadcast/src/main.rs
+++ b/task/udpbroadcast/src/main.rs
@@ -23,16 +23,16 @@ fn main() -> ! {
     #[cfg(feature = "vlan")]
     let mut vid_iter = VLAN_RANGE.cycle();
 
-    // We broadcast the HUBRIS_IMAGE_ID repeatedly, because we have to broadcast
-    // *something*, and this allows `humility rpc` to detect valid targets.
-    let image_id = kipc::read_image_id();
-
+    // We broadcast a 14-byte packet of (MAC_ADDRESS, HUBRIS_IMAGE_ID)
+    // repeatedly.  This both allows the network to discover our MAC and IP
+    // address (through normal L2/L3 mechanisms), *and* lets `humility rpc`
+    // detect valid targets.
     let mut out = [0u8; 14];
     match net.get_mac_address() {
         Ok(mac) => out[0..6].copy_from_slice(&mac.0),
         Err(_) => panic!(),
     }
-    out[6..].copy_from_slice(image_id.as_bytes());
+    out[6..].copy_from_slice(kipc::read_image_id().as_bytes());
 
     loop {
         let meta = UdpMetadata {

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 task-net-api = {path = "../net-api"}
+zerocopy = "0.6.1"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "task-udprpc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+task-net-api = {path = "../net-api"}
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "task-udprpc"
+test = false
+bench = false

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -8,6 +8,9 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 task-net-api = {path = "../net-api"}
 zerocopy = "0.6.1"
 
+[features]
+vlan = ["task-net-api/vlan"]
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
                 let r = if (meta.size as usize) < HEADER_SIZE {
                     RpcReply::TooShort
                 } else if image_id != header.image_id {
-                    tx_data_buf[1..9].copy_from_slice(&image_id.as_bytes());
+                    tx_data_buf[1..9].copy_from_slice(image_id.as_bytes());
                     RpcReply::BadImageId
                 } else if meta.size as usize
                     != HEADER_SIZE + header.nbytes as usize

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use task_net_api::*;
+use userlib::*;
+
+task_slot!(NET, net);
+
+#[export_name = "main"]
+fn main() -> ! {
+    let net = NET.get_task_id();
+    let net = Net::from(net);
+
+    const SOCKET: SocketName = SocketName::rpc;
+
+    loop {
+        // Tiiiiiny payload buffer
+        let mut rx_data_buf = [0u8; 256];
+        let mut tx_data_buf = [0u8; 256];
+        match net.recv_packet(
+            SOCKET,
+            LargePayloadBehavior::Discard,
+            &mut rx_data_buf,
+        ) {
+            Ok(mut meta) => {
+                let task =
+                    u16::from_be_bytes(rx_data_buf[0..2].try_into().unwrap());
+                let op =
+                    u16::from_be_bytes(rx_data_buf[2..4].try_into().unwrap());
+                let nreply =
+                    u16::from_be_bytes(rx_data_buf[4..6].try_into().unwrap());
+                let nbytes =
+                    u16::from_be_bytes(rx_data_buf[6..8].try_into().unwrap());
+
+                let (code, _) = sys_send(
+                    TaskId(task),
+                    op,
+                    &rx_data_buf[8..(nbytes as usize + 8)],
+                    &mut tx_data_buf[4..(nreply as usize + 4)],
+                    &[],
+                );
+                tx_data_buf[0..4].copy_from_slice(&code.to_be_bytes());
+                meta.size = nreply as u32 + 4;
+
+                net.send_packet(
+                    SOCKET,
+                    meta,
+                    &tx_data_buf[0..meta.size as usize],
+                )
+                .unwrap();
+            }
+            Err(RecvError::QueueEmpty) => {
+                // Our incoming queue is empty. Wait for more packets.
+                sys_recv_closed(&mut [], 1, TaskId::KERNEL).unwrap();
+            }
+            Err(RecvError::NotYours | RecvError::Other) => panic!(),
+        }
+        // Try again.
+    }
+}

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
                     meta.size = 1;
                 } else if expected_id != image_id {
                     tx_data_buf[0] = RpcReply::BadImageId as u8;
-                    rx_data_buf[1..9].copy_from_slice(&image_id.to_be_bytes());
+                    tx_data_buf[1..9].copy_from_slice(&image_id.to_be_bytes());
                     meta.size = 9;
                 } else if meta.size != 16 + nbytes as u32 {
                     tx_data_buf[0] = RpcReply::NBytesMismatch as u8;
@@ -102,10 +102,10 @@ fn main() -> ! {
                         TaskId(task),
                         op,
                         &rx_data_buf[16..(nbytes + 16)],
-                        &mut tx_data_buf[5..(nreply + 4)],
+                        &mut tx_data_buf[5..(nreply + 5)],
                         &[],
                     );
-                    if len != nreply {
+                    if rc == 0 && len != nreply {
                         tx_data_buf[0] = RpcReply::NReplyMismatch as u8;
                         meta.size = 1;
                     } else {

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> ! {
                     RpcReply::NBytesMismatch
                 } else if nbytes + HEADER_SIZE > rx_data_buf.len() {
                     RpcReply::NBytesOverflow
-                } else if nreply + 4 > tx_data_buf.len() {
+                } else if nreply + REPLY_PREFIX_SIZE > tx_data_buf.len() {
                     RpcReply::NReplyOverflow
                 } else {
                     let rx_data = &rx_data_buf[HEADER_SIZE..][..nbytes];

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -48,10 +48,12 @@ fn main() -> ! {
     let net = Net::from(net);
 
     const SOCKET: SocketName = SocketName::rpc;
+
+    // We use the image id to make sure that we're compatible, since we're
+    // sending raw bytes using `sys_send`.  This isn't robust against malicious
+    // behavior, but prevents basic user error.
     let image_id = kipc::read_image_id();
 
-    // We use the image id to make sure that we're compatible.
-    //
     // The output format is dependent on status code.  The first byte is always
     // a member of `RpcReply` as a `u8`.
     // - `NBytesMismatch`, `NReplyMismatch`, `NReplyOverflow` return nothing
@@ -122,6 +124,7 @@ fn main() -> ! {
                     (r, nreply)
                 };
 
+                // Store the `RpcReply` return code and return size
                 tx_data_buf[0] = r as u8;
                 meta.size = match r {
                     RpcReply::TooShort

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -10,46 +10,102 @@ use userlib::*;
 
 task_slot!(NET, net);
 
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+enum RpcReply {
+    Ok,
+    BadImageId,
+    NBytesMismatch,
+    NBytesOverflow,
+    NReplyMismatch,
+    NReplyOverflow,
+}
+
 #[export_name = "main"]
 fn main() -> ! {
     let net = NET.get_task_id();
     let net = Net::from(net);
 
     const SOCKET: SocketName = SocketName::rpc;
+    let image_id = kipc::read_image_id();
 
+    // We expect request packets to be tightly packed in the order
+    //      image id: u64,
+    //      task: u16,
+    //      op: u16,
+    //      nreply: u16,
+    //      nbytes: u16,
+    //      data: nbytes
+    //
+    // `humility rpc` must cooperate with this layout!
+    // We use the image id to make sure that we're compatible.
+    //
+    // The output format is dependent on status code.  The first byte is always
+    // a member of `RpcReply` as a `u8`.
+    // - `NBytesMismatch`, `NBytesOverflow`, `NReplyMismatch`, `NReplyOverflow`
+    //   return nothing else (so the reply is 1 byte)
+    // - `BadImageId` is followed by the *actual* 64-bit image id as a big-endian
+    //   value
+    // - `Ok` is followed by the return code as a 32-bit, big-endian value,
+    //   then by `nreply` bytes of reply.
     loop {
-        // Tiiiiiny payload buffer
-        let mut rx_data_buf = [0u8; 256];
-        let mut tx_data_buf = [0u8; 256];
+        let mut rx_data_buf = [0u8; 1024];
+        let mut tx_data_buf = [0u8; 1024];
         match net.recv_packet(
             SOCKET,
             LargePayloadBehavior::Discard,
             &mut rx_data_buf,
         ) {
             Ok(mut meta) => {
+                // Hard-coded to match behavior in `humility rpc`
+                let expected_id =
+                    u64::from_be_bytes(rx_data_buf[0..8].try_into().unwrap());
                 let task =
-                    u16::from_be_bytes(rx_data_buf[0..2].try_into().unwrap());
+                    u16::from_be_bytes(rx_data_buf[8..10].try_into().unwrap());
                 let op =
-                    u16::from_be_bytes(rx_data_buf[2..4].try_into().unwrap());
+                    u16::from_be_bytes(rx_data_buf[10..12].try_into().unwrap());
                 let nreply =
-                    u16::from_be_bytes(rx_data_buf[4..6].try_into().unwrap());
+                    u16::from_be_bytes(rx_data_buf[12..14].try_into().unwrap())
+                        as usize;
                 let nbytes =
-                    u16::from_be_bytes(rx_data_buf[6..8].try_into().unwrap());
+                    u16::from_be_bytes(rx_data_buf[14..16].try_into().unwrap())
+                        as usize;
 
-                let (code, _) = sys_send(
-                    TaskId(task),
-                    op,
-                    &rx_data_buf[8..(nbytes as usize + 8)],
-                    &mut tx_data_buf[4..(nreply as usize + 4)],
-                    &[],
-                );
-                tx_data_buf[0..4].copy_from_slice(&code.to_be_bytes());
-                meta.size = nreply as u32 + 4;
+                if expected_id != image_id {
+                    tx_data_buf[0] = RpcReply::BadImageId as u8;
+                    rx_data_buf[1..9].copy_from_slice(&image_id.to_be_bytes());
+                    meta.size = 9;
+                } else if meta.size != 16 + nbytes as u32 {
+                    tx_data_buf[0] = RpcReply::NBytesMismatch as u8;
+                    meta.size = 1;
+                } else if nbytes + 16 > rx_data_buf.len() {
+                    tx_data_buf[0] = RpcReply::NBytesOverflow as u8;
+                    meta.size = 1;
+                } else if nreply + 4 > tx_data_buf.len() {
+                    tx_data_buf[0] = RpcReply::NReplyOverflow as u8;
+                    meta.size = 1;
+                } else {
+                    let (rc, len) = sys_send(
+                        TaskId(task),
+                        op,
+                        &rx_data_buf[16..(nbytes + 16)],
+                        &mut tx_data_buf[5..(nreply + 4)],
+                        &[],
+                    );
+                    if len != nreply {
+                        tx_data_buf[0] = RpcReply::NReplyMismatch as u8;
+                        meta.size = 1;
+                    } else {
+                        tx_data_buf[0] = RpcReply::Ok as u8;
+                        tx_data_buf[1..5].copy_from_slice(&rc.to_be_bytes());
+                        meta.size = nreply as u32 + 5;
+                    }
+                }
 
                 net.send_packet(
                     SOCKET,
                     meta,
-                    &tx_data_buf[0..meta.size as usize],
+                    &tx_data_buf[0..(meta.size as usize)],
                 )
                 .unwrap();
             }

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -7,7 +7,7 @@
 
 use task_net_api::*;
 use userlib::*;
-use zerocopy::FromBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 task_slot!(NET, net);
 
@@ -86,7 +86,7 @@ fn main() -> ! {
                 let r = if (meta.size as usize) < HEADER_SIZE {
                     RpcReply::TooShort
                 } else if image_id != header.image_id {
-                    tx_data_buf[1..9].copy_from_slice(&image_id.to_le_bytes());
+                    tx_data_buf[1..9].copy_from_slice(&image_id.as_bytes());
                     RpcReply::BadImageId
                 } else if meta.size as usize
                     != HEADER_SIZE + header.nbytes as usize


### PR DESCRIPTION
This PR adds a relatively minimal `task-udprpc`, which accepts specially-constructed UDP packets and executes them as Hiffy calls.

It still needs some clean-up, so I'm marking it as a draft for now.

The Humility side is implemented in [humility#216](https://github.com/oxidecomputer/humility/pull/216)