### PR TITLE
mgmt-gateway refactor: extract generic `UpdateBuffer`

### DIFF
--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -17,6 +17,7 @@ use task_net_api::{
 use userlib::{sys_recv_closed, task_slot, TaskId, UnwrapLite};
 
 mod mgs_common;
+mod update_buffer;
 
 // If the build system enables multiple of the gimlet/sidecar/psc features, this
 // sequence of `cfg_attr`s will trigger an unused_attributes warning. We can

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -2,14 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{update_buffer::UpdateBuffer, Log, MgsMessage, __RINGBUF};
+use crate::{update_buffer::UpdateBuffer, Log, MgsMessage};
 use core::convert::Infallible;
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
 use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
     DiscoverResponse, ResponseError, SpPort, SpState, UpdateChunk, UpdateStart,
 };
-use ringbuf::ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 
 // TODO How are we versioning SP images? This is a placeholder.
 const VERSION: u32 = 1;
@@ -48,12 +48,12 @@ impl MgsCommon {
         &mut self,
         port: SpPort,
     ) -> Result<DiscoverResponse, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::Discovery));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Discovery));
         Ok(DiscoverResponse { sp_port: port })
     }
 
     pub(crate) fn sp_state(&mut self) -> Result<SpState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SpState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpState));
 
         // TODO Replace with the real serial number once it's available; for now
         // use the stm32 96-bit uid
@@ -77,7 +77,7 @@ impl MgsCommon {
         &mut self,
         update: UpdateStart,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStart {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStart {
             length: update.total_size
         }));
 
@@ -97,7 +97,7 @@ impl MgsCommon {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
             offset: chunk.offset,
         }));
 
@@ -108,7 +108,7 @@ impl MgsCommon {
     pub(crate) fn reset_prepare(&mut self) -> Result<(), ResponseError> {
         // TODO: Add some kind of auth check before performing a reset.
         // https://github.com/oxidecomputer/hubris/issues/723
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SysResetPrepare));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SysResetPrepare));
         self.reset_requested = true;
         Ok(())
     }

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -2,16 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{update_buffer::UpdateBuffer, Log, MgsMessage, __RINGBUF};
 use core::convert::Infallible;
-
-use crate::{Log, MgsMessage, __RINGBUF};
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
 use drv_update_api::{Update, UpdateTarget};
 use gateway_messages::{
     DiscoverResponse, ResponseError, SpPort, SpState, UpdateChunk, UpdateStart,
 };
 use ringbuf::ringbuf_entry;
-use userlib::UnwrapLite;
 
 // TODO How are we versioning SP images? This is a placeholder.
 const VERSION: u32 = 1;
@@ -19,8 +17,7 @@ const VERSION: u32 = 1;
 /// Provider of MGS handler logic common to all targets (gimlet, sidecar, psc).
 pub(crate) struct MgsCommon {
     update_task: Update,
-    // TODO: Make this non-`Option` and use new update abort APIs.
-    update_buf: Option<UpdateBuffer>,
+    update_buf: UpdateBuffer<Update, BLOCK_SIZE_BYTES>,
     reset_requested: bool,
 }
 
@@ -28,7 +25,21 @@ impl MgsCommon {
     pub(crate) fn claim_static_resources() -> Self {
         Self {
             update_task: Update::from(crate::UPDATE_SERVER.get_task_id()),
-            update_buf: None,
+            update_buf: UpdateBuffer::new(
+                claim_update_buffer_static(),
+                // callback to write one block
+                |update_task, block_index, data| {
+                    update_task
+                        .write_one_block(block_index, data)
+                        .map_err(|err| ResponseError::UpdateFailed(err as u32))
+                },
+                // callback to finalize after all blocks written
+                |update_task| {
+                    update_task
+                        .finish_image_update()
+                        .map_err(|err| ResponseError::UpdateFailed(err as u32))
+                },
+            ),
             reset_requested: false,
         }
     }
@@ -70,22 +81,13 @@ impl MgsCommon {
             length: update.total_size
         }));
 
