### PR TITLE
mgmt-gateway: Refine serial console messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,12 +58,11 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.4"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
+checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
  "critical-section",
- "riscv-target",
 ]
 
 [[package]]
@@ -95,7 +94,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -441,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
+checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
@@ -1554,7 +1553,6 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=55d36d983ac656c3e39c7d6ffeae362199227472#55d36d983ac656c3e39c7d6ffeae362199227472"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -1706,12 +1704,13 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe65ef062f1af5b1b189842b0bc45bd671c38e1d22c6aa22e6ada03d01026d53"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version 0.4.0",
  "serde",
  "spin 0.9.2",
  "stable_deref_trait",
@@ -2658,6 +2657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.13",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2739,12 @@ dependencies = [
  "semver-parser 0.10.2",
  "serde",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "semver-parser"
@@ -3162,6 +3176,7 @@ dependencies = [
  "drv-stm32xx-uid",
  "drv-update-api",
  "gateway-messages",
+ "heapless",
  "mutable-statics",
  "num-traits",
  "ringbuf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?rev=55d36d983ac656c3e39c7d6ffeae362199227472#55d36d983ac656c3e39c7d6ffeae362199227472"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,6 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=631e6d76dcfc7316f795ef86c82c7f2712de3e8b#631e6d76dcfc7316f795ef86c82c7f2712de3e8b"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -19,8 +19,7 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-#gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "631e6d76dcfc7316f795ef86c82c7f2712de3e8b"}
-gateway-messages = {path = "../../../omicron/gateway-messages"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "55d36d983ac656c3e39c7d6ffeae362199227472"}
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -19,7 +19,8 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "631e6d76dcfc7316f795ef86c82c7f2712de3e8b"}
+#gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "631e6d76dcfc7316f795ef86c82c7f2712de3e8b"}
+gateway-messages = {path = "../../../omicron/gateway-messages"}
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 cfg-if = "1"
+heapless = "0.7.16"
 num-traits = {version = "0.2", default-features = false}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
