### PR TITLE
mgmt-gateway: Add update status and update IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=e6eccffb236d0c242b5f90d30d01daa47aa9d89f#e6eccffb236d0c242b5f90d30d01daa47aa9d89f"
+source = "git+https://github.com/oxidecomputer/omicron?rev=d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91#d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -1670,6 +1670,7 @@ dependencies = [
  "serde_repr",
  "smoltcp",
  "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -4068,6 +4069,12 @@ dependencies = [
  "unwrap-lite",
  "zerocopy",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 
 [[package]]
 name = "vcell"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -224,8 +224,8 @@ features = ["vlan"]
 [tasks.mgmt_gateway]
 name = "task-mgmt-gateway"
 priority = 6
-max-sizes = {flash = 32768, ram = 8192}
-stacksize = 1536
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 2048
 start = true
 uses = [
     "usart1",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -141,8 +141,8 @@ features = ["vlan"]
 [tasks.mgmt_gateway]
 name = "task-mgmt-gateway"
 priority = 4
-max-sizes = {flash = 32768, ram = 8192}
-stacksize = 1536
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 2048
 start = true
 uses = [
     "usart1",

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -20,7 +20,7 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "e6eccffb236d0c242b5f90d30d01daa47aa9d89f"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91"}
 
 [features]
 gimlet = []

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -7,7 +7,7 @@
 
 use gateway_messages::{
     sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, SpComponent,
-    SpPort,
+    SpPort, UpdateId,
 };
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
@@ -52,7 +52,7 @@ enum Log {
     UsartRxOverrun,
     UsartRxBufferDataDropped { num_bytes: u64 },
     SerialConsoleSend { buffered: usize },
-    UpdatePartial { bytes_written: usize },
+    UpdatePartial { bytes_written: u32 },
     UpdateComplete,
     HostFlashSectorsErased { num_sectors: usize },
 }
@@ -77,17 +77,16 @@ enum MgsMessage {
     SerialConsoleDetach,
     UpdatePrepare {
         component: SpComponent,
-        stream_id: u64,
+        id: UpdateId,
         length: u32,
         slot: u16,
-    },
-    UpdatePrepareStatus {
-        component: SpComponent,
-        stream_id: u64,
     },
     UpdateChunk {
         component: SpComponent,
         offset: u32,
+    },
+    UpdateStatus {
+        component: SpComponent,
     },
     UpdateAbort {
         component: SpComponent,

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -5,10 +5,10 @@
 use crate::{update_buffer::UpdateBuffer, Log, MgsMessage};
 use core::convert::Infallible;
 use drv_update_api::stm32h7::BLOCK_SIZE_BYTES;
-use drv_update_api::{Update, UpdateTarget};
+use drv_update_api::{Update, UpdateError, UpdateTarget};
 use gateway_messages::{
     DiscoverResponse, ResponseError, SpComponent, SpPort, SpState, UpdateChunk,
-    UpdatePrepare, UpdatePrepareStatusRequest, UpdatePrepareStatusResponse,
+    UpdateId, UpdatePrepare, UpdateStatus,
 };
 use ringbuf::ringbuf_entry_root;
 
@@ -94,23 +94,9 @@ impl MgsCommon {
             .prep_image_update(UpdateTarget::Alternate)
             .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
 
-        self.update_buf
-            .start(update.stream_id, update.total_size as usize);
+        self.update_buf.start(update.id, update.total_size);
 
         Ok(())
-    }
-
-    pub(crate) fn update_prepare_status(
-        &mut self,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError> {
-        self.update_buf
-            .ensure_matching_stream_id(request.stream_id)?;
-
-        // We immediately prepare for update in `update_prepare()`
-        // and have no followup work to do; if this stream ID
-        // matches, we're already prepared.
-        Ok(UpdatePrepareStatusResponse { done: true })
     }
 
     pub(crate) fn update_chunk(
@@ -119,21 +105,44 @@ impl MgsCommon {
         data: &[u8],
     ) -> Result<(), ResponseError> {
         self.update_buf
-            .ingest_chunk(
-                chunk.stream_id,
-                &self.update_task,
-                chunk.offset,
-                data,
-            )
+            .ingest_chunk(&chunk.id, &self.update_task, chunk.offset, data)
             .map(|_progress| ())
     }
 
-    pub(crate) fn update_abort(&mut self) -> Result<(), ResponseError> {
-        self.update_task
-            .abort_update()
-            .map_err(|err| ResponseError::UpdateFailed(err as u32))?;
+    pub(crate) fn status(&self) -> UpdateStatus {
+        self.update_buf.status()
+    }
 
-        self.update_buf.reset();
+    pub(crate) fn update_abort(
+        &mut self,
+        id: &UpdateId,
+    ) -> Result<(), ResponseError> {
+        // We will allow the abort if either:
+        //
+        // 1. We have an in-progress update that matches `id`
+        // 2. We do not have an in-progress update
+        //
+        // We only want to return an error if we have a _different_ in-progress
+        // update.
+        match self.update_buf.in_progress_update_id() {
+            Some(in_progress_id) if id != in_progress_id => {
+                return Err(ResponseError::UpdateInProgress(
+                    self.update_buf.status(),
+                ));
+            }
+            _ => (),
+        }
+
+        match self.update_task.abort_update() {
+            // Aborting an update that hasn't started yet is fine; either way
+            // our caller is clear to start a new update.
+            Ok(()) | Err(UpdateError::UpdateNotStarted) => (),
+            Err(other) => {
+                return Err(ResponseError::UpdateFailed(other as u32))
+            }
+        }
+
+        self.update_buf.abort();
 
         Ok(())
     }

--- a/task/mgmt-gateway/src/mgs_gimlet.rs
+++ b/task/mgmt-gateway/src/mgs_gimlet.rs
@@ -2,10 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::update_buffer::{UpdateBuffer, UpdateProgress};
 use crate::{
-    mgs_common::MgsCommon, vlan_id_from_sp_port, Log, MgsMessage, SYS,
-    USART_IRQ,
+    mgs_common::MgsCommon, update_buffer::UpdateBuffer, vlan_id_from_sp_port,
+    Log, MgsMessage, SYS, USART_IRQ,
 };
 use core::convert::Infallible;
 use core::ops::Range;
@@ -19,7 +18,8 @@ use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
     SpComponent, SpMessage, SpMessageKind, SpPort, SpState, UpdateChunk,
-    UpdatePrepare, UpdatePrepareStatusRequest, UpdatePrepareStatusResponse,
+    UpdateId, UpdatePreparationProgress, UpdatePreparationStatus,
+    UpdatePrepare, UpdateStatus,
 };
 use heapless::Deque;
 use ringbuf::ringbuf_entry_root;
@@ -220,34 +220,14 @@ impl SpHandler for MgsHandler {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
-            stream_id: update.stream_id,
+            id: update.id,
             slot: update.slot,
         }));
 
         match update.component {
             SpComponent::SP_ITSELF => self.common.update_prepare(update),
-            SpComponent::SP3_HOST_CPU => self.host_flash_update.prepare(update),
-            _ => Err(ResponseError::RequestUnsupportedForComponent),
-        }
-    }
-
-    fn update_prepare_status(
-        &mut self,
-        _sender: SocketAddrV6,
-        _port: SpPort,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepareStatus {
-            component: request.component,
-            stream_id: request.stream_id,
-        }));
-
-        match request.component {
-            SpComponent::SP_ITSELF => {
-                self.common.update_prepare_status(request)
-            }
-            SpComponent::SP3_HOST_CPU => {
-                self.host_flash_update.prepare_status(request)
+            SpComponent::HOST_CPU_BOOT_FLASH => {
+                self.host_flash_update.prepare(update)
             }
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
@@ -267,9 +247,26 @@ impl SpHandler for MgsHandler {
 
         match chunk.component {
             SpComponent::SP_ITSELF => self.common.update_chunk(chunk, data),
-            SpComponent::SP3_HOST_CPU => {
+            SpComponent::HOST_CPU_BOOT_FLASH => {
                 self.host_flash_update.ingest_chunk(chunk, data)
             }
+            _ => Err(ResponseError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn update_status(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<UpdateStatus, ResponseError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
+        }));
+
+        match component {
+            SpComponent::SP_ITSELF => Ok(self.common.status()),
+            SpComponent::HOST_CPU_BOOT_FLASH => self.host_flash_update.status(),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }
@@ -279,14 +276,17 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
         component: SpComponent,
+        id: UpdateId,
     ) -> Result<(), ResponseError> {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
             component
         }));
 
         match component {
-            SpComponent::SP_ITSELF => self.common.update_abort(),
-            SpComponent::SP3_HOST_CPU => self.host_flash_update.abort(),
+            SpComponent::SP_ITSELF => self.common.update_abort(&id),
+            SpComponent::HOST_CPU_BOOT_FLASH => {
+                self.host_flash_update.abort(&id)
+            }
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }
@@ -674,6 +674,34 @@ impl HostFlashUpdate {
         }
     }
 
+    fn status(&self) -> Result<UpdateStatus, ResponseError> {
+        let status = self.buf.status();
+        match &status {
+            // `UpdateBuffer` never sets its status to "preparing", as it
+            // doesn't know anything about that stage.
+            UpdateStatus::Preparing { .. } => panic!(),
+            UpdateStatus::InProgress(sub_status) => {
+                if let Some(sector_erase) = self.sector_erase.as_ref() {
+                    // If we're still erasing sectors, we shouldn't have
+                    // ingested any chunks yet.
+                    assert!(sub_status.bytes_received == 0);
+
+                    sector_erase.progress().map(|progress| {
+                        UpdateStatus::Preparing(UpdatePreparationStatus {
+                            id: sub_status.id,
+                            progress: Some(progress),
+                        })
+                    })
+                } else {
+                    Ok(status)
+                }
+            }
+            UpdateStatus::None
+            | UpdateStatus::Complete(_)
+            | UpdateStatus::Aborted(_) => Ok(status),
+        }
+    }
+
     fn needs_sectors_erased(&self) -> bool {
         self.sector_erase.is_some()
     }
@@ -727,31 +755,9 @@ impl HostFlashUpdate {
         self.sector_erase =
             Some(HostFlashSectorErase::new(capacity / SECTOR_SIZE_BYTES));
 
-        self.buf.start(update.stream_id, update.total_size as usize);
+        self.buf.start(update.id, update.total_size);
 
         Ok(())
-    }
-
-    fn prepare_status(
-        &self,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError> {
-        self.buf.ensure_matching_stream_id(request.stream_id)?;
-
-        // Have we failed erasing sectors?
-        if let Some(err) = self
-            .sector_erase
-            .as_ref()
-            .and_then(HostFlashSectorErase::most_recent_error)
-        {
-            return Err(ResponseError::UpdateFailed(err as u32));
-        }
-
-        // We have an update in progress that matches request.stream_id; do we
-        // still have sectors to erase?
-        Ok(UpdatePrepareStatusResponse {
-            done: self.sector_erase.is_none(),
-        })
     }
 
     fn ingest_chunk(
@@ -764,25 +770,28 @@ impl HostFlashUpdate {
             return Err(ResponseError::UpdateNotPrepared);
         }
 
-        match self.buf.ingest_chunk(
-            chunk.stream_id,
-            &self.task,
-            chunk.offset,
-            data,
-        )? {
-            UpdateProgress::Complete => {
-                // Update complete; we can now accept a new update.
-                self.buf.reset();
-            }
-            UpdateProgress::Incomplete => (),
-        }
-        Ok(())
+        self.buf
+            .ingest_chunk(&chunk.id, &self.task, chunk.offset, data)
     }
 
-    fn abort(&mut self) -> Result<(), ResponseError> {
+    fn abort(&mut self, id: &UpdateId) -> Result<(), ResponseError> {
+        // We will allow the abort if either:
+        //
+        // 1. We have an in-progress update that matches `id`
+        // 2. We do not have an in-progress update
+        //
+        // We only want to return an error if we have a _different_ in-progress
+        // update.
+        match self.buf.in_progress_update_id() {
+            Some(in_progress_id) if id != in_progress_id => {
+                return Err(ResponseError::UpdateInProgress(self.buf.status()));
+            }
+            _ => (),
+        }
+
         // TODO should we erase the slot?
         // TODO should we set_dev() back to what it was (if we changed it)?
-        self.buf.reset();
+        self.buf.abort();
         self.sector_erase = None;
         Ok(())
     }
@@ -805,8 +814,15 @@ impl HostFlashSectorErase {
         self.sectors_to_erase.is_empty()
     }
 
-    fn most_recent_error(&self) -> Option<HfError> {
-        self.most_recent_error
+    fn progress(&self) -> Result<UpdatePreparationProgress, ResponseError> {
+        if let Some(err) = self.most_recent_error {
+            Err(ResponseError::UpdateFailed(err as u32))
+        } else {
+            Ok(UpdatePreparationProgress {
+                current: self.sectors_to_erase.start as u32,
+                total: self.sectors_to_erase.end as u32,
+            })
+        }
     }
 
     fn erase_sectors_if_needed(&mut self, task: &HostFlash) {

--- a/task/mgmt-gateway/src/mgs_psc.rs
+++ b/task/mgmt-gateway/src/mgs_psc.rs
@@ -8,8 +8,8 @@ use crate::{mgs_common::MgsCommon, Log, MgsMessage};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
-    SpComponent, SpPort, SpState, UpdateChunk, UpdatePrepare,
-    UpdatePrepareStatusRequest, UpdatePrepareStatusResponse,
+    SpComponent, SpPort, SpState, UpdateChunk, UpdateId, UpdatePrepare,
+    UpdateStatus,
 };
 use ringbuf::ringbuf_entry_root;
 use task_net_api::UdpMetadata;
@@ -111,7 +111,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
-            stream_id: update.stream_id,
+            id: update.id,
             slot: update.slot,
         }));
 
@@ -121,21 +121,18 @@ impl SpHandler for MgsHandler {
         }
     }
 
-    fn update_prepare_status(
+    fn update_status(
         &mut self,
         _sender: SocketAddrV6,
         _port: SpPort,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepareStatus {
-            component: request.component,
-            stream_id: request.stream_id,
+        component: SpComponent,
+    ) -> Result<UpdateStatus, ResponseError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
         }));
 
