### PR TITLE
Refactor in prep for gimlet/sidecar/psc variants of mgmt-gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?rev=f2e6237e57a36873fc748b6ecd9e42b8ef208c88#f2e6237e57a36873fc748b6ecd9e42b8ef208c88"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -5,23 +5,16 @@
 #![no_std]
 #![no_main]
 
-use drv_stm32h7_usart::Usart;
 use gateway_messages::{
-    sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, SpComponent,
-    SpMessage, SpMessageKind, SpPort,
+    sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, SpPort,
 };
-use heapless::Deque;
-use mgs_handler::UsartFlush;
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
 use task_net_api::{
     Address, LargePayloadBehavior, Net, RecvError, SendError, SocketName,
     UdpMetadata,
 };
-use userlib::{
-    sys_get_timer, sys_irq_control, sys_recv_closed, sys_set_timer, task_slot,
-    TaskId, UnwrapLite,
-};
+use userlib::{sys_recv_closed, task_slot, TaskId, UnwrapLite};
 
 mod mgs_handler;
 
@@ -88,20 +81,12 @@ const USART_IRQ: u32 = 1 << 1;
 // Must not conflict with IRQs above!
 const TIMER_IRQ: u32 = 1 << 2;
 
-// Send any buffered serial console data to MGS when our oldest buffered byte is
-// this old, even if our buffer isn't full yet.
-const SERIAL_CONSOLE_FLUSH_TIMEOUT_MILLIS: u64 = 500;
-
 const SOCKET: SocketName = SocketName::mgmt_gateway;
 
 #[export_name = "main"]
 fn main() {
-    let usart = UsartHandler::new(configure_usart(), claim_uart_bufs_static());
-    let mut mgs_handler = MgsHandler::new(usart);
+    let mut mgs_handler = MgsHandler::claim_static_resources();
     let mut net_handler = NetHandler::new(claim_net_bufs_static());
-
-    // Enbale USART interrupts.
-    sys_irq_control(USART_IRQ, true);
 
     loop {
         let note = sys_recv_closed(
@@ -114,162 +99,11 @@ fn main() {
         ringbuf_entry!(Log::Wake(note));
 
         if (note & USART_IRQ) != 0 {
-            mgs_handler.usart.run_until_blocked();
-            sys_irq_control(USART_IRQ, true);
+            mgs_handler.drive_usart();
         }
 
-        if (note & NET_IRQ) != 0 || mgs_handler.needs_usart_flush_to_mgs() {
+        if (note & NET_IRQ) != 0 || mgs_handler.wants_to_send_packet_to_mgs() {
             net_handler.run_until_blocked(&mut mgs_handler);
-        }
-    }
-}
-
-struct UsartHandler {
-    usart: Usart,
-    to_tx: &'static mut Deque<u8, { gateway_messages::MAX_SERIALIZED_SIZE }>,
-    from_rx: &'static mut Deque<u8, { gateway_messages::MAX_SERIALIZED_SIZE }>,
-    from_rx_flush_deadline: Option<u64>,
-    from_rx_offset: u64,
-}
-
-impl UsartHandler {
-    fn new(
-        usart: Usart,
-        buffers: [&'static mut Deque<u8, { gateway_messages::MAX_SERIALIZED_SIZE }>;
-            2],
-    ) -> Self {
-        let [to_tx, from_rx] = buffers;
-        Self {
-            usart,
-            to_tx,
-            from_rx,
-            from_rx_flush_deadline: None,
-            from_rx_offset: 0,
-        }
-    }
-
-    fn tx_buffer_remaining_capacity(&self) -> usize {
-        self.to_tx.capacity() - self.to_tx.len()
-    }
-
-    /// Panics if `self.tx_buffer_remaining_capacity() < data.len()`.
-    fn tx_buffer_append(&mut self, data: &[u8]) {
-        if self.to_tx.is_empty() {
-            self.usart.enable_tx_fifo_empty_interrupt();
-        }
-        for &b in data {
-            self.to_tx.push_back(b).unwrap_lite();
-        }
-    }
-
-    fn should_flush_to_mgs(&self) -> bool {
-        // Bail out early if our buffer is empty or full.
-        let len = self.from_rx.len();
-        if len == 0 {
-            return false;
-        } else if len == self.from_rx.capacity() {
-            return true;
-        }
-
-        // Otherwise, only flush if we're past our deadline.
-        self.from_rx_flush_deadline
-            .map(|deadline| sys_get_timer().now >= deadline)
-            .unwrap_or(false)
-    }
-
-    fn clear_rx_data(&mut self) {
-        self.from_rx.clear();
-        self.from_rx_flush_deadline = None;
-        sys_set_timer(None, TIMER_IRQ);
-    }
-
-    fn drain_flushed_data(&mut self, n: usize) {
-        self.from_rx.drain_front(n);
-        self.from_rx_offset += n as u64;
-        self.from_rx_flush_deadline = None;
-        self.start_flush_timer_if_needed();
-    }
-
-    fn start_flush_timer_if_needed(&mut self) {
-        if self.from_rx_flush_deadline.is_none() && !self.from_rx.is_empty() {
-            let deadline =
-                sys_get_timer().now + SERIAL_CONSOLE_FLUSH_TIMEOUT_MILLIS;
-            self.from_rx_flush_deadline = Some(deadline);
-            sys_set_timer(Some(deadline), TIMER_IRQ);
-        }
-    }
-
-    fn run_until_blocked(&mut self) {
-        // Transmit as much as we have and can.
-        let mut n_transmitted = 0;
-        for &b in &*self.to_tx {
-            if self.usart.try_tx_push(b) {
-                n_transmitted += 1;
-            } else {
-                break;
-            }
-        }
-
-        // Clean up / ringbuf debug log after transmitting.
-        if n_transmitted > 0 {
-            ringbuf_entry!(Log::UsartTx {
-                num_bytes: n_transmitted
-            });
-            self.to_tx.drain_front(n_transmitted);
-        }
-        if self.to_tx.is_empty() {
-            self.usart.disable_tx_fifo_empty_interrupt();
-        } else {
-            ringbuf_entry!(Log::UsartTxFull {
-                remaining: self.to_tx.len()
-            });
-        }
-
-        // Clear any errors.
-        if self.usart.check_and_clear_rx_overrun() {
-            ringbuf_entry!(Log::UsartRxOverrun);
-            // TODO-correctness Should we notify MGS of dropped data here? We
-            // could increment `self.from_rx_offset`, but (a) we don't know how
-            // much data we lost, and (b) it would indicate lost data in the
-            // wrong place (i.e., data lost at the current
-            // `self.from_rx_offset`, instead of `self.from_rx_offset +
-            // self.from_rx.len()`, which is where we actually are now).
-        }
-
-        // Recv as much as we can from the USART FIFO, even if we have to
-        // discard old data to do so.
-        let mut n_received = 0;
-        let mut discarded_data = 0;
-        while let Some(b) = self.usart.try_rx_pop() {
-            n_received += 1;
-            match self.from_rx.push_back(b) {
-                Ok(()) => (),
-                Err(b) => {
-                    // If `push_back` failed, we know there is at least one
-                    // item, allowing us to unwrap `pop_front`. At that point we
-                    // know there's space for at least one, allowing us to
-                    // unwrap a subsequent `push_back`.
-                    self.from_rx.pop_front().unwrap_lite();
-                    self.from_rx.push_back(b).unwrap_lite();
-                    discarded_data += 1;
-                }
-            }
-        }
-
-        // Update our offset, which will allow MGS to know we discarded data,
-        // and log that fact locally via ringbuf.
-        self.from_rx_offset += discarded_data;
-        if discarded_data > 0 {
-            ringbuf_entry!(Log::UsartRxBufferDataDropped {
-                num_bytes: discarded_data
-            });
-        }
-
-        if n_received > 0 {
-            ringbuf_entry!(Log::UsartRx {
-                num_bytes: n_received
-            });
-            self.start_flush_timer_if_needed();
         }
     }
 }
@@ -318,12 +152,8 @@ impl NetHandler {
                 }
             }
 
-            // Do we need to send usart data to MGS?
-            if let Some(to_flush) = mgs_handler.flush_usart_to_mgs() {
-                ringbuf_entry!(Log::SerialConsoleSend {
-                    buffered: to_flush.usart.from_rx.len()
-                });
-                let meta = self.build_serial_console_packet(to_flush);
+            // Do we need to send a packet to MGS?
+            if let Some(meta) = mgs_handler.packet_to_mgs(self.tx_buf) {
                 self.packet_to_send = Some(meta);
 
                 // Loop back to send.
@@ -344,39 +174,6 @@ impl NetHandler {
                 }
                 Err(RecvError::NotYours | RecvError::Other) => panic!(),
             }
-        }
-    }
-
-    fn build_serial_console_packet(
-        &mut self,
-        to_flush: UsartFlush<'_>,
-    ) -> UdpMetadata {
-        let message = SpMessage {
-            version: gateway_messages::version::V1,
-            kind: SpMessageKind::SerialConsole {
-                component: SpComponent::SP3_HOST_CPU,
-                offset: to_flush.usart.from_rx_offset,
-            },
-        };
-
-        let (from_rx0, from_rx1) = to_flush.usart.from_rx.as_slices();
-        let (n, written) = gateway_messages::serialize_with_trailing_data(
-            self.tx_buf,
-            &message,
-            &[from_rx0, from_rx1],
-        );
-
-        // Note: We do not wait for an ack from MGS after sending this data; we
-        // hope it receives it, but if not, it's lost. We don't have the buffer
-        // space to keep a bunch of data around waiting for acks, and in
-        // practice we don't expect lost packets to be a problem.
-        to_flush.usart.drain_flushed_data(written);
-
-        UdpMetadata {
-            addr: Address::Ipv6(to_flush.destination.ip.into()),
-            port: to_flush.destination.port,
-            size: n as u32,
-            vid: vlan_id_from_sp_port(to_flush.port),
         }
     }
 
@@ -433,95 +230,6 @@ fn vlan_id_from_sp_port(port: SpPort) -> u16 {
         SpPort::One => VLAN_RANGE.start,
         SpPort::Two => VLAN_RANGE.start + 1,
     }
-}
-
-fn configure_usart() -> Usart {
-    use drv_stm32h7_usart::device;
-    use drv_stm32h7_usart::drv_stm32xx_sys_api::*;
-
-    // TODO: this module should _not_ know our clock rate. That's a hack.
-    const CLOCK_HZ: u32 = 100_000_000;
-
-    const BAUD_RATE: u32 = 115_200;
-
-    let usart;
-    let peripheral;
-    let pins;
-
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "usart1")] {
-            const PINS: &[(PinSet, Alternate)] = &[
-                (Port::B.pin(6).and_pin(7), Alternate::AF7),
-            ];
-
-            // From thin air, pluck a pointer to the USART register block.
-            //
-            // Safety: this is needlessly unsafe in the API. The USART is
-            // essentially a static, and we access it through a & reference so
-            // aliasing is not a concern. Were it literally a static, we could
-            // just reference it.
-            usart = unsafe { &*device::USART1::ptr() };
-            peripheral = Peripheral::Usart1;
-            pins = PINS;
-        } else if #[cfg(feature = "usart2")] {
-            const PINS: &[(PinSet, Alternate)] = &[
-                (Port::D.pin(5).and_pin(6), Alternate::AF7),
-            ];
-            usart = unsafe { &*device::USART2::ptr() };
-            peripheral = Peripheral::Usart2;
-            pins = PINS;
-        } else {
-            compile_error!("no usartX feature specified");
-        }
-    }
-
-    Usart::turn_on(
-        &Sys::from(SYS.get_task_id()),
-        usart,
-        peripheral,
-        pins,
-        CLOCK_HZ,
-        BAUD_RATE,
-    )
-}
-
-trait DequeExt {
-    fn drain_front(&mut self, n: usize);
-}
-
-impl<T, const N: usize> DequeExt for Deque<T, N> {
-    fn drain_front(&mut self, n: usize) {
-        for _ in 0..n {
-            self.pop_front().unwrap_lite();
-        }
-    }
-}
-
-/// For our buffers for interacting with the USART FIFO, we want `Deque`s rather
-/// than `ArrayVec`s to allow (relatively) cheaply popping data off the front as
-/// its transferred in/out of the FIFO.
-fn claim_uart_bufs_static(
-) -> [&'static mut Deque<u8, { gateway_messages::MAX_SERIALIZED_SIZE }>; 2] {
-    use core::sync::atomic::{AtomicBool, Ordering};
-    static mut UART_RX_BUF: Deque<
-        u8,
-        { gateway_messages::MAX_SERIALIZED_SIZE },
-    > = Deque::new();
-    static mut UART_TX_BUF: Deque<
-        u8,
-        { gateway_messages::MAX_SERIALIZED_SIZE },
-    > = Deque::new();
-
-    static TAKEN: AtomicBool = AtomicBool::new(false);
-    if TAKEN.swap(true, Ordering::Relaxed) {
-        panic!()
-    }
-
-    // Safety: unsafe because of references to mutable statics; safe because of
-    // the AtomicBool swap above, combined with the lexical scoping of
-    // `UART_{RX,TX}_BUF`, means that these references can't be aliased by any
-    // other reference in the program.
-    [unsafe { &mut UART_RX_BUF }, unsafe { &mut UART_TX_BUF }]
 }
 
 /// Grabs reference to a static array sized to hold an incoming message. Can