-        if let Some(progress) = self.update_buf.as_ref() {
-            return Err(ResponseError::UpdateInProgress {
-                bytes_received: progress.bytes_written as u32,
-            });
-        }
+        self.update_buf.ensure_no_update_in_progress()?;
 
         self.update_task
             .prep_image_update(UpdateTarget::Alternate)
             .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
 
-        // We can only call `claim_static_resources` once; we bail out above
-        // if `self.update_buf` is already `Some(_)`, and after we claim it
-        // here, we store that into `self.update_buf` (and never clear it).
-        let mut update_buffer = UpdateBuffer::claim_static_resources();
-        update_buffer.total_length = update.total_size as usize;
-        self.update_buf = Some(update_buffer);
+        self.update_buf.start(update.total_size as usize);
 
         Ok(())
     }
@@ -99,14 +101,7 @@ impl MgsCommon {
             offset: chunk.offset,
         }));
 
-        let update_buf = self
-            .update_buf
-            .as_mut()
-            .ok_or(ResponseError::InvalidUpdateChunk)?;
-
-        update_buf.ingest_chunk(&self.update_task, chunk.offset, data)?;
-
-        Ok(())
+        self.update_buf.ingest_chunk(&self.update_task, chunk.offset, data)
     }
 
     pub(crate) fn reset_prepare(&mut self) -> Result<(), ResponseError> {
@@ -131,92 +126,6 @@ impl MgsCommon {
 
         // If `request_reset()` returns, something has gone very wrong.
         panic!()
-    }
-}
-
-struct UpdateBuffer {
-    total_length: usize,
-    bytes_written: usize,
-    current_block: &'static mut heapless::Vec<u8, BLOCK_SIZE_BYTES>,
-}
-
-impl UpdateBuffer {
-    fn claim_static_resources() -> Self {
-        Self {
-            total_length: 0,
-            bytes_written: 0,
-            current_block: claim_update_buffer_static(),
-        }
-    }
-
-    fn ingest_chunk(
-        &mut self,
-        update_task: &Update,
-        offset: u32,
-        mut data: &[u8],
-    ) -> Result<(), ResponseError> {
-        // Reject chunks that don't match our current progress.
-        if offset as usize != self.bytes_written {
-            return Err(ResponseError::UpdateInProgress {
-                bytes_received: self.bytes_written as u32,
-            });
-        }
-
-        // Reject chunks that would go past the total size we're expecting.
-        if self.bytes_written + data.len() > self.total_length {
-            return Err(ResponseError::InvalidUpdateChunk);
-        }
-
-        while !data.is_empty() {
-            let cap = self.current_block.capacity() - self.current_block.len();
-            assert!(cap > 0);
-            let to_copy = usize::min(cap, data.len());
-
-            let current_block_index = self.bytes_written / BLOCK_SIZE_BYTES;
-            self.current_block
-                .extend_from_slice(&data[..to_copy])
-                .unwrap_lite();
-            data = &data[to_copy..];
-            self.bytes_written += to_copy;
-
-            // If the block is full or this is the final block, send it to the
-            // update task.
-            if self.current_block.len() == self.current_block.capacity()
-                || self.bytes_written == self.total_length
-            {
-                let result = update_task
-                    .write_one_block(current_block_index, &self.current_block)
-                    .map_err(|err| ResponseError::UpdateFailed(err as u32));
-
-                // Unconditionally clear our block buffer after attempting to
-                // write the block.
-                let n = self.current_block.len();
-                self.current_block.clear();
-
-                // If writing this block failed, roll back our `bytes_written`
-                // counter to the beginning of the block we just tried to write.
-                if let Err(err) = result {
-                    self.bytes_written -= n;
-                    return Err(err);
-                }
-            }
-        }
-
-        // Finalizing the update is implicit (we finalize if we just wrote the
-        // last block). Should we make it explict somehow? Maybe that comes with
-        // adding auth / code signing?
-        if self.bytes_written == self.total_length {
-            update_task
-                .finish_image_update()
-                .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
-            ringbuf_entry!(Log::UpdateComplete);
-        } else {
-            ringbuf_entry!(Log::UpdatePartial {
-                bytes_written: self.bytes_written
-            });
-        }
-
-        Ok(())
     }
 }
 

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -101,7 +101,8 @@ impl MgsCommon {
             offset: chunk.offset,
         }));
 
