### PR TITLE
Change the Salty library we use to an oxide fork with zeroize.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,8 +2815,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "salty"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cdd38ed8bfe51e53ee991aae0791b94349d0a05cfdecd283835a8a965d4c37"
+source = "git+https://github.com/oxidecomputer/salty?rev=eb3c31858f631a7fb9934246c8efdef080d05726#eb3c31858f631a7fb9934246c8efdef080d05726"
 dependencies = [
  "ed25519",
  "subtle",

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2021"
 hkdf = { version = "0.12", default-features = false }
 hubpack = "0.1"
 lpc55-pac = "0.3"
-salty = "0.2"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"
 sha3 = { version = "0.10", default-features = false }
 unwrap-lite = { path = "../unwrap-lite" }
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
+
+[dependencies.salty]
+git = "https://github.com/oxidecomputer/salty"
+rev = "eb3c31858f631a7fb9934246c8efdef080d05726"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -18,7 +18,6 @@ lpc55-pac = {version = "0.3.0", features = ["rt"]}
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 hmac = { version = "0.10.1", default-features = false }
-salty = { version = "0.2", optional = true }
 sha3 = { version = "0.10", default-features = false, optional = true }
 zerocopy = "0.6.1"
 abi = { path = "../sys/abi" }
@@ -31,6 +30,11 @@ nb = "1"
 package = "dice"
 path = "../lib/dice"
 default-features = false
+optional = true
+
+[dependencies.salty]
+git = "https://github.com/oxidecomputer/salty"
+rev = "eb3c31858f631a7fb9934246c8efdef080d05726"
 optional = true
 
 [[bin]]


### PR DESCRIPTION
This can be reverted once upstream merges & releases https://github.com/ycrypto/salty/pull/26 or something similar.