### PR TITLE
Extend the update API

### DIFF
--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -6,6 +6,21 @@
 
 use derive_idol_err::IdolError;
 use userlib::{sys_send, FromPrimitive};
+use zerocopy::AsBytes;
+
+#[repr(u8)]
+#[derive(FromPrimitive, AsBytes, PartialEq, Clone, Copy)]
+pub enum UpdateTarget {
+    // Represents targets where we only ever write to a single
+    // alternate flash location. This is typically used in
+    // conjunction with a bank swap feature.
+    Alternate = 1,
+    // Represents targets where we must write to a specific range
+    // of flash.
+    ImageA = 2,
+    ImageB = 3,
+    Bootloader = 4,
+}
 
 #[derive(FromPrimitive, IdolError)]
 #[repr(u32)]
@@ -24,6 +39,9 @@ pub enum UpdateError {
     StrobeErr = 11,
     ProgSeqErr = 12,
     WriteProtErr = 13,
+    BadImageType = 14,
+    UpdateAlreadyFinished = 15,
+    UpdateNotStarted = 16,
 }
 
 pub mod stm32h7 {

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -13,7 +13,12 @@ Interface(
 		),
 		"prep_image_update": (
 			doc: "Do any necessary preparation for writing the image. This may include erasing flash and unlocking registers",
-			args : { },
+			args : {
+                            "image_type": (
+                                  type: "UpdateTarget",
+                                  recv: FromPrimitive("u8"),
+                            )
+                        },
 			reply : Result(
 				ok: "()",
 				err: CLike("UpdateError"),
@@ -28,6 +33,14 @@ Interface(
 				"block": (type: "[u8]", read: true, max_len: Some(1024)),
 			},
 			reply: Result (
+				ok: "()",
+				err: CLike("UpdateError"),
+			),
+		),
+		"abort_update": (
+			doc: "Cancel the current update in progress. Must call prep_image_update again before restarting.",
+			args : { },
+			reply : Result(
 				ok: "()",
 				err: CLike("UpdateError"),
 			),

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -6,7 +6,7 @@ use core::convert::Infallible;
 
 use crate::{Log, MgsMessage, UsartHandler, __RINGBUF};
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
-use drv_update_api::Update;
+use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
     sp_impl::SocketAddrV6,
     sp_impl::{SerialConsolePacketizer, SpHandler},
@@ -164,7 +164,7 @@ impl SpHandler for MgsHandler {
         }
 
         self.update_task
-            .prep_image_update()
+            .prep_image_update(UpdateTarget::Alternate)
             .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
 
         // We can only call `claim_update_buffer_static` once; we bail out above


### PR DESCRIPTION
- Prep now requires an image type to indicate which image is being
  updated.
- Add an `abort_update` function if the calling task decides they
  need to stop an update.
- Added a few more error types to better specify exactly what may have
  gone wrong.