### PR TITLE
Add support for `Addrmap` to `fpga-regmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
  "drv-i2c-api",
  "drv-onewire",
  "num-traits",
- "pmbus 0.1.0 (git+https://github.com/oxidecomputer/pmbus)",
+ "pmbus",
  "ringbuf",
  "userlib",
  "zerocopy",
@@ -1826,15 +1826,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hif"
-version = "0.2.3"
-dependencies = [
- "pkg-version",
- "postcard",
- "serde",
-]
-
-[[package]]
-name = "hif"
 version = "0.3.1"
 source = "git+https://github.com/oxidecomputer/hif#34aace65cbf458129dcd8007715a94bc488b2931"
 dependencies = [
@@ -2563,20 +2554,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-dependencies = [
- "anyhow",
- "convert_case 0.3.2",
- "libm",
- "num-derive",
- "num-traits",
- "ron 0.6.6",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "pmbus"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/pmbus#1907e4470c84f7dfd86e8ca9a910f97ce548076e"
 dependencies = [
  "anyhow",
@@ -3121,14 +3098,6 @@ dependencies = [
 [[package]]
 name = "spd"
 version = "0.1.0"
-dependencies = [
- "num-derive",
- "num-traits",
-]
-
-[[package]]
-name = "spd"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/spd#e37e79f6d7d4805b8a6a8c4d37699c4bd60222ea"
 dependencies = [
  "num-derive",
@@ -3365,7 +3334,7 @@ dependencies = [
  "drv-stm32xx-i2c",
  "drv-stm32xx-sys-api",
  "drv-update-api",
- "hif 0.3.1",
+ "hif",
  "hubris-num-tasks",
  "num-traits",
  "ringbuf",
@@ -3628,7 +3597,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "spd 0.1.0 (git+https://github.com/oxidecomputer/spd)",
+ "spd",
  "stm32h7",
  "userlib",
 ]


### PR DESCRIPTION
Addresses are flattened with increasingly long prefixes (based on `addrmap`'s `inst_name`); the register map itself is split into nested modules.

Fixes #768 