### PR TITLE
lib-dice: Add magic value to handoff structure.

### DIFF
--- a/stage0/src/dice.rs
+++ b/stage0/src/dice.rs
@@ -72,11 +72,7 @@ pub fn run(image: &Image) {
         &deviceid_keypair,
     );
 
-    let alias_data = AliasData {
-        seed: alias_okm,
-        alias_cert,
-        deviceid_cert,
-    };
+    let alias_data = AliasData::new(alias_okm, alias_cert, deviceid_cert);
 
     handoff.store(&alias_data);
 }


### PR DESCRIPTION
This is intended as a more robust mechanism for the task consuming the DICE artifacts to identify valid values.