-        self.update_buf.ingest_chunk(&self.update_task, chunk.offset, data)
+        self.update_buf
+            .ingest_chunk(&self.update_task, chunk.offset, data)
     }
 
     pub(crate) fn reset_prepare(&mut self) -> Result<(), ResponseError> {

--- a/task/mgmt-gateway/src/mgs_psc.rs
+++ b/task/mgmt-gateway/src/mgs_psc.rs
@@ -4,13 +4,13 @@
 
 use core::convert::Infallible;
 
-use crate::{mgs_common::MgsCommon, Log, MgsMessage, __RINGBUF};
+use crate::{mgs_common::MgsCommon, Log, MgsMessage};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
     SpComponent, SpPort, SpState, UpdateChunk, UpdateStart,
 };
-use ringbuf::ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_net_api::UdpMetadata;
 
 pub(crate) struct MgsHandler {
@@ -55,7 +55,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
+            target
+        }));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -64,7 +66,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<BulkIgnitionState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -75,7 +77,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -115,7 +117,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -126,7 +128,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -138,7 +140,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 

--- a/task/mgmt-gateway/src/mgs_sidecar.rs
+++ b/task/mgmt-gateway/src/mgs_sidecar.rs
@@ -4,13 +4,13 @@
 
 use core::convert::Infallible;
 
-use crate::{mgs_common::MgsCommon, Log, MgsMessage, __RINGBUF};
+use crate::{mgs_common::MgsCommon, Log, MgsMessage};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
     SpComponent, SpPort, SpState, UpdateChunk, UpdateStart,
 };
-use ringbuf::ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_net_api::UdpMetadata;
 
 pub(crate) struct MgsHandler {
@@ -55,7 +55,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
+            target
+        }));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -64,7 +66,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<BulkIgnitionState, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -75,7 +77,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -115,7 +117,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
@@ -126,7 +128,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -138,7 +140,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), ResponseError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(ResponseError::RequestUnsupportedForSp)
     }
 

