### PR TITLE
Add mgmt-gateway to gimlet/sidecar/psc builds

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -34,7 +34,7 @@ on-state-change = {net = {bit-number = 3}}
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy"]
+request_reset = ["hiffy", "mgmt_gateway"]
 
 [tasks.net]
 name = "task-net"
@@ -177,6 +177,15 @@ uses = ["quadspi"]
 interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
+[tasks.update_server]
+name = "stm32h7-update-server"
+priority = 3
+max-sizes = {flash = 16384, ram = 4096}
+stacksize = 2048
+start = true
+uses = ["flash_controller", "bank2"]
+interrupts = {"flash_controller.irq" = 0b1}
+
 [tasks.sensor]
 name = "task-sensor"
 features = ["itm"]
@@ -211,6 +220,20 @@ stacksize = 4096
 start = true
 task-slots = ["net"]
 features = ["vlan"]
+
+[tasks.mgmt_gateway]
+name = "task-mgmt-gateway"
+priority = 6
+max-sizes = {flash = 32768, ram = 8192}
+stacksize = 1536
+start = true
+uses = [
+    "usart1",
+    "system_flash", # TODO also used by `net`, both to read the stm32 uid
+]
+task-slots = ["jefe", "net", "update_server", "sys"]
+features = ["gimlet", "usart1", "vlan"]
+interrupts = {"usart1.irq" = 0b10}
 
 [tasks.validate]
 name = "task-validate"
@@ -777,3 +800,10 @@ owner = {name = "udprpc", notification = 1}
 port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.mgmt_gateway]
+kind = "udp"
+owner = {name = "mgmt_gateway", notification = 0b01}
+port = 11111 # TODO do we have a documented port for MGS traffic?
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -149,7 +149,7 @@ uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
 ]
 task-slots = ["jefe", "net", "update_server", "sys"]
-features = ["usart1", "vlan"]
+features = ["gimlet", "usart1", "vlan"]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.validate]

--- a/app/psc/app.toml
+++ b/app/psc/app.toml
@@ -85,6 +85,15 @@ task-slots = ["sys"]
 "i2c4.event" = 0b0000_1000
 "i2c4.error" = 0b0000_1000
 
+[tasks.update_server]
+name = "stm32h7-update-server"
+priority = 2
+max-sizes = {flash = 16384, ram = 4096}
+stacksize = 2048
+start = true
+uses = ["flash_controller", "bank2"]
+interrupts = {"flash_controller.irq" = 0b1}
+
 [tasks.hiffy]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
@@ -105,6 +114,18 @@ uses = ["eth", "eth_dma", "system_flash"]
 start = true
 interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }]
+
+[tasks.mgmt_gateway]
+name = "task-mgmt-gateway"
+priority = 4
+max-sizes = {flash = 32768, ram = 8192}
+stacksize = 1536
+start = true
+uses = [
+    "system_flash", # TODO also used by `net`, both to read the stm32 uid
+]
+task-slots = ["jefe", "net", "update_server", "sys"]
+features = ["psc", "vlan"]
 
 [tasks.udpecho]
 name = "task-udpecho"
@@ -359,3 +380,10 @@ owner = {name = "udprpc", notification = 1}
 port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.mgmt_gateway]
+kind = "udp"
+owner = {name = "mgmt_gateway", notification = 0b01}
+port = 11111 # TODO do we have a documented port for MGS traffic?
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -7,7 +7,7 @@ memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"
-requires = {flash = 22776, ram = 5424}
+requires = {flash = 22776, ram = 5840}
 #
 # For the kernel (and for any task that logs), we are required to enable
 # either "itm" (denoting logging/panicking via ARM's Instrumentation Trace
@@ -97,6 +97,15 @@ task-slots = ["sys"]
 [tasks.spi5_driver.config.spi]
 global_config = "spi5"
 
+[tasks.update_server]
+name = "stm32h7-update-server"
+priority = 3
+max-sizes = {flash = 16384, ram = 4096}
+stacksize = 2048
+start = true
+uses = ["flash_controller", "bank2"]
+interrupts = {"flash_controller.irq" = 0b1}
+
 [tasks.net]
 name = "task-net"
 stacksize = 4640
