### PR TITLE
Faster MDIO!

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -77,7 +77,7 @@ features = ["h743"]
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys"]
 
 [tasks.user_leds]

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -75,9 +75,9 @@ priority = 2
 max-sizes = {flash = 65536, ram = 8192, sram1 = 32768}
 features = ["h743"]
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys"]
 
 [tasks.user_leds]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -76,7 +76,7 @@ features = ["h753"]
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys"]
 
 [tasks.user_leds]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -74,9 +74,9 @@ priority = 2
 max-sizes = {flash = 131072, ram = 16384, sram1 = 32768}
 features = ["h753"]
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys"]
 
 [tasks.user_leds]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -46,7 +46,7 @@ max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -44,7 +44,7 @@ priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash", "tim16"]]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
 interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -44,9 +44,9 @@ priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -80,7 +80,7 @@ max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "user_leds", { spi_driver = "spi2_driver" }]
 
 [tasks.udpecho]

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -78,9 +78,9 @@ priority = 3
 features = ["mgmt", "h753"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys", "user_leds", { spi_driver = "spi2_driver" }]
 
 [tasks.udpecho]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -149,7 +149,7 @@ max-sizes = {flash = 65536, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "spi_driver" ]
 
 [tasks.udpecho]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -147,9 +147,9 @@ priority = 3
 features = ["h753", "vlan", "gimletlet-nic"]
 max-sizes = {flash = 65536, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys", "spi_driver" ]
 
 [tasks.udpecho]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -112,7 +112,7 @@ max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", { spi_driver = "spi2_driver" }]
 
 [tasks.mgmt_gateway]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -110,9 +110,9 @@ priority = 3
 features = ["mgmt", "h753", "vlan"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys", { spi_driver = "spi2_driver" }]
 
 [tasks.mgmt_gateway]

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -124,9 +124,9 @@ priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "system_flash"]
+uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
 task-slots = ["sys",
               { spi_driver = "spi3_driver" },
               { seq = "sequencer" }]

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -126,7 +126,7 @@ max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "system_flash", "tim16"]
 start = true
-interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10000}
+interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys",
               { spi_driver = "spi3_driver" },
               { seq = "sequencer" }]

--- a/chips/stm32h7/chip.toml
+++ b/chips/stm32h7/chip.toml
@@ -136,6 +136,11 @@ address = 0x52002000
 size = 0x2000
 interrupts = { irq = 4 }
 
+[tim16]
+address = 0x40014400
+size = 0x400
+interrupts = { irq = 117 }
+
 [bank2]
 address = 0x08100000
 size = 0x00100000

--- a/drv/stm32h7-eth/src/lib.rs
+++ b/drv/stm32h7-eth/src/lib.rs
@@ -36,6 +36,16 @@ pub struct Ethernet {
     tx_ring: crate::ring::TxRing,
     /// Control of the RX ring.
     rx_ring: crate::ring::RxRing,
+
+    /// Pointer to the timer registers. We use the timer for timing MDIO
+    /// transactions, since the MDIO hardware doesn't provide any kind of
+    /// interrupts.
+    ///
+    /// The PAC models all the timers as distinct types, so if you'd like to use
+    /// a different timer ... well, sorry.
+    mdio_timer: &'static device::tim16::RegisterBlock,
+    /// Notification mask for the timer interrupt.
+    mdio_timer_irq_mask: u32,
 }
 
 /// As the name implies, this spins until a predicate becomes true, in a crappy
