### PR TITLE
Add `capacity()` idol call to gimlet-hf-server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ version = "0.1.0"
 dependencies = [
  "derive-idol-err",
  "drv-hash-api",
+ "drv-qspi-api",
  "idol",
  "num-traits",
  "userlib",
@@ -1098,6 +1099,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-qspi-api"
+version = "0.1.0"
+
+[[package]]
 name = "drv-rng-api"
 version = "0.1.0"
 dependencies = [
@@ -1323,6 +1328,7 @@ dependencies = [
 name = "drv-stm32h7-qspi"
 version = "0.1.0"
 dependencies = [
+ "drv-qspi-api",
  "stm32h7",
  "userlib",
  "vcell",

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -10,6 +10,7 @@ derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
+drv-qspi-api = {path = "../qspi-api"}
 drv-hash-api = {path = "../hash-api"}
 
 [build-dependencies]

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -45,4 +45,16 @@ pub enum HfDevSelect {
     Flash1 = 1,
 }
 
+/// Size in bytes of a single page of data (i.e., the max length of slice we
+/// accept for `page_program()` and `read()`).
+// Note: There is no static check that this matches what's in our idl file in
+// terms of _client_ generation, but the server can use this constant in its
+// trait impl, which will produce a compile-time error if it doesn't match the
+// length in the idl file.
+pub const PAGE_SIZE_BYTES: usize = 256;
+
+/// Size in bytes of a single sector of data (i.e., the size of the data erased
+/// by a call to `sector_erase()`).
+pub const SECTOR_SIZE_BYTES: usize = 65_536;
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -11,6 +11,8 @@ use drv_hash_api::SHA256_SZ;
 use userlib::*;
 use zerocopy::AsBytes;
 
+pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
+
 /// Errors that can be produced from the host flash server API.
 ///
 /// This enumeration doesn't include errors that result from configuration
@@ -44,17 +46,5 @@ pub enum HfDevSelect {
     Flash0 = 0,
     Flash1 = 1,
 }
-
-/// Size in bytes of a single page of data (i.e., the max length of slice we
-/// accept for `page_program()` and `read()`).
-// Note: There is no static check that this matches what's in our idl file in
-// terms of _client_ generation, but the server can use this constant in its
-// trait impl, which will produce a compile-time error if it doesn't match the
-// length in the idl file.
-pub const PAGE_SIZE_BYTES: usize = 256;
-
-/// Size in bytes of a single sector of data (i.e., the size of the data erased
-/// by a call to `sector_erase()`).
-pub const SECTOR_SIZE_BYTES: usize = 65_536;
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> ! {
     // TODO: If different flash parts are used on the same board name,
     // then hard-coding commands, capacity, and clocks will get us into
     // trouble. Someday we will need more flexability here.
-    let capacity = {
+    let log2_capacity = {
         let mut idbuf = [0; 20];
         qspi.read_id(&mut idbuf);
 
@@ -122,21 +122,20 @@ fn main() -> ! {
         }
     };
 
-    if capacity.is_none() {
+    if log2_capacity.is_none() {
         loop {
             // We are dead now.
             hl::sleep_for(1000);
         }
     }
-    let capacity = capacity.unwrap();
-    qspi.configure(cfg.clock, capacity);
+    let log2_capacity = log2_capacity.unwrap();
+    qspi.configure(cfg.clock, log2_capacity);
 
     let mut buffer = [0; idl::INCOMING_SIZE];
     let mut server = ServerImpl {
         qspi,
         block: [0; 256],
-        // Capacity is stored as log2 size
-        capacity: 1 << capacity,
+        capacity: 1 << log2_capacity,
         mux_state: HfMuxState::SP,
         dev_state: HfDevSelect::Flash0,
         mux_select_pin: cfg.sp_host_mux_select,

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -31,7 +31,7 @@ use stm32h7::stm32h753 as device;
 use drv_hash_api as hash_api;
 use drv_hash_api::SHA256_SZ;
 
-use drv_gimlet_hf_api::{HfDevSelect, HfError, HfMuxState};
+use drv_gimlet_hf_api::{HfDevSelect, HfError, HfMuxState, PAGE_SIZE_BYTES};
 
 task_slot!(SYS, sys);
 #[cfg(feature = "hash")]
@@ -135,6 +135,8 @@ fn main() -> ! {
     let mut server = ServerImpl {
         qspi,
         block: [0; 256],
+        // Capacity is stored as log2 size
+        capacity: 1 << capacity,
         mux_state: HfMuxState::SP,
         dev_state: HfDevSelect::Flash0,
         mux_select_pin: cfg.sp_host_mux_select,
@@ -149,6 +151,7 @@ fn main() -> ! {
 struct ServerImpl {
     qspi: Qspi,
     block: [u8; 256],
+    capacity: usize,
 
     /// Selects between the SP and SP3 talking to the QSPI flash
     mux_state: HfMuxState,
@@ -187,6 +190,13 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         Ok(idbuf)
     }
 
+    fn capacity(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<usize, RequestError<HfError>> {
+        Ok(self.capacity)
+    }
+
     fn read_status(
         &mut self,
         _: &RecvMessage,
@@ -210,7 +220,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
         addr: u32,
-        data: LenLimit<Leased<R, [u8]>, 256>,
+        data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
     ) -> Result<(), RequestError<HfError>> {
         self.check_muxed_to_sp()?;
         // Read the entire data block into our address space.
@@ -229,7 +239,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
         addr: u32,
-        dest: LenLimit<Leased<W, [u8]>, 256>,
+        dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
     ) -> Result<(), RequestError<HfError>> {
         self.check_muxed_to_sp()?;
         self.qspi.read_memory(addr, &mut self.block[..dest.len()]);

--- a/drv/qspi-api/Cargo.toml
+++ b/drv/qspi-api/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "drv-qspi-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false

--- a/drv/qspi-api/src/lib.rs
+++ b/drv/qspi-api/src/lib.rs
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! QSPI constants used by the QSPI driver and its users.
+
+#![no_std]
+
+/// Size in bytes of a single page of data (i.e., the max length of slice we
+/// accept for `page_program()` and `read_memory()`).
+///
+/// This value is really a property of the flash we're talking to and not this
+/// driver, but it's correct for all our current parts. If that changes, this
+/// will need to change to something more flexible.
+pub const PAGE_SIZE_BYTES: usize = 256;
+
+/// Size in bytes of a single sector of data (i.e., the size of the data erased
+/// by a call to `sector_erase()`).
+///
+/// This value is really a property of the flash we're talking to and not this
+/// driver, but it's correct for all our current parts. If that changes, this
+/// will need to change to something more flexible.
+pub const SECTOR_SIZE_BYTES: usize = 65_536;
+
+pub enum Command {
+    ReadStatusReg = 0x05,
+    WriteEnable = 0x06,
+    PageProgram = 0x12,
+    Read = 0x13,
+
+    // Note, There are multiple ReadId commands.
+    // Gimlet and Gemini's flash parts both respond to 0x9F.
+    // Gemini's does not respond to 0x9E (returns all zeros).
+    // TODO: Proper flash chip quirk support.
+    ReadId = 0x9F,
+
+    BulkErase = 0xC7,
+    SectorErase = 0xDC,
+}
+
+impl From<Command> for u8 {
+    fn from(c: Command) -> u8 {
+        c as u8
+    }
+}

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -3,9 +3,8 @@ name = "drv-stm32h7-qspi"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+drv-qspi-api = {path = "../qspi-api"}
 stm32h7 = { version = "0.14", default-features = false }
 vcell = "0.1.2"
 zerocopy = "0.6.1"

--- a/drv/stm32h7-qspi/src/lib.rs
+++ b/drv/stm32h7-qspi/src/lib.rs
@@ -14,6 +14,7 @@ use stm32h7::stm32h743 as device;
 #[cfg(feature = "h753")]
 use stm32h7::stm32h753 as device;
 
+use drv_qspi_api::Command;
 use userlib::{sys_irq_control, sys_recv_closed, TaskId};
 use zerocopy::AsBytes;
 
@@ -24,28 +25,6 @@ const FIFO_THRESH: usize = 16;
 pub struct Qspi {
     reg: &'static device::quadspi::RegisterBlock,
     interrupt: u32,
-}
-
-enum Command {
-    ReadStatusReg = 0x05,
-    WriteEnable = 0x06,
-    PageProgram = 0x12,
-    Read = 0x13,
-
-    // Note, There are multiple ReadId commands.
-    // Gimlet and Gemini's flash parts both respond to 0x9F.
-    // Gemini's does not respond to 0x9E (returns all zeros).
-    // TODO: Proper flash chip quirk support.
-    ReadId = 0x9F,
-
-    BulkErase = 0xC7,
-    SectorErase = 0xDC,
-}
-
-impl From<Command> for u8 {
-    fn from(c: Command) -> u8 {
-        c as u8
-    }
 }
 
 impl Qspi {

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -10,6 +10,14 @@ Interface(
                 err: CLike("HfError"),
             ),
         ),
+        "capacity": (
+            doc: "Return the flash capacity in bytes.",
+            args: {},
+            reply: Result(
+                ok: "usize",
+                err: CLike("HfError"),
+            ),
+        ),
         "read_status": (
             args: {},
             reply: Result(


### PR DESCRIPTION
Also adds a couple constants to its API describing the sizes of `page_program()` and `sector_erase()` operations.

All of these additions will be used by `mgmt-gateway` shortly in updating the host boot flash.