@@ -110,6 +119,18 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys",
               { spi_driver = "spi3_driver" },
               { seq = "sequencer" }]
+
+[tasks.mgmt_gateway]
+name = "task-mgmt-gateway"
+priority = 6
+max-sizes = {flash = 32768, ram = 8192}
+stacksize = 1536
+start = true
+uses = [
+    "system_flash", # TODO also used by `net`, both to read the stm32 uid
+]
+task-slots = ["jefe", "net", "update_server", "sys"]
+features = ["sidecar", "vlan"]
 
 [tasks.udpecho]
 name = "task-udpecho"
@@ -746,3 +767,10 @@ owner = {name = "udprpc", notification = 1}
 port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.mgmt_gateway]
+kind = "udp"
+owner = {name = "mgmt_gateway", notification = 0b01}
+port = 11111 # TODO do we have a documented port for MGS traffic?
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -23,6 +23,10 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "f2e6237e57a36873fc748b6ecd9e42b8ef208c88"}
 
 [features]
+gimlet = []
+sidecar = []
+psc = []
+
 vlan = ["task-net-api/vlan"]
 usart1 = []
 usart2 = []

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -16,6 +16,16 @@ use task_net_api::{
 };
 use userlib::{sys_recv_closed, task_slot, TaskId, UnwrapLite};
 
+mod mgs_common;
+
+// If the build system enables multiple of the gimlet/sidecar/psc features, this
+// sequence of `cfg_attr`s will trigger an unused_attributes warning. We can
+// turn this into a hard error via this `deny`, which will catch any such build
+// system misconfiguration.
+#[deny(unused_attributes)]
+#[cfg_attr(feature = "gimlet", path = "mgs_gimlet.rs")]
+#[cfg_attr(feature = "sidecar", path = "mgs_sidecar.rs")]
+#[cfg_attr(feature = "psc", path = "mgs_psc.rs")]
 mod mgs_handler;
 
 use self::mgs_handler::MgsHandler;
@@ -27,6 +37,7 @@ task_slot!(NET, net);
 task_slot!(SYS, sys);
 task_slot!(UPDATE_SERVER, update_server);
 
+#[allow(dead_code)] // Not all cases are used by all variants
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Log {
     Empty,
@@ -222,6 +233,7 @@ fn sp_port_from_udp_metadata(meta: &UdpMetadata) -> SpPort {
     }
 }
 
