### PR TITLE
Restrict operation callers in app.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
+source = "git+https://github.com/oxidecomputer/idolatry.git#cf366c0f8d3efc57eec6eb764eb5fc04bbf1a9fe"
 dependencies = [
  "indexmap",
  "quote",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#285d92876b95f3f1c706e4a98aaa954d167b9de4"
+source = "git+https://github.com/oxidecomputer/idolatry.git#cf366c0f8d3efc57eec6eb764eb5fc04bbf1a9fe"
 dependencies = [
  "userlib",
  "zerocopy",

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -28,9 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-on-state-change = {net = {bit-number = 3}}
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -29,9 +29,12 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.jefe.config]
-state-owner = "gimlet_seq"
 on-state-change = {net = {bit-number = 3}}
-reset-reason-owner = "sys"
+
+[tasks.jefe.config.allowed-callers]
+set_state = ["gimlet_seq"]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.net]
 name = "task-net"

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -32,8 +32,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy", "mgmt_gateway"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -27,8 +27,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -28,8 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-reset-reason-owner = "sys"
+[tasks.jefe.config.allowed-callers]
+set_reset_reason = ["sys"]
+request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -8,16 +8,21 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 fn main() -> Result<()> {
-    idol::server::build_server_support(
+    let cfg = build_util::task_maybe_config::<Config>()?.unwrap_or_default();
+
+    let allowed_callers = build_util::task_ids()
+        .remap_allowed_caller_names_to_ids(&cfg.allowed_callers)?;
+
+    idol::server::build_restricted_server_support(
         "../../idl/jefe.idol",
         "server_stub.rs",
         idol::server::ServerStyle::InOrder,
+        &allowed_callers,
     )
     .unwrap();
 
     build_util::expose_m_profile();
 
-    let cfg = build_util::task_maybe_config::<Config>()?.unwrap_or_default();
     let out_dir = std::env::var("OUT_DIR")?;
     let dest_path = std::path::Path::new(&out_dir).join("jefe_config.rs");
     let mut out =
@@ -36,24 +41,6 @@ fn main() -> Result<()> {
     }
     writeln!(out, "];")?;
 
-    write!(out, "pub(crate) const STATE_OWNER: Option<{}> = ", task)?;
-    if let Some(owner) = cfg.state_owner {
-        writeln!(out, "Some({}::{});", task, owner)?;
-    } else {
-        writeln!(out, "None;")?;
-    }
-
-    write!(
-        out,
-        "pub(crate) const RESET_REASON_OWNER: Option<{}> = ",
-        task
-    )?;
-    if let Some(owner) = cfg.reset_reason_owner {
-        writeln!(out, "Some({}::{});", task, owner)?;
-    } else {
-        writeln!(out, "None;")?;
-    }
-
     Ok(())
 }
 
@@ -65,15 +52,9 @@ struct Config {
     /// `StateChange` record.
     #[serde(default)]
     on_state_change: BTreeMap<String, StateChange>,
-    /// Name of task responsible for state changes. If provided, a state change
-    /// request from any other task will result in that task being faulted.
+    /// Map of operation names to tasks allowed to call them.
     #[serde(default)]
-    state_owner: Option<String>,
-    /// Name of task responsible for setting the reset reason. If provided, a
-    /// request to set the reset reason from any other task will result in that
-    /// task being faulted.
-    #[serde(default)]
-    reset_reason_owner: Option<String>,
+    allowed_callers: BTreeMap<String, Vec<String>>,
 }
 
 /// Description of something a task wants done on state change.

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -171,19 +171,9 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
     fn set_reset_reason(
         &mut self,
-        msg: &userlib::RecvMessage,
+        _msg: &userlib::RecvMessage,
         reason: ResetReason,
     ) -> Result<(), idol_runtime::RequestError<Infallible>> {
-        // If a task is designated as the reset reason owner, ensure that this
-        // RPC came from that task.
-        if let Some(owner) = generated::RESET_REASON_OWNER {
-            if msg.sender.index() != owner as usize {
-                // We'll pretend this operation doesn't exist.
-                // TODO this should be AccessViolation but that isn't exposed in
-                // the current version of idol.
-                return Err(idol_runtime::ClientError::UnknownOperation.fail());
-            }
-        }
         self.reset_reason = reason;
         Ok(())
     }
@@ -197,20 +187,9 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
     fn set_state(
         &mut self,
-        msg: &userlib::RecvMessage,
+        _msg: &userlib::RecvMessage,
         state: u32,
     ) -> Result<(), idol_runtime::RequestError<Infallible>> {
-        // If a task is designated as state owner, ensure that this RPC came
-        // from that task.
-        if let Some(owner) = generated::STATE_OWNER {
-            if msg.sender.index() != owner as usize {
-                // We'll pretend this operation doesn't exist.
-                // TODO this should be AccessViolation but that isn't exposed in
-                // the current version of idol.
-                return Err(idol_runtime::ClientError::UnknownOperation.fail());
-            }
-        }
-
         if self.state != state {
             self.state = state;
 


### PR DESCRIPTION
This allows us to remove the by-hand check for `state-owner` and `reset-reason-owner` in jefe's config and server implementation, in favor of passing the list of allowed callers to idolatry and letting it put the check in the generated code (via https://github.com/oxidecomputer/idolatry/pull/22).

While I was in here, I added restrictions on `request-reset` (to `hiffy`/`mgmt-gateway`), fixing #699.

Callers that attempt to perform operations that they aren't allowed to will now see `AccessViolation` errors instead of `UnknownOperation`.