-        match request.component {
-            SpComponent::SP_ITSELF => {
-                self.common.update_prepare_status(request)
-            }
+        match component {
+            SpComponent::SP_ITSELF => Ok(self.common.status()),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }
@@ -163,13 +160,14 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
         component: SpComponent,
+        id: UpdateId,
     ) -> Result<(), ResponseError> {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
             component
         }));
 
         match component {
-            SpComponent::SP_ITSELF => self.common.update_abort(),
+            SpComponent::SP_ITSELF => self.common.update_abort(&id),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }

--- a/task/mgmt-gateway/src/mgs_sidecar.rs
+++ b/task/mgmt-gateway/src/mgs_sidecar.rs
@@ -8,8 +8,8 @@ use crate::{mgs_common::MgsCommon, Log, MgsMessage};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
     DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
-    SpComponent, SpPort, SpState, UpdateChunk, UpdatePrepare,
-    UpdatePrepareStatusRequest, UpdatePrepareStatusResponse,
+    SpComponent, SpPort, SpState, UpdateChunk, UpdateId, UpdatePrepare,
+    UpdateStatus,
 };
 use ringbuf::ringbuf_entry_root;
 use task_net_api::UdpMetadata;
@@ -111,7 +111,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
-            stream_id: update.stream_id,
+            id: update.id,
             slot: update.slot,
         }));
 
