### PR TITLE
Fix auxflash slot size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ name = "drv-auxflash-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
+ "cfg-if",
  "drv-auxflash-api",
  "drv-qspi-api",
  "drv-stm32h7-qspi",

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -14,6 +14,7 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
 
+cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 sha3 = {version = "0.10", default-features = false}
 stm32h7 = { version = "0.14", default-features = false }

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -390,8 +390,11 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
         if slot >= SLOT_COUNT {
             return Err(AuxFlashError::InvalidSlot.into());
         }
+        if offset >= SLOT_SIZE as u32 {
+            return Err(AuxFlashError::AddressOverflow.into());
+        }
         let addr = slot as usize * SLOT_SIZE + offset as usize;
-        if addr >= SLOT_SIZE {
+        if addr > u32::MAX as usize {
             return Err(AuxFlashError::AddressOverflow.into());
         }
 

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -47,7 +47,7 @@ struct SlotReader<'a> {
 
 impl<'a> TlvcRead for SlotReader<'a> {
     fn extent(&self) -> Result<u64, TlvcReadError> {
-        // Hard-coded slot size of 1MiB
+        // Hard-coded slot size, on a per-board basis
         Ok(SLOT_SIZE as u64)
     }
     fn read_exact(

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -381,6 +381,26 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
         Ok(())
     }
 
+    fn slot_sector_erase(
+        &mut self,
+        _: &RecvMessage,
+        slot: u32,
+        offset: u32,
+    ) -> Result<(), RequestError<AuxFlashError>> {
+        if slot >= SLOT_COUNT {
+            return Err(AuxFlashError::InvalidSlot.into());
+        }
+        let addr = slot as usize * SLOT_SIZE + offset as usize;
+        if addr >= SLOT_SIZE {
+            return Err(AuxFlashError::AddressOverflow.into());
+        }
+
+        self.set_and_check_write_enable()?;
+        self.qspi.sector_erase(addr as u32);
+        self.poll_for_write_complete(Some(1));
+        Ok(())
+    }
+
     fn write_slot_with_offset(
         &mut self,
         _: &RecvMessage,

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -13,12 +13,17 @@ use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
 use userlib::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(target_board="sidecar-1")] {
+    if #[cfg(target_board="sidecar-a")] {
         const MEMORY_SIZE: u32 = 16 << 20; // 16 MiB
         const SLOT_COUNT: u32 = 8;
         const SLOT_SIZE: usize = (MEMORY_SIZE / SLOT_COUNT) as usize;
     } else {
-        panic!("No auxflash support for this board")
+        compile_error!("No auxflash support for this board");
+        // Dummy values so that the error above is obvious; otherwise, the
+        // compiler throws out a bunch of other errors.
+        const MEMORY_SIZE: u32 = 0;
+        const SLOT_COUNT: u32 = 0;
+        const SLOT_SIZE: usize = 0;
     }
 }
 

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -41,6 +41,17 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "slot_sector_erase": (
+            doc: "erase a particular sector within a slot",
+            args: {
+                "slot": "u32",
+                "offset": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
         "read_slot_chck": (
             doc: "reads and verifies the CHCK field in an auxiliary flash slot",
             args: {

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -17,6 +17,13 @@ Interface(
                 err: CLike("AuxFlashError"),
             ),
         ),
+        "slot_size": (
+            doc: "returns the size of a slot, in bytes",
+            reply: Result(
+                ok: "u32",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
         "read_status": (
             doc: "reads the auxiliary flash chip's status register",
             reply: Result(


### PR DESCRIPTION
The RFD had a mix of 1 MiB and 2 MiB.  This standardizes on 2 MiB, but makes it board-dependent (and adds an API to query it!)