--- a/task/mgmt-gateway/src/mgs_handler.rs
+++ b/task/mgmt-gateway/src/mgs_handler.rs
@@ -2,31 +2,49 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{
+    vlan_id_from_sp_port, Log, MgsMessage, SYS, TIMER_IRQ, USART_IRQ, __RINGBUF,
+};
 use core::convert::Infallible;
-
-use crate::{Log, MgsMessage, UsartHandler, __RINGBUF};
+use core::sync::atomic::{AtomicBool, Ordering};
+use drv_stm32h7_usart::Usart;
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
 use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
-    SpComponent, SpPort, SpState, UpdateChunk, UpdateStart,
+    SpComponent, SpMessage, SpMessageKind, SpPort, SpState, UpdateChunk,
+    UpdateStart,
 };
+use heapless::Deque;
 use mutable_statics::mutable_statics;
 use ringbuf::ringbuf_entry;
+use task_net_api::{Address, UdpMetadata};
 use tinyvec::ArrayVec;
+use userlib::{sys_get_timer, sys_irq_control, sys_set_timer, UnwrapLite};
+
+/// Buffer sizes for serial console UDP / USART proxying.
+///
+/// MGS -> SP should be at least as large as the amount of data we can receive
+/// in a single packet; otherwise MGS will have to resend data in subsequent
+/// packets.
+///
+/// SP -> MGS can be whatever size we want, but the larger it is the less likely
+/// we are to lose data while waiting to flush from our buffer out to UDP.
+const MGS_TO_SP_SERIAL_CONSOLE_BUFFER_SIZE: usize =
+    gateway_messages::MAX_SERIALIZED_SIZE;
+const SP_TO_MGS_SERIAL_CONSOLE_BUFFER_SIZE: usize =
+    gateway_messages::MAX_SERIALIZED_SIZE;
+
+/// Send any buffered serial console data to MGS when our oldest buffered byte
+/// is this old, even if our buffer isn't full yet.
+const SERIAL_CONSOLE_FLUSH_TIMEOUT_MILLIS: u64 = 500;
 
 // TODO How are we versioning SP images? This is a placeholder.
 const VERSION: u32 = 1;
 
