### PR TITLE
Add `SendLeaseRead/Write` functions

### DIFF
--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -292,7 +292,7 @@ pub(crate) fn send_lease_read(
 
 ///
 /// Function to send an arbitrary message to an arbitrary task with a single
-/// read lease attached to the tail end of `rval` (shared with reply bytes)
+/// write lease attached to the tail end of `rval` (shared with reply bytes)
 ///
 /// arg2+n+2: Size of lease
 /// arg2+n+1: Number of reply bytes

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -160,6 +160,264 @@ pub(crate) fn send(
     Ok(nreply)
 }
 
+///
+/// Function to send an arbitrary message to an arbitrary task with a single
+/// read lease attached to `data`.
+///
+/// arg2+n+2: Size of lease
+/// arg2+n+1: Number of reply bytes
+/// arg2+n: Number of bytes
+/// arg2: Argument bytes
+/// arg1: Operation
+/// arg0: Task
+///
+#[allow(dead_code)]
+pub(crate) fn send_lease_read(
+    stack: &[Option<u32>],
+    data: &[u8],
+    rval: &mut [u8],
+) -> Result<usize, Failure> {
+    let mut payload = [0u8; 32];
+
+    if stack.len() < 5 {
+        return Err(Failure::Fault(Fault::MissingParameters));
+    }
+
+    let sp = stack.len();
+
+    let nlease = match stack[sp - 1] {
+        Some(nlease) => nlease as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(5)));
+        }
+    };
+    if nlease > data.len() {
+        return Err(Failure::Fault(Fault::BadParameter(5)));
+    }
+
+    let nreply = match stack[sp - 2] {
+        Some(nreply) => nreply as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(4)));
+        }
+    };
+
+    if nreply > rval.len() {
+        return Err(Failure::Fault(Fault::ReturnStackOverflow));
+    }
+
+    let nbytes = match stack[sp - 3] {
+        Some(nbytes) => nbytes as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(3)));
+        }
+    };
+
+    if stack.len() < nbytes + 5 {
+        return Err(Failure::Fault(Fault::StackUnderflow));
+    }
+
+    let fp = sp - (nbytes + 5);
+
+    let task = match stack[fp + 0] {
+        Some(task) => {
+            if task >= NUM_TASKS as u32 {
+                return Err(Failure::Fault(Fault::BadParameter(0)));
+            }
+
+            let prototype =
+                TaskId::for_index_and_gen(task as usize, Generation::default());
+
+            sys_refresh_task_id(prototype)
+        }
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(0)));
+        }
+    };
+
+    let op = match stack[fp + 1] {
+        Some(op) => {
+            if op > core::u16::MAX.into() {
+                return Err(Failure::Fault(Fault::BadParameter(1)));
+            }
+
+            op as u16
+        }
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(1)));
+        }
+    };
+
+    //
+    // Time to assemble the actual bytes of our payload.
+    //
+    if nbytes > payload.len() {
+        return Err(Failure::Fault(Fault::StackUnderflow));
+    }
+
+    let base = fp + 2;
+
+    for i in base..base + nbytes {
+        payload[i - base] = match stack[i] {
+            Some(byte) => {
+                if byte > core::u8::MAX.into() {
+                    return Err(Failure::Fault(Fault::BadParameter(2)));
+                }
+
+                byte as u8
+            }
+            None => {
+                return Err(Failure::Fault(Fault::EmptyParameter(2)));
+            }
+        };
+    }
+
+    //
+    // We have it all! Time to send.
+    //
+    let (code, _) = sys_send(
+        task,
+        op,
+        &payload[0..nbytes],
+        &mut rval[0..nreply],
+        &[userlib::Lease::read_only(&data[..nlease])],
+    );
+
+    if code != 0 {
+        return Err(Failure::FunctionError(code));
+    }
+
+    Ok(nreply)
+}
+
+///
+/// Function to send an arbitrary message to an arbitrary task with a single
+/// read lease attached to the tail end of `rval` (shared with reply bytes)
+///
+/// arg2+n+2: Size of lease
+/// arg2+n+1: Number of reply bytes
+/// arg2+n: Number of bytes
+/// arg2: Argument bytes
+/// arg1: Operation
+/// arg0: Task
+///
+#[allow(dead_code)]
+pub(crate) fn send_lease_write(
+    stack: &[Option<u32>],
+    _data: &[u8],
+    rval: &mut [u8],
+) -> Result<usize, Failure> {
+    let mut payload = [0u8; 32];
+
+    if stack.len() < 5 {
+        return Err(Failure::Fault(Fault::MissingParameters));
+    }
+
+    let sp = stack.len();
+
+    let nlease = match stack[sp - 1] {
+        Some(nlease) => nlease as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(5)));
+        }
+    };
+
+    let nreply = match stack[sp - 2] {
+        Some(nreply) => nreply as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(4)));
+        }
+    };
+
+    if nreply + nlease > rval.len() {
+        return Err(Failure::Fault(Fault::ReturnStackOverflow));
+    }
+
+    let nbytes = match stack[sp - 3] {
+        Some(nbytes) => nbytes as usize,
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(3)));
+        }
+    };
+
+    if stack.len() < nbytes + 5 {
+        return Err(Failure::Fault(Fault::StackUnderflow));
+    }
+
+    let fp = sp - (nbytes + 5);
+
+    let task = match stack[fp + 0] {
+        Some(task) => {
+            if task >= NUM_TASKS as u32 {
+                return Err(Failure::Fault(Fault::BadParameter(0)));
+            }
+
+            let prototype =
+                TaskId::for_index_and_gen(task as usize, Generation::default());
+
+            sys_refresh_task_id(prototype)
+        }
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(0)));
+        }
+    };
+
+    let op = match stack[fp + 1] {
+        Some(op) => {
+            if op > core::u16::MAX.into() {
+                return Err(Failure::Fault(Fault::BadParameter(1)));
+            }
+
+            op as u16
+        }
+        None => {
+            return Err(Failure::Fault(Fault::EmptyParameter(1)));
+        }
+    };
+
+    //
+    // Time to assemble the actual bytes of our payload.
+    //
+    if nbytes > payload.len() {
+        return Err(Failure::Fault(Fault::StackUnderflow));
+    }
+
+    let base = fp + 2;
+
+    for i in base..base + nbytes {
+        payload[i - base] = match stack[i] {
+            Some(byte) => {
+                if byte > core::u8::MAX.into() {
+                    return Err(Failure::Fault(Fault::BadParameter(2)));
+                }
+
+                byte as u8
+            }
+            None => {
+                return Err(Failure::Fault(Fault::EmptyParameter(2)));
+            }
+        };
+    }
+
+    //
+    // We have it all! Time to send.
+    //
+    let (rval, lease) = rval.split_at_mut(nreply);
+    let (code, _) = sys_send(
+        task,
+        op,
+        &payload[0..nbytes],
+        rval,
+        &[userlib::Lease::write_only(&mut lease[..nlease])],
+    );
+
+    if code != 0 {
+        return Err(Failure::FunctionError(code));
+    }
+
+    Ok(nreply)
+}
+
 #[cfg(feature = "spi")]
 fn spi_args(stack: &[Option<u32>]) -> Result<(TaskId, u8, usize), Failure> {
     if stack.len() < 3 {

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -415,7 +415,7 @@ pub(crate) fn send_lease_write(
         return Err(Failure::FunctionError(code));
     }
 
-    Ok(nreply)
+    Ok(nreply + nlease)
 }
 
 #[cfg(feature = "spi")]

--- a/task/hiffy/src/generic.rs
+++ b/task/hiffy/src/generic.rs
@@ -15,8 +15,12 @@ pub enum Functions {
 #[no_mangle]
 static HIFFY_FUNCTIONS: Option<&Functions> = None;
 
-pub(crate) static HIFFY_FUNCS: &[Function] =
-    &[crate::common::sleep, crate::common::send];
+pub(crate) static HIFFY_FUNCS: &[Function] = &[
+    crate::common::sleep,
+    crate::common::send,
+    crate::common::send_lease_read,
+    crate::common::send_lease_write,
+];
 
 pub(crate) fn trace_execute(_offset: usize, _op: hif::Op) {}
 

--- a/task/hiffy/src/generic.rs
+++ b/task/hiffy/src/generic.rs
@@ -10,6 +10,8 @@ pub struct Buffer(u8);
 pub enum Functions {
     Sleep(u16, u32),
     Send((Task, u16, Buffer, usize), u32),
+    SendLeaseRead((Task, u16, Buffer, usize, usize), u32),
+    SendLeaseWrite((Task, u16, Buffer, usize, usize), u32),
 }
 
 #[no_mangle]

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -354,6 +354,8 @@ fn gpio_reset(
 pub(crate) static HIFFY_FUNCS: &[Function] = &[
     crate::common::sleep,
     crate::common::send,
+    crate::common::send_lease_read,
+    crate::common::send_lease_write,
     #[cfg(feature = "gpio")]
     gpio_input,
     #[cfg(feature = "gpio")]

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -35,6 +35,8 @@ pub struct Buffer(u8);
 pub enum Functions {
     Sleep(u16, u32),
     Send((Task, u16, Buffer, usize), u32),
+    SendLeaseRead((Task, u16, Buffer, usize, usize), u32),
+    SendLeaseWrite((Task, u16, Buffer, usize, usize), u32),
     #[cfg(feature = "gpio")]
     GpioInput(drv_lpc55_gpio_api::Pin, drv_lpc55_gpio_api::GpioError),
     #[cfg(feature = "gpio")]

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -55,6 +55,8 @@ pub struct Buffer(u8);
 pub enum Functions {
     Sleep(u16, u32),
     Send((Task, u16, Buffer, usize), u32),
+    SendLeaseRead((Task, u16, Buffer, usize, usize), u32),
+    SendLeaseWrite((Task, u16, Buffer, usize, usize), u32),
     #[cfg(feature = "i2c")]
     I2cRead(
         (Controller, PortIndex, Mux, Segment, u8, u8, usize),
@@ -541,6 +543,8 @@ fn gpio_configure(
 pub(crate) static HIFFY_FUNCS: &[Function] = &[
     crate::common::sleep,
     crate::common::send,
+    crate::common::send_lease_read,
+    crate::common::send_lease_write,
     #[cfg(feature = "i2c")]
     i2c_read,
     #[cfg(feature = "i2c")]


### PR DESCRIPTION
This is infrastructure for allowing `humility` to make _generic_ calls that require a lease, rather than having to special-case them (e.g. `qspi_page_program`).