### PR TITLE
mgmt-gateway: Handle requests to get/set power state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "drv-gimlet-hf-api",
+ "drv-gimlet-seq-api",
  "drv-stm32h7-usart",
  "drv-stm32xx-uid",
  "drv-update-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?rev=d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91#d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91"
+source = "git+https://github.com/oxidecomputer/omicron?rev=7e5d68e0094bcf40f55e7640b2a8a56e4f743409#7e5d68e0094bcf40f55e7640b2a8a56e4f743409"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-mock-gimlet-seq-server"
+version = "0.1.0"
+dependencies = [
+ "drv-gimlet-seq-api",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-onewire"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "cfg-if",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",
+ "drv-sidecar-seq-api",
  "drv-stm32h7-usart",
  "drv-stm32xx-uid",
  "drv-update-api",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -242,7 +242,7 @@ uses = [
     "usart1",
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
 ]
-task-slots = ["jefe", "net", "update_server", "sys", "hf"]
+task-slots = ["jefe", "net", "update_server", "sys", "hf", "gimlet_seq"]
 features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
 interrupts = {"usart1.irq" = 0b10}
 

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -79,6 +79,12 @@ max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 
+[tasks.gimlet_seq]
+name = "drv-mock-gimlet-seq-server"
+priority = 2
+max-sizes = {flash = 2048, ram = 1024 }
+start = true
+
 [tasks.pong]
 name = "task-pong"
 priority = 3
@@ -159,7 +165,7 @@ uses = [
     "usart1",
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
 ]
-task-slots = ["jefe", "net", "update_server", "sys", "hf"]
+task-slots = ["jefe", "net", "update_server", "sys", "hf", "gimlet_seq"]
 features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
 interrupts = {"usart1.irq" = 0b10}
 

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -140,7 +140,7 @@ start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
 ]
-task-slots = ["jefe", "net", "update_server", "sys"]
+task-slots = ["jefe", "net", "update_server", "sys", "sequencer"]
 features = ["sidecar", "vlan"]
 
 [tasks.udpecho]

