### PR TITLE
simplify duplicate job removal

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,21 +1,11 @@
 name: dist
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
-  skip_duplicate_jobs:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          concurrent_skipping: 'same_content'
-          skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
-    needs: skip_duplicate_jobs
-    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: dist
     runs-on: '${{ matrix.os }}'
     strategy:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,24 +5,12 @@
 # * checkout PR head commit https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
 name: documentation
 on:
+  pull_request:
   push:
-    branches:
-      - master
+    branches: [master]
+
 jobs:
-  skip_duplicate_jobs:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          concurrent_skipping: 'same_content'
-          skip_after_successful_duplicate: 'true'
-          paths: '["doc/**"]'
   deploy:
-    needs: skip_duplicate_jobs
-    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.1

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,5 +1,9 @@
 name: formatting
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We would get duplicate builds for PRs because we want to check on master, but also on pull requests. Due to using 'push' for master, we'd end up with these duplicate jobs, and used this action to sort out the duplicates.

This change simplifies this by only doing the 'push' actions on master, and not on PR branches.