### PR TITLE
Minor auxflash API updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ name = "drv-auxflash-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
+ "drv-qspi-api",
  "idol",
  "num-traits",
  "sha3",
@@ -748,7 +749,6 @@ dependencies = [
  "build-util",
  "cfg-if",
  "drv-auxflash-api",
- "drv-qspi-api",
  "drv-stm32h7-qspi",
  "drv-stm32xx-sys-api",
  "idol",

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 derive-idol-err = {path = "../../lib/derive-idol-err" }
+drv-qspi-api = {path = "../qspi-api"}
 userlib = {path = "../../sys/userlib"}
 
 tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -11,6 +11,8 @@ use sha3::{Digest, Sha3_256};
 use tlvc::{TlvcRead, TlvcReader};
 use userlib::*;
 
+pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
+
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum AuxFlashError {
     WriteEnableFailed = 1,
@@ -41,6 +43,8 @@ pub enum AuxFlashError {
     NoActiveSlot,
     /// There is no blob with this name
     NoSuchBlob,
+    /// Writes to the currently-active slot are not allowed
+    SlotActive,
 }
 
 #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::AsBytes)]

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 drv-auxflash-api = {path = "../auxflash-api", default-features = false}
-drv-qspi-api = {path = "../qspi-api"}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}

--- a/idl/auxflash.idol
+++ b/idl/auxflash.idol
@@ -91,7 +91,14 @@ Interface(
             ),
         ),
         "scan_and_get_active_slot": (
-            doc: "Searches for a slot with a checksum that matches the one in the Hubris image",
+            doc: "DEPRECATED; use active_slot() instead",
+            reply: Result(
+                ok: "u32",
+                err: CLike("AuxFlashError"),
+            ),
+        ),
+        "get_active_slot": (
+            doc: "Returns the slot containing the checksum that matches the one in the Hubris image",
             reply: Result(
                 ok: "u32",
                 err: CLike("AuxFlashError"),


### PR DESCRIPTION
* Re-export page/sector size from `auxflash-api`
* Refuse to write to the currently-active slot
* Only scan for the active slot once on task start
  - Add new `get_active_slot()` idl function
  - `scan_and_get_active_slot()` is documented as deprecated; it no longer scans and now just calls `get_active_slot()`