@@ -121,21 +121,18 @@ impl SpHandler for MgsHandler {
         }
     }
 
-    fn update_prepare_status(
+    fn update_status(
         &mut self,
         _sender: SocketAddrV6,
         _port: SpPort,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepareStatus {
-            component: request.component,
-            stream_id: request.stream_id,
+        component: SpComponent,
+    ) -> Result<UpdateStatus, ResponseError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
         }));
 
-        match request.component {
-            SpComponent::SP_ITSELF => {
-                self.common.update_prepare_status(request)
-            }
+        match component {
+            SpComponent::SP_ITSELF => Ok(self.common.status()),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }
@@ -163,13 +160,14 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
         component: SpComponent,
+        id: UpdateId,
     ) -> Result<(), ResponseError> {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
             component
         }));
 
         match component {
-            SpComponent::SP_ITSELF => self.common.update_abort(),
+            SpComponent::SP_ITSELF => self.common.update_abort(&id),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
     }

--- a/task/mgmt-gateway/src/update_buffer.rs
+++ b/task/mgmt-gateway/src/update_buffer.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::Log;
-use gateway_messages::ResponseError;
+use gateway_messages::{
+    ResponseError, UpdateId, UpdateInProgressStatus, UpdateStatus,
+};
 use ringbuf::ringbuf_entry_root;
 use userlib::UnwrapLite;
 