+#[allow(dead_code)]
 fn vlan_id_from_sp_port(port: SpPort) -> u16 {
     use task_net_api::VLAN_RANGE;
     assert_eq!(VLAN_RANGE.len(), 2);

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -1,0 +1,226 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::convert::Infallible;
+
+use crate::{Log, MgsMessage, __RINGBUF};
+use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
+use drv_update_api::{Update, UpdateTarget};
+use gateway_messages::{
+    DiscoverResponse, ResponseError, SpPort, SpState,
+    UpdateChunk, UpdateStart,
+};
+use mutable_statics::mutable_statics;
+use ringbuf::ringbuf_entry;
+use tinyvec::ArrayVec;
+
+// TODO How are we versioning SP images? This is a placeholder.
+const VERSION: u32 = 1;
+
+/// Provider of MGS handler logic common to all targets (gimlet, sidecar, psc).
+pub(crate) struct MgsCommon {
+    update_task: Update,
+    // TODO: Make this non-`Option` and use new update abort APIs.
+    update_buf: Option<&'static mut UpdateBuffer>,
+    reset_requested: bool,
+}
+
+impl MgsCommon {
+    pub(crate) fn claim_static_resources() -> Self {
+        Self {
+            update_task: Update::from(crate::UPDATE_SERVER.get_task_id()),
+            update_buf: None,
+            reset_requested: false,
+        }
+    }
+
+    pub(crate) fn discover(
+        &mut self,
+        port: SpPort,
+    ) -> Result<DiscoverResponse, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::Discovery));
+        Ok(DiscoverResponse { sp_port: port })
+    }
+
+    pub(crate) fn sp_state(&mut self) -> Result<SpState, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SpState));
+
+        // TODO Replace with the real serial number once it's available; for now
+        // use the stm32 96-bit uid
+        let mut serial_number = [0; 16];
+        for (to, from) in serial_number.iter_mut().zip(
+            drv_stm32xx_uid::read_uid()
+                .iter()
+                .map(|x| x.to_be_bytes())
+                .flatten(),
+        ) {
+            *to = from;
+        }
+
+        Ok(SpState {
+            serial_number,
+            version: VERSION,
+        })
+    }
+
+    pub(crate) fn update_start(
+        &mut self,
+        update: UpdateStart,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStart {
+            length: update.total_size
+        }));
+
+        if let Some(progress) = self.update_buf.as_ref() {
+            return Err(ResponseError::UpdateInProgress {
+                bytes_received: progress.bytes_written as u32,
+            });
+        }
+
+        self.update_task
+            .prep_image_update(UpdateTarget::Alternate)
+            .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+
+        // We can only call `claim_update_buffer_static` once; we bail out above
+        // if `self.update_buf` is already `Some(_)`, and after we claim it
+        // here, we store that into `self.update_buf` (and never clear it).
+        let update_buffer = claim_update_buffer_static();
+        update_buffer.total_length = update.total_size as usize;
+        self.update_buf = Some(update_buffer);
+
+        Ok(())
+    }
+
+    pub(crate) fn update_chunk(
+        &mut self,
+        chunk: UpdateChunk,
+        data: &[u8],
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+            offset: chunk.offset,
+        }));
+
+        let update_buf = self
+            .update_buf
+            .as_mut()
+            .ok_or(ResponseError::InvalidUpdateChunk)?;
+
+        update_buf.ingest_chunk(&self.update_task, chunk.offset, data)?;
+
+        Ok(())
+    }
+
+    pub(crate) fn reset_prepare(&mut self) -> Result<(), ResponseError> {
+        // TODO: Add some kind of auth check before performing a reset.
+        // https://github.com/oxidecomputer/hubris/issues/723
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SysResetPrepare));
+        self.reset_requested = true;
+        Ok(())
+    }
+
+    pub(crate) fn reset_trigger(
+        &mut self,
+    ) -> Result<Infallible, ResponseError> {
+        // TODO: Add some kind of auth check before performing a reset.
+        // https://github.com/oxidecomputer/hubris/issues/723
+        if !self.reset_requested {
+            return Err(ResponseError::SysResetTriggerWithoutPrepare);
+        }
+
+        let jefe = task_jefe_api::Jefe::from(crate::JEFE.get_task_id());
+        jefe.request_reset();
+
+        // If `request_reset()` returns, something has gone very wrong.
+        panic!()
+    }
+}
+
+#[derive(Default)]
+struct UpdateBuffer {
+    total_length: usize,
+    bytes_written: usize,
+    current_block: ArrayVec<[u8; BLOCK_SIZE_BYTES]>,
+}
+
+impl UpdateBuffer {
+    fn ingest_chunk(
+        &mut self,
+        update_task: &Update,
+        offset: u32,
+        mut data: &[u8],
+    ) -> Result<(), ResponseError> {
+        // Reject chunks that don't match our current progress.
+        if offset as usize != self.bytes_written {
+            return Err(ResponseError::UpdateInProgress {
+                bytes_received: self.bytes_written as u32,
+            });
+        }
+
+        // Reject chunks that would go past the total size we're expecting.
+        if self.bytes_written + data.len() > self.total_length {
+            return Err(ResponseError::InvalidUpdateChunk);
+        }
+
+        while !data.is_empty() {
+            let cap = self.current_block.capacity() - self.current_block.len();
+            assert!(cap > 0);
+            let to_copy = usize::min(cap, data.len());
+
+            let current_block_index = self.bytes_written / BLOCK_SIZE_BYTES;
+            self.current_block.extend_from_slice(&data[..to_copy]);
+            data = &data[to_copy..];
+            self.bytes_written += to_copy;
+
+            // If the block is full or this is the final block, send it to the
+            // update task.
+            if self.current_block.len() == self.current_block.capacity()
+                || self.bytes_written == self.total_length
+            {
+                let result = update_task
+                    .write_one_block(current_block_index, &self.current_block)
+                    .map_err(|err| ResponseError::UpdateFailed(err as u32));
+
+                // Unconditionally clear our block buffer after attempting to
+                // write the block.
+                let n = self.current_block.len();
+                self.current_block.clear();
+
+                // If writing this block failed, roll back our `bytes_written`
+                // counter to the beginning of the block we just tried to write.
+                if let Err(err) = result {
+                    self.bytes_written -= n;
+                    return Err(err);
+                }
+            }
+        }
+
+        // Finalizing the update is implicit (we finalize if we just wrote the
+        // last block). Should we make it explict somehow? Maybe that comes with
+        // adding auth / code signing?
+        if self.bytes_written == self.total_length {
+            update_task
+                .finish_image_update()
+                .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+            ringbuf_entry!(Log::UpdateComplete);
+        } else {
+            ringbuf_entry!(Log::UpdatePartial {
+                bytes_written: self.bytes_written
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Grabs reference to a static `UpdateBuffer`. Can only be called once!
+fn claim_update_buffer_static() -> &'static mut UpdateBuffer {
+    // TODO: `mutable_statics!` is currently limited in what inputs it accepts,
+    // and in particular only accepts static mut arrays. We only want a single
+    // `UpdateBuffer`, so we create an array of length 1 and grab its only
+    // element.
+    let update_buffer_array = mutable_statics! {
+        static mut BUF: [UpdateBuffer; 1] = [Default::default(); _];
+    };
+    &mut update_buffer_array[0]
+}

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -8,8 +8,7 @@ use crate::{Log, MgsMessage, __RINGBUF};
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
 use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
-    DiscoverResponse, ResponseError, SpPort, SpState,
-    UpdateChunk, UpdateStart,
+    DiscoverResponse, ResponseError, SpPort, SpState, UpdateChunk, UpdateStart,
 };
 use mutable_statics::mutable_statics;
 use ringbuf::ringbuf_entry;

--- a/task/mgmt-gateway/src/mgs_gimlet.rs
+++ b/task/mgmt-gateway/src/mgs_gimlet.rs
@@ -3,13 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
-    vlan_id_from_sp_port, Log, MgsMessage, SYS, TIMER_IRQ, USART_IRQ, __RINGBUF,
+    mgs_common::MgsCommon, vlan_id_from_sp_port, Log, MgsMessage, SYS,
+    TIMER_IRQ, USART_IRQ, __RINGBUF,
 };
 use core::convert::Infallible;
 use core::sync::atomic::{AtomicBool, Ordering};
 use drv_stm32h7_usart::Usart;
-use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
-use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
@@ -40,16 +39,11 @@ const SP_TO_MGS_SERIAL_CONSOLE_BUFFER_SIZE: usize =
 /// is this old, even if our buffer isn't full yet.
 const SERIAL_CONSOLE_FLUSH_TIMEOUT_MILLIS: u64 = 500;
 
-// TODO How are we versioning SP images? This is a placeholder.
-const VERSION: u32 = 1;
-
 pub(crate) struct MgsHandler {
+    common: MgsCommon,
     usart: UsartHandler,
     attached_serial_console_mgs: Option<(SocketAddrV6, SpPort)>,
     serial_console_write_offset: u64,
-    update_task: Update,
-    update_progress: Option<&'static mut UpdateBuffer>,
-    reset_requested: bool,
 }
 
 impl MgsHandler {
@@ -58,12 +52,10 @@ impl MgsHandler {
     pub(crate) fn claim_static_resources() -> Self {
         let usart = UsartHandler::claim_static_resources();
         Self {
+            common: MgsCommon::claim_static_resources(),
             usart,
             attached_serial_console_mgs: None,
             serial_console_write_offset: 0,
-            update_task: Update::from(crate::UPDATE_SERVER.get_task_id()),
-            update_progress: None,
-            reset_requested: false,
         }
     }
 
@@ -141,8 +133,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<DiscoverResponse, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::Discovery));
-        Ok(DiscoverResponse { sp_port: port })
+        self.common.discover(port)
     }
 
     fn ignition_state(
@@ -183,24 +174,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<SpState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SpState));
-
-        // TODO Replace with the real serial number once it's available; for now
-        // use the stm32 96-bit uid
-        let mut serial_number = [0; 16];
-        for (to, from) in serial_number.iter_mut().zip(
-            drv_stm32xx_uid::read_uid()
-                .iter()
-                .map(|x| x.to_be_bytes())
-                .flatten(),
-        ) {
-            *to = from;
-        }
-
-        Ok(SpState {
-            serial_number,
-            version: VERSION,
-        })
+        self.common.sp_state()
     }
 
     fn update_start(
@@ -209,28 +183,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: UpdateStart,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStart {
-            length: update.total_size
-        }));
-
-        if let Some(progress) = self.update_progress.as_ref() {
-            return Err(ResponseError::UpdateInProgress {
-                bytes_received: progress.bytes_written as u32,
-            });
-        }
-
-        self.update_task
-            .prep_image_update(UpdateTarget::Alternate)
-            .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
-
-        // We can only call `claim_update_buffer_static` once; we bail out above
-        // if `self.update_progress` is already `Some(_)`, and after we claim it
-        // here, we store that into `self.update_progress` (and never clear it).
-        let update_buffer = claim_update_buffer_static();
-        update_buffer.total_length = update.total_size as usize;
-        self.update_progress = Some(update_buffer);
-
-        Ok(())
+        self.common.update_start(update)
     }
 
     fn update_chunk(
@@ -240,18 +193,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
-            offset: chunk.offset,
-        }));
-
-        let update_progress = self
-            .update_progress
-            .as_mut()
-            .ok_or(ResponseError::InvalidUpdateChunk)?;
-
-        update_progress.ingest_chunk(&self.update_task, chunk.offset, data)?;
-
-        Ok(())
+        self.common.update_chunk(chunk, data)
     }
 
     fn serial_console_attach(
@@ -339,11 +281,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), ResponseError> {
-        // TODO: Add some kind of auth check before performing a reset.
-        // https://github.com/oxidecomputer/hubris/issues/723
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SysResetPrepare));
-        self.reset_requested = true;
-        Ok(())
+        self.common.reset_prepare()
     }
 
     fn reset_trigger(
@@ -351,94 +289,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<Infallible, ResponseError> {
-        // TODO: Add some kind of auth check before performing a reset.
-        // https://github.com/oxidecomputer/hubris/issues/723
-        if !self.reset_requested {
-            return Err(ResponseError::SysResetTriggerWithoutPrepare);
-        }
-
-        let jefe = task_jefe_api::Jefe::from(crate::JEFE.get_task_id());
-        jefe.request_reset();
-
-        // If `request_reset()` returns, something has gone very wrong.
-        panic!()
-    }
-}
-
-#[derive(Default)]
-struct UpdateBuffer {
-    total_length: usize,
-    bytes_written: usize,
-    current_block: ArrayVec<[u8; BLOCK_SIZE_BYTES]>,
-}
-
-impl UpdateBuffer {
-    fn ingest_chunk(
-        &mut self,
-        update_task: &Update,
-        offset: u32,
-        mut data: &[u8],
-    ) -> Result<(), ResponseError> {
-        // Reject chunks that don't match our current progress.
-        if offset as usize != self.bytes_written {
-            return Err(ResponseError::UpdateInProgress {
-                bytes_received: self.bytes_written as u32,
-            });
-        }
-
-        // Reject chunks that would go past the total size we're expecting.
-        if self.bytes_written + data.len() > self.total_length {
-            return Err(ResponseError::InvalidUpdateChunk);
-        }
-
-        while !data.is_empty() {
-            let cap = self.current_block.capacity() - self.current_block.len();
-            assert!(cap > 0);
-            let to_copy = usize::min(cap, data.len());
-
-            let current_block_index = self.bytes_written / BLOCK_SIZE_BYTES;
-            self.current_block.extend_from_slice(&data[..to_copy]);
-            data = &data[to_copy..];
-            self.bytes_written += to_copy;
-
-            // If the block is full or this is the final block, send it to the
-            // update task.
-            if self.current_block.len() == self.current_block.capacity()
-                || self.bytes_written == self.total_length
-            {
-                let result = update_task
-                    .write_one_block(current_block_index, &self.current_block)
-                    .map_err(|err| ResponseError::UpdateFailed(err as u32));
-
-                // Unconditionally clear our block buffer after attempting to
-                // write the block.
-                let n = self.current_block.len();
-                self.current_block.clear();
-
-                // If writing this block failed, roll back our `bytes_written`
-                // counter to the beginning of the block we just tried to write.
-                if let Err(err) = result {
-                    self.bytes_written -= n;
-                    return Err(err);
-                }
-            }
-        }
-
-        // Finalizing the update is implicit (we finalize if we just wrote the
-        // last block). Should we make it explict somehow? Maybe that comes with
-        // adding auth / code signing?
-        if self.bytes_written == self.total_length {
-            update_task
-                .finish_image_update()
-                .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
-            ringbuf_entry!(Log::UpdateComplete);
-        } else {
-            ringbuf_entry!(Log::UpdatePartial {
-                bytes_written: self.bytes_written
-            });
-        }
-
-        Ok(())
+        self.common.reset_trigger()
     }
 }
 
