### PR TITLE
userlib: add cortex-m dep to force inline-asm feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,7 @@ dependencies = [
  "bstringify",
  "build-util",
  "cfg-if",
+ "cortex-m",
  "num-derive",
  "num-traits",
  "paste",

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -29,6 +29,25 @@ armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 #
 num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
 
+[target.thumbv7em-none-eabihf.dependencies]
+# Note: we don't use cortex-m directly, this is here to ensure that the
+# feature is consistently specified in all tasks, to reduce overbuilding
+# of the PACs.
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+
+# We're repeating this a bazillion times because Cargo only gives us two
+# options: (1) define on the entire target triple, or (2) define on
+# target_arch, which Cargo rounds down to "arm". i.e. we can't detect
+# Cortex-Ms specifically. Thanks, Cargo.
+[target.thumbv7m-none-eabi.dependencies]
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+[target.thumbv7em-none-eabi.dependencies]
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+[target.thumbv6m-none-eabi.dependencies]
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+[target.thumbv8m.main-none-eabihf.dependencies]
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+
 [build-dependencies]
 build-util = {path = "../../build/util"}
 


### PR DESCRIPTION
We were rebuilding PACs twice for most applications, once for tasks
where the inline-asm feature is set somewhere in their dependency graph,
and once for tasks where it isn't. The inline-asm feature is thankfully
going away in cortex-m 0.8 (it should be a build-time capability
detection rather than a user-visible feature), but for now, we'll just
force it on in the one library that all tasks include: userlib.

This knocks a minute or more off a clean build for stm32h7, where the
PAC is particularly expensive.