--- a/task/mgmt-gateway/src/update_buffer.rs
+++ b/task/mgmt-gateway/src/update_buffer.rs
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{Log, __RINGBUF};
+use core::marker::PhantomData;
+use gateway_messages::ResponseError;
+use ringbuf::ringbuf_entry;
+use userlib::UnwrapLite;
+
+/// `UpdateBuffer` provides common logic for apply updates over the management
+/// network, assuming a common pattern of:
+///
+/// 1. A fixed block size.
+/// 2. Update size is known when the update begins, but data arives in
+///    arbitrarily-sized chunks.
+/// 3. A function to call for each complete block (and the final, potentially
+///    short block).
+/// 4. A function to call once all blocks have been written.
+pub struct UpdateBuffer<T, const BLOCK_SIZE: usize> {
+    total_length: usize,
+    bytes_written: usize,
+    current_block: &'static mut heapless::Vec<u8, BLOCK_SIZE>,
+    update_in_progress: bool,
+    write_block_fn: fn(&T, usize, &[u8]) -> Result<(), ResponseError>,
+    finalize_fn: fn(&T) -> Result<(), ResponseError>,
+    marker: PhantomData<fn() -> T>,
+}
+
+impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
+    pub fn new(
+        buf: &'static mut heapless::Vec<u8, BLOCK_SIZE>,
+        write_block_fn: fn(
+            user_data: &T,
+            block_number: usize,
+            block_data: &[u8],
+        ) -> Result<(), ResponseError>,
+        finalize_fn: fn(user_data: &T) -> Result<(), ResponseError>,
+    ) -> Self {
+        Self {
+            total_length: 0,
+            bytes_written: 0,
+            current_block: buf,
+            update_in_progress: false,
+            write_block_fn,
+            finalize_fn,
+            marker: PhantomData,
+        }
+    }
+
+    pub fn ensure_no_update_in_progress(&self) -> Result<(), ResponseError> {
+        if self.update_in_progress {
+            Err(ResponseError::UpdateInProgress {
+                bytes_received: self.bytes_written as u32,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Panics if an update is in progress; use
+    /// [`ensure_no_update_in_progress()`] first.
+    pub fn start(&mut self, total_length: usize) {
+        if self.update_in_progress {
+            panic!();
+        }
+
+        self.update_in_progress = true;
+        self.total_length = total_length;
+        self.bytes_written = 0;
+        self.current_block.clear();
+    }
+
+    pub fn ingest_chunk(
+        &mut self,
+        user_data: &T,
+        offset: u32,
+        mut data: &[u8],
+    ) -> Result<(), ResponseError> {
+        // Reject chunks if we don't have an update in progress.
+        if !self.update_in_progress {
+            return Err(ResponseError::InvalidUpdateChunk);
+        }
+
+        // Reject chunks that don't match our current progress.
+        if offset as usize != self.bytes_written {
+            return Err(ResponseError::UpdateInProgress {
+                bytes_received: self.bytes_written as u32,
+            });
+        }
+
+        // Reject chunks that would go past the total size we're expecting.
+        if self.bytes_written + data.len() > self.total_length {
+            return Err(ResponseError::InvalidUpdateChunk);
+        }
+
+        while !data.is_empty() {
+            let cap = self.current_block.capacity() - self.current_block.len();
+            assert!(cap > 0);
+            let to_copy = usize::min(cap, data.len());
+
+            let current_block_index = self.bytes_written / BLOCK_SIZE;
+            self.current_block
+                .extend_from_slice(&data[..to_copy])
+                .unwrap_lite();
+            data = &data[to_copy..];
+            self.bytes_written += to_copy;
+
+            // If the block is full or this is the final block, send it to the
+            // update task.
+            if self.current_block.len() == self.current_block.capacity()
+                || self.bytes_written == self.total_length
+            {
+                let result = (self.write_block_fn)(
+                    user_data,
+                    current_block_index,
+                    &self.current_block,
+                );
+
+                // Unconditionally clear our block buffer after attempting to
+                // write the block.
+                let n = self.current_block.len();
+                self.current_block.clear();
+
+                // If writing this block failed, roll back our `bytes_written`
+                // counter to the beginning of the block we just tried to write.
+                if let Err(err) = result {
+                    self.bytes_written -= n;
+                    return Err(err);
+                }
+            }
+        }
+
+        // Finalizing the update is implicit (we finalize if we just wrote the
+        // last block). Should we make it explict somehow? Maybe that comes with
+        // adding auth / code signing?
+        if self.bytes_written == self.total_length {
+            (self.finalize_fn)(user_data)?;
+            ringbuf_entry!(Log::UpdateComplete);
+        } else {
+            ringbuf_entry!(Log::UpdatePartial {
+                bytes_written: self.bytes_written
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/task/mgmt-gateway/src/update_buffer.rs
+++ b/task/mgmt-gateway/src/update_buffer.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{Log, __RINGBUF};
+use crate::Log;
 use gateway_messages::ResponseError;
-use ringbuf::ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use userlib::UnwrapLite;
 
 /// Type alias for a callback function that writes a single block of data.
@@ -140,9 +140,9 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
         // adding auth / code signing?
         if self.bytes_written == self.total_length {
             (self.finalize_fn)(user_data)?;
-            ringbuf_entry!(Log::UpdateComplete);
+            ringbuf_entry_root!(Log::UpdateComplete);
         } else {
-            ringbuf_entry!(Log::UpdatePartial {
+            ringbuf_entry_root!(Log::UpdatePartial {
                 bytes_written: self.bytes_written
             });
         }


### PR DESCRIPTION
This PR extracts `UpdateBuffer` from `mgs_common.rs` (where it's used to buffer incoming an incoming SP image) and makes it generic over:

* the block size
* the function to write a single block
* the function to finalize after the last block is written

which will allow it to be used for both SP updates (in this PR) and host boot flash updates (in a subsequent PR), and hopefully other update components in the future.

One design choice that I'm not sure about - carving it out like this assumes separate buffers for every component we want to update. That theoretically allows multiple component updates to be streamed in simultaneously, but it also may end up being prohibitive in memory usage, because it means we set a side a component-update-block-sized buffer for each one. If we end up wanting to share a single or small number of shared update buffers, this will need some changes.