@@ -19,7 +20,7 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "55d36d983ac656c3e39c7d6ffeae362199227472"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "f2e6237e57a36873fc748b6ecd9e42b8ef208c88"}
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -212,7 +212,9 @@ impl UsartHandler {
 
         // Clean up / ringbuf debug log after transmitting.
         if n_transmitted > 0 {
-            ringbuf_entry!(Log::UsartTx { num_bytes: n_transmitted });
+            ringbuf_entry!(Log::UsartTx {
+                num_bytes: n_transmitted
+            });
             self.to_tx.drain_front(n_transmitted);
         }
         if self.to_tx.is_empty() {
@@ -264,7 +266,9 @@ impl UsartHandler {
         }
 
         if n_received > 0 {
-            ringbuf_entry!(Log::UsartRx { num_bytes: n_received });
+            ringbuf_entry!(Log::UsartRx {
+                num_bytes: n_received
+            });
             self.start_flush_timer_if_needed();
         }
     }

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -63,9 +63,12 @@ enum MgsMessage {
         command: IgnitionCommand,
     },
     SpState,
+    SerialConsoleAttach,
     SerialConsoleWrite {
+        offset: u64,
         length: u16,
     },
+    SerialConsoleDetach,
     UpdateStart {
         length: u32,
     },

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -29,6 +29,7 @@ pub(crate) struct UsartFlush<'a> {
 pub(crate) struct MgsHandler {
     pub(crate) usart: UsartHandler,
     attached_serial_console_mgs: Option<(SocketAddrV6, SpPort)>,
+    serial_console_write_offset: u64,
     update_task: Update,
     update_progress: Option<&'static mut UpdateBuffer>,
     reset_requested: bool,
@@ -39,6 +40,7 @@ impl MgsHandler {
         Self {
             usart,
             attached_serial_console_mgs: None,
+            serial_console_write_offset: 0,
             update_task: Update::from(crate::UPDATE_SERVER.get_task_id()),
             update_progress: None,
             reset_requested: false,
@@ -188,16 +190,13 @@ impl SpHandler for MgsHandler {
         Ok(())
     }
 
-    fn serial_console_write(
+    fn serial_console_attach(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-        data: &[u8],
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
-            length: data.len() as u16
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
 
         // Including a component in the serial console messages is half-baked at
         // the moment; we can at least check that it's the one component we
@@ -206,19 +205,68 @@ impl SpHandler for MgsHandler {
             return Err(ResponseError::RequestUnsupportedForComponent);
         }
 
-        // TODO serial console access should require auth; for now, receiving
-        // serial console data implicitly attaches us
-        self.attached_serial_console_mgs = Some((sender, port));
-
-        // TODO-cleanup This rejects the entire message if it doesn't all fit in
-        // our buffer; we could accept part of the data if some of it fits.
-        // Needs cooperation from MGS.
-        if self.usart.tx_buffer_remaining_capacity() >= data.len() {
-            self.usart.tx_buffer_append(data);
-            Ok(())
-        } else {
-            Err(ResponseError::Busy)
+        if self.attached_serial_console_mgs.is_some() {
+            return Err(ResponseError::SerialConsoleAlreadyAttached);
         }
+
+        // TODO: Add some kind of auth check before allowing a serial console
+        // attach. https://github.com/oxidecomputer/hubris/issues/723
+        self.attached_serial_console_mgs = Some((sender, port));
+        self.serial_console_write_offset = 0;
+        Ok(())
+    }
+
+    fn serial_console_write(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        mut offset: u64,
+        mut data: &[u8],
+    ) -> Result<u64, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+            offset,
+            length: data.len() as u16
+        }));
+
+        // TODO: Add some kind of auth check before allowing a serial console
+        // attach. https://github.com/oxidecomputer/hubris/issues/723
+        //
+        // As a temporary measure, we can at least ensure that we only allow
+        // writes from the attached console.
+        if Some((sender, port)) != self.attached_serial_console_mgs {
+            return Err(ResponseError::SerialConsoleNotAttached);
+        }
+
+        // Have we already received some or all of this data? (MGS may resend
+        // packets that for which it hasn't received our ACK.)
+        if self.serial_console_write_offset > offset {
+            let skip = self.serial_console_write_offset - offset;
+            // Have we already seen _all_ of this data? If so, just reply that
+            // we're ready for the data that comes after it.
+            if skip >= data.len() as u64 {
+                return Ok(offset + data.len() as u64);
+            }
+            offset = self.serial_console_write_offset;
+            data = &data[skip as usize..];
+        }
+
+        // Buffer as much of `data` as we can, then notify MGS how much we
+        // ingested.
+        let can_recv =
+            usize::min(self.usart.tx_buffer_remaining_capacity(), data.len());
+        self.usart.tx_buffer_append(&data[..can_recv]);
+        self.serial_console_write_offset = offset + can_recv as u64;
+        Ok(self.serial_console_write_offset)
+    }
+
+    fn serial_console_detach(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        self.attached_serial_console_mgs = None;
+        Ok(())
     }
 
     fn reset_prepare(

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -20,8 +20,7 @@ use tinyvec::ArrayVec;
 const VERSION: u32 = 1;
 
 pub(crate) struct UsartFlush<'a> {
-    pub(crate) data:
-        &'a mut ArrayVec<[u8; gateway_messages::MAX_SERIALIZED_SIZE]>,
+    pub(crate) usart: &'a mut UsartHandler,
     pub(crate) destination: SocketAddrV6,
     pub(crate) port: SpPort,
 }
@@ -59,7 +58,7 @@ impl MgsHandler {
 
         if let Some((mgs_addr, sp_port)) = self.attached_serial_console_mgs {
             Some(UsartFlush {
-                data: self.usart.from_rx,
+                usart: &mut self.usart,
                 destination: mgs_addr,
                 port: sp_port,
             })
@@ -213,6 +212,7 @@ impl SpHandler for MgsHandler {
         // attach. https://github.com/oxidecomputer/hubris/issues/723
         self.attached_serial_console_mgs = Some((sender, port));
         self.serial_console_write_offset = 0;
+        self.usart.from_rx_offset = 0;
         Ok(())
     }
 


### PR DESCRIPTION
This is the hubris half to https://github.com/oxidecomputer/omicron/pull/1651 that lets us address a few lingering TODOs:

1. Attaching and detaching an MGS instance to a particular SP's proxied serial console are now explicit messages; previously attaching was implicit when MGS sent data, and detaching was implicit when a new MGS instance attached, neither of which was ideal.
2. MGS -> SP serial console data packets now include an offset, allowing the SP to detect and ignore any resent UDP packets. Previously if MGS resent a serial console data packet because it missed an ack, the SP had no way to know it had already seen it, and it would forward it along the uart a second time.
3. SP -> MGS serial console data packets now include an offset. We do not ack SP -> MGS messages, both because the logic to do that on the SP would be tricky and because it has very little recourse for unacked messages (it can't apply backpressure on a uart, and it can't buffer data arbitrarily long). As of this PR MGS can at least know and log when data has been lost due to a networking or SP buffering issue.