@@ -18,11 +20,6 @@ pub type WriteBlockFn<T> = fn(
 /// have been successfully written.
 pub type FinalizeFn<T> = fn(user_data: &T) -> Result<(), ResponseError>;
 
-pub enum UpdateProgress {
-    Complete,
-    Incomplete,
-}
-
 /// `UpdateBuffer` provides common logic for apply updates over the management
 /// network, assuming a common pattern of:
 ///
@@ -33,9 +30,10 @@ pub enum UpdateProgress {
 ///    short block).
 /// 4. A function to call once all blocks have been written.
 pub struct UpdateBuffer<T, const BLOCK_SIZE: usize> {
-    current_update_stream_id: Option<u64>,
-    total_length: usize,
-    bytes_written: usize,
+    // We never set `status` to `UpdateStatus::Preparing`, so in all matches
+    // below we panic on that arm. If there is a long-running preparation
+    // process, our caller will handle that status report.
+    status: UpdateStatus,
     current_block: &'static mut heapless::Vec<u8, BLOCK_SIZE>,
     write_block_fn: WriteBlockFn<T>,
     finalize_fn: FinalizeFn<T>,
@@ -48,82 +46,100 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
         finalize_fn: FinalizeFn<T>,
     ) -> Self {
         Self {
-            current_update_stream_id: None,
-            total_length: 0,
-            bytes_written: 0,
+            status: UpdateStatus::None,
             current_block: buf,
             write_block_fn,
             finalize_fn,
         }
     }
 
+    pub fn status(&self) -> UpdateStatus {
+        self.status
+    }
+
     pub fn ensure_no_update_in_progress(&self) -> Result<(), ResponseError> {
-        if self.current_update_stream_id.is_some() {
-            Err(ResponseError::UpdateInProgress {
-                bytes_received: self.bytes_written as u32,
-            })
-        } else {
-            Ok(())
+        match self.status {
+            UpdateStatus::Preparing { .. } => panic!(),
+            status @ UpdateStatus::InProgress(_) => {
+                Err(ResponseError::UpdateInProgress(status))
+            }
+            UpdateStatus::None
+            | UpdateStatus::Complete(_)
+            | UpdateStatus::Aborted(_) => Ok(()),
         }
     }
 
-    pub fn ensure_matching_stream_id(
-        &self,
-        stream_id: u64,
-    ) -> Result<(), ResponseError> {
-        match self.current_update_stream_id {
-            None => Err(ResponseError::UpdateNotPrepared),
-            Some(s) => {
-                if s == stream_id {
-                    Ok(())
-                } else {
-                    Err(ResponseError::InvalidUpdateStreamId {
-                        sp_stream_id: s,
-                    })
-                }
-            }
+    pub fn in_progress_update_id(&self) -> Option<&UpdateId> {
+        match &self.status {
+            UpdateStatus::Preparing { .. } => panic!(),
+            UpdateStatus::InProgress(status) => Some(&status.id),
+            UpdateStatus::None
+            | UpdateStatus::Complete(_)
+            | UpdateStatus::Aborted(_) => None,
         }
     }
 
     /// Panics if an update is in progress; use
     /// [`ensure_no_update_in_progress()`] first.
-    pub fn start(&mut self, stream_id: u64, total_length: usize) {
-        if self.current_update_stream_id.is_some() {
+    pub fn start(&mut self, update_id: UpdateId, total_size: u32) {
+        if self.ensure_no_update_in_progress().is_err() {
             panic!();
         }
 
-        self.current_update_stream_id = Some(stream_id);
-        self.total_length = total_length;
-        self.bytes_written = 0;
+        self.status = UpdateStatus::InProgress(UpdateInProgressStatus {
+            id: update_id,
+            bytes_received: 0,
+            total_size,
+        });
         self.current_block.clear();
     }
 
-    pub fn reset(&mut self) {
-        self.current_update_stream_id = None;
-        self.total_length = 0;
-        self.bytes_written = 0;
-        self.current_block.clear();
+    pub fn abort(&mut self) {
+        match self.status {
+            UpdateStatus::Preparing { .. } => panic!(),
+            UpdateStatus::InProgress(status) => {
+                self.status = UpdateStatus::Aborted(status.id);
+            }
+            UpdateStatus::None
+            | UpdateStatus::Complete(_)
+            | UpdateStatus::Aborted(_) => (),
+        }
     }
 
     pub fn ingest_chunk(
         &mut self,
-        stream_id: u64,
+        update_id: &UpdateId,
         user_data: &T,
         offset: u32,
         mut data: &[u8],
-    ) -> Result<UpdateProgress, ResponseError> {
-        // Reject chunks that don't match our current stream.
-        self.ensure_matching_stream_id(stream_id)?;
+    ) -> Result<(), ResponseError> {
+        // Check that we have an update currently in progress.
+        let status = match &mut self.status {
+            UpdateStatus::Preparing { .. } => panic!(),
+            UpdateStatus::InProgress(status) => status,
+            UpdateStatus::None
+            | UpdateStatus::Complete(_)
+            | UpdateStatus::Aborted(_) => {
+                return Err(ResponseError::UpdateNotPrepared);
+            }
+        };
 
-        // Reject chunks that don't match our current progress.
-        if offset as usize != self.bytes_written {
-            return Err(ResponseError::UpdateInProgress {
-                bytes_received: self.bytes_written as u32,
+        // Reject chunks that don't match our current update ID.
+        if &status.id != update_id {
+            return Err(ResponseError::InvalidUpdateId {
+                sp_update_id: status.id,
             });
         }
 
+        // Reject chunks that don't match our current progress.
+        if offset != status.bytes_received {
+            return Err(ResponseError::UpdateInProgress(
+                UpdateStatus::InProgress(*status),
+            ));
+        }
+
         // Reject chunks that would go past the total size we're expecting.
-        if self.bytes_written + data.len() > self.total_length {
+        if status.bytes_received + data.len() as u32 > status.total_size {
             return Err(ResponseError::InvalidUpdateChunk);
         }
 
@@ -132,17 +148,18 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
             assert!(cap > 0);
             let to_copy = usize::min(cap, data.len());
 
-            let current_block_index = self.bytes_written / BLOCK_SIZE;
+            let current_block_index =
+                status.bytes_received as usize / BLOCK_SIZE;
             self.current_block
                 .extend_from_slice(&data[..to_copy])
                 .unwrap_lite();
             data = &data[to_copy..];
-            self.bytes_written += to_copy;
+            status.bytes_received += to_copy as u32;
 
             // If the block is full or this is the final block, send it to the
             // update task.
             if self.current_block.len() == self.current_block.capacity()
-                || self.bytes_written == self.total_length
+                || status.bytes_received == status.total_size
             {
                 let result = (self.write_block_fn)(
                     user_data,
@@ -155,10 +172,10 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
                 let n = self.current_block.len();
                 self.current_block.clear();
 
-                // If writing this block failed, roll back our `bytes_written`
+                // If writing this block failed, roll back our `bytes_received`
                 // counter to the beginning of the block we just tried to write.
                 if let Err(err) = result {
-                    self.bytes_written -= n;
+                    status.bytes_received -= n as u32;
                     return Err(err);
                 }
             }
@@ -167,15 +184,16 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
         // Finalizing the update is implicit (we finalize if we just wrote the
         // last block). Should we make it explict somehow? Maybe that comes with
         // adding auth / code signing?
-        if self.bytes_written == self.total_length {
+        if status.bytes_received == status.total_size {
             (self.finalize_fn)(user_data)?;
+            self.status = UpdateStatus::Complete(*update_id);
             ringbuf_entry_root!(Log::UpdateComplete);
-            Ok(UpdateProgress::Complete)
+            Ok(())
         } else {
             ringbuf_entry_root!(Log::UpdatePartial {
-                bytes_written: self.bytes_written
+                bytes_written: status.bytes_received
             });
-            Ok(UpdateProgress::Incomplete)
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
This is the companion to the larger MGS change in https://github.com/oxidecomputer/omicron/pull/1714. From the SP's side,
the changes are relatively minor:

1. We removed "update prepare status" in favor of the more general "update status"
2. Update messages now always include an update ID, and for "update abort" we only abort if the ID matches our current in-progress update.