--- a/drv/mock-gimlet-seq-server/Cargo.toml
+++ b/drv/mock-gimlet-seq-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "drv-mock-gimlet-seq-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }
+drv-gimlet-seq-api = {path = "../gimlet-seq-api"}
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/mock-gimlet-seq-server/build.rs
+++ b/drv/mock-gimlet-seq-server/build.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::server::build_server_support(
+        "../../idl/gimlet-seq.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Server for managing the Gimlet sequencing process.
+
+#![no_std]
+#![no_main]
+
+use drv_gimlet_seq_api::{PowerState, SeqError};
+use idol_runtime::RequestError;
+use userlib::RecvMessage;
+
+#[export_name = "main"]
+fn main() -> ! {
+    let mut buffer = [0; idl::INCOMING_SIZE];
+    let mut server = ServerImpl {
+        state: PowerState::A2,
+    };
+
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
+    }
+}
+
+struct ServerImpl {
+    state: PowerState,
+}
+
+impl idl::InOrderSequencerImpl for ServerImpl {
+    fn get_state(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<PowerState, RequestError<SeqError>> {
+        Ok(self.state)
+    }
+
+    fn set_state(
+        &mut self,
+        _: &RecvMessage,
+        state: PowerState,
+    ) -> Result<(), RequestError<SeqError>> {
+        match (self.state, state) {
+            (PowerState::A2, PowerState::A0)
+            | (PowerState::A0, PowerState::A2)
+            | (PowerState::A0PlusHP, PowerState::A2)
+            | (PowerState::A0Thermtrip, PowerState::A2) => {
+                self.state = state;
+                Ok(())
+            }
+
+            _ => Err(RequestError::Runtime(SeqError::IllegalTransition)),
+        }
+    }
+
+    fn fans_on(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<SeqError>> {
+        Ok(())
+    }
+
+    fn fans_off(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<SeqError>> {
+        Ok(())
+    }
+}
+
+mod idl {
+    use super::{PowerState, SeqError};
+
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}

--- a/idl/gimlet-seq.idol
+++ b/idl/gimlet-seq.idol
@@ -3,7 +3,7 @@
 Interface(
     name: "Sequencer",
     ops: {
-	"get_state": (
+        "get_state": (
             doc: "Return the power state",
             reply: Result(
                 ok: (
@@ -13,7 +13,7 @@ Interface(
                 err: CLike("SeqError"),
             ),
         ),
-	"set_state": (
+        "set_state": (
             doc: "Set the power state",
             args: {
                 "state": (

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -11,6 +11,7 @@ serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
 
 drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api"}
+drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api"}
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"]}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
 drv-update-api = {path = "../../drv/update-api"}

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -22,7 +22,7 @@ task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91"}
+gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "7e5d68e0094bcf40f55e7640b2a8a56e4f743409"}
 
 [features]
 gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]

--- a/task/mgmt-gateway/Cargo.toml
+++ b/task/mgmt-gateway/Cargo.toml
@@ -10,9 +10,10 @@ num-traits = {version = "0.2", default-features = false}
 serde = {version = "1", default-features = false, features = ["derive"]}
 ssmarshal = {version = "1", default-features = false}
 
-drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api"}
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api"}
-drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"]}
+drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
+drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
+drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
+drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"], optional = true}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
 drv-update-api = {path = "../../drv/update-api"}
 mutable-statics = {path = "../../lib/mutable-statics"}
@@ -24,8 +25,8 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 gateway-messages = {git = "https://github.com/oxidecomputer/omicron", rev = "d8c5b937ba0ad9c00bfa4771cae4211ab2a0db91"}
 
 [features]
-gimlet = []
-sidecar = []
+gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]
+sidecar = ["drv-sidecar-seq-api"]
 psc = []
 
 vlan = ["task-net-api/vlan"]

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -91,7 +91,7 @@ enum MgsMessage {
     UpdateAbort {
         component: SpComponent,
     },
-    SysResetPrepare,
+    ResetPrepare,
 }
 
 ringbuf!(Log, 16, Log::Empty);

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -6,8 +6,8 @@
 #![no_main]
 
 use gateway_messages::{
-    sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, SpComponent,
-    SpPort, UpdateId,
+    sp_impl, sp_impl::Error as MgsDispatchError, IgnitionCommand, PowerState,
+    SpComponent, SpPort, UpdateId,
 };
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
@@ -91,6 +91,8 @@ enum MgsMessage {
     UpdateAbort {
         component: SpComponent,
     },
+    GetPowerState,
+    SetPowerState(PowerState),
     ResetPrepare,
 }
 

--- a/task/mgmt-gateway/src/mgs_common.rs
+++ b/task/mgmt-gateway/src/mgs_common.rs
@@ -145,7 +145,7 @@ impl MgsCommon {
     pub(crate) fn reset_prepare(&mut self) -> Result<(), ResponseError> {
         // TODO: Add some kind of auth check before performing a reset.
         // https://github.com/oxidecomputer/hubris/issues/723
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SysResetPrepare));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ResetPrepare));
         self.reset_requested = true;
         Ok(())
     }
@@ -156,7 +156,7 @@ impl MgsCommon {
         // TODO: Add some kind of auth check before performing a reset.
         // https://github.com/oxidecomputer/hubris/issues/723
         if !self.reset_requested {
-            return Err(ResponseError::SysResetTriggerWithoutPrepare);
+            return Err(ResponseError::ResetTriggerWithoutPrepare);
         }
 
         let jefe = task_jefe_api::Jefe::from(crate::JEFE.get_task_id());

--- a/task/mgmt-gateway/src/mgs_psc.rs
+++ b/task/mgmt-gateway/src/mgs_psc.rs
@@ -7,9 +7,9 @@ use core::convert::Infallible;
 use crate::{mgs_common::MgsCommon, Log, MgsMessage};
 use gateway_messages::{
     sp_impl::SocketAddrV6, sp_impl::SpHandler, BulkIgnitionState,
-    DiscoverResponse, IgnitionCommand, IgnitionState, ResponseError,
-    SpComponent, SpPort, SpState, UpdateChunk, UpdateId, UpdatePrepare,
-    UpdateStatus,
+    DiscoverResponse, IgnitionCommand, IgnitionState, PowerState,
+    ResponseError, SpComponent, SpPort, SpState, UpdateChunk, UpdateId,
+    UpdatePrepare, UpdateStatus,
 };
 use ringbuf::ringbuf_entry_root;
 use task_net_api::UdpMetadata;
@@ -170,6 +170,31 @@ impl SpHandler for MgsHandler {
             SpComponent::SP_ITSELF => self.common.update_abort(&id),
             _ => Err(ResponseError::RequestUnsupportedForComponent),
         }
+    }
+
+    fn power_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<PowerState, ResponseError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
+
+        // We have no states other than A2.
+        Ok(PowerState::A2)
+    }
+
+    fn set_power_state(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        power_state: PowerState,
+    ) -> Result<(), ResponseError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
+            power_state
+        )));
+
+        // We have no states other than A2; always fail.
+        Err(ResponseError::RequestUnsupportedForSp)
     }
 
     fn serial_console_attach(


### PR DESCRIPTION
The main change in this is that the `SpHandler` trait now has `power_state()` and `set_power_state()` methods, and our gimlet/sidecar handlers attempt to implement them faithfully. (The psc handler implements them trivially.)

Other changes that came along for the ride (the first is not related, but is a tiny cleanup):

1. Removed the `Sys...` prefix in a handful of places we were still referring to `SysReset`
2. Added a `mock-gimlet-seq-server` task and added it to gimletlet's app.toml to allow test work of the power state APIs on gimletlet