@@ -691,16 +542,4 @@ fn claim_sp_to_mgs_usart_buf_static(
     // `UART_RX_BUF`, means that this reference can't be aliased by any
     // other reference in the program.
     unsafe { &mut UART_RX_BUF }
-}
-
-/// Grabs reference to a static `UpdateBuffer`. Can only be called once!
-fn claim_update_buffer_static() -> &'static mut UpdateBuffer {
-    // TODO: `mutable_statics!` is currently limited in what inputs it accepts,
-    // and in particular only accepts static mut arrays. We only want a single
-    // `UpdateBuffer`, so we create an array of length 1 and grab its only
-    // element.
-    let update_buffer_array = mutable_statics! {
-        static mut BUF: [UpdateBuffer; 1] = [Default::default(); _];
-    };
-    &mut update_buffer_array[0]
 }

--- a/task/mgmt-gateway/src/mgs_gimlet.rs
+++ b/task/mgmt-gateway/src/mgs_gimlet.rs
@@ -16,10 +16,8 @@ use gateway_messages::{
     UpdateStart,
 };
 use heapless::Deque;
-use mutable_statics::mutable_statics;
 use ringbuf::ringbuf_entry;
 use task_net_api::{Address, UdpMetadata};
-use tinyvec::ArrayVec;
 use userlib::{sys_get_timer, sys_irq_control, sys_set_timer, UnwrapLite};
 
 /// Buffer sizes for serial console UDP / USART proxying.

