### PR TITLE
Add `auxflash` task and blob generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-auxflash-server"
+version = "0.1.0"
+dependencies = [
+ "drv-stm32h7-qspi",
+ "drv-stm32xx-sys-api",
+ "stm32h7",
+ "userlib",
+]
+
+[[package]]
 name = "drv-eeprom"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
 name = "crc-any"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +440,12 @@ checksum = "073375684a58dece169afbdc9879a027f3698118ad3814938316c6002b7aa921"
 dependencies = [
  "debug-helper",
 ]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
 
 [[package]]
 name = "crc32fast"
@@ -729,6 +744,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "stm32h7",
+ "tlvc",
  "userlib",
  "zerocopy",
 ]
@@ -3990,6 +4006,22 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+
+[[package]]
+name = "tlvc"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/tlvc.git#7f09138f8ccf994c77ddaf15baa6967889447856"
+dependencies = [
+ "byteorder",
+ "crc",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "sha3",
  "stm32h7",
  "tlvc",
  "userlib",
@@ -4007,12 +4008,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 
 [[package]]
 name = "tlvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,13 +707,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-auxflash-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-auxflash-server"
 version = "0.1.0"
 dependencies = [
+ "build-util",
+ "drv-auxflash-api",
  "drv-stm32h7-qspi",
  "drv-stm32xx-sys-api",
+ "idol",
+ "idol-runtime",
+ "num-traits",
  "stm32h7",
  "userlib",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "tlvc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc.git#7f09138f8ccf994c77ddaf15baa6967889447856"
+source = "git+https://github.com/oxidecomputer/tlvc#7f09138f8ccf994c77ddaf15baa6967889447856"
 dependencies = [
  "byteorder",
  "crc",
@@ -4227,6 +4227,7 @@ dependencies = [
  "dunce",
  "filetime",
  "fnv",
+ "gnarle",
  "goblin",
  "indexmap",
  "lpc55_sign",
@@ -4237,8 +4238,10 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
+ "sha3",
  "srec",
  "strsim",
+ "tlvc",
  "toml",
  "walkdir",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "num-traits",
  "sha3",
  "stm32h7",
- "tlvc",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc.git)",
  "userlib",
  "zerocopy",
 ]
@@ -2809,6 +2809,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "rot-carrier"
 version = "0.1.0"
 dependencies = [
@@ -4013,10 +4024,31 @@ dependencies = [
 [[package]]
 name = "tlvc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc#7f09138f8ccf994c77ddaf15baa6967889447856"
+source = "git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text#0dfa4980667dfaf4e59d8bfff016e50f4282c9de"
 dependencies = [
  "byteorder",
  "crc",
+ "zerocopy",
+]
+
+[[package]]
+name = "tlvc"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/tlvc.git#7f09138f8ccf994c77ddaf15baa6967889447856"
+dependencies = [
+ "byteorder",
+ "crc",
+ "zerocopy",
+]
+
+[[package]]
+name = "tlvc-text"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text#0dfa4980667dfaf4e59d8bfff016e50f4282c9de"
+dependencies = [
+ "ron 0.8.0",
+ "serde",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text)",
  "zerocopy",
 ]
 
@@ -4242,7 +4274,8 @@ dependencies = [
  "sha3",
  "srec",
  "strsim",
- "tlvc",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text)",
+ "tlvc-text",
  "toml",
  "walkdir",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "drv-auxflash-api",
+ "drv-qspi-api",
  "drv-stm32h7-qspi",
  "drv-stm32xx-sys-api",
  "idol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "num-traits",
  "sha3",
  "stm32h7",
- "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc.git)",
+ "tlvc",
  "userlib",
  "zerocopy",
 ]
@@ -4024,17 +4024,7 @@ dependencies = [
 [[package]]
 name = "tlvc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text#0dfa4980667dfaf4e59d8bfff016e50f4282c9de"
-dependencies = [
- "byteorder",
- "crc",
- "zerocopy",
-]
-
-[[package]]
-name = "tlvc"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc.git#7f09138f8ccf994c77ddaf15baa6967889447856"
+source = "git+https://github.com/oxidecomputer/tlvc#2643765eb7775d1f5e8ec56910f1ab15e9c75170"
 dependencies = [
  "byteorder",
  "crc",
@@ -4044,11 +4034,11 @@ dependencies = [
 [[package]]
 name = "tlvc-text"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text#0dfa4980667dfaf4e59d8bfff016e50f4282c9de"
+source = "git+https://github.com/oxidecomputer/tlvc#2643765eb7775d1f5e8ec56910f1ab15e9c75170"
 dependencies = [
  "ron 0.8.0",
  "serde",
- "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text)",
+ "tlvc",
  "zerocopy",
 ]
 
@@ -4274,7 +4264,7 @@ dependencies = [
  "sha3",
  "srec",
  "strsim",
- "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=update-tlvc-text)",
+ "tlvc",
  "tlvc-text",
  "toml",
  "walkdir",

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -109,12 +109,12 @@ interrupts = {"flash_controller.irq" = 0b1}
 [tasks.auxflash]
 name = "drv-auxflash-server"
 priority = 3
-max-sizes = {flash = 32768, ram = 2048}
+max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
 uses = ["quadspi"]
 start = true
 interrupts = {"quadspi.irq" = 1}
-stacksize = 1920
+stacksize = 2688
 task-slots = ["sys"]
 
 [tasks.net]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -114,7 +114,7 @@ features = ["h753"]
 uses = ["quadspi"]
 start = true
 interrupts = {"quadspi.irq" = 1}
-stacksize = 2688
+stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.net]

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -785,3 +785,13 @@ owner = {name = "mgmt_gateway", notification = 0b01}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[[auxflash.blobs]]
+file = "drv/sidecar-mainboard-controller/sidecar_mainboard_controller.bit"
+compress = true
+tag = "FPGA"
+
+[[auxflash.blobs]]
+file = "drv/sidecar-front-io/sidecar_qsfp_x32_controller.bit"
+compress = true
+tag = "QSFP"

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -7,7 +7,7 @@ memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"
-requires = {flash = 22776, ram = 5840}
+requires = {flash = 22776, ram = 6200}
 #
 # For the kernel (and for any task that logs), we are required to enable
 # either "itm" (denoting logging/panicking via ARM's Instrumentation Trace
@@ -109,7 +109,7 @@ interrupts = {"flash_controller.irq" = 0b1}
 [tasks.auxflash]
 name = "drv-auxflash-server"
 priority = 3
-max-sizes = {flash = 16384, ram = 2048}
+max-sizes = {flash = 32768, ram = 2048}
 features = ["h753"]
 uses = ["quadspi"]
 start = true

--- a/app/sidecar/app.toml
+++ b/app/sidecar/app.toml
@@ -106,6 +106,17 @@ start = true
 uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
+[tasks.auxflash]
+name = "drv-auxflash-server"
+priority = 3
+max-sizes = {flash = 16384, ram = 2048}
+features = ["h753"]
+uses = ["quadspi"]
+start = true
+interrupts = {"quadspi.irq" = 1}
+stacksize = 1920
+task-slots = ["sys"]
+
 [tasks.net]
 name = "task-net"
 stacksize = 4640

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -26,6 +26,9 @@ serde_json = "1.0.56"
 path-slash = "0.1.3"
 ctrlc = "3.1.5"
 dunce = "1.0.2"
+tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
+gnarle = {path = "../../lib/gnarle", features=["std"]}
+sha3 = {version = "0.10", default-features = false}
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
 # on the version that works for us
 zip = "=0.5.6"

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -26,7 +26,8 @@ serde_json = "1.0.56"
 path-slash = "0.1.3"
 ctrlc = "3.1.5"
 dunce = "1.0.2"
-tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
+tlvc = {git = "https://github.com/oxidecomputer/tlvc", branch = "update-tlvc-text"}
+tlvc-text = {git = "https://github.com/oxidecomputer/tlvc", branch = "update-tlvc-text"}
 gnarle = {path = "../../lib/gnarle", features=["std"]}
 sha3 = {version = "0.10", default-features = false}
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -26,8 +26,8 @@ serde_json = "1.0.56"
 path-slash = "0.1.3"
 ctrlc = "3.1.5"
 dunce = "1.0.2"
-tlvc = {git = "https://github.com/oxidecomputer/tlvc", branch = "update-tlvc-text"}
-tlvc-text = {git = "https://github.com/oxidecomputer/tlvc", branch = "update-tlvc-text"}
+tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
+tlvc-text = {git = "https://github.com/oxidecomputer/tlvc"}
 gnarle = {path = "../../lib/gnarle", features=["std"]}
 sha3 = {version = "0.10", default-features = false}
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay

--- a/build/xtask/src/auxflash.rs
+++ b/build/xtask/src/auxflash.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use sha3::{Digest, Sha3_256};
+use zerocopy::AsBytes;
+
+/// List of binary blobs to include in the auxiliary flash binary shipped with
+/// this image.  The auxiliary flash is used to offload storage of large
+/// configuration files (e.g. FPGA bitstreams)
+#[derive(Clone, Debug, Deserialize)]
+pub struct AuxFlash {
+    pub blobs: Vec<AuxFlashBlob>,
+}
+
+/// A single binary blob, encoded into the auxiliary flash file.
+#[derive(Clone, Debug, Deserialize)]
+pub struct AuxFlashBlob {
+    pub file: String,
+    pub compress: bool,
+    pub tag: String,
+}
+
+/// Encode the given data as a tagged TLV-C chunk
+fn data_to_tlvc(tag: &str, data: &[u8]) -> Result<Vec<u8>> {
+    if tag.len() != 4 {
+        bail!("Tag must be a 4-byte value, not '{}'", tag);
+    }
+    let mut out = vec![];
+    let mut header = tlvc::ChunkHeader {
+        tag: tag.as_bytes().try_into().unwrap(),
+        len: 0.into(),
+        header_checksum: 0.into(),
+    };
+    out.extend(header.as_bytes());
+
+    let c = tlvc::compute_body_crc(data);
+
+    out.extend(data);
+    let body_len = out.len() - std::mem::size_of::<tlvc::ChunkHeader>();
+    let body_len = u32::try_from(body_len).unwrap();
+
+    // TLV-C requires the body to be padded to a multiple of four!
+    while out.len() & 0b11 != 0 {
+        out.push(0);
+    }
+    out.extend(c.to_le_bytes());
+
+    // Update the header.
+    header.len.set(body_len);
+    header.header_checksum.set(header.compute_checksum());
+
+    out[..std::mem::size_of::<tlvc::ChunkHeader>()]
+        .copy_from_slice(header.as_bytes());
+    Ok(out)
+}
+
+/// Packs a single blob into a TLV-C structure
+fn pack_blob(blob: &AuxFlashBlob) -> Result<Vec<u8>> {
+    let data = std::fs::read(&blob.file)
+        .with_context(|| format!("Could not read blob {}", blob.file))?;
+    let data = if blob.compress {
+        gnarle::compress_to_vec(&data)
+    } else {
+        data
+    };
+    data_to_tlvc(&blob.tag, &data)
+}
+
+/// Constructs an auxiliary flash image, based on RFD 311
+///
+/// Returns the checksum and the raw data to be saved
+pub fn build_auxflash(aux: &AuxFlash) -> Result<([u8; 32], Vec<u8>)> {
+    let mut auxi = vec![];
+    for f in &aux.blobs {
+        auxi.extend(pack_blob(f)?);
+    }
+    let sha = Sha3_256::digest(&auxi);
+
+    let mut out = vec![];
+    out.extend(data_to_tlvc("CHCK", &sha)?);
+    out.extend(data_to_tlvc("AUXI", &auxi)?);
+    Ok((sha.into(), out))
+}

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -38,6 +38,23 @@ struct RawConfig {
     config: Option<ordered_toml::Value>,
     #[serde(default)]
     secure_task: Option<String>,
+    auxflash: Option<AuxFlash>,
+}
+
+/// List of binary blobs to include in the auxiliary flash binary shipped with
+/// this image.  The auxiliary flash is used to offload storage of large
+/// configuration files (e.g. FPGA bitstreams)
+#[derive(Clone, Debug, Deserialize)]
+pub struct AuxFlash {
+    pub blobs: Vec<AuxFlashBlob>,
+}
+
+/// A single binary blob, encoded into the auxiliary flash file.
+#[derive(Clone, Debug, Deserialize)]
+pub struct AuxFlashBlob {
+    pub file: String,
+    pub compress: bool,
+    pub tag: String,
 }
 
 #[derive(Clone, Debug)]
@@ -60,6 +77,7 @@ pub struct Config {
     pub buildhash: u64,
     pub app_toml_path: PathBuf,
     pub secure_task: Option<String>,
+    pub auxflash: Option<AuxFlash>,
 }
 
 impl Config {
@@ -123,6 +141,7 @@ impl Config {
             peripherals,
             extratext: toml.extratext,
             config: toml.config,
+            auxflash: toml.auxflash,
             buildhash,
             app_toml_path: cfg.to_owned(),
             secure_task: toml.secure_task,

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -619,6 +619,7 @@ fn pack_blob(blob: &AuxFlashBlob) -> Result<Vec<u8>> {
     data_to_tlvc(&blob.tag, &data)
 }
 
+/// Constructs an auxiliary flash image, based on RFD 311
 fn build_auxflash(aux: &AuxFlash) -> Result<Vec<u8>> {
     let mut auxi = vec![];
     for f in &aux.blobs {

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 
 use crate::config::Config;
 
+mod auxflash;
 mod clippy;
 mod config;
 mod dist;

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
+
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "drv-auxflash-api"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+userlib = {path = "../../sys/userlib"}
+num-traits = { version = "0.2.12", default-features = false }
+zerocopy = "0.6.1"
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/auxflash-api/build.rs
+++ b/drv/auxflash-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/auxflash.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! API crate for the Gimlet Host Flash server.
+//! API crate for the auxiliary flash IC
 
 #![no_std]
 
@@ -13,7 +13,19 @@ use zerocopy::AsBytes;
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum AuxFlashError {
     WriteEnableFailed = 1,
-    ServerRestarted = 2,
+    ServerRestarted,
+    TlvcReaderBeginFailed,
+
+    /// The `CHCK` block does not have 32 bytes of data
+    BadChckSize,
+    /// There is no `CHCK` block in this slot
+    MissingChck,
+    /// There is no `AUXI` block in this slot
+    MissingAuxi,
+    /// There is more than one `CHCK` block in this slot
+    MultipleChck,
+    /// The `CHCK` checksum disagrees with the actual slot data (`AUXI`)
+    ChckMismatch,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -8,7 +8,6 @@
 
 use derive_idol_err::IdolError;
 use userlib::*;
-use zerocopy::AsBytes;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
 pub enum AuxFlashError {
@@ -28,6 +27,8 @@ pub enum AuxFlashError {
     MultipleChck,
     /// The `CHCK` checksum disagrees with the actual slot data (`AUXI`)
     ChckMismatch,
+    /// Failed during a call to `ChunkHandle::read_exact`
+    ChunkReadFail,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API crate for the Gimlet Host Flash server.
+
+#![no_std]
+
+use derive_idol_err::IdolError;
+use userlib::*;
+use zerocopy::AsBytes;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+pub enum AuxFlashError {
+    WriteEnableFailed = 1,
+    ServerRestarted = 2,
+}
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -31,4 +31,12 @@ pub enum AuxFlashError {
     ChunkReadFail,
 }
 
+#[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(transparent)]
+pub struct AuxFlashId(pub [u8; 20]);
+
+#[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(transparent)]
+pub struct AuxFlashChecksum(pub [u8; 32]);
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -16,6 +16,8 @@ pub enum AuxFlashError {
     ServerRestarted,
     TlvcReaderBeginFailed,
 
+    /// The requested slot exceeds the slot count
+    InvalidSlot,
     /// The `CHCK` block does not have 32 bytes of data
     BadChckSize,
     /// There is no `CHCK` block in this slot

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -35,6 +35,8 @@ pub enum AuxFlashError {
     AddressOverflow,
     /// The start address of a write command is not aligned to a page boundary
     UnalignedAddress,
+    /// There is no active slot
+    NoActiveSlot,
 }
 
 #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -25,10 +25,14 @@ pub enum AuxFlashError {
     MissingAuxi,
     /// There is more than one `CHCK` block in this slot
     MultipleChck,
+    /// There is more than one `AUXI` block in this slot
+    MultipleAuxi,
     /// The `CHCK` checksum disagrees with the actual slot data (`AUXI`)
     ChckMismatch,
     /// Failed during a call to `ChunkHandle::read_exact`
     ChunkReadFail,
+    /// The end address of the read or write exceeds the slot boundaries
+    AddressOverflow,
 }
 
 #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -33,6 +33,8 @@ pub enum AuxFlashError {
     ChunkReadFail,
     /// The end address of the read or write exceeds the slot boundaries
     AddressOverflow,
+    /// The start address of a write command is not aligned to a page boundary
+    UnalignedAddress,
 }
 
 #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -14,6 +14,7 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
 
 num-traits = { version = "0.2.12", default-features = false }
+sha3 = {version = "0.10", default-features = false}
 stm32h7 = { version = "0.14", default-features = false }
 zerocopy = "0.6.1"
 

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "drv-auxflash-server"
+version = "0.1.0"
+authors = ["Matt Keeter <matt@oxide.computer>"]
+edition = "2021"
+
+[dependencies]
+stm32h7 = { version = "0.14", default-features = false }
+drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
+drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+
+[features]
+h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-auxflash-server"
+test = false
+bench = false

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -11,6 +11,7 @@ drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
 
 num-traits = { version = "0.2.12", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -5,10 +5,20 @@ authors = ["Matt Keeter <matt@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
-stm32h7 = { version = "0.14", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
+drv-auxflash-api = {path = "../auxflash-api", default-features = false}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
+drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+num-traits = { version = "0.2.12", default-features = false }
+stm32h7 = { version = "0.14", default-features = false }
+zerocopy = "0.6.1"
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 drv-auxflash-api = {path = "../auxflash-api", default-features = false}
+drv-qspi-api = {path = "../qspi-api"}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}

--- a/drv/auxflash-server/README.mkdn
+++ b/drv/auxflash-server/README.mkdn
@@ -1,0 +1,5 @@
+# Task Template
+
+Copy this directory to get started writing a new task. Don't forget to add your
+task to `workspace.members` in the root `Cargo.toml`! (If you forget, `cargo`
+will remind you.)

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_util::expose_target_board();
+
+    idol::server::build_server_support(
+        "../../idl/auxflash.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -18,13 +18,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let out_dir = std::env::var("OUT_DIR")?;
             let dest_path = std::path::Path::new(&out_dir).join("checksum.rs");
             let mut file = std::fs::File::create(&dest_path)?;
-            writeln!(&mut file,
-                "const AUXI_CHECKSUM: [u8; 32] = {};", e)?;
-
-        },
-        Err(std::env::VarError::NotPresent) =>
-            panic!("Could not find HUBRIS_AUXFLASH_CHECKSUM in environment. \
-                    Is there at least one [[auxflash.blobs]] in the app?"),
+            writeln!(&mut file, "const AUXI_CHECKSUM: [u8; 32] = {};", e)?;
+        }
+        Err(std::env::VarError::NotPresent) => panic!(
+            "Could not find HUBRIS_AUXFLASH_CHECKSUM in environment. \
+                    Is there at least one [[auxflash.blobs]] in the app?"
+        ),
         Err(e) => panic!("Could not find HUBRIS_AUXFLASH_CHECKSUM: {:?}", e),
     }
 

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
@@ -10,6 +11,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "server_stub.rs",
         idol::server::ServerStyle::InOrder,
     )?;
+
+    println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM");
+    match std::env::var("HUBRIS_AUXFLASH_CHECKSUM") {
+        Ok(e) => {
+            let out_dir = std::env::var("OUT_DIR")?;
+            let dest_path = std::path::Path::new(&out_dir).join("checksum.rs");
+            let mut file = std::fs::File::create(&dest_path)?;
+            writeln!(&mut file,
+                "const AUXI_CHECKSUM: [u8; 32] = {};", e)?;
+
+        },
+        Err(std::env::VarError::NotPresent) =>
+            panic!("Could not find HUBRIS_AUXFLASH_CHECKSUM in environment. \
+                    Is there at least one [[auxflash.blobs]] in the app?"),
+        Err(e) => panic!("Could not find HUBRIS_AUXFLASH_CHECKSUM: {:?}", e),
+    }
 
     Ok(())
 }

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> ! {
         qspi,
         active_slot: None,
     };
-    server.scan_for_active_slot();
+    let _ = server.scan_for_active_slot();
 
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
@@ -148,7 +148,7 @@ struct ServerImpl {
 }
 
 impl ServerImpl {
-    fn scan_for_active_slot(&mut self)  {
+    fn scan_for_active_slot(&mut self) {
         self.active_slot = None;
         for i in 0..SLOT_COUNT {
             if let Ok(chck) = self.read_slot_checksum(i) {
@@ -187,7 +187,10 @@ impl ServerImpl {
         }
         Ok(())
     }
-    fn read_slot_checksum(&self, slot: u32) -> Result<AuxFlashChecksum, AuxFlashError> {
+    fn read_slot_checksum(
+        &self,
+        slot: u32,
+    ) -> Result<AuxFlashChecksum, AuxFlashError> {
         if slot >= SLOT_COUNT {
             return Err(AuxFlashError::InvalidSlot);
         }
@@ -368,6 +371,15 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
             addr += amount;
         }
         Ok(())
+    }
+
+    fn scan_and_get_active_slot(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<AuxFlashError>> {
+        self.scan_for_active_slot();
+        self.active_slot
+            .ok_or_else(|| AuxFlashError::NoActiveSlot.into())
     }
 }
 

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use userlib::*;
+
+/* Sidecar-only for now!
+ *
+ * SP_QSPI_RESET_L     PF5     GPIO
+ * SP_QSPI_CLK         PF10    QUADSPI_CLK
+ * SP_QSPI_IO0 (SI)    PF8     QUADSPI_BK1_IO0
+ * SP_QSPI_IO1 (SO)    PF9     QUADSPI_BK1_IO1
+ * SP_QSPI_CS_L        PG6     QUADSPI_BK1_NCS (or GPIO?)
+ * SP_QSPI_IO2 (*WP)   PF7     QUADSPI_BK1_IO2
+ * SP_QSPI_IO3 (*HOLD) PF6     QUADSPI_BK1_IO3
+ */
+
+/* Gimlet uses SPI instead
+ *
+ * SP_TO_FLASH_SPI_HOLD_N  PB8     GPIO
+ * SP_TO_FLASH_SPI_CLK     PB13    SPI2_SCK
+ * SP_TO_FLASH_SPI_MISO    PB14    SPI2_MISO
+ * SP_TO_FLASH_SPI_MOSI    PB15    SPI2_MOSI
+ * SP_TO_FLASH_SPI_CS      PB12    SPI2_NSS (or GPIO)
+ * SP_TO_FLASH_SPI_WP_N    PB9     GPIO
+ *
+ * (This is `local_flash` in `gimlet/rev-b.toml`)
+ */
+
+#[export_name = "main"]
+fn main() -> ! {
+    loop {
+        // NOTE: you need to put code here before running this! Otherwise LLVM
+        // will turn this into a single undefined instruction.
+    }
+}

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -7,17 +7,6 @@
 
 use userlib::*;
 
-/* Sidecar-only for now!
- *
- * SP_QSPI_RESET_L     PF5     GPIO
- * SP_QSPI_CLK         PF10    QUADSPI_CLK
- * SP_QSPI_IO0 (SI)    PF8     QUADSPI_BK1_IO0
- * SP_QSPI_IO1 (SO)    PF9     QUADSPI_BK1_IO1
- * SP_QSPI_CS_L        PG6     QUADSPI_BK1_NCS (or GPIO?)
- * SP_QSPI_IO2 (*WP)   PF7     QUADSPI_BK1_IO2
- * SP_QSPI_IO3 (*HOLD) PF6     QUADSPI_BK1_IO3
- */
-
 /* Gimlet uses SPI instead
  *
  * SP_TO_FLASH_SPI_HOLD_N  PB8     GPIO
@@ -30,10 +19,89 @@ use userlib::*;
  * (This is `local_flash` in `gimlet/rev-b.toml`)
  */
 
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
+use drv_stm32h7_qspi::Qspi;
+use drv_stm32xx_sys_api as sys_api;
+
+task_slot!(SYS, sys);
+
+const QSPI_IRQ: u32 = 1;
+
 #[export_name = "main"]
 fn main() -> ! {
+    let sys = sys_api::Sys::from(SYS.get_task_id());
+
+    sys.enable_clock(sys_api::Peripheral::QuadSpi);
+    sys.leave_reset(sys_api::Peripheral::QuadSpi);
+
+    let reg = unsafe { &*device::QUADSPI::ptr() };
+    let qspi = Qspi::new(reg, QSPI_IRQ);
+
+    let clock = 5; // 200MHz kernel / 5 = 40MHz clock
+    qspi.configure(clock, 24); // 2**24 = 16MiB = 128Mib
+
+    // Sidecar-only for now!
+    //
+    // This is mostly copied from `gimlet-hf-server`, with a few pin adjustments
+    //
+    // SP_QSPI_RESET_L     PF5     GPIO
+    // SP_QSPI_CLK         PF10    QUADSPI_CLK
+    // SP_QSPI_IO0 (SI)    PF8     QUADSPI_BK1_IO0
+    // SP_QSPI_IO1 (SO)    PF9     QUADSPI_BK1_IO1
+    // SP_QSPI_CS_L        PG6     QUADSPI_BK1_NCS (or GPIO?)
+    // SP_QSPI_IO2 (*WP)   PF7     QUADSPI_BK1_IO2
+    // SP_QSPI_IO3 (*HOLD) PF6     QUADSPI_BK1_IO3
+    sys.gpio_configure_alternate(
+        sys_api::Port::F.pin(6).and_pin(7).and_pin(10),
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Medium,
+        sys_api::Pull::None,
+        sys_api::Alternate::AF9,
+    )
+    .unwrap();
+    sys.gpio_configure_alternate(
+        sys_api::Port::F.pin(8).and_pin(9),
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Medium,
+        sys_api::Pull::None,
+        sys_api::Alternate::AF10,
+    )
+    .unwrap();
+    sys.gpio_configure_alternate(
+        sys_api::Port::G.pin(6),
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Medium,
+        sys_api::Pull::None,
+        sys_api::Alternate::AF10,
+    )
+    .unwrap();
+
+    let qspi_reset = sys_api::Port::F.pin(5);
+    sys.gpio_reset(qspi_reset).unwrap();
+    sys.gpio_configure_output(
+        qspi_reset,
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Low,
+        sys_api::Pull::None,
+    )
+    .unwrap();
+
+    // TODO: The best clock frequency to use can vary based on the flash
+    // part, the command used, and signal integrity limits of the board.
+
+    // Ensure hold time for reset in case we just restarted.
+    // TODO look up actual hold time requirement
+    hl::sleep_for(1);
+
+    // Release reset and let it stabilize.
+    sys.gpio_set(qspi_reset).unwrap();
+    hl::sleep_for(10);
+
+    // TODO: check the ID and make sure it's what we expect
+
     loop {
-        // NOTE: you need to put code here before running this! Otherwise LLVM
-        // will turn this into a single undefined instruction.
+        hl::sleep_for(1000);
     }
 }

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -152,7 +152,7 @@ impl ServerImpl {
         self.active_slot = None;
         for i in 0..SLOT_COUNT {
             if let Ok(chck) = self.read_slot_checksum(i) {
-                if chck == AUXI_CHECKSUM {
+                if chck.0 == AUXI_CHECKSUM {
                     self.active_slot = Some(i);
                     break;
                 }
@@ -379,3 +379,5 @@ mod idl {
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
+
+include!(concat!(env!("OUT_DIR"), "/checksum.rs"));

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -239,10 +239,10 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
             return Err(AuxFlashError::MissingChck.into());
         } else if chck_actual.is_none() {
             return Err(AuxFlashError::MissingAuxi.into());
-        //} else if chck_expected != chck_actual {
-        //    return Err(AuxFlashError::ChckMismatch.into());
+        } else if chck_expected != chck_actual {
+            return Err(AuxFlashError::ChckMismatch.into());
         } else {
-            return Ok(AuxFlashChecksum(chck_actual.unwrap()));
+            return Ok(AuxFlashChecksum(chck_expected.unwrap()));
         }
     }
 

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -9,6 +9,12 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "slot_count": (
+            reply: Result(
+                ok: "u32",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
         "read_status": (
             reply: Result(
                 ok: "u8",
@@ -20,7 +26,7 @@ Interface(
                 "slot": "u32",
             },
             reply: Result(
-                ok: "[u32; 4]",
+                ok: "[u8; 32]",
                 err: CLike("AuxFlashError"),
             ),
         ),

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -45,7 +45,7 @@ Interface(
                 "offset": "u32",
             },
             leases: {
-                "data": (type: "[u8]", read: true, max_len: Some(2048)),
+                "data": (type: "[u8]", read: true),
             },
             reply: Result(
                 ok: "()",
@@ -58,7 +58,7 @@ Interface(
                 "offset": "u32",
             },
             leases: {
-                "data": (type: "[u8]", write: true, max_len: Some(256)),
+                "data": (type: "[u8]", write: true),
             },
             reply: Result(
                 ok: "()",

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -1,0 +1,28 @@
+// Auxiliary Flash API
+
+Interface(
+    name: "AuxFlash",
+    ops: {
+        "read_id": (
+            reply: Result(
+                ok: "[u8; 20]",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+        "read_status": (
+            reply: Result(
+                ok: "u8",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+        "read_slot_chck": (
+            args: {
+                "slot": "u32",
+            },
+            reply: Result(
+                ok: "[u32; 4]",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+    }
+)

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -52,5 +52,18 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "read_slot_with_offset": (
+            args: {
+                "slot": "u32",
+                "offset": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", write: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
     }
 )

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -45,7 +45,7 @@ Interface(
                 "offset": "u32",
             },
             leases: {
-                "data": (type: "[u8]", read: true, max_len: Some(256)),
+                "data": (type: "[u8]", read: true, max_len: Some(2048)),
             },
             reply: Result(
                 ok: "()",

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -21,12 +21,34 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "erase_slot": (
+            args: {
+                "slot": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
         "read_slot_chck": (
             args: {
                 "slot": "u32",
             },
             reply: Result(
                 ok: "[u8; 32]",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+        "write_slot_with_offset": (
+            args: {
+                "slot": "u32",
+                "offset": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
                 err: CLike("AuxFlashError"),
             ),
         ),

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -5,7 +5,7 @@ Interface(
     ops: {
         "read_id": (
             reply: Result(
-                ok: "[u8; 20]",
+                ok: "AuxFlashId",
                 err: CLike("AuxFlashError"),
             ),
         ),
@@ -35,7 +35,7 @@ Interface(
                 "slot": "u32",
             },
             reply: Result(
-                ok: "[u8; 32]",
+                ok: "AuxFlashChecksum",
                 err: CLike("AuxFlashError"),
             ),
         ),

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -4,24 +4,28 @@ Interface(
     name: "AuxFlash",
     ops: {
         "read_id": (
+            doc: "reads the chip ID from the auxiliary flash chip",
             reply: Result(
                 ok: "AuxFlashId",
                 err: CLike("AuxFlashError"),
             ),
         ),
         "slot_count": (
+            doc: "returns the number of slots in our auxiliary flash",
             reply: Result(
                 ok: "u32",
                 err: CLike("AuxFlashError"),
             ),
         ),
         "read_status": (
+            doc: "reads the auxiliary flash chip's status register",
             reply: Result(
                 ok: "u8",
                 err: CLike("AuxFlashError"),
             ),
         ),
         "erase_slot": (
+            doc: "erases the given slot",
             args: {
                 "slot": "u32",
             },
@@ -31,6 +35,7 @@ Interface(
             ),
         ),
         "read_slot_chck": (
+            doc: "reads and verifies the CHCK field in an auxiliary flash slot",
             args: {
                 "slot": "u32",
             },
@@ -40,6 +45,7 @@ Interface(
             ),
         ),
         "write_slot_with_offset": (
+            doc: "writes to a particular memory offset in a slot (must be a multiple of 256)",
             args: {
                 "slot": "u32",
                 "offset": "u32",
@@ -53,6 +59,7 @@ Interface(
             ),
         ),
         "read_slot_with_offset": (
+            doc: "reads from a particular memory offset in a slot (must be a multiple of 256)",
             args: {
                 "slot": "u32",
                 "offset": "u32",
@@ -66,8 +73,16 @@ Interface(
             ),
         ),
         "scan_and_get_active_slot": (
+            doc: "Searches for a slot with a checksum that matches the one in the Hubris image",
             reply: Result(
                 ok: "u32",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+        "ensure_redundancy": (
+            doc: "If necessary, flashes data from the active slot to the spare slot",
+            reply: Result(
+                ok: "()",
                 err: CLike("AuxFlashError"),
             ),
         ),

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -65,5 +65,11 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "scan_and_get_active_slot": (
+            reply: Result(
+                ok: "u32",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
     }
 )


### PR DESCRIPTION
This is the first step of implementing RFD 311.  It does two things:

- Adds a small `auxflash` task to the Sidecar image, which can read, write, and validate checksums of slots in the auxiliary flash chip
- Inserts `[[auxflash.blobs]]` into the config file, which specifies files to be packed into `auxi.tlvc` in the resulting Hubris archive