@@ -69,6 +79,8 @@ impl Ethernet {
         dma: &'static device::ethernet_dma::RegisterBlock,
         tx_ring: crate::ring::TxRing,
         rx_ring: crate::ring::RxRing,
+        mdio_timer: &'static device::tim16::RegisterBlock,
+        mdio_timer_irq_mask: u32,
     ) -> Self {
         // The DMA register block contains the soft-reset for the entire system.
         // We need to do this soft-reset even straight out of chip reset,
@@ -219,12 +231,30 @@ impl Ethernet {
         // Enable transmit and receive.
         mac.maccr.modify(|_, w| w.te().set_bit().re().set_bit());
 
+        // Configure our timer, but leave it disabled.
+        mdio_timer.cr1.write(|w| {
+            // Enable one-pulse mode to use the timer as a one-shot.
+            w.opm().set_bit();
+            w
+        });
+        mdio_timer.dier.write(|w| {
+            // Enable interrupt on update (rollover).
+            w.uie().set_bit();
+            w
+        });
+        // Configure the timer's prescaler to use the same factor we chose for
+        // MDIO, above. TODO: this may need to be scaled as the reference clocks
+        // may not be the same.
+        mdio_timer.psc.write(|w| w.psc().bits(102));
+
         Self {
             mac,
             _mtl: mtl,
             dma,
             tx_ring,
             rx_ring,
+            mdio_timer,
+            mdio_timer_irq_mask,
         }
     }
 
@@ -332,6 +362,42 @@ impl Ethernet {
                 .mb()
                 .set_bit()
         });
+
+        // An MDIO/SMI read operation always consists of
+        // - 32 bit preamble
+        // - start bit
+        // - 2 bit opcode
+        // - 5 bit phy address
+        // - 5 bit register address
+        // - 2 turnaround bits
+        // - 16 bit response
+        // ...for a total of 63 bits.
+        const MDIO_READ_BITS: usize = 63;
+        // So we want to program the timer to count up to that many bits, and
+        // then interrupt us. Since the ARR value is _included_ in the count,
+        // this actually counts out our number of bits _plus one,_ and that's
+        // okay because it ensures we've got some padding.
+        self.mdio_timer.arr.write(|w| w.arr().bits(MDIO_READ_BITS as u16));
+        self.mdio_timer.cnt.write(|w| w.cnt().bits(0));
+        // Force update
+        self.mdio_timer.egr.write(|w| w.ug().set_bit());
+        // Clear existing interrupt flags.
+        self.mdio_timer.sr.write(|w| w.uif().clear_bit());
+        // Go!
+        self.mdio_timer.cr1.modify(|_, w| w.cen().set_bit());
+        // Enable the IRQ.
+        userlib::sys_irq_control(self.mdio_timer_irq_mask, true);
+        // Wait for it. Avoid spurious notifications by checking if the timer
+        // has disabled itself before proceeding.
+        loop {
+            userlib::sys_irq_control(self.mdio_timer_irq_mask, true);
+            let _ = userlib::sys_recv_closed(&mut [], self.mdio_timer_irq_mask, userlib::TaskId::KERNEL);
+            if !self.mdio_timer.cr1.read().cen().bit() {
+                break;
+            }
+        }
+
+        if self.is_smi_busy() { panic!(); }
     }
 
     /// Performs a SMI read from PHY address `phy`, register number `register`,
