### PR TITLE
host-sp-comms: implement rebooting the host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
  "drv-i2c-api",
  "drv-onewire",
  "num-traits",
- "pmbus 0.1.0 (git+https://github.com/oxidecomputer/pmbus)",
+ "pmbus",
  "ringbuf",
  "userlib",
  "zerocopy",
@@ -1859,15 +1859,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hif"
-version = "0.2.3"
-dependencies = [
- "pkg-version",
- "postcard",
- "serde",
-]
-
-[[package]]
-name = "hif"
 version = "0.3.1"
 source = "git+https://github.com/oxidecomputer/hif#34aace65cbf458129dcd8007715a94bc488b2931"
 dependencies = [
@@ -2627,20 +2618,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-dependencies = [
- "anyhow",
- "convert_case 0.3.2",
- "libm",
- "num-derive",
- "num-traits",
- "ron 0.6.6",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "pmbus"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/pmbus#9f5d86bfd04cbb6d7a7fcb38e00071c8b643f6f3"
 dependencies = [
  "anyhow",
@@ -3185,14 +3162,6 @@ dependencies = [
 [[package]]
 name = "spd"
 version = "0.1.0"
-dependencies = [
- "num-derive",
- "num-traits",
-]
-
-[[package]]
-name = "spd"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/spd#e37e79f6d7d4805b8a6a8c4d37699c4bd60222ea"
 dependencies = [
  "num-derive",
@@ -3429,7 +3398,7 @@ dependencies = [
  "drv-stm32xx-i2c",
  "drv-stm32xx-sys-api",
  "drv-update-api",
- "hif 0.3.1",
+ "hif",
  "hubris-num-tasks",
  "num-traits",
  "ringbuf",
@@ -3712,7 +3681,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "spd 0.1.0 (git+https://github.com/oxidecomputer/spd)",
+ "spd",
  "stm32h7",
  "userlib",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,6 +3446,7 @@ dependencies = [
  "cfg-if",
  "corncobs",
  "cortex-m",
+ "drv-gimlet-seq-api",
  "drv-stm32h7-usart",
  "heapless",
  "host-sp-messages",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -204,7 +204,7 @@ priority = 5
 max-sizes = {flash = 16384, ram = 16384}
 stacksize = 2048
 start = true
-task-slots = ["sys"]
+task-slots = ["sys", "gimlet_seq"]
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -28,8 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-on-state-change = {net = {bit-number = 3}}
+[tasks.jefe.config.on-state-change]
+net = {bit-number = 3}
+host_sp_comms = {bit-number = 1}
 
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -118,7 +118,7 @@ priority = 3
 max-sizes = {flash = 16384, ram = 16384}
 stacksize = 2048
 start = true
-task-slots = ["sys"]
+task-slots = ["sys", "gimlet_seq"]
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -28,7 +28,11 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config.on-state-change]
+host_sp_comms = {bit-number = 1}
+
 [tasks.jefe.config.allowed-callers]
+set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
 request_reset = ["hiffy", "mgmt_gateway"]
 
@@ -85,6 +89,7 @@ name = "drv-mock-gimlet-seq-server"
 priority = 2
 max-sizes = {flash = 2048, ram = 1024 }
 start = true
+task-slots = ["jefe"]
 
 [tasks.pong]
 name = "task-pong"

--- a/drv/mock-gimlet-seq-server/Cargo.toml
+++ b/drv/mock-gimlet-seq-server/Cargo.toml
@@ -10,5 +10,7 @@ num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-seq-api = {path = "../gimlet-seq-api"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
+task-jefe-api = {path = "../../task/jefe-api"}
+
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -17,11 +17,7 @@ userlib::task_slot!(JEFE, jefe);
 #[export_name = "main"]
 fn main() -> ! {
     let mut buffer = [0; idl::INCOMING_SIZE];
-    let mut server = ServerImpl {
-        jefe: Jefe::from(JEFE.get_task_id()),
-    };
-
-    server.set_state_impl(PowerState::A2);
+    let mut server = ServerImpl::init(Jefe::from(JEFE.get_task_id()));
 
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
@@ -33,6 +29,12 @@ struct ServerImpl {
 }
 
 impl ServerImpl {
+    fn init(jefe: Jefe) -> Self {
+        let me = Self { jefe };
+        me.set_state_impl(PowerState::A2);
+        me
+    }
+
     fn get_state_impl(&self) -> PowerState {
         // Only we should be setting the state, and we set it to A2 on startup;
         // this conversion should never fail.

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -69,9 +69,7 @@ pub enum HostToSp {
         reason: u8,
     },
     HostPanic {
-        status: u16,
-        cpu: u16,
-        thread: u64,
+        code: u16,
         // Followed by a binary data blob (panic message?)
     },
     GetStatus,

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -13,6 +13,7 @@ ringbuf = {path = "../../lib/ringbuf"}
 userlib = {path = "../../sys/userlib"}
 
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", optional = true}
+drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api"}
 host-sp-messages = {path = "../../lib/host-sp-messages"}
 
 [build-dependencies]

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -129,7 +129,7 @@ impl ServerImpl {
         }
     }
 
-    /// Power of the host (i.e., transition to A2).
+    /// Power off the host (i.e., transition to A2).
     ///
     /// If `reboot` is true and we successfully instruct the sequencer to
     /// transition to A2, we set `self.reboot_state` to

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -344,7 +344,7 @@ impl ServerImpl {
             HostToSp::GetStatus => SpToHost::Status(self.status),
             HostToSp::ClearStatus { mask } => {
                 self.status &= Status::from_bits_truncate(!mask);
-                SpToHost::Ack
+                SpToHost::Status(self.status)
             }
             HostToSp::GetAlert { mask: _ } => {
                 // TODO define alerts

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -353,8 +353,7 @@ impl ServerImpl {
             }
             HostToSp::HostPanic { .. } => {
                 // TODO log event and/or forward to MGS
-                action = Some(Action::RebootHost);
-                None
+                Some(SpToHost::Ack)
             }
             HostToSp::GetStatus => Some(SpToHost::Status(self.status)),
             HostToSp::ClearStatus { mask } => {

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -33,7 +33,6 @@ enum Trace {
     UartTxFull,
     UartRx(u8),
     UartRxOverrun,
-    Notification(u32),
     ClearStatus { mask: u64 },
     RebootSetA2,
     JefeNotification(PowerState),
@@ -73,7 +72,6 @@ fn main() -> ! {
         )
         .unwrap_lite()
         .operation;
-        ringbuf_entry!(Trace::Notification(note));
 
         server.handle_notification(note);
     }

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         task, count
     )?;
     for (name, rec) in cfg.on_state_change {
-        writeln!(out, "    ({}::{}, 1 << {})", task, name, rec.bit_number)?;
+        writeln!(out, "    ({}::{}, 1 << {}),", task, name, rec.bit_number)?;
     }
     writeln!(out, "];")?;
 


### PR DESCRIPTION
We reboot the host in response to a reboot request, and we power off the host in response to a power off request. In both cases, we do _not_ send a response on the uart.

The diff looks larger than it actually is because some things moved around and `git diff` doesn't handle it particularly well; it might be clearer to step through the commits individually.

This builds on #795 and should be merged after it.

A general comment - I'm not in love with the way the sequencer presents `PowerState` (and in particular the additive states beyond A0/A2). I asked about this in the hubris channel some, and am curious if we'd be better served if we modeled it more like

```rust
enum PowerState {
    A0(A0AdditiveState),
    A1,
    A2(A2AdditiveState),
}
```

where `AxAdditiveState` could be an enum or a bit mask? The implementation of `power_off_host()` on this PR is where this is most obvious. What's not obvious is that given the current gimlet-seq implementation, I believe `gimlet_seq.set_state()` will always fail if the current state is one of the A2 additive states. (Raw `PowerState::A2` is fine.)