### PR TITLE
lib-dice: Replace START / END with Range in cert templates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "serde-big-array",
  "sha3",
  "unwrap-lite",
+ "zerocopy",
  "zeroize",
 ]
 

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -12,6 +12,7 @@ serde-big-array = "0.4"
 sha3 = { version = "0.10", default-features = false }
 unwrap-lite = { path = "../unwrap-lite" }
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
+zerocopy = "0.6"
 
 [dependencies.salty]
 git = "https://github.com/oxidecomputer/salty"

--- a/lib/dice/src/alias_cert_tmpl.rs
+++ b/lib/dice/src/alias_cert_tmpl.rs
@@ -10,48 +10,17 @@
 // validity etc) are then removed.
 //
 // TODO: generate cert template DER from ASN.1 & text config
-#[allow(dead_code)]
+
+use core::ops::Range;
+
 pub const SIZE: usize = 608;
-#[allow(dead_code)]
-pub const SERIAL_NUMBER_START: usize = 15;
-#[allow(dead_code)]
-pub const SERIAL_NUMBER_END: usize = 16;
-#[allow(dead_code)]
-pub const ISSUER_SN_START: usize = 169;
-#[allow(dead_code)]
-pub const ISSUER_SN_END: usize = 181;
-#[allow(dead_code)]
-pub const SN_LENGTH: usize = 12;
-#[allow(dead_code)]
-pub const NOTBEFORE_START: usize = 185;
-#[allow(dead_code)]
-pub const NOTBEFORE_END: usize = 198;
-#[allow(dead_code)]
-pub const NOTBEFORE_LENGTH: usize = 13;
-#[allow(dead_code)]
-pub const SUBJECT_SN_START: usize = 357;
-#[allow(dead_code)]
-pub const SUBJECT_SN_END: usize = 369;
-#[allow(dead_code)]
-pub const PUB_START: usize = 381;
-#[allow(dead_code)]
-pub const PUB_END: usize = 413;
-#[allow(dead_code)]
-pub const SIG_START: usize = 544;
-#[allow(dead_code)]
-pub const SIG_END: usize = 608;
-#[allow(dead_code)]
-pub const SIGNDATA_START: usize = 4;
-#[allow(dead_code)]
-pub const SIGNDATA_END: usize = 534;
-#[allow(dead_code)]
-pub const SIGNDATA_LENGTH: usize = 530;
-#[allow(dead_code)]
-pub const FWID_START: usize = 502;
-#[allow(dead_code)]
-pub const FWID_END: usize = 534;
-#[allow(dead_code)]
-pub const FWID_LENGTH: usize = 32;
+pub const SERIAL_NUMBER_RANGE: Range<usize> = 15..16;
+pub const ISSUER_SN_RANGE: Range<usize> = 169..181;
+pub const SUBJECT_SN_RANGE: Range<usize> = 357..369;
+pub const PUB_RANGE: Range<usize> = 381..413;
+pub const SIG_RANGE: Range<usize> = 544..608;
+pub const SIGNDATA_RANGE: Range<usize> = 4..534;
+pub const FWID_RANGE: Range<usize> = 502..534;
 pub const CERT_TMPL: [u8; 608] = [
     0x30, 0x82, 0x02, 0x5c, 0x30, 0x82, 0x02, 0x0e, 0xa0, 0x03, 0x02, 0x01,
     0x02, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x30,

--- a/lib/dice/src/deviceid_cert_tmpl.rs
+++ b/lib/dice/src/deviceid_cert_tmpl.rs
@@ -10,42 +10,16 @@
 // validity etc) are then removed.
 //
 // TODO: generate cert template DER from ASN.1 & text config
-#[allow(dead_code)]
+
+use core::ops::Range;
+
 pub const SIZE: usize = 531;
-#[allow(dead_code)]
-pub const SERIAL_NUMBER_START: usize = 15;
-#[allow(dead_code)]
-pub const SERIAL_NUMBER_END: usize = 16;
-#[allow(dead_code)]
-pub const ISSUER_SN_START: usize = 169;
-#[allow(dead_code)]
-pub const ISSUER_SN_END: usize = 181;
-#[allow(dead_code)]
-pub const SN_LENGTH: usize = 12;
-#[allow(dead_code)]
-pub const NOTBEFORE_START: usize = 185;
-#[allow(dead_code)]
-pub const NOTBEFORE_END: usize = 198;
-#[allow(dead_code)]
-pub const NOTBEFORE_LENGTH: usize = 13;
-#[allow(dead_code)]
-pub const SUBJECT_SN_START: usize = 361;
-#[allow(dead_code)]
-pub const SUBJECT_SN_END: usize = 373;
-#[allow(dead_code)]
-pub const PUB_START: usize = 385;
-#[allow(dead_code)]
-pub const PUB_END: usize = 417;
-#[allow(dead_code)]
-pub const SIG_START: usize = 467;
-#[allow(dead_code)]
-pub const SIG_END: usize = 531;
-#[allow(dead_code)]
-pub const SIGNDATA_START: usize = 4;
-#[allow(dead_code)]
-pub const SIGNDATA_END: usize = 457;
-#[allow(dead_code)]
-pub const SIGNDATA_LENGTH: usize = 453;
+pub const SERIAL_NUMBER_RANGE: Range<usize> = 15..16;
+pub const ISSUER_SN_RANGE: Range<usize> = 169..181;
+pub const SUBJECT_SN_RANGE: Range<usize> = 361..373;
+pub const PUB_RANGE: Range<usize> = 385..417;
+pub const SIG_RANGE: Range<usize> = 467..531;
+pub const SIGNDATA_RANGE: Range<usize> = 4..457;
 pub const CERT_TMPL: [u8; 531] = [
     0x30, 0x82, 0x02, 0x0f, 0x30, 0x82, 0x01, 0xc1, 0xa0, 0x03, 0x02, 0x01,
     0x02, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x30,

--- a/stage0/src/dice.rs
+++ b/stage0/src/dice.rs
@@ -5,8 +5,8 @@
 use crate::image_header::Image;
 use core::str::FromStr;
 use dice_crate::{
-    AliasCert, AliasData, AliasOkm, Cdi, CdiL1, DeviceIdOkm, DeviceIdSelfCert,
-    Handoff, SeedBuf, SerialNumber,
+    AliasCert, AliasData, AliasOkm, Cdi, CdiL1, CertSerialNumber, DeviceIdOkm,
+    DeviceIdSelfCert, Handoff, SeedBuf, SerialNumber,
 };
 use lpc55_pac::Peripherals;
 use salty::signature::Keypair;
@@ -40,11 +40,10 @@ pub fn run(image: &Image) {
 
     let dname_sn = get_serial_number();
     let deviceid_keypair = get_deviceid_keypair(&cdi);
-    let mut cert_sn = 0;
+    let mut cert_sn = CertSerialNumber::default();
 
     let deviceid_cert =
-        DeviceIdSelfCert::new(cert_sn, &dname_sn, &deviceid_keypair);
-    cert_sn += 1;
+        DeviceIdSelfCert::new(&cert_sn.next(), &dname_sn, &deviceid_keypair);
 
     // Collect hash(es) of TCB. The first TCB Component Identifier (TCI)
     // calculated is the Hubris image. The DICE specs call this collection
@@ -65,7 +64,7 @@ pub fn run(image: &Image) {
     let alias_keypair = Keypair::from(alias_okm.as_bytes());
 
     let alias_cert = AliasCert::new(
-        cert_sn,
+        &cert_sn.next(),
         &dname_sn,
         &alias_keypair.public,
         fwid.as_ref(),


### PR DESCRIPTION
This simplifies the get / set functions in the Cert trait. This resolves #747