### PR TITLE
stm32h7: allow optional mapping into AXI SRAM

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -2,6 +2,7 @@ name = "gimlet-b"
 target = "thumbv7em-none-eabihf"
 board = "gimlet-b"
 chip = "../../chips/stm32h7"
+memory = "memory-large.toml"
 stacksize = 896
 
 [kernel]

--- a/chips/stm32h7/memory-large.toml
+++ b/chips/stm32h7/memory-large.toml
@@ -1,0 +1,25 @@
+# Flash sections are mapped into flash bank 1 (of 2).
+[[flash]]
+address = 0x08000000
+size = 1048576
+read = true
+execute = true
+
+# This maps RAM into AXI SRAM, a 512 kiB bank. This is turned on by default by
+# the stm32h7 startup code.
+[[ram]]
+address = 0x24000000
+size = 524288
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise
+
+# Network buffers are placed in sram1, which is directly accessible by the
+# Ethernet MAC.
+[[sram1]]
+address = 0x30000000
+size = 0x20000
+read = true
+write = true
+dma = true
+


### PR DESCRIPTION
By default, apps on stm32h7 are mapped into a 128 kiB RAM on the
processor's local bus. This is great because it's zero-wait-state.

However, there are a lot more RAMs than that. This adds an alternate
memory file for mapping all of an application into the 512 kiB AXI SRAM,
which has more wait states (though not many more) but is 4x larger.

This is in lieu of a smarter memory allocator that can distribute across
RAMs based on their properties, which we'll want to do eventually.