### PR TITLE
mgmt-gateway: Update to new MGS serialization of large messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,13 +1554,15 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=45286415755d5ec7c0d3683addc9942832244eff#45286415755d5ec7c0d3683addc9942832244eff"
+source = "git+https://github.com/oxidecomputer/omicron?rev=631e6d76dcfc7316f795ef86c82c7f2712de3e8b#631e6d76dcfc7316f795ef86c82c7f2712de3e8b"
 dependencies = [
  "bitflags",
  "hubpack",
  "serde",
+ "serde-big-array",
  "serde_repr",
  "smoltcp",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2747,18 +2749,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.141"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af873f2c95b99fcb0bd0fe622a43e29514658873c8ceba88c4cb88833a22500"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.141"
+name = "serde-big-array"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75743a150d003dd863b51dc809bcad0d73f2102c53632f1e954e738192a3413f"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2949,6 +2960,12 @@ dependencies = [
  "sha2",
  "zerocopy",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stm32f3"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -142,7 +142,7 @@ features = ["vlan"]
 name = "task-mgmt-gateway"
 priority = 4
 max-sizes = {flash = 32768, ram = 8192}
-stacksize = 4096
+stacksize = 1536
 start = true
 uses = [
     "usart1",

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -19,7 +19,7 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "45286415755d5ec7c0d3683addc9942832244eff"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "631e6d76dcfc7316f795ef86c82c7f2712de3e8b"}
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -7,10 +7,10 @@
 
 use drv_stm32h7_usart::Usart;
 use gateway_messages::{
-    sp_impl, sp_impl::Error as MgsDispatchError, sp_impl::SocketAddrV6,
-    IgnitionCommand, Request, SerialConsole, SerializedSize, SpMessage,
-    SpMessageKind, SpPort,
+    sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, SpComponent,
+    SpMessage, SpMessageKind, SpPort,
 };
+use mgs_handler::UsartFlush;
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
 use task_net_api::{
@@ -26,6 +26,8 @@ use userlib::{
 mod mgs_handler;
 
 use self::mgs_handler::MgsHandler;
+
+type SerializedMessageBuf = [u8; gateway_messages::MAX_SERIALIZED_SIZE];
 
 task_slot!(JEFE, jefe);
 task_slot!(NET, net);
@@ -44,7 +46,7 @@ enum Log {
     UsartTxFull { remaining: usize },
     UsartRx { num_bytes: usize },
     UsartRxOverrun,
-    SerialConsoleSend { len: u16 },
+    SerialConsoleSend { buffered: usize },
     UpdatePartial { bytes_written: usize },
     UpdateComplete,
 }
@@ -90,9 +92,9 @@ const SOCKET: SocketName = SocketName::mgmt_gateway;
 
 #[export_name = "main"]
 fn main() {
-    let usart = UsartHandler::new(configure_usart());
+    let usart = UsartHandler::new(configure_usart(), claim_uart_bufs_static());
     let mut mgs_handler = MgsHandler::new(usart);
-    let mut net_handler = NetHandler::new(claim_request_buf_static());
+    let mut net_handler = NetHandler::new(claim_net_bufs_static());
 
     // Enbale USART interrupts.
     sys_irq_control(USART_IRQ, true);
@@ -120,17 +122,20 @@ fn main() {
 
 struct UsartHandler {
     usart: Usart,
-    to_tx: ArrayVec<[u8; SerialConsole::MAX_DATA_PER_PACKET]>,
-    from_rx: ArrayVec<[u8; SerialConsole::MAX_DATA_PER_PACKET]>,
+    to_tx: &'static mut ArrayVec<SerializedMessageBuf>,
+    from_rx: &'static mut ArrayVec<SerializedMessageBuf>,
     from_rx_flush_deadline: Option<u64>,
 }
 
 impl UsartHandler {
-    fn new(usart: Usart) -> Self {
+    fn new(
+        usart: Usart,
+        [to_tx, from_rx]: &'static mut [ArrayVec<SerializedMessageBuf>; 2],
+    ) -> Self {
         Self {
             usart,
-            to_tx: ArrayVec::default(),
-            from_rx: ArrayVec::default(),
+            to_tx,
+            from_rx,
             from_rx_flush_deadline: None,
         }
     }
@@ -170,7 +175,7 @@ impl UsartHandler {
     fn run_until_blocked(&mut self) {
         // Transmit as much as we have and can.
         let mut n = 0;
-        for &b in &self.to_tx {
+        for &b in &*self.to_tx {
             if self.usart.try_tx_push(b) {
                 n += 1;
             } else {
@@ -227,16 +232,16 @@ impl UsartHandler {
 
 struct NetHandler {
     net: Net,
-    tx_buf: [u8; SpMessage::MAX_SIZE],
-    rx_buf: &'static mut [u8; Request::MAX_SIZE],
+    tx_buf: &'static mut SerializedMessageBuf,
+    rx_buf: &'static mut SerializedMessageBuf,
     packet_to_send: Option<UdpMetadata>,
 }
 
 impl NetHandler {
-    fn new(rx_buf: &'static mut [u8; Request::MAX_SIZE]) -> Self {
+    fn new([tx_buf, rx_buf]: &'static mut [SerializedMessageBuf; 2]) -> Self {
         Self {
             net: Net::from(NET.get_task_id()),
-            tx_buf: [0; SpMessage::MAX_SIZE],
+            tx_buf,
             rx_buf,
             packet_to_send: None,
         }
@@ -269,17 +274,11 @@ impl NetHandler {
             }
 
             // Do we need to send usart data to MGS?
-            if let Some((serial_console_packet, mgs_addr, sp_port)) =
-                mgs_handler.flush_usart_to_mgs()
-            {
+            if let Some(to_flush) = mgs_handler.flush_usart_to_mgs() {
                 ringbuf_entry!(Log::SerialConsoleSend {
-                    len: serial_console_packet.len
+                    buffered: to_flush.data.len()
                 });
-                let meta = self.build_serial_console_packet(
-                    serial_console_packet,
-                    mgs_addr,
-                    sp_port,
-                );
+                let meta = self.build_serial_console_packet(to_flush);
                 self.packet_to_send = Some(meta);
 
                 // Loop back to send.
@@ -305,25 +304,28 @@ impl NetHandler {
 
     fn build_serial_console_packet(
         &mut self,
-        packet: SerialConsole,
-        mgs_addr: SocketAddrV6,
-        sp_port: SpPort,
+        to_flush: UsartFlush<'_>,
     ) -> UdpMetadata {
         let message = SpMessage {
             version: gateway_messages::version::V1,
-            kind: SpMessageKind::SerialConsole(packet),
+            kind: SpMessageKind::SerialConsole(SpComponent::SP3_HOST_CPU),
         };
 
-        // We know `self.tx_buf` is large enough for any `SpMessage`, so we can
-        // unwrap this `serialize()`.
-        let n = gateway_messages::serialize(&mut self.tx_buf, &message)
-            .unwrap_lite();
+        let (n, written) = gateway_messages::serialize_with_trailing_data(
+            self.tx_buf,
+            &message,
+            to_flush.data,
+        );
+
+        // TODO-correctness: We shouldn't drain this data until we know MGS has
+        // received it. Currently we don't get ACKs from MGS; this needs work!
+        to_flush.data.drain(..written);
 
         UdpMetadata {
-            addr: Address::Ipv6(mgs_addr.ip.into()),
-            port: mgs_addr.port,
+            addr: Address::Ipv6(to_flush.destination.ip.into()),
+            port: to_flush.destination.port,
             size: n as u32,
-            vid: vlan_id_from_sp_port(sp_port),
+            vid: vlan_id_from_sp_port(to_flush.port),
         }
     }
 
@@ -432,10 +434,26 @@ fn configure_usart() -> Usart {
     )
 }
 
-/// Grabs reference to a static array sized to hold a `Request`. Can only be
-/// called once!
-fn claim_request_buf_static() -> &'static mut [u8; Request::MAX_SIZE] {
+/// Grabs reference to two static `ArrayVec`s for bidirectional buffering of
+/// uart data.
+///
+/// These buffers are slightly oversized in terms of what we could send/receive
+/// in a single packet, since `MAX_SERIALIZED_SIZE` includes space for the
+/// message header, but that's relatively harmless.
+fn claim_uart_bufs_static() -> &'static mut [ArrayVec<SerializedMessageBuf>; 2]
+{
     mutable_statics! {
-        static mut REQUEST_BUF: [u8; Request::MAX_SIZE] = [0; _];
+        static mut BUFS:
+            [ArrayVec<SerializedMessageBuf>; 2]
+                = [ArrayVec::default(); _];
+    }
+}
+
+/// Grabs reference to a static array sized to hold an incoming message. Can
+/// only be called once!
+fn claim_net_bufs_static() -> &'static mut [SerializedMessageBuf; 2] {
+    mutable_statics! {
+        static mut BUFS: [SerializedMessageBuf; 2] =
+            [[0; gateway_messages::MAX_SERIALIZED_SIZE]; _];
     }
 }

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -130,8 +130,9 @@ struct UsartHandler {
 impl UsartHandler {
     fn new(
         usart: Usart,
-        [to_tx, from_rx]: &'static mut [ArrayVec<SerializedMessageBuf>; 2],
+        buffers: &'static mut [ArrayVec<SerializedMessageBuf>; 2],
     ) -> Self {
+        let [to_tx, from_rx] = buffers;
         Self {
             usart,
             to_tx,
@@ -238,7 +239,8 @@ struct NetHandler {
 }
 
 impl NetHandler {
-    fn new([tx_buf, rx_buf]: &'static mut [SerializedMessageBuf; 2]) -> Self {
+    fn new(buffers: &'static mut [SerializedMessageBuf; 2]) -> Self {
+        let [tx_buf, rx_buf] = buffers;
         Self {
             net: Net::from(NET.get_task_id()),
             tx_buf,
@@ -443,9 +445,8 @@ fn configure_usart() -> Usart {
 fn claim_uart_bufs_static() -> &'static mut [ArrayVec<SerializedMessageBuf>; 2]
 {
     mutable_statics! {
-        static mut BUFS:
-            [ArrayVec<SerializedMessageBuf>; 2]
-                = [ArrayVec::default(); _];
+        static mut BUFS: [ArrayVec<SerializedMessageBuf>; 2] =
+            [ArrayVec::default(); _];
     }
 }
 


### PR DESCRIPTION
Update payloads and serial console packets are now serialized as raw
data _after_ a hubpack-encoded message, instead of the data being
embedded as part of the hubpack message. Formerly we were required to
allocate several moderately-sized arrays on the stack and copy data
unnecessarily; now the raw data is borrowed from the receive buffer we
pass to `net`, which requires no extra copies or stack allocation of
large arrays.

This is the hubris half of https://github.com/oxidecomputer/omicron/pull/1645, which did the MGS side of this work.

We get significant improvements in flash and stack, and a modest improvement in ram (although it doesn't look like it at first glance). Before this PR:

```
# xtask sizes
PROGRAM        REGION  USED   SIZE   LIMIT
mgmt_gateway   flash   26764  32768  32768
               ram     6444   8192   8192

# stackmargin after performing an update, before resetting
ID TASK                STACKBASE  STACKSIZE   MAXDEPTH     MARGIN
11 mgmt_gateway       0x20004000       4096       3416        680
```

After this PR:

```
# xtask sizes
PROGRAM        REGION  USED   SIZE   LIMIT
mgmt_gateway   flash   19220  32768  32768
               ram     7456   8192   8192
               
# stackmargin after performing an update, before resetting
ID TASK                STACKBASE  STACKSIZE   MAXDEPTH     MARGIN
11 mgmt_gateway       0x20004000       1536       1048        488
```

Our absolute ram usage goes up by about 1k, but our buffers are significantly larger: we can now receive ~1k update chunks (previously 512 bytes), and we can send and receive ~1k serial console packets (previously 128 bytes). Handwaving a bit, I think we have about 1.8k more buffer space for only 1k more ram usage.