### PR TITLE
Fix VSC8562 Tx/Rx counters

### DIFF
--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -321,13 +321,21 @@ impl Bsp {
             out.vsc85x2_rx[i].media_bad = rx;
 
             if self.vsc85x2.has_mac_counters() {
+                // The VSC8562 has "surprising" notions of Tx vs Rx.
+                // Specifically, on the MAC side, "Tx" is from the host MAC's
+                // perspective!  This means that the Tx lines are *inputs*
+                // to the VSC8562, i.e. what most people would expect to be
+                // "receive" signals.
+                //
+                // Here, we swap TX and RX in the returned struct, so that they
+                // match normal expectations.
                 let (tx, rx) = decode_tx_rx(phy.mac_tx_rx_good(), port)?;
-                out.vsc85x2_tx[i].mac_good = tx;
-                out.vsc85x2_rx[i].mac_good = rx;
+                out.vsc85x2_tx[i].mac_good = rx; // swap!
+                out.vsc85x2_rx[i].mac_good = tx; // swap!
 
                 let (tx, rx) = decode_tx_rx(phy.mac_tx_rx_bad(), port)?;
-                out.vsc85x2_tx[i].mac_bad = tx;
-                out.vsc85x2_rx[i].mac_bad = rx;
+                out.vsc85x2_tx[i].mac_bad = rx; // swap!
+                out.vsc85x2_rx[i].mac_bad = tx; // swap!
             }
         }
 


### PR DESCRIPTION
It turns out the "Tx = input, Rx = output" MAC signal naming conventional also applies to these counters.

<img width="698" alt="Screen Shot 2022-08-22 at 2 29 23 PM" src="https://user-images.githubusercontent.com/745333/185994042-5b550d13-01a5-4282-aa96-be4c523b24fc.png">

Closes #667 