### PR TITLE
Fill gaps in binaries with `0xff`

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1979,6 +1979,8 @@ fn objcopy_translate_format(
         .arg(in_format)
         .arg("-O")
         .arg(out_format)
+        .arg("--gap-fill")
+        .arg("0xFF")
         .arg(src)
         .arg(dest);
 


### PR DESCRIPTION
By default, objcopy will fill gaps in sections with `0x00`. The flash
programming sequence on the STM32 will not program the gaps and will
leave them in the default state of `0xff`. This results in a mismatch
between the generated binary and flash. From a running program
perspective this is fine but it results in incorrect calculations of
expected values in flash. Fix this by filling the gap with `0xff`.