--- a/task/mgmt-gateway/src/mgs_psc.rs
+++ b/task/mgmt-gateway/src/mgs_psc.rs
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::convert::Infallible;
+
+use crate::{mgs_common::MgsCommon, Log, MgsMessage, __RINGBUF};
+use gateway_messages::{
+    sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
+    DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
+    SpComponent, SpPort, SpState, UpdateChunk, UpdateStart,
+};
+use ringbuf::ringbuf_entry;
+use task_net_api::UdpMetadata;
+
+pub(crate) struct MgsHandler {
+    common: MgsCommon,
+}
+
+impl MgsHandler {
+    /// Instantiate an `MgsHandler` that claims static buffers and device
+    /// resources. Can only be called once; will panic if called multiple times!
+    pub(crate) fn claim_static_resources() -> Self {
+        Self {
+            common: MgsCommon::claim_static_resources(),
+        }
+    }
+
+    pub(crate) fn drive_usart(&mut self) {}
+
+    pub(crate) fn wants_to_send_packet_to_mgs(&mut self) -> bool {
+        false
+    }
+
+    pub(crate) fn packet_to_mgs(
+        &mut self,
+        _tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Option<UdpMetadata> {
+        None
+    }
+}
+
+impl SpHandler for MgsHandler {
+    fn discover(
+        &mut self,
+        _sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<DiscoverResponse, ResponseError> {
+        self.common.discover(port)
+    }
+
+    fn ignition_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: u8,
+    ) -> Result<IgnitionState, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn bulk_ignition_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<BulkIgnitionState, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn ignition_command(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: u8,
+        command: IgnitionCommand,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+            target,
+            command
+        }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sp_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<SpState, ResponseError> {
+        self.common.sp_state()
+    }
+
+    fn update_start(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        update: UpdateStart,
+    ) -> Result<(), ResponseError> {
+        self.common.update_start(update)
+    }
+
+    fn update_chunk(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        chunk: UpdateChunk,
+        data: &[u8],
+    ) -> Result<(), ResponseError> {
+        self.common.update_chunk(chunk, data)
+    }
+
+    fn serial_console_attach(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        _component: SpComponent,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_write(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<u64, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+            offset,
+            length: data.len() as u16
+        }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_detach(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn reset_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        self.common.reset_prepare()
+    }
+
+    fn reset_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<Infallible, ResponseError> {
+        self.common.reset_trigger()
+    }
+}

--- a/task/mgmt-gateway/src/mgs_sidecar.rs
+++ b/task/mgmt-gateway/src/mgs_sidecar.rs
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::convert::Infallible;
+
+use crate::{mgs_common::MgsCommon, Log, MgsMessage, __RINGBUF};
+use gateway_messages::{
+    sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
+    DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
+    SpComponent, SpPort, SpState, UpdateChunk, UpdateStart,
+};
+use ringbuf::ringbuf_entry;
+use task_net_api::UdpMetadata;
+
+pub(crate) struct MgsHandler {
+    common: MgsCommon,
+}
+
+impl MgsHandler {
+    /// Instantiate an `MgsHandler` that claims static buffers and device
+    /// resources. Can only be called once; will panic if called multiple times!
+    pub(crate) fn claim_static_resources() -> Self {
+        Self {
+            common: MgsCommon::claim_static_resources(),
+        }
+    }
+
+    pub(crate) fn drive_usart(&mut self) {}
+
+    pub(crate) fn wants_to_send_packet_to_mgs(&mut self) -> bool {
+        false
+    }
+
+    pub(crate) fn packet_to_mgs(
+        &mut self,
+        _tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Option<UdpMetadata> {
+        None
+    }
+}
+
+impl SpHandler for MgsHandler {
+    fn discover(
+        &mut self,
+        _sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<DiscoverResponse, ResponseError> {
+        self.common.discover(port)
+    }
+
+    fn ignition_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: u8,
+    ) -> Result<IgnitionState, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn bulk_ignition_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<BulkIgnitionState, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn ignition_command(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: u8,
+        command: IgnitionCommand,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+            target,
+            command
+        }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sp_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<SpState, ResponseError> {
+        self.common.sp_state()
+    }
+
+    fn update_start(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        update: UpdateStart,
+    ) -> Result<(), ResponseError> {
+        self.common.update_start(update)
+    }
+
+    fn update_chunk(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        chunk: UpdateChunk,
+        data: &[u8],
+    ) -> Result<(), ResponseError> {
+        self.common.update_chunk(chunk, data)
+    }
+
+    fn serial_console_attach(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        _component: SpComponent,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_write(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<u64, ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+            offset,
+            length: data.len() as u16
+        }));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_detach(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn reset_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), ResponseError> {
+        self.common.reset_prepare()
+    }
+
+    fn reset_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<Infallible, ResponseError> {
+        self.common.reset_trigger()
+    }
+}


### PR DESCRIPTION
Builds on #738. The bulk of the code changes here are to break `mgs_handler.rs` up into gimlet-specific parts (serial console proxying) and common parts (updating the SP, etc.); the latter have moved to `mgs_common.rs`. What was `mgs_handler` is now `mgs_gimlet`, and this PR adds new `mgs_sidecar` and `mgs_psc` submodules (that only support the functionality provided by `mgs_common`). Exactly one of the three modules must be selected via the appropriate cargo feature. Failing to enable one feature (or enabling more than one) will result in a compilation error.