### PR TITLE
Make `sidecar/rev-a.toml` clippy-clean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#4e7bf5330420153b08309da0f02061dd8afd4765"
+source = "git+https://github.com/oxidecomputer/idolatry.git#8eb16148fe7a9aa3892e518d35509ce80dcc6d88"
 dependencies = [
  "indexmap",
  "quote",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#4e7bf5330420153b08309da0f02061dd8afd4765"
+source = "git+https://github.com/oxidecomputer/idolatry.git#8eb16148fe7a9aa3892e518d35509ce80dcc6d88"
 dependencies = [
  "userlib",
  "zerocopy",
@@ -2562,7 +2562,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/pmbus#1907e4470c84f7dfd86e8ca9a910f97ce548076e"
+source = "git+https://github.com/oxidecomputer/pmbus#9f5d86bfd04cbb6d7a7fcb38e00071c8b643f6f3"
 dependencies = [
  "anyhow",
  "convert_case 0.3.2",

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -54,7 +54,7 @@ fn recurse_addr_map(
                 children,
             } => {
                 recurse_addr_map(
-                    &children,
+                    children,
                     offset + addr_offset,
                     &format!("{inst_name}_{prefix}"),
                     output,
@@ -80,7 +80,7 @@ pub enum Addr {{"
     )
     .unwrap();
 
-    recurse_addr_map(&children, 0, "", output);
+    recurse_addr_map(children, 0, "", output);
 
     writeln!(output, "}}").unwrap();
     writeln!(
@@ -159,7 +159,7 @@ fn write_node_reg(node: &Node, prefix: &str, output: &mut String) {
 {prefix}    pub mod {inst_name} {{",
             )
             .unwrap();
-            recurse_reg_map(&children, &format!("    {prefix}"), output);
+            recurse_reg_map(children, &format!("    {prefix}"), output);
             writeln!(output, "{prefix}    }}").unwrap();
         }
 
@@ -190,7 +190,7 @@ pub mod Reg {{"
     )
     .unwrap();
 
-    recurse_reg_map(&children, "", output);
+    recurse_reg_map(children, "", output);
 
     writeln!(output, "}}").unwrap();
 }

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -164,7 +164,7 @@ struct I2cSensors {
     names: Option<Vec<String>>,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Disposition {
     /// controller is an initiator
     Initiator,
@@ -497,7 +497,7 @@ impl ConfigGenerator {
 
         for c in &self.controllers {
             for port in c.ports.values() {
-                if port.muxes.len() > 0 {
+                if !port.muxes.is_empty() {
                     nmuxedbuses += 1;
                 }
 
@@ -569,7 +569,7 @@ impl ConfigGenerator {
 
                     let driver_struct = format!(
                         "{}{}",
-                        (&mux.driver[..1].to_string()).to_uppercase(),
+                        mux.driver[..1].to_uppercase(),
                         &mux.driver[1..]
                     );
 
@@ -1009,20 +1009,18 @@ impl ConfigGenerator {
                 } else {
                     d.name.clone()
                 }
-            } else {
-                if let Some(names) = &d.sensors.as_ref().unwrap().names {
-                    if idx >= names.len() {
-                        panic!(
-                            "name array is too short ({}) for sensor index ({})",
-                            names.len(),
-                            idx
-                        );
-                    } else {
-                        Some(names[idx].clone())
-                    }
+            } else if let Some(names) = &d.sensors.as_ref().unwrap().names {
+                if idx >= names.len() {
+                    panic!(
+                        "name array is too short ({}) for sensor index ({})",
+                        names.len(),
+                        idx
+                    );
                 } else {
-                    d.name.clone()
+                    Some(names[idx].clone())
                 }
+            } else {
+                d.name.clone()
             };
 
             if let Some(bus) = &d.bus {

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -385,10 +385,11 @@ impl ConfigGenerator {
             I2cController {{
                 controller: Controller::I2C{controller},
                 peripheral: Peripheral::I2c{controller},
-                notification: (1 << ({controller} - 1)),
+                notification: (1 << {shift}),
                 registers: unsafe {{ &*device::I2C{controller}::ptr() }},
             }},"##,
-                controller = c.controller
+                shift = c.controller - 1,
+                controller = c.controller,
             )?;
         }
 

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -101,6 +101,8 @@ pub fn run(
         cmd.arg("clippy::identity_op");
         cmd.arg("-A");
         cmd.arg("clippy::too_many_arguments");
+        cmd.arg("-W");
+        cmd.arg("elided_lifetimes_in_paths");
 
         for opt in options {
             cmd.arg(opt);

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -430,7 +430,7 @@ impl Config {
 }
 
 /// Represents an MPU's desired alignment strategy
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum MpuAlignment {
     /// Regions should be power-of-two sized and aligned
     PowerOfTwo,

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -11,7 +11,7 @@ use sha3::{Digest, Sha3_256};
 use tlvc::{TlvcRead, TlvcReader};
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum AuxFlashError {
     WriteEnableFailed = 1,
     ServerRestarted,

--- a/drv/fpga-api/src/lib.rs
+++ b/drv/fpga-api/src/lib.rs
@@ -358,7 +358,7 @@ pub fn load_bitstream_from_auxflash(
             return Err(FpgaError::AuxReadError);
         }
 
-        if let Err(e) = bitstream.continue_load(&chunk) {
+        if let Err(e) = bitstream.continue_load(chunk) {
             let _ = bitstream.cancel_load();
             return Err(e);
         }

--- a/drv/fpga-api/src/lib.rs
+++ b/drv/fpga-api/src/lib.rs
@@ -15,7 +15,7 @@ use zerocopy::{AsBytes, FromBytes};
 #[cfg(feature = "auxflash")]
 use drv_auxflash_api::{AuxFlash, AuxFlashBlob};
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FpgaError {
     ImplError(u8),
     BitstreamError(u8),
@@ -94,7 +94,7 @@ impl core::convert::TryFrom<u32> for FpgaError {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum DeviceState {
     Unknown = 0,
@@ -104,14 +104,14 @@ pub enum DeviceState {
     Error = 4,
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum BitstreamType {
     Uncompressed = 0,
     Compressed = 1,
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum WriteOp {
     Write = 0,

--- a/drv/fpga-devices/src/ecp5.rs
+++ b/drv/fpga-devices/src/ecp5.rs
@@ -218,7 +218,7 @@ impl<Driver: Ecp5Driver> Ecp5<Driver> {
 
     /// Lock (resources in) the driver, returning a lock object which
     /// automatically releases the driver when dropped.
-    fn lock(&self) -> Result<Ecp5Lock<Driver>, Driver::Error> {
+    fn lock(&self) -> Result<Ecp5Lock<'_, Driver>, Driver::Error> {
         self.driver.configuration_lock()?;
         ringbuf_entry!(Trace::Lock);
         Ok(Ecp5Lock(&self.driver))

--- a/drv/fpga-devices/src/ecp5.rs
+++ b/drv/fpga-devices/src/ecp5.rs
@@ -12,7 +12,7 @@ use zerocopy::{AsBytes, FromBytes};
 
 /// ECP5 IDCODE values, found in Table B.5, p. 58, Lattice Semi FPGA-TN-02039-2.0.
 #[derive(
-    Copy, Clone, Debug, FromPrimitive, ToPrimitive, PartialEq, AsBytes,
+    Copy, Clone, Debug, FromPrimitive, ToPrimitive, Eq, PartialEq, AsBytes,
 )]
 #[repr(u32)]
 pub enum Id {
@@ -32,7 +32,7 @@ pub enum Id {
 /// Possible bitstream error codes returned by the device. These values are
 /// taken from Table 4.2, p. 10, Lattice Semi FPGA-TN-02039-2.0.
 #[derive(
-    Copy, Clone, Debug, FromPrimitive, ToPrimitive, PartialEq, AsBytes,
+    Copy, Clone, Debug, FromPrimitive, ToPrimitive, Eq, PartialEq, AsBytes,
 )]
 #[repr(u8)]
 pub enum BitstreamError {

--- a/drv/fpga-devices/src/ecp5.rs
+++ b/drv/fpga-devices/src/ecp5.rs
@@ -88,7 +88,7 @@ impl Status {
 /// This is a subset of Table 6.4, p. 32, Lattice Semi FPGA-TN-02039-2.0. The
 /// table header suggests these are opcodes for SPI commands, but they seem to
 /// apply to JTAG as well.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum Command {
     Noop = 0xff,
@@ -104,7 +104,7 @@ pub enum Command {
     BitstreamBurst = 0x7a,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Trace {
     None,
     Disabled,

--- a/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
+++ b/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
@@ -121,7 +121,7 @@ impl Driver {
         &self,
         device_id: usize,
         pins: DevicePins,
-    ) -> Result<DeviceInstance, Error> {
+    ) -> Result<DeviceInstance<'_>, Error> {
         let output_pins =
             pins.init_n | pins.program_n | pins.user_design_reset_n;
 
@@ -148,7 +148,7 @@ impl Driver {
         &self,
         device0_pins: DevicePins,
         device1_pins: DevicePins,
-    ) -> Result<[Ecp5<DeviceInstance>; 2], Error> {
+    ) -> Result<[Ecp5<DeviceInstance<'_>>; 2], Error> {
         Ok([
             Ecp5::new(self.init_device(0, device0_pins)?),
             Ecp5::new(self.init_device(1, device1_pins)?),

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -27,7 +27,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     DeviceId(u8, u32),

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -17,7 +17,7 @@ pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
 ///
 /// This enumeration doesn't include errors that result from configuration
 /// issues, like sending host flash messages to some other task.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum HfError {
     WriteEnableFailed = 1,
     ServerRestarted = 2,
@@ -31,7 +31,7 @@ pub enum HfError {
 }
 
 /// Controls whether the SP or host CPU has access to flash
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum HfMuxState {
     SP = 1,
@@ -40,7 +40,7 @@ pub enum HfMuxState {
 
 /// Selects between multiple flash chips. This is not used on all hardware
 /// revisions; it was added in Gimlet rev B.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum HfDevSelect {
     Flash0 = 0,

--- a/drv/hash-api/src/lib.rs
+++ b/drv/hash-api/src/lib.rs
@@ -15,7 +15,7 @@ pub const SHA256_SZ: usize = 32;
 ///
 /// This enumeration doesn't include errors that result from configuration
 /// issues, like sending host flash messages to some other task.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum HashError {
     NotInitialized = 1,
     InvalidState = 2,

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -27,7 +27,7 @@ use zerocopy::{AsBytes, FromBytes};
 use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(FromPrimitive, PartialEq)]
+#[derive(FromPrimitive, Eq, PartialEq)]
 pub enum Op {
     WriteRead = 1,
     WriteReadBlock = 2,
@@ -37,7 +37,7 @@ pub enum Op {
 /// the case of [`ResponseCode::Dead`]).  These response codes pretty specific,
 /// not because the caller is expected to necessarily handle them differently,
 /// but to give upstack software some modicum of context surrounding the error.
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 #[repr(u32)]
 pub enum ResponseCode {
     /// Server has died
@@ -91,7 +91,7 @@ pub enum ResponseCode {
 /// assumed to follow the numbering for the peripheral as described by the
 /// microcontroller.
 ///
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Controller {
     I2C0 = 0,
@@ -105,7 +105,7 @@ pub enum Controller {
     Mock = 0xff,
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 #[allow(clippy::unusual_byte_groupings)]
 pub enum ReservedAddress {
     GeneralCall = 0b0000_000,
@@ -137,14 +137,14 @@ pub enum ReservedAddress {
 /// letter/number convention should be used (e.g., "B1") -- but this is purely
 /// convention.
 ///
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 pub struct PortIndex(pub u8);
 
 ///
 /// A multiplexer identifier for a given I2C bus.  Multiplexer identifiers
 /// need not start at 0.
 ///
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Mux {
     M1 = 1,
@@ -157,7 +157,7 @@ pub enum Mux {
 /// A segment identifier on a given multiplexer.  Segment identifiers
 /// need not start at 0.
 ///
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Segment {
     S1 = 1,

--- a/drv/i2c-devices/src/adm1272.rs
+++ b/drv/i2c-devices/src/adm1272.rs
@@ -13,7 +13,7 @@ use pmbus::commands::*;
 use ringbuf::*;
 use userlib::units::*;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     BadRead { cmd: u8, code: ResponseCode },
     BadWrite { cmd: u8, code: ResponseCode },

--- a/drv/i2c-devices/src/at24csw080.rs
+++ b/drv/i2c-devices/src/at24csw080.rs
@@ -284,7 +284,7 @@ impl At24Csw080 {
         addr: u8,
         val: u8,
     ) -> Result<(), Error> {
-        if addr < 16 || addr >= 32 {
+        if !(16..32).contains(&addr) {
             return Err(Error::InvalidSecurityRegisterWriteByte(addr));
         }
         let reg_addr = 0b1000_0000 | addr;

--- a/drv/i2c-devices/src/at24csw080.rs
+++ b/drv/i2c-devices/src/at24csw080.rs
@@ -32,7 +32,7 @@ pub struct At24Csw080 {
     device: handle::DeviceHandle,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The low-level I2C communication returned an error
     I2cError(ResponseCode),

--- a/drv/i2c-devices/src/ds2482.rs
+++ b/drv/i2c-devices/src/ds2482.rs
@@ -10,7 +10,7 @@ use drv_onewire::Identifier;
 use ringbuf::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Command {
     OneWireTriplet = 0x78,
     OneWireSingleBit = 0x87,
@@ -52,7 +52,7 @@ bitfield! {
     direction, set_direction: 7;
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     Status = 0xf0,
     ReadData = 0xe1,

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -20,6 +20,7 @@ pub enum I2cWatchdog {
     ThirtySeconds = 0b11,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(FromPrimitive)]
 #[repr(u8)]
 enum Frequency {
@@ -37,6 +38,7 @@ enum Frequency {
     F25000Hz = 0b1011,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[allow(dead_code)]
 enum SpinUp {
     NoSpinUp = 0b00,

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -73,7 +73,7 @@ bitfield! {
 }
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Register {
     GlobalConfiguration = 0x00,
     PWMFrequency = 0x01,
@@ -183,7 +183,7 @@ pub struct Max31790 {
 
 pub const MAX_FANS: u8 = 6;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Fan(u8);
 
 impl TryFrom<u8> for Fan {

--- a/drv/i2c-devices/src/max5970.rs
+++ b/drv/i2c-devices/src/max5970.rs
@@ -9,7 +9,7 @@ use drv_i2c_api::*;
 use userlib::*;
 
 #[allow(dead_code, non_camel_case_types)]
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Register {
     /// High 8 bits ([9:2]) of latest current-signal
     adc_chx_cs_msb_ch1 = 0x00,

--- a/drv/i2c-devices/src/pca9538.rs
+++ b/drv/i2c-devices/src/pca9538.rs
@@ -10,7 +10,7 @@ use userlib::*;
 
 /// `PinSet` is a bit vector indicating on which pins/ports a given operation is
 /// applied.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub struct PinSet(u8);
 
 impl PinSet {
@@ -40,7 +40,7 @@ impl core::ops::BitOr for PinSet {
 /// Pins in a `PinSet` can be configured as either `Input` or `Output`. Note
 /// that even when configured as output, the status of the pin will be reflected
 /// in the result of `read(..)`.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 #[repr(u8)]
 pub enum Mode {
     Input = 0,
@@ -48,14 +48,14 @@ pub enum Mode {
 }
 
 /// Pins in a `PinSet` can be configured with `Normal` or `Inverted` polarity.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 #[repr(u8)]
 pub enum Polarity {
     Normal = 0,
     Inverted = 1,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 enum Register {
     InputPort = 0x00,
     OutputPort = 0x01,

--- a/drv/i2c-devices/src/pct2075.rs
+++ b/drv/i2c-devices/src/pct2075.rs
@@ -9,7 +9,7 @@ use drv_i2c_api::*;
 use userlib::units::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     Temp = 0x00,
     Conf = 0x01,

--- a/drv/i2c-devices/src/sbtsi.rs
+++ b/drv/i2c-devices/src/sbtsi.rs
@@ -9,7 +9,7 @@ use drv_i2c_api::*;
 use userlib::units::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     CpuTempInt = 0x01,
     Status = 0x02,

--- a/drv/i2c-devices/src/tmp117.rs
+++ b/drv/i2c-devices/src/tmp117.rs
@@ -9,7 +9,7 @@ use drv_i2c_api::*;
 use userlib::units::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     TempResult = 0x00,
     Configuration = 0x01,

--- a/drv/i2c-devices/src/tmp451.rs
+++ b/drv/i2c-devices/src/tmp451.rs
@@ -9,7 +9,7 @@ use drv_i2c_api::*;
 use userlib::units::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     LocalTempHiByte = 0x00,
     RemoteTempHiByte = 0x01,

--- a/drv/i2c-devices/src/tse2004av.rs
+++ b/drv/i2c-devices/src/tse2004av.rs
@@ -10,7 +10,7 @@ use drv_i2c_api::*;
 use userlib::units::*;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Register {
     Capabilities = 0x00,
     Configuration = 0x01,

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -12,7 +12,7 @@ pub use registers::{MIBCounter, Register};
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     SpiError(SpiError),
     WrongChipId(u16),
@@ -50,7 +50,7 @@ pub enum Mode {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     Read(Register, u16),
@@ -63,7 +63,7 @@ ringbuf!(Trace, 16, Trace::None);
 
 /// Data from a management information base (MIB) counter on the chip,
 /// used to monitor port activity for network management.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MIBCounterValue {
     None,
     Count(u32),
@@ -76,14 +76,14 @@ impl Default for MIBCounterValue {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SourcePort {
     Port1,
     Port2,
     Port3,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct KszRawMacTableEntry {
     /// Number of valid entries in the table
     pub count: u32,

--- a/drv/ksz8463/src/registers.rs
+++ b/drv/ksz8463/src/registers.rs
@@ -6,7 +6,7 @@ use userlib::FromPrimitive;
 
 /// Offsets used to access MIB counters
 /// (see Table 4-200 in the datasheet for details)
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MIBCounter {
     /// Rx lo-priority (default) octet count, including bad packets.
     RxLoPriorityByte = 0x0,
@@ -105,7 +105,7 @@ pub enum MIBCounter {
     TxMultipleCollision = 0x1F,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 #[allow(non_camel_case_types)]
 pub enum Register {
     // Table 4-2

--- a/drv/lpc55-gpio-api/src/lib.rs
+++ b/drv/lpc55-gpio-api/src/lib.rs
@@ -139,7 +139,7 @@ pub enum Mode {
     Repeater = 3,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Digimode {
     Analog = 0,
     Digital = 1,
@@ -151,7 +151,7 @@ impl Into<bool> for Digimode {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Slew {
     Standard = 0,
     Fast = 1,
@@ -163,7 +163,7 @@ impl Into<bool> for Slew {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Invert {
     Disable = 0,
     Enabled = 1,
@@ -175,7 +175,7 @@ impl Into<bool> for Invert {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Opendrain {
     Normal = 0,
     Opendrain = 1,

--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -37,7 +37,7 @@ pub struct PortCounters {
 
 /// Error-code-only version of [VscError], for use in RPC calls
 #[derive(
-    Copy, Clone, Debug, PartialEq, FromPrimitive, ToPrimitive, IdolError,
+    Copy, Clone, Debug, Eq, PartialEq, FromPrimitive, ToPrimitive, IdolError,
 )]
 #[repr(C)]
 pub enum MonorailError {

--- a/drv/onewire-devices/src/ds18b20.rs
+++ b/drv/onewire-devices/src/ds18b20.rs
@@ -37,7 +37,7 @@ use userlib::units::*;
 
 /// A DS18B20 command
 #[allow(dead_code)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Command {
     ConvertT = 0x44,
     WriteScratchpad = 0x4e,

--- a/drv/onewire/src/lib.rs
+++ b/drv/onewire/src/lib.rs
@@ -17,7 +17,7 @@ use userlib::*;
 /// 1-wire commands.  Most devices support more commands, but these commands
 /// are supported by all devices.
 #[allow(dead_code)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Command {
     SearchROM = 0xf0,
     ReadROM = 0x33,
@@ -29,7 +29,7 @@ pub enum Command {
 /// Family of 1-wire device. The most complete list seems to be found at:
 /// <http://owfs.sourceforge.net/family.html>.  We want to keep this list
 /// as short as possible.
-#[derive(Copy, Clone, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Eq, PartialEq, FromPrimitive)]
 pub enum Family {
     DS18B20 = 0x28,
 }

--- a/drv/sidecar-mainboard-controller/src/tofino2.rs
+++ b/drv/sidecar-mainboard-controller/src/tofino2.rs
@@ -7,7 +7,7 @@ use drv_fpga_api::{FpgaError, FpgaUserDesign, WriteOp};
 use userlib::FromPrimitive;
 use zerocopy::AsBytes;
 
-#[derive(Copy, Clone, PartialEq, FromPrimitive, AsBytes)]
+#[derive(Copy, Clone, Eq, PartialEq, FromPrimitive, AsBytes)]
 #[repr(u8)]
 pub enum TofinoSeqState {
     Initial = 0,
@@ -17,7 +17,7 @@ pub enum TofinoSeqState {
     InPowerDown = 4,
 }
 
-#[derive(Copy, Clone, PartialEq, FromPrimitive, AsBytes)]
+#[derive(Copy, Clone, Eq, PartialEq, FromPrimitive, AsBytes)]
 #[repr(u8)]
 pub enum TofinoSeqError {
     None = 0,
@@ -32,7 +32,7 @@ pub enum TofinoSeqError {
 
 /// VID to voltage mapping. The VID values are specified in TF2-DS2, with the
 /// actual voltage values derived experimentally after load testing the PDN.
-#[derive(Copy, Clone, PartialEq, FromPrimitive, AsBytes)]
+#[derive(Copy, Clone, Eq, PartialEq, FromPrimitive, AsBytes)]
 #[repr(u8)]
 pub enum Tofino2Vid {
     V0P922 = 0b1111,
@@ -49,7 +49,7 @@ pub struct Sequencer {
     fpga: FpgaUserDesign,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Status {
     state: TofinoSeqState,
     error: TofinoSeqError,
@@ -58,7 +58,7 @@ pub struct Status {
     pcie_status: u8,
 }
 
-#[derive(Copy, Clone, PartialEq, FromPrimitive, AsBytes)]
+#[derive(Copy, Clone, Eq, PartialEq, FromPrimitive, AsBytes)]
 #[repr(u8)]
 pub enum TofinoPcieReset {
     HostControl,

--- a/drv/sidecar-seq-api/src/lib.rs
+++ b/drv/sidecar-seq-api/src/lib.rs
@@ -14,7 +14,7 @@ pub use drv_sidecar_mainboard_controller::tofino2::{
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum SeqError {
     FpgaError = 1,
     IllegalTransition = 2,
@@ -32,7 +32,7 @@ impl From<FpgaError> for SeqError {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, AsBytes)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, AsBytes)]
 #[repr(u8)]
 pub enum TofinoSequencerPolicy {
     Disabled = 0,

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -50,7 +50,7 @@ impl Spi {
         &self,
         device_index: u8,
         assert_cs: CsState,
-    ) -> Result<ControllerLock, SpiError> {
+    ) -> Result<ControllerLock<'_>, SpiError> {
         self.lock(device_index, assert_cs)?;
         Ok(ControllerLock(self))
     }
@@ -153,7 +153,7 @@ impl SpiDevice {
     pub fn lock_auto(
         &self,
         assert_cs: CsState,
-    ) -> Result<ControllerLock, SpiError> {
+    ) -> Result<ControllerLock<'_>, SpiError> {
         self.server.lock_auto(self.device_index, assert_cs)
     }
 

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -9,7 +9,7 @@
 use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 #[repr(u32)]
 pub enum SpiError {
     /// Transfer size is 0 or exceeds maximum

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -183,7 +183,7 @@ impl<'a> ServerImpl<'a> {
 
         for (i, c) in bytes.chunks_exact(4).enumerate() {
             let mut word: [u8; 4] = [0; 4];
-            word.copy_from_slice(&c);
+            word.copy_from_slice(c);
 
             // SAFETY
             // This code is running out of bank #1. The programming for bank #2
@@ -347,7 +347,7 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
             const FLASH_WORDS_PER_BLOCK: usize =
                 BLOCK_SIZE_BYTES / FLASH_WORD_BYTES;
 
-            self.write_word(block_num * FLASH_WORDS_PER_BLOCK + i, &c)?;
+            self.write_word(block_num * FLASH_WORDS_PER_BLOCK + i, c)?;
         }
 
         Ok(())

--- a/drv/stm32xx-gpio-common/src/lib.rs
+++ b/drv/stm32xx-gpio-common/src/lib.rs
@@ -75,7 +75,7 @@ impl PinSet {
 }
 
 /// Possible modes for a GPIO pin.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Mode {
     /// Digital input. This activates a Schmitt trigger on the pin, which is
     /// great for receiving digital signals, but can burn a lot of current if
@@ -97,7 +97,7 @@ pub enum Mode {
 }
 
 /// Drive modes for a GPIO pin.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum OutputType {
     /// The pin will be driven both high and low in `Output` and `Alternate`
     /// modes.
@@ -114,7 +114,7 @@ pub enum OutputType {
 /// to generating reflections and EMI. Note that you need to check the datasheet
 /// for the specific part you're targeting to get the actual speeds of these
 /// drive settings. The notes below are thus vague.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Speed {
     /// Slowest and generally correct drive speed (up to, say, 10MHz or so).
     Low = 0b00,
@@ -130,7 +130,7 @@ pub enum Speed {
 ///
 /// Note that the pull resistors apply in all modes, so, you can apply these to
 /// an input, and you will want to turn them off for `Analog`.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Pull {
     /// Both resistors off.
     None = 0b00,
@@ -147,7 +147,7 @@ pub enum Pull {
 /// These are numbers and not, like, convenient human-readable peripheral names
 /// because the mapping from pin + AF to signal is very complex. See the
 /// datasheet.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum Alternate {
     AF0 = 0,
     AF1 = 1,

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -43,11 +43,11 @@ fn validate_port(
 }
 
 fn find_mux(
-    controller: &I2cController,
+    controller: &I2cController<'_>,
     port: PortIndex,
-    muxes: &[I2cMux],
+    muxes: &[I2cMux<'_>],
     mux: Option<(Mux, Segment)>,
-    mut func: impl FnMut(&I2cMux, Mux, Segment) -> Result<(), ResponseCode>,
+    mut func: impl FnMut(&I2cMux<'_>, Mux, Segment) -> Result<(), ResponseCode>,
 ) -> Result<(), ResponseCode> {
     match mux {
         Some((id, segment)) => {
@@ -71,10 +71,10 @@ fn find_mux(
 
 fn configure_mux(
     map: &mut MuxMap,
-    controller: &I2cController,
+    controller: &I2cController<'_>,
     port: PortIndex,
     mux: Option<(Mux, Segment)>,
-    muxes: &[I2cMux],
+    muxes: &[I2cMux<'_>],
     ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
     //
@@ -153,9 +153,9 @@ ringbuf!(Trace, 8, Trace::None);
 
 fn reset_if_needed(
     code: ResponseCode,
-    controller: &I2cController,
+    controller: &I2cController<'_>,
     port: PortIndex,
-    muxes: &[I2cMux],
+    muxes: &[I2cMux<'_>],
     mux: Option<(Mux, Segment)>,
 ) {
     match code {
@@ -319,7 +319,7 @@ fn main() -> ! {
     }
 }
 
-fn turn_on_i2c(controllers: &[I2cController]) {
+fn turn_on_i2c(controllers: &[I2cController<'_>]) {
     let sys = Sys::from(SYS.get_task_id());
 
     for controller in controllers {
@@ -327,7 +327,7 @@ fn turn_on_i2c(controllers: &[I2cController]) {
     }
 }
 
-fn configure_controllers(controllers: &[I2cController]) {
+fn configure_controllers(controllers: &[I2cController<'_>]) {
     for controller in controllers {
         controller.configure();
         sys_irq_control(controller.notification, true);
@@ -336,7 +336,7 @@ fn configure_controllers(controllers: &[I2cController]) {
 
 fn configure_port(
     map: &mut PortMap,
-    controller: &I2cController,
+    controller: &I2cController<'_>,
     port: PortIndex,
     pins: &[I2cPin],
 ) {
@@ -381,7 +381,7 @@ fn configure_port(
 }
 
 fn configure_pins(
-    controllers: &[I2cController],
+    controllers: &[I2cController<'_>],
     pins: &[I2cPin],
     map: &mut PortMap,
 ) {
@@ -417,8 +417,8 @@ fn configure_pins(
 }
 
 fn configure_muxes(
-    muxes: &[I2cMux],
-    controllers: &[I2cController],
+    muxes: &[I2cMux<'_>],
+    controllers: &[I2cController<'_>],
     pins: &[I2cPin],
     map: &mut PortMap,
     ctrl: &I2cControl,

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -141,7 +141,7 @@ fn configure_mux(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    Trace,
+    Error, // ringbuf line indications error location
     Reset(Controller, PortIndex),
     ResetMux(Mux),
     SegmentFailed(ResponseCode),
@@ -254,7 +254,7 @@ fn main() -> ! {
                 ) {
                     Ok(_) => {}
                     Err(code) => {
-                        ringbuf_entry!(Trace::Trace);
+                        ringbuf_entry!(Trace::Error);
                         reset_if_needed(code, controller, port, &muxes, mux);
                         return Err(code);
                     }
@@ -305,7 +305,7 @@ fn main() -> ! {
                     &ctrl,
                 ) {
                     Err(code) => {
-                        ringbuf_entry!(Trace::Trace);
+                        ringbuf_entry!(Trace::Error);
                         reset_if_needed(code, controller, port, &muxes, mux);
                         Err(code)
                     }

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -141,7 +141,7 @@ fn configure_mux(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    Error, // ringbuf line indications error location
+    Error, // ringbuf line indicates error location
     Reset(Controller, PortIndex),
     ResetMux(Mux),
     SegmentFailed(ResponseCode),

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -115,7 +115,7 @@ pub struct I2cMux<'a> {
 ///
 /// An enum describing the amount to read
 ///
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ReadLength {
     /// Fixed length to read
     Fixed(usize),
@@ -123,7 +123,7 @@ pub enum ReadLength {
     Variable,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     WaitISR(u32),
     WriteISR(u32),

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -154,7 +154,7 @@ enum Trace {
 
 ringbuf!(Trace, 48, Trace::None);
 
-impl<'a> I2cMux<'_> {
+impl I2cMux<'_> {
     /// A convenience routine to translate an error induced by in-band
     /// management into one that can be returned to a caller
     fn error_code(
@@ -206,7 +206,7 @@ impl<'a> I2cMux<'_> {
     }
 }
 
-impl<'a> I2cController<'a> {
+impl I2cController<'_> {
     pub fn enable(&self, sys: &sys_api::Sys) {
         sys.enable_clock(self.peripheral);
         sys.leave_reset(self.peripheral);

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -79,8 +79,8 @@ pub trait I2cMuxDriver {
     /// instance to a [`Gpio`] task.
     fn configure(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         sys: &sys_api::Sys,
         ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode>;
@@ -88,7 +88,7 @@ pub trait I2cMuxDriver {
     /// Reset the mux
     fn reset(
         &self,
-        mux: &I2cMux,
+        mux: &I2cMux<'_>,
         sys: &sys_api::Sys,
     ) -> Result<(), drv_i2c_api::ResponseCode>;
 
@@ -96,8 +96,8 @@ pub trait I2cMuxDriver {
     /// all segments if None is explicitly specified as the segment)
     fn enable_segment(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         segment: Option<drv_i2c_api::Segment>,
         ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode>;

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -65,7 +65,7 @@ pub struct I2cControl {
     pub wfi: fn(u32),
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum I2cKonamiCode {
     Read,
     Write,

--- a/drv/stm32xx-i2c/src/ltc4306.rs
+++ b/drv/stm32xx-i2c/src/ltc4306.rs
@@ -85,8 +85,8 @@ bitfield! {
 ringbuf!(u8, 16, 0);
 
 fn read_reg_u8(
-    mux: &I2cMux,
-    controller: &I2cController,
+    mux: &I2cMux<'_>,
+    controller: &I2cController<'_>,
     reg: u8,
     ctrl: &I2cControl,
 ) -> Result<u8, ResponseCode> {
@@ -110,8 +110,8 @@ fn read_reg_u8(
 }
 
 fn write_reg_u8(
-    mux: &I2cMux,
-    controller: &I2cController,
+    mux: &I2cMux<'_>,
+    controller: &I2cController<'_>,
     reg: u8,
     val: u8,
     ctrl: &I2cControl,
@@ -132,8 +132,8 @@ fn write_reg_u8(
 impl I2cMuxDriver for Ltc4306 {
     fn configure(
         &self,
-        mux: &I2cMux,
-        _controller: &I2cController,
+        mux: &I2cMux<'_>,
+        _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
         _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
@@ -142,8 +142,8 @@ impl I2cMuxDriver for Ltc4306 {
 
     fn enable_segment(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         segment: Option<Segment>,
         ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
@@ -183,7 +183,7 @@ impl I2cMuxDriver for Ltc4306 {
 
     fn reset(
         &self,
-        mux: &I2cMux,
+        mux: &I2cMux<'_>,
         gpio: &sys_api::Sys,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.reset(gpio)

--- a/drv/stm32xx-i2c/src/ltc4306.rs
+++ b/drv/stm32xx-i2c/src/ltc4306.rs
@@ -13,7 +13,7 @@ use userlib::*;
 pub struct Ltc4306;
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Register0(u8);
     connected, _: 7;
     not_alert1, _: 6;
@@ -26,7 +26,7 @@ bitfield! {
 }
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Register1(u8);
     upstream_accelerators_enable, set_upstream_accelerators_enable: 7;
     downstream_accelerators_enable, set_downstream_accelerators_enable: 6;
@@ -36,7 +36,7 @@ bitfield! {
     gpio2_logic_state, _: 0;
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 #[allow(clippy::enum_variant_names)] // not great, TODO
 enum Timeout {
     TimeoutDisabled = 0b00,
@@ -58,7 +58,7 @@ impl From<Timeout> for u8 {
 }
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Register2(u8);
     gpio1_mode_input, set_gpio1_mode_input: 7;
     gpio2_mode_input, set_gpio2_mode_input: 6;
@@ -70,7 +70,7 @@ bitfield! {
 }
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Register3(u8);
     bus1_connected, set_bus1_connected: 7;
     bus2_connected, set_bus2_connected: 6;

--- a/drv/stm32xx-i2c/src/max7358.rs
+++ b/drv/stm32xx-i2c/src/max7358.rs
@@ -12,7 +12,7 @@ use userlib::*;
 
 pub struct Max7358;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 enum Register {
     SwitchControl = 0x00,
     Configuration = 0x01,
@@ -36,7 +36,7 @@ impl From<Register> for u8 {
 }
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct SwitchControl(u8);
     channel7_selected, set_channel7_selected: 7;
     channel6_selected, set_channel6_selected: 6;
@@ -49,7 +49,7 @@ bitfield! {
 }
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Configuration(u8);
     preconnect_test_enabled, set_preconnect_test_enabled: 7;
     basic_mode_enabled, set_basic_mode_enabled: 6;
@@ -61,7 +61,7 @@ bitfield! {
     interrupt_enabled, set_interrupt_enabled: 0;
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     Read(Register, u8),
     Write(Register, u8),

--- a/drv/stm32xx-i2c/src/max7358.rs
+++ b/drv/stm32xx-i2c/src/max7358.rs
@@ -71,8 +71,8 @@ enum Trace {
 ringbuf!(Trace, 32, Trace::None);
 
 fn read_regs(
-    mux: &I2cMux,
-    controller: &I2cController,
+    mux: &I2cMux<'_>,
+    controller: &I2cController<'_>,
     rbuf: &mut [u8],
     ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
@@ -99,8 +99,8 @@ fn read_regs(
 }
 
 fn write_reg(
-    mux: &I2cMux,
-    controller: &I2cController,
+    mux: &I2cMux<'_>,
+    controller: &I2cController<'_>,
     reg: Register,
     val: u8,
     ctrl: &I2cControl,
@@ -139,8 +139,8 @@ fn write_reg(
 impl I2cMuxDriver for Max7358 {
     fn configure(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
         ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
@@ -193,8 +193,8 @@ impl I2cMuxDriver for Max7358 {
 
     fn enable_segment(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         segment: Option<Segment>,
         ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
@@ -234,7 +234,7 @@ impl I2cMuxDriver for Max7358 {
 
     fn reset(
         &self,
-        mux: &I2cMux,
+        mux: &I2cMux<'_>,
         gpio: &sys_api::Sys,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.reset(gpio)

--- a/drv/stm32xx-i2c/src/pca9548.rs
+++ b/drv/stm32xx-i2c/src/pca9548.rs
@@ -26,8 +26,8 @@ bitfield! {
 impl I2cMuxDriver for Pca9548 {
     fn configure(
         &self,
-        mux: &I2cMux,
-        _controller: &I2cController,
+        mux: &I2cMux<'_>,
+        _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
         _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
@@ -36,8 +36,8 @@ impl I2cMuxDriver for Pca9548 {
 
     fn enable_segment(
         &self,
-        mux: &I2cMux,
-        controller: &I2cController,
+        mux: &I2cMux<'_>,
+        controller: &I2cController<'_>,
         segment: Option<Segment>,
         ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
@@ -91,7 +91,7 @@ impl I2cMuxDriver for Pca9548 {
 
     fn reset(
         &self,
-        mux: &I2cMux,
+        mux: &I2cMux<'_>,
         gpio: &sys_api::Sys,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.reset(gpio)

--- a/drv/stm32xx-i2c/src/pca9548.rs
+++ b/drv/stm32xx-i2c/src/pca9548.rs
@@ -11,7 +11,7 @@ use drv_i2c_api::{ResponseCode, Segment};
 pub struct Pca9548;
 
 bitfield! {
-    #[derive(Copy, Clone, PartialEq)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct ControlRegister(u8);
     channel7_enabled, set_channel7_enabled: 7;
     channel6_enabled, set_channel6_enabled: 6;

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -9,7 +9,7 @@ use userlib::{sys_send, FromPrimitive};
 use zerocopy::AsBytes;
 
 #[repr(u8)]
-#[derive(FromPrimitive, AsBytes, PartialEq, Clone, Copy)]
+#[derive(FromPrimitive, AsBytes, Eq, PartialEq, Clone, Copy)]
 pub enum UpdateTarget {
     // Represents targets where we only ever write to a single
     // alternate flash location. This is typically used in

--- a/drv/vsc-err/src/lib.rs
+++ b/drv/vsc-err/src/lib.rs
@@ -12,7 +12,7 @@
 use drv_spi_api::SpiError;
 use idol_runtime::ServerDeath;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum VscError {
     SpiError(SpiError),
     ServerDied,

--- a/drv/vsc7448/src/serdes10g.rs
+++ b/drv/vsc7448/src/serdes10g.rs
@@ -7,13 +7,13 @@ use crate::{Vsc7448Rw, VscError};
 use userlib::hl;
 use vsc7448_pac::*;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Mode {
     Lan10g(SerdesPresetType),
     Sgmii,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
     f_pll_khz_plain: u32,
 
@@ -717,14 +717,14 @@ impl Config {
 }
 
 /// Equivalent to `vtss_sd10g65_preset_t`
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SerdesPresetType {
     DacHw, // VTSS_SD10G65_DAC_HW
     KrHw,  // VTSS_SD10G65_KR_HW, i.e. 10GBASE-KR
 }
 
 /// Equivalent to `vtss_sd10g65_preset_struct_t`
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct SerdesRxPreset {
     synth_phase_data: u8,
     ib_main_thres_offs: u8,
@@ -786,7 +786,7 @@ impl SerdesRxPreset {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct SerdesApcPreset {
     ld_lev_ini: u8,
     range_sel: u8,
@@ -849,7 +849,7 @@ impl SerdesApcPreset {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 struct SynthSettingsCalc {
     freq_mult: u16,
     freqm: u64,
@@ -894,7 +894,7 @@ fn calc_gcd(num_in: u64, mut div: u64) -> u64 {
     div
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct FrequencySetup {
     f_pll_khz: u32,
     ratio_num: u32,
@@ -920,7 +920,7 @@ impl FrequencySetup {
 }
 
 /// Roughly based on `vtss_sd10g65_synth_mult_calc_rslt_t`
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 struct SynthMultCalc {
     speed_sel: bool, // SYNTH_SPEED_SEL
     fbdiv_sel: u8,   // SYNTH_FBDIV_SEL
@@ -974,7 +974,7 @@ impl SynthMultCalc {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 struct FrequencyDecoderBypass {
     freq_mult: u16,
     freq_mult_hi: u8,

--- a/drv/vsc7448/src/spi.rs
+++ b/drv/vsc7448/src/spi.rs
@@ -34,7 +34,7 @@ impl Vsc7448Spi {
 
     #[inline(never)]
     fn read_core(&self, orig_addr: u32) -> Result<u32, VscError> {
-        if orig_addr < 0x71000000 || orig_addr >= 0x72000000 {
+        if !(0x71000000..0x72000000).contains(&orig_addr) {
             return Err(VscError::BadRegAddr(orig_addr));
         }
 
@@ -97,7 +97,7 @@ impl Vsc7448Spi {
 
     #[inline(never)]
     fn write_core(&self, reg_addr: u32, value: u32) -> Result<(), VscError> {
-        if reg_addr < 0x71000000 || reg_addr >= 0x72000000 {
+        if !(0x71000000..0x72000000).contains(&reg_addr) {
             return Err(VscError::BadRegAddr(reg_addr));
         }
 

--- a/drv/vsc85xx/src/atom.rs
+++ b/drv/vsc85xx/src/atom.rs
@@ -8,7 +8,9 @@ use vsc7448_pac::phy;
 use vsc_err::VscError;
 
 /// Based on `vtss_atom_patch_suspend` in the SDK
-pub fn atom_patch_suspend<P: PhyRw>(phy: &mut Phy<P>) -> Result<(), VscError> {
+pub fn atom_patch_suspend<P: PhyRw>(
+    phy: &mut Phy<'_, P>,
+) -> Result<(), VscError> {
     // We don't have VeriPHY running, so skip the first conditional
     let v = phy.read(phy::GPIO::MICRO_PAGE())?;
     if (v.0 & 0x4000) == 0 {
@@ -21,7 +23,9 @@ pub fn atom_patch_suspend<P: PhyRw>(phy: &mut Phy<P>) -> Result<(), VscError> {
 }
 
 /// Based on `vtss_atom_patch_suspend` in the SDK
-pub fn atom_patch_resume<P: PhyRw>(phy: &mut Phy<P>) -> Result<(), VscError> {
+pub fn atom_patch_resume<P: PhyRw>(
+    phy: &mut Phy<'_, P>,
+) -> Result<(), VscError> {
     // We don't have VeriPHY running, so skip the first conditional
     let v = phy.read(phy::GPIO::MICRO_PAGE())?;
     if (v.0 & 0x4000) != 0 {

--- a/drv/vsc85xx/src/atom.rs
+++ b/drv/vsc85xx/src/atom.rs
@@ -8,9 +8,7 @@ use vsc7448_pac::phy;
 use vsc_err::VscError;
 
 /// Based on `vtss_atom_patch_suspend` in the SDK
-pub fn atom_patch_suspend<'a, 'b, P: PhyRw>(
-    phy: &'b mut Phy<'a, P>,
-) -> Result<(), VscError> {
+pub fn atom_patch_suspend<P: PhyRw>(phy: &mut Phy<P>) -> Result<(), VscError> {
     // We don't have VeriPHY running, so skip the first conditional
     let v = phy.read(phy::GPIO::MICRO_PAGE())?;
     if (v.0 & 0x4000) == 0 {
@@ -23,9 +21,7 @@ pub fn atom_patch_suspend<'a, 'b, P: PhyRw>(
 }
 
 /// Based on `vtss_atom_patch_suspend` in the SDK
-pub fn atom_patch_resume<'a, 'b, P: PhyRw>(
-    phy: &'b mut Phy<'a, P>,
-) -> Result<(), VscError> {
+pub fn atom_patch_resume<P: PhyRw>(phy: &mut Phy<P>) -> Result<(), VscError> {
     // We don't have VeriPHY running, so skip the first conditional
     let v = phy.read(phy::GPIO::MICRO_PAGE())?;
     if (v.0 & 0x4000) != 0 {

--- a/drv/vsc85xx/src/led.rs
+++ b/drv/vsc85xx/src/led.rs
@@ -5,7 +5,7 @@
 use crate::{Phy, PhyRw, VscError};
 use vsc7448_pac::phy;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LED {
     LED0 = 0,
     LED1,
@@ -13,7 +13,7 @@ pub enum LED {
     LED3,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LEDMode {
     LinkActivity = 0,
     Link1000Activity,

--- a/drv/vsc85xx/src/lib.rs
+++ b/drv/vsc85xx/src/lib.rs
@@ -179,7 +179,7 @@ impl<'a, P: PhyRw> Phy<'a, P> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     Vsc8504Init(u8),
@@ -202,7 +202,7 @@ ringbuf!(Trace, 16, Trace::None);
 /// a counter which isn't available on this particular PHY (in particular,
 /// the VSC8552 doesn't have MAC counters); `Inactive` means that the counter
 /// is available but the active bit is cleared.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Counter {
     Unavailable,
     Inactive,

--- a/drv/vsc85xx/src/tesla.rs
+++ b/drv/vsc85xx/src/tesla.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use core::convert::TryInto;
-
 use crate::util::detype;
 use crate::Trace;
 use crate::{Phy, PhyRw};
@@ -138,13 +136,13 @@ impl<'a, 'b, P: PhyRw> TeslaPhy<'a, 'b, P> {
 
         self.phy.cmd(MCB_CFG_BUF_START_ADDR)?; // Line 3998
 
-        for i in 0..38 {
+        for byte in &mut cfg {
             // "read the value of cfg_buf[idx] w/ post-incr."
             self.phy.cmd(0x9007)?;
             let r = self.phy.read(phy::GPIO::MICRO_PAGE())?;
 
             // "get bits 11:4 from return value"
-            cfg[i] = (u16::from(r) >> 4) as u8;
+            *byte = (u16::from(r) >> 4) as u8;
         }
         Ok(TeslaSerdes6gPatch { cfg })
     }
@@ -223,7 +221,7 @@ impl<'a, 'b, P: PhyRw> TeslaPhy<'a, 'b, P> {
 
         // Set the start address
         let addr = MCB_CFG_BUF_START_ADDR + bits.start() / 8;
-        self.phy.cmd(addr.try_into().unwrap())?;
+        self.phy.cmd(addr)?;
 
         while mask != 0 {
             self.phy.cmd(0x8007)?; // Read cfg_buffer[byte], no post-increment

--- a/drv/vsc85xx/src/util.rs
+++ b/drv/vsc85xx/src/util.rs
@@ -57,7 +57,7 @@ impl<'a, P: PhyRw> Phy<'a, P> {
     }
 
     /// Calls a function with broadcast writes enabled, then unsets the flag
-    pub(crate) fn broadcast<F: Fn(&Phy<P>) -> Result<(), VscError>>(
+    pub(crate) fn broadcast<F: Fn(&Phy<'_, P>) -> Result<(), VscError>>(
         &self,
         f: F,
     ) -> Result<(), VscError> {

--- a/drv/vsc85xx/src/vsc8562.rs
+++ b/drv/vsc85xx/src/vsc8562.rs
@@ -154,7 +154,7 @@ impl<'a, 'b, P: PhyRw> Vsc8562Phy<'a, 'b, P> {
         //      phy_reset_private
         //          port_reset
         //              vtss_phy_soft_reset_port
-        crate::atom::atom_patch_suspend(&mut self.phy)?;
+        crate::atom::atom_patch_suspend(self.phy)?;
 
         // Do the actual PHY reset (line 937)
         self.phy.software_reset()?;
@@ -190,7 +190,7 @@ impl<'a, 'b, P: PhyRw> Vsc8562Phy<'a, 'b, P> {
         // Cat5 copper only.
 
         // We are now exiting vtss_phy_soft_reset_port
-        crate::atom::atom_patch_resume(&mut self.phy)?; // line 980
+        crate::atom::atom_patch_resume(self.phy)?; // line 980
 
         // We are now exiting port_reset.
 

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -234,6 +234,7 @@ macro_rules! ringbuf_entry {
 
 /// Inserts data into an unnamed ringbuffer at the root of this crate
 #[cfg(not(feature = "disabled"))]
+#[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! ringbuf_entry_root {
     ($payload:expr) => {

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -237,7 +237,7 @@ pub const HUBRIS_TASK_IRQ_LOOKUP: SortedList::<abi::InterruptOwner, &'static [ab
                 .join("\n        ");
             writeln!(file, "
 use phash::PerfectHashMap;
-pub const HUBRIS_TASK_IRQ_LOOKUP: PerfectHashMap::<abi::InterruptOwner, &'static [abi::InterruptNum]> = PerfectHashMap {{
+pub const HUBRIS_TASK_IRQ_LOOKUP: PerfectHashMap::<'_, abi::InterruptOwner, &'static [abi::InterruptNum]> = PerfectHashMap {{
     m: {:#x},
     values: &[
         {}
@@ -291,7 +291,7 @@ pub const HUBRIS_TASK_IRQ_LOOKUP: NestedPerfectHashMap::<abi::InterruptOwner, &'
                 .collect::<Vec<String>>()
                 .join("\n        ");
             writeln!(file, "
-pub const HUBRIS_IRQ_TASK_LOOKUP: PerfectHashMap::<abi::InterruptNum, abi::InterruptOwner> = PerfectHashMap {{
+pub const HUBRIS_IRQ_TASK_LOOKUP: PerfectHashMap::<'_, abi::InterruptNum, abi::InterruptOwner> = PerfectHashMap {{
     m: {:#x},
     values: &[
         {}

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -244,7 +244,7 @@ impl<T> Clone for USlice<T> {
 /// Can't `derive(Debug)` for `USlice` because that puts a `Debug` requirement
 /// on `T`, and that's silly.
 impl<T> core::fmt::Debug for USlice<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("USlice")
             .field("base_address", &self.base_address)
             .field("length", &self.length)

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1297,7 +1297,7 @@ pub unsafe extern "C" fn _start() -> ! {
 /// stackmargin`.
 #[cfg(feature = "panic-messages")]
 #[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     // Implementation Note
     //
     // This is a panic handler (obvs). Panic handlers have a unique
@@ -1444,7 +1444,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 /// than a proper panic message, the stack trace can still be informative.
 #[cfg(not(feature = "panic-messages"))]
 #[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
+fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
     sys_panic(b"PANIC")
 }
 

--- a/sys/userlib/src/units.rs
+++ b/sys/userlib/src/units.rs
@@ -13,11 +13,11 @@ use core::convert::TryFrom;
 pub struct Celsius(pub f32);
 
 /// Rotations per minute
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Debug)]
 pub struct Rpm(pub u16);
 
 /// PWM duty cycle (0-100)
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct PWMDuty(pub u8);
 

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -160,19 +160,21 @@ fn main() -> ! {
 
         let text = unsafe { &HIFFY_TEXT };
         let data = unsafe { &HIFFY_DATA };
-        let mut rstack = unsafe { &mut HIFFY_RSTACK[0..] };
+        let rstack = unsafe { &mut HIFFY_RSTACK[0..] };
 
         let check = |offset: usize, op: &Op| -> Result<(), Failure> {
             trace_execute(offset, *op);
             Ok(())
         };
 
+        // XXX: workaround for false-positive due to rust-lang/rust-clippy#9126
+        #[allow(clippy::explicit_auto_deref)]
         let rv = execute::<_, NLABELS>(
             text,
             HIFFY_FUNCS,
             data,
             &mut stack,
-            &mut rstack,
+            rstack,
             &mut *HIFFY_SCRATCH.borrow_mut(),
             check,
         );

--- a/task/jefe/src/external.rs
+++ b/task/jefe/src/external.rs
@@ -53,7 +53,7 @@ use ringbuf::*;
 use userlib::*;
 
 /// The actual requests that we honor from an external source entity
-#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
+#[derive(FromPrimitive, Copy, Clone, Debug, Eq, PartialEq)]
 enum Request {
     None = 0,
     Start = 1,
@@ -62,17 +62,17 @@ enum Request {
     Fault = 4,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Error {
     IllegalTask,
     BadTask,
     BadRequest,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct TaskIndex(u16);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     Request(Request, TaskIndex),

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -98,7 +98,7 @@ fn log_fault(t: usize, fault: &abi::FaultInfo) {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Disposition {
     Restart,
     Start,

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -232,7 +232,7 @@ impl NetHandler {
             sp_port_from_udp_metadata(&meta),
             &self.rx_buf[..meta.size as usize],
             mgs_handler,
-            &mut self.tx_buf,
+            self.tx_buf,
         ) {
             Ok(n) => {
                 meta.size = n as u32;

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -62,8 +62,7 @@ impl MgsCommon {
         for (to, from) in serial_number.iter_mut().zip(
             drv_stm32xx_uid::read_uid()
                 .iter()
-                .map(|x| x.to_be_bytes())
-                .flatten(),
+                .flat_map(|x| x.to_be_bytes()),
         ) {
             *to = from;
         }

--- a/task/mgmt-gateway/src/update_buffer.rs
+++ b/task/mgmt-gateway/src/update_buffer.rs
@@ -164,7 +164,7 @@ impl<T, const BLOCK_SIZE: usize> UpdateBuffer<T, BLOCK_SIZE> {
                 let result = (self.write_block_fn)(
                     user_data,
                     current_block_index,
-                    &self.current_block,
+                    self.current_block,
                 );
 
                 // Unconditionally clear our block buffer after attempting to

--- a/task/monorail-server/src/bsp/sidecar_1.rs
+++ b/task/monorail-server/src/bsp/sidecar_1.rs
@@ -463,7 +463,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
     ///
     /// Returns `None` if the given port isn't associated with a PHY
     /// (for example, because it's an SGMII link)
-    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<GenericPhyRw>) -> T>(
+    pub fn phy_fn<T, F: Fn(vsc85xx::Phy<'_, GenericPhyRw<'_>>) -> T>(
         &mut self,
         port: u8,
         callback: F,

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -70,7 +70,7 @@ impl<'a, R: Vsc7448Rw> ServerImpl<'a, R> {
     }
 
     fn decode_phy_id<P: vsc85xx::PhyRw>(
-        phy: &vsc85xx::Phy<P>,
+        phy: &vsc85xx::Phy<'_, P>,
     ) -> Result<(u32, PhyType), VscError> {
         let id = phy.read_id()?;
         let ty = match id {

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -453,7 +453,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         const VSC8504_BASE_PORT: u8 = 40;
         self.bsp
             .phy_fn(VSC8504_BASE_PORT, |mut phy| {
-                let (id, ty) = Self::decode_phy_id(&mut phy)?;
+                let (id, ty) = Self::decode_phy_id(&phy)?;
                 if ty == PhyType::Vsc8504 {
                     vsc85xx::tesla::TeslaPhy { phy: &mut phy }
                         .read_patch_settings()
@@ -476,7 +476,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         const VSC8504_BASE_PORT: u8 = 40;
         self.bsp
             .phy_fn(VSC8504_BASE_PORT, |mut phy| {
-                let (id, ty) = Self::decode_phy_id(&mut phy)?;
+                let (id, ty) = Self::decode_phy_id(&phy)?;
                 if ty == PhyType::Vsc8504 {
                     vsc85xx::tesla::TeslaPhy { phy: &mut phy }
                         .read_serdes6g_ob()
@@ -504,7 +504,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         const VSC8504_BASE_PORT: u8 = 40;
         self.bsp
             .phy_fn(VSC8504_BASE_PORT, |mut phy| {
-                let (id, ty) = Self::decode_phy_id(&mut phy)?;
+                let (id, ty) = Self::decode_phy_id(&phy)?;
                 if ty == PhyType::Vsc8504 {
                     let mut tesla = vsc85xx::tesla::TeslaPhy { phy: &mut phy };
                     tesla.tune_serdes6g_ob(
@@ -541,7 +541,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
     ) -> Result<(), RequestError<MonorailError>> {
         const VSC8564_BASE_PORT: u8 = 44;
         let r = self.bsp.phy_fn(VSC8564_BASE_PORT, |mut phy| {
-            let (id, ty) = Self::decode_phy_id(&mut phy)?;
+            let (id, ty) = Self::decode_phy_id(&phy)?;
             if ty == PhyType::Vsc8562 {
                 use vsc85xx::vsc8562::{Sd6gObCfg, Vsc8562Phy};
                 let mut v = Vsc8562Phy { phy: &mut phy };
@@ -555,7 +555,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     ob_sr,
                 })
             } else {
-                Err(VscError::BadPhyId(id).into())
+                Err(VscError::BadPhyId(id))
             }
         });
         match r {
@@ -577,13 +577,13 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
     ) -> Result<(), RequestError<MonorailError>> {
         const VSC8564_BASE_PORT: u8 = 44;
         let r = self.bsp.phy_fn(VSC8564_BASE_PORT, |mut phy| {
-            let (id, ty) = Self::decode_phy_id(&mut phy)?;
+            let (id, ty) = Self::decode_phy_id(&phy)?;
             if ty == PhyType::Vsc8562 {
                 use vsc85xx::vsc8562::{Sd6gObCfg1, Vsc8562Phy};
                 let mut v = Vsc8562Phy { phy: &mut phy };
                 v.tune_sd6g_ob_cfg1(Sd6gObCfg1 { ob_ena_cas, ob_lev })
             } else {
-                Err(VscError::BadPhyId(id).into())
+                Err(VscError::BadPhyId(id))
             }
         });
         match r {
@@ -603,12 +603,12 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
     ) -> Result<vsc85xx::vsc8562::Sd6gObCfg1, RequestError<MonorailError>> {
         const VSC8564_BASE_PORT: u8 = 44;
         let r = self.bsp.phy_fn(VSC8564_BASE_PORT, |mut phy| {
-            let (id, ty) = Self::decode_phy_id(&mut phy)?;
+            let (id, ty) = Self::decode_phy_id(&phy)?;
             if ty == PhyType::Vsc8562 {
                 let mut v = vsc85xx::vsc8562::Vsc8562Phy { phy: &mut phy };
                 v.read_sd6g_ob_cfg1()
             } else {
-                Err(VscError::BadPhyId(id).into())
+                Err(VscError::BadPhyId(id))
             }
         });
         match r {
@@ -628,12 +628,12 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
     ) -> Result<vsc85xx::vsc8562::Sd6gObCfg, RequestError<MonorailError>> {
         const VSC8564_BASE_PORT: u8 = 44;
         let r = self.bsp.phy_fn(VSC8564_BASE_PORT, |mut phy| {
-            let (id, ty) = Self::decode_phy_id(&mut phy)?;
+            let (id, ty) = Self::decode_phy_id(&phy)?;
             if ty == PhyType::Vsc8562 {
                 let mut v = vsc85xx::vsc8562::Vsc8562Phy { phy: &mut phy };
                 v.read_sd6g_ob_cfg()
             } else {
-                Err(VscError::BadPhyId(id).into())
+                Err(VscError::BadPhyId(id))
             }
         });
         match r {

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -42,7 +42,7 @@ fn generate_net_config(
     )?;
 
     #[cfg(feature = "vlan")]
-    build_net::generate_vlan_consts(&config, &mut out)?;
+    build_net::generate_vlan_consts(config, &mut out)?;
 
     for (name, socket) in &config.sockets {
         writeln!(

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -21,7 +21,7 @@ use vsc85xx::VscError;
 task_slot!(SPI, spi_driver);
 task_slot!(USER_LEDS, user_leds);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     BspConfigured,

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -17,7 +17,7 @@ use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     BspConfigured,

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -29,7 +29,7 @@ pub enum Ksz8463ResetSpeed {
     Normal,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     Ksz8463Err { port: u8, err: KszError },
@@ -174,7 +174,7 @@ impl Bsp {
         eth: &Ethernet,
     ) -> Result<u16, PhyError> {
         if port >= 2 {
-            Err(PhyError::InvalidPort.into())
+            Err(PhyError::InvalidPort)
         } else {
             let rw = &mut MiimBridge::new(eth);
             self.vsc85x2
@@ -194,7 +194,7 @@ impl Bsp {
         eth: &Ethernet,
     ) -> Result<(), PhyError> {
         if port >= 2 {
-            Err(PhyError::InvalidPort.into())
+            Err(PhyError::InvalidPort)
         } else {
             let rw = &mut MiimBridge::new(eth);
             self.vsc85x2
@@ -302,7 +302,7 @@ impl Bsp {
             Ok((tx, rx)) => Ok((decode_counter(tx), decode_counter(rx))),
             Err(err) => {
                 ringbuf_entry!(Trace::Vsc85x2Err { port, err });
-                return Err(MgmtError::VscError);
+                Err(MgmtError::VscError)
             }
         };
         let rw = &mut MiimBridge::new(eth);

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -195,7 +195,7 @@ impl<'a> ServerImpl<'a> {
                 socket_handles.iter().zip(&generated::SOCKET_PORTS)
             {
                 iface
-                    .get_socket::<UdpSocket>(h)
+                    .get_socket::<UdpSocket<'_>>(h)
                     .bind((ipv6_addr, port))
                     .map_err(|_| ())
                     .unwrap();
@@ -274,7 +274,7 @@ impl<'a> ServerImpl<'a> {
         vlan_index: usize,
     ) -> Result<&mut UdpSocket<'static>, ClientError> {
         Ok(self.ifaces[vlan_index]
-            .get_socket::<UdpSocket>(self.get_handle(index, vlan_index)?))
+            .get_socket::<UdpSocket<'_>>(self.get_handle(index, vlan_index)?))
     }
 }
 

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -158,7 +158,7 @@ impl<'a> ServerImpl<'a> {
         let sockets = generated::construct_sockets();
         assert_eq!(sockets.0.len(), VLAN_COUNT);
 
-        let start_mac = mac.clone();
+        let start_mac = mac;
         for sockets in sockets.0.into_iter() {
             let neighbor_cache_storage = neighbor_cache_iter.next().unwrap();
             let neighbor_cache = smoltcp::iface::NeighborCache::new(
@@ -168,7 +168,7 @@ impl<'a> ServerImpl<'a> {
             let socket_storage = socket_storage_iter.next().unwrap();
             let builder = smoltcp::iface::InterfaceBuilder::new(
                 VLanEthernet {
-                    eth: &eth,
+                    eth,
                     vid: vid_iter.next().unwrap(),
                 },
                 &mut socket_storage[..],
@@ -246,7 +246,7 @@ impl<'a> ServerImpl<'a> {
     }
 
     pub fn wake(&self) {
-        self.bsp.wake(&self.eth)
+        self.bsp.wake(self.eth)
     }
 
     fn get_handle(

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -37,7 +37,7 @@ include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 
 use i2c_config::sensors;
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 enum Device {
     IBC(Bmr491),
     Core(Raa229618),

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -58,7 +58,7 @@ impl From<ResponseCode> for NoData {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum SensorError {
     InvalidSensor = 1,
     NoReading = 2,

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -10,7 +10,7 @@ use derive_idol_err::IdolError;
 use drv_i2c_api::ResponseCode;
 use userlib::*;
 
-#[derive(zerocopy::AsBytes, Copy, Clone, Debug, PartialEq)]
+#[derive(zerocopy::AsBytes, Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
 pub struct SensorId(pub usize);
 
@@ -33,7 +33,9 @@ pub enum Reading {
     NoData(NoData),
 }
 
-#[derive(zerocopy::AsBytes, Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(
+    zerocopy::AsBytes, Copy, Clone, Debug, FromPrimitive, Eq, PartialEq,
+)]
 #[repr(u8)]
 pub enum NoData {
     DeviceOff,

--- a/task/spd/src/ltc4306.rs
+++ b/task/spd/src/ltc4306.rs
@@ -24,7 +24,7 @@ const REGISTER_3: u8 = 3;
 //
 const CONNECTED_NOT_FAILED: u8 = 0b1000_0100;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     /// idle
     Idle,

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -9,7 +9,7 @@
 use derive_idol_err::IdolError;
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ThermalError {
     InvalidFan = 1,
     InvalidPWM = 2,
@@ -19,7 +19,7 @@ pub enum ThermalError {
     InvalidWatchdogTime = 6,
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq)]
 pub enum ThermalMode {
     /// The thermal loop has not started.  This is the initial state, but
     /// should be transient, as the thermal task turns on.

--- a/task/thermal/src/bsp.rs
+++ b/task/thermal/src/bsp.rs
@@ -29,10 +29,10 @@ pub(crate) trait BspT {
     /// Fan control IC for a specified fan. Note that the input is a global
     /// fan index, and the BSP translates from this global index to a specific
     /// control and local fan index.
-    fn fan_control(&self, fan: crate::Fan) -> crate::control::FanControl;
+    fn fan_control(&self, fan: crate::Fan) -> crate::control::FanControl<'_>;
 
     /// All fan control ICs
-    fn for_each_fctrl(&self, fctrl: impl FnMut(crate::control::FanControl));
+    fn for_each_fctrl(&self, fctrl: impl FnMut(crate::control::FanControl<'_>));
 
     /// Returns a `u32` with a single bit set that corresponds to a power mode,
     /// which in turn determines which sensors are active.

--- a/task/thermal/src/bsp/sidecar_a.rs
+++ b/task/thermal/src/bsp/sidecar_a.rs
@@ -56,7 +56,7 @@ impl BspT for Bsp {
         &self.fans
     }
 
-    fn fan_control(&self, fan: crate::Fan) -> crate::control::FanControl {
+    fn fan_control(&self, fan: crate::Fan) -> crate::control::FanControl<'_> {
         //
         // Fan 0/1 are on the east max31790; fan 2/3 are on west max31790.  And
         // because each fan has in fact two fans, here is the mapping of
@@ -93,7 +93,7 @@ impl BspT for Bsp {
         }
     }
 
-    fn for_each_fctrl(&self, mut fctrl: impl FnMut(FanControl)) {
+    fn for_each_fctrl(&self, mut fctrl: impl FnMut(FanControl<'_>)) {
         // Run the function on each fan control chip
         fctrl(self.fan_control(0.into()));
         fctrl(self.fan_control(4.into()));

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -18,7 +18,7 @@ use userlib::units::{Celsius, PWMDuty, Rpm};
 /// Type containing all of our temperature sensor types, so we can store them
 /// generically in an array.  These are all `I2cDevice`s, so functions on
 /// this `enum` return an `drv_i2c_api::ResponseCode`.
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 pub enum Device {
     Tmp117(Tmp117),
     Tmp451(Tmp451),

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -32,7 +32,7 @@ use userlib::*;
 // We define our own Fan type, as we may have more fans than any single
 // controller supports.
 //
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Fan(u8);
 
 impl From<usize> for Fan {
@@ -46,7 +46,7 @@ use task_sensor_api::Sensor as SensorApi;
 task_slot!(I2C, i2c_driver);
 task_slot!(SENSOR, sensor);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Trace {
     None,
     Start,

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -142,9 +142,7 @@ impl<'a, B: BspT> idl::InOrderThermalImpl for ServerImpl<'a, B> {
         // Delegate to inner function after doing type conversions
         let initial_pwm = PWMDuty::try_from(initial_pwm)
             .map_err(|_| ThermalError::InvalidPWM)?;
-        (self as &mut ServerImpl<B>)
-            .set_mode_manual(initial_pwm)
-            .map_err(Into::into)
+        ServerImpl::<B>::set_mode_manual(self, initial_pwm).map_err(Into::into)
     }
 
     fn set_mode_auto(
@@ -155,17 +153,14 @@ impl<'a, B: BspT> idl::InOrderThermalImpl for ServerImpl<'a, B> {
         // Delegate to inner function after doing type conversions
         let initial_pwm = PWMDuty::try_from(initial_pwm)
             .map_err(|_| ThermalError::InvalidPWM)?;
-        (self as &mut ServerImpl<B>)
-            .set_mode_auto(initial_pwm)
-            .map_err(Into::into)
+        ServerImpl::<B>::set_mode_auto(self, initial_pwm).map_err(Into::into)
     }
 
     fn disable_watchdog(
         &mut self,
         _: &RecvMessage,
     ) -> Result<(), RequestError<ThermalError>> {
-        (self as &mut ServerImpl<B>)
-            .set_watchdog(I2cWatchdog::Disabled)
+        ServerImpl::<B>::set_watchdog(self, I2cWatchdog::Disabled)
             .map_err(Into::into)
     }
 
@@ -180,9 +175,7 @@ impl<'a, B: BspT> idl::InOrderThermalImpl for ServerImpl<'a, B> {
             30 => I2cWatchdog::ThirtySeconds,
             _ => return Err(ThermalError::InvalidWatchdogTime.into()),
         };
-        (self as &mut ServerImpl<B>)
-            .set_watchdog(wd)
-            .map_err(Into::into)
+        ServerImpl::<B>::set_watchdog(self, wd).map_err(Into::into)
     }
 }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -224,8 +224,8 @@ fn main() -> ! {
 
     ringbuf_entry!(Trace::Start);
 
-    let mut bsp = Bsp::new(i2c_task);
-    let control = ThermalControl::new(&mut bsp, sensor_api);
+    let bsp = Bsp::new(i2c_task);
+    let control = ThermalControl::new(&bsp, sensor_api);
 
     // This will put our timer in the past, and should immediately kick us.
     let deadline = sys_get_timer().now;

--- a/task/validate-api/src/lib.rs
+++ b/task/validate-api/src/lib.rs
@@ -11,7 +11,7 @@ use drv_i2c_api::ResponseCode;
 use userlib::*;
 use zerocopy::AsBytes;
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, IdolError)]
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ValidateError {
     InvalidDevice = 1,
     BadValidation = 2,

--- a/test/test-api/src/lib.rs
+++ b/test/test-api/src/lib.rs
@@ -7,7 +7,7 @@
 use userlib::*;
 
 /// Operations that are performed by the test-assist
-#[derive(FromPrimitive, Debug, PartialEq)]
+#[derive(FromPrimitive, Debug, Eq, PartialEq)]
 pub enum AssistOp {
     JustReply = 0,
     SendBack = 1,

--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -9,7 +9,7 @@
 use serde::{Deserialize, Serialize};
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum IdolTestError {
     UhOh = 1,
     YouAskedForThis = 2,


### PR DESCRIPTION
Clippy doesn't want us to construct needless references, and _really_ wants you to derive `Eq` if you're deriving `PartialEq`.