### PR TITLE
Replace tinyvec::ArrayVec with heapless::{Vec,Deque}.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,7 +3185,6 @@ dependencies = [
  "ssmarshal",
  "task-jefe-api",
  "task-net-api",
- "tinyvec",
  "userlib",
 ]
 
@@ -3426,8 +3425,8 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "drv-stm32h7-usart",
+ "heapless",
  "ringbuf",
- "tinyvec",
  "userlib",
 ]
 
@@ -3731,12 +3730,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 
 [[package]]
 name = "toml"

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -9,7 +9,6 @@ heapless = "0.7.16"
 num-traits = {version = "0.2", default-features = false}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
-tinyvec = "1.6"
 
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"]}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -30,8 +30,6 @@ mod mgs_handler;
 
 use self::mgs_handler::MgsHandler;
 
-type SerializedMessageBuf = [u8; gateway_messages::MAX_SERIALIZED_SIZE];
-
 task_slot!(JEFE, jefe);
 task_slot!(NET, net);
 task_slot!(SYS, sys);
@@ -97,7 +95,7 @@ const SOCKET: SocketName = SocketName::mgmt_gateway;
 #[export_name = "main"]
 fn main() {
     let mut mgs_handler = MgsHandler::claim_static_resources();
-    let mut net_handler = NetHandler::new(claim_net_bufs_static());
+    let mut net_handler = NetHandler::claim_static_resources();
 
     loop {
         let note = sys_recv_closed(
@@ -121,14 +119,21 @@ fn main() {
 
 struct NetHandler {
     net: Net,
-    tx_buf: &'static mut SerializedMessageBuf,
-    rx_buf: &'static mut SerializedMessageBuf,
+    tx_buf: &'static mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    rx_buf: &'static mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     packet_to_send: Option<UdpMetadata>,
 }
 
 impl NetHandler {
-    fn new(buffers: &'static mut [SerializedMessageBuf; 2]) -> Self {
-        let [tx_buf, rx_buf] = buffers;
+    fn claim_static_resources() -> Self {
+        let tx_buf = mutable_statics! {
+            static mut NET_TX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
+                [0; _];
+        };
+        let rx_buf = mutable_statics! {
+            static mut NET_RX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
+                [0; _];
+        };
         Self {
             net: Net::from(NET.get_task_id()),
             tx_buf,
@@ -241,14 +246,5 @@ fn vlan_id_from_sp_port(port: SpPort) -> u16 {
     match port {
         SpPort::One => VLAN_RANGE.start,
         SpPort::Two => VLAN_RANGE.start + 1,
-    }
-}
-
-/// Grabs reference to a static array sized to hold an incoming message. Can
-/// only be called once!
-fn claim_net_bufs_static() -> &'static mut [SerializedMessageBuf; 2] {
-    mutable_statics! {
-        static mut BUFS: [SerializedMessageBuf; 2] =
-            [[0; gateway_messages::MAX_SERIALIZED_SIZE]; _];
     }
 }

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -126,11 +126,10 @@ struct NetHandler {
 
 impl NetHandler {
     fn claim_static_resources() -> Self {
-        let tx_buf = mutable_statics! {
+        let (tx_buf, rx_buf) = mutable_statics! {
             static mut NET_TX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
                 [0; _];
-        };
-        let rx_buf = mutable_statics! {
+
             static mut NET_RX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
                 [0; _];
         };

--- a/task/uartecho/Cargo.toml
+++ b/task/uartecho/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 [dependencies]
 cfg-if = "1"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
+heapless = "0.7.16"
 ringbuf = {path = "../../lib/ringbuf"}
-tinyvec = "1.5.1"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", optional = true}


### PR DESCRIPTION
Because `heapless` data structures' `::new()` methods are const, we can
put them into statics directly. This allows us to reduce all our
`mutable_statics!` usage to plain `[u8; N]` arrays, avoiding any stack
issues related to https://github.com/oxidecomputer/hubris/issues/741.