-pub(crate) struct UsartFlush<'a> {
-    pub(crate) usart: &'a mut UsartHandler,
-    pub(crate) destination: SocketAddrV6,
-    pub(crate) port: SpPort,
-}
-
 pub(crate) struct MgsHandler {
-    pub(crate) usart: UsartHandler,
+    usart: UsartHandler,
     attached_serial_console_mgs: Option<(SocketAddrV6, SpPort)>,
     serial_console_write_offset: u64,
     update_task: Update,
@@ -35,7 +53,10 @@ pub(crate) struct MgsHandler {
 }
 
 impl MgsHandler {
-    pub(crate) fn new(usart: UsartHandler) -> Self {
+    /// Instantiate an `MgsHandler` that claims static buffers and device
+    /// resources. Can only be called once; will panic if called multiple times!
+    pub(crate) fn claim_static_resources() -> Self {
+        let usart = UsartHandler::claim_static_resources();
         Self {
             usart,
             attached_serial_console_mgs: None,
@@ -46,27 +67,71 @@ impl MgsHandler {
         }
     }
 
-    pub(crate) fn needs_usart_flush_to_mgs(&self) -> bool {
+    pub(crate) fn drive_usart(&mut self) {
+        self.usart.run_until_blocked();
+    }
+
+    pub(crate) fn wants_to_send_packet_to_mgs(&mut self) -> bool {
+        // Do we have an attached serial console session MGS?
+        if self.attached_serial_console_mgs.is_none() {
+            self.usart.clear_rx_data();
+            return false;
+        }
+
         self.usart.should_flush_to_mgs()
     }
 
-    pub(crate) fn flush_usart_to_mgs(&mut self) -> Option<UsartFlush<'_>> {
-        // Bail if we don't have any data to flush.
-        if !self.needs_usart_flush_to_mgs() {
+    pub(crate) fn packet_to_mgs(
+        &mut self,
+        tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Option<UdpMetadata> {
+        // Should we flush any buffered usart data out to MGS?
+        if !self.usart.should_flush_to_mgs() {
             return None;
         }
 
-        if let Some((mgs_addr, sp_port)) = self.attached_serial_console_mgs {
-            Some(UsartFlush {
-                usart: &mut self.usart,
-                destination: mgs_addr,
-                port: sp_port,
-            })
-        } else {
-            // We have data to flush but no attached MGS instance; discard it.
-            self.usart.clear_rx_data();
-            None
-        }
+        // Do we have an attached MGS instance?
+        let (mgs_addr, sp_port) = match self.attached_serial_console_mgs {
+            Some((mgs_addr, sp_port)) => (mgs_addr, sp_port),
+            None => {
+                // Discard any buffered data and reset any usart-related timers.
+                self.usart.clear_rx_data();
+                return None;
+            }
+        };
+
+        // We have data we want to flush and an attached MGS; build our packet.
+        ringbuf_entry!(Log::SerialConsoleSend {
+            buffered: self.usart.from_rx.len(),
+        });
+
+        let message = SpMessage {
+            version: gateway_messages::version::V1,
+            kind: SpMessageKind::SerialConsole {
+                component: SpComponent::SP3_HOST_CPU,
+                offset: self.usart.from_rx_offset,
+            },
+        };
+
+        let (from_rx0, from_rx1) = self.usart.from_rx.as_slices();
+        let (n, written) = gateway_messages::serialize_with_trailing_data(
+            tx_buf,
+            &message,
+            &[from_rx0, from_rx1],
+        );
+
+        // Note: We do not wait for an ack from MGS after sending this data; we
+        // hope it receives it, but if not, it's lost. We don't have the buffer
+        // space to keep a bunch of data around waiting for acks, and in
+        // practice we don't expect lost packets to be a problem.
+        self.usart.drain_flushed_data(written);
+
+        Some(UdpMetadata {
+            addr: Address::Ipv6(mgs_addr.ip.into()),
+            port: mgs_addr.port,
+            size: n as u32,
+            vid: vlan_id_from_sp_port(sp_port),
+        })
     }
 }
 
@@ -375,6 +440,257 @@ impl UpdateBuffer {
 
         Ok(())
     }
+}
+
+struct UsartHandler {
+    usart: Usart,
+    to_tx: &'static mut Deque<u8, MGS_TO_SP_SERIAL_CONSOLE_BUFFER_SIZE>,
+    from_rx: &'static mut Deque<u8, SP_TO_MGS_SERIAL_CONSOLE_BUFFER_SIZE>,
+    from_rx_flush_deadline: Option<u64>,
+    from_rx_offset: u64,
+}
+
+impl UsartHandler {
+    fn claim_static_resources() -> Self {
+        let usart = configure_usart();
+        let to_tx = claim_mgs_to_sp_usart_buf_static();
+        let from_rx = claim_sp_to_mgs_usart_buf_static();
+
+        // Enbale USART interrupts.
+        sys_irq_control(USART_IRQ, true);
+
+        Self {
+            usart,
+            to_tx,
+            from_rx,
+            from_rx_flush_deadline: None,
+            from_rx_offset: 0,
+        }
+    }
+
+    fn tx_buffer_remaining_capacity(&self) -> usize {
+        self.to_tx.capacity() - self.to_tx.len()
+    }
+
+    /// Panics if `self.tx_buffer_remaining_capacity() < data.len()`.
+    fn tx_buffer_append(&mut self, data: &[u8]) {
+        if self.to_tx.is_empty() {
+            self.usart.enable_tx_fifo_empty_interrupt();
+        }
+        for &b in data {
+            self.to_tx.push_back(b).unwrap_lite();
+        }
+    }
+
+    fn should_flush_to_mgs(&self) -> bool {
+        // Bail out early if our buffer is empty or full.
+        let len = self.from_rx.len();
+        if len == 0 {
+            return false;
+        } else if len == self.from_rx.capacity() {
+            return true;
+        }
+
+        // Otherwise, only flush if we're past our deadline.
+        self.from_rx_flush_deadline
+            .map(|deadline| sys_get_timer().now >= deadline)
+            .unwrap_or(false)
+    }
+
+    fn clear_rx_data(&mut self) {
+        self.from_rx.clear();
+        self.from_rx_flush_deadline = None;
+        sys_set_timer(None, TIMER_IRQ);
+    }
+
+    fn drain_flushed_data(&mut self, n: usize) {
+        self.from_rx.drain_front(n);
+        self.from_rx_offset += n as u64;
+        self.from_rx_flush_deadline = None;
+        self.start_flush_timer_if_needed();
+    }
+
+    fn start_flush_timer_if_needed(&mut self) {
+        if self.from_rx_flush_deadline.is_none() && !self.from_rx.is_empty() {
+            let deadline =
+                sys_get_timer().now + SERIAL_CONSOLE_FLUSH_TIMEOUT_MILLIS;
+            self.from_rx_flush_deadline = Some(deadline);
+            sys_set_timer(Some(deadline), TIMER_IRQ);
+        }
+    }
+
+    fn run_until_blocked(&mut self) {
+        // Transmit as much as we have and can.
+        let mut n_transmitted = 0;
+        for &b in &*self.to_tx {
+            if self.usart.try_tx_push(b) {
+                n_transmitted += 1;
+            } else {
+                break;
+            }
+        }
+
+        // Clean up / ringbuf debug log after transmitting.
+        if n_transmitted > 0 {
+            ringbuf_entry!(Log::UsartTx {
+                num_bytes: n_transmitted
+            });
+            self.to_tx.drain_front(n_transmitted);
+        }
+        if self.to_tx.is_empty() {
+            self.usart.disable_tx_fifo_empty_interrupt();
+        } else {
+            ringbuf_entry!(Log::UsartTxFull {
+                remaining: self.to_tx.len()
+            });
+        }
+
+        // Clear any errors.
+        if self.usart.check_and_clear_rx_overrun() {
+            ringbuf_entry!(Log::UsartRxOverrun);
+            // TODO-correctness Should we notify MGS of dropped data here? We
+            // could increment `self.from_rx_offset`, but (a) we don't know how
+            // much data we lost, and (b) it would indicate lost data in the
+            // wrong place (i.e., data lost at the current
+            // `self.from_rx_offset`, instead of `self.from_rx_offset +
+            // self.from_rx.len()`, which is where we actually are now).
+        }
+
+        // Recv as much as we can from the USART FIFO, even if we have to
+        // discard old data to do so.
+        let mut n_received = 0;
+        let mut discarded_data = 0;
+        while let Some(b) = self.usart.try_rx_pop() {
+            n_received += 1;
+            match self.from_rx.push_back(b) {
+                Ok(()) => (),
+                Err(b) => {
+                    // If `push_back` failed, we know there is at least one
+                    // item, allowing us to unwrap `pop_front`. At that point we
+                    // know there's space for at least one, allowing us to
+                    // unwrap a subsequent `push_back`.
+                    self.from_rx.pop_front().unwrap_lite();
+                    self.from_rx.push_back(b).unwrap_lite();
+                    discarded_data += 1;
+                }
+            }
+        }
+
+        // Update our offset, which will allow MGS to know we discarded data,
+        // and log that fact locally via ringbuf.
+        self.from_rx_offset += discarded_data;
+        if discarded_data > 0 {
+            ringbuf_entry!(Log::UsartRxBufferDataDropped {
+                num_bytes: discarded_data
+            });
+        }
+
+        if n_received > 0 {
+            ringbuf_entry!(Log::UsartRx {
+                num_bytes: n_received
+            });
+            self.start_flush_timer_if_needed();
+        }
+
+        // Re-enable USART interrupts.
+        sys_irq_control(USART_IRQ, true);
+    }
+}
+
+fn configure_usart() -> Usart {
+    use drv_stm32h7_usart::device;
+    use drv_stm32h7_usart::drv_stm32xx_sys_api::*;
+
+    // TODO: this module should _not_ know our clock rate. That's a hack.
+    const CLOCK_HZ: u32 = 100_000_000;
+
+    const BAUD_RATE: u32 = 115_200;
+
+    let usart;
+    let peripheral;
+    let pins;
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "usart1")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::B.pin(6).and_pin(7), Alternate::AF7),
+            ];
+
+            // From thin air, pluck a pointer to the USART register block.
+            //
+            // Safety: this is needlessly unsafe in the API. The USART is
+            // essentially a static, and we access it through a & reference so
+            // aliasing is not a concern. Were it literally a static, we could
+            // just reference it.
+            usart = unsafe { &*device::USART1::ptr() };
+            peripheral = Peripheral::Usart1;
+            pins = PINS;
+        } else if #[cfg(feature = "usart2")] {
+            const PINS: &[(PinSet, Alternate)] = &[
+                (Port::D.pin(5).and_pin(6), Alternate::AF7),
+            ];
+            usart = unsafe { &*device::USART2::ptr() };
+            peripheral = Peripheral::Usart2;
+            pins = PINS;
+        } else {
+            compile_error!("no usartX feature specified");
+        }
+    }
+
+    Usart::turn_on(
+        &Sys::from(SYS.get_task_id()),
+        usart,
+        peripheral,
+        pins,
+        CLOCK_HZ,
+        BAUD_RATE,
+    )
+}
+
+trait DequeExt {
+    fn drain_front(&mut self, n: usize);
+}
+
+impl<T, const N: usize> DequeExt for Deque<T, N> {
+    fn drain_front(&mut self, n: usize) {
+        for _ in 0..n {
+            self.pop_front().unwrap_lite();
+        }
+    }
+}
+
+fn claim_mgs_to_sp_usart_buf_static(
+) -> &'static mut Deque<u8, MGS_TO_SP_SERIAL_CONSOLE_BUFFER_SIZE> {
+    static mut UART_TX_BUF: Deque<u8, MGS_TO_SP_SERIAL_CONSOLE_BUFFER_SIZE> =
+        Deque::new();
+
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::Relaxed) {
+        panic!()
+    }
+
+    // Safety: unsafe because of references to mutable statics; safe because of
+    // the AtomicBool swap above, combined with the lexical scoping of
+    // `UART_TX_BUF`, means that this reference can't be aliased by any
+    // other reference in the program.
+    unsafe { &mut UART_TX_BUF }
+}
+
+fn claim_sp_to_mgs_usart_buf_static(
+) -> &'static mut Deque<u8, SP_TO_MGS_SERIAL_CONSOLE_BUFFER_SIZE> {
+    static mut UART_RX_BUF: Deque<u8, SP_TO_MGS_SERIAL_CONSOLE_BUFFER_SIZE> =
+        Deque::new();
+
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::Relaxed) {
+        panic!()
+    }
+
+    // Safety: unsafe because of references to mutable statics; safe because of
+    // the AtomicBool swap above, combined with the lexical scoping of
+    // `UART_RX_BUF`, means that this reference can't be aliased by any
+    // other reference in the program.
+    unsafe { &mut UART_RX_BUF }
 }
 
 /// Grabs reference to a static `UpdateBuffer`. Can only be called once!


### PR DESCRIPTION
Builds on #737. No functional changes. Moves usart logic out of main and into `mgs_handler` (which will become the gimlet-specific MGS handler in a subsequent PR), and renames a few methods. Review can be light.