@@ -342,7 +408,8 @@ impl Ethernet {
     /// page access register may not be set to 0, so this could return values
     /// from a register on an extended page!
     pub fn smi_read(&self, phy: u8, register: impl Into<u8>) -> u16 {
-        // Wait until peripheral is free.
+        // Wait until peripheral is free. This spin loop should not spin in
+        // practice because we block waiting for any operations we issue.
         crappy_spin_until(|| !self.is_smi_busy());
 
         // Load address + start transaction
@@ -358,8 +425,39 @@ impl Ethernet {
                 .set_bit()
         });
 
-        // Wait until it finishes.
-        crappy_spin_until(|| !self.is_smi_busy());
+        // An MDIO/SMI read operation always consists of
+        // - 32 bit preamble
+        // - start bit
+        // - 2 bit opcode
+        // - 5 bit phy address
+        // - 5 bit register address
+        // - 2 turnaround bits
+        // - 16 bit response
+        // ...for a total of 63 bits.
+        const MDIO_READ_BITS: usize = 63;
+        // So we want to program the timer to count up to that many bits, and
+        // then interrupt us. Since the ARR value is _included_ in the count,
+        // this actually counts out our number of bits _plus one,_ and that's
+        // okay because it ensures we've got some padding.
+        self.mdio_timer.arr.write(|w| w.arr().bits(MDIO_READ_BITS as u16));
+        self.mdio_timer.cnt.write(|w| w.cnt().bits(0));
+        // Force update
+        self.mdio_timer.egr.write(|w| w.ug().set_bit());
+        // Clear existing interrupt flags.
+        self.mdio_timer.sr.write(|w| w.uif().clear_bit());
+        // Go!
+        self.mdio_timer.cr1.modify(|_, w| w.cen().set_bit());
+        // Wait for it. Avoid spurious notifications by checking if the timer
+        // has disabled itself before proceeding.
+        loop {
+            userlib::sys_irq_control(self.mdio_timer_irq_mask, true);
+            let _ = userlib::sys_recv_closed(&mut [], self.mdio_timer_irq_mask, userlib::TaskId::KERNEL);
+            if !self.mdio_timer.cr1.read().cen().bit() {
+                break;
+            }
+        }
+
+        if self.is_smi_busy() { panic!(); }
 
         self.mac.macmdiodr.read().md().bits()
     }

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -87,13 +87,11 @@ const RX_RING_SZ: usize = 4;
 /// Notification mask for our IRQ; must match configuration in app.toml.
 const ETH_IRQ: u32 = 1 << 0;
 
+/// Notification mask for MDIO timer; must match configuration in app.toml.
+const MDIO_TIMER_IRQ: u32 = 1 << 1;
+
 /// Notification mask for optional periodic logging
-const WAKE_IRQ: u32 = 1 << 1;
-
-// NOTE: bit 3 is used in the BSPs!
-
-/// Notification mask for MDIO timer.
-const MDIO_TIMER_IRQ: u32 = 1 << 4;
+const WAKE_IRQ: u32 = 1 << 2;
 
 /// Number of entries to maintain in our neighbor cache (ARP/NDP).
 const NEIGHBORS: usize = 4;

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -85,10 +85,15 @@ const TX_RING_SZ: usize = 4;
 const RX_RING_SZ: usize = 4;
 
 /// Notification mask for our IRQ; must match configuration in app.toml.
-const ETH_IRQ: u32 = 1;
+const ETH_IRQ: u32 = 1 << 0;
 
 /// Notification mask for optional periodic logging
-const WAKE_IRQ: u32 = 2;
+const WAKE_IRQ: u32 = 1 << 1;
+
+// NOTE: bit 3 is used in the BSPs!
+
+/// Notification mask for MDIO timer.
+const MDIO_TIMER_IRQ: u32 = 1 << 4;
 
 /// Number of entries to maintain in our neighbor cache (ARP/NDP).
 const NEIGHBORS: usize = 4;
@@ -120,6 +125,11 @@ fn main() -> ! {
     sys.enter_reset(drv_stm32xx_sys_api::Peripheral::Eth1Mac);
     sys.leave_reset(drv_stm32xx_sys_api::Peripheral::Eth1Mac);
 
+    // Reset our MDIO timer.
+    sys.enable_clock(drv_stm32xx_sys_api::Peripheral::Tim16);
+    sys.enter_reset(drv_stm32xx_sys_api::Peripheral::Tim16);
+    sys.leave_reset(drv_stm32xx_sys_api::Peripheral::Tim16);
+
     // Do preliminary pin configuration
     bsp::configure_ethernet_pins(&sys);
 
@@ -136,6 +146,8 @@ fn main() -> ! {
         unsafe { &*device::ETHERNET_DMA::ptr() },
         tx_ring,
         rx_ring,
+        unsafe { &*device::TIM16::ptr() },
+        MDIO_TIMER_IRQ,
     );
 
     // Set up the network stack.


### PR DESCRIPTION
This switches MDIO to using a timer-based wait for sub-millisecond delays, bringing the VSC7448 boot sequence from 8 to 4 seconds!