### PR TITLE
Move aux flash sizes to app.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,10 +732,12 @@ dependencies = [
 name = "drv-auxflash-api"
 version = "0.1.0"
 dependencies = [
+ "build-util",
  "derive-idol-err",
  "drv-qspi-api",
  "idol",
  "num-traits",
+ "serde",
  "sha3",
  "tlvc",
  "userlib",
@@ -746,7 +748,6 @@ dependencies = [
 name = "drv-auxflash-server"
 version = "0.1.0"
 dependencies = [
- "build-util",
  "cfg-if",
  "drv-auxflash-api",
  "drv-stm32h7-qspi",

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -787,6 +787,10 @@ port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
+[config.auxflash]
+memory-size = 16_777_216 # 16 MiB
+slot-count = 8
+
 [[auxflash.blobs]]
 file = "drv/sidecar-mainboard-controller/sidecar_mainboard_controller.bit"
 compress = true

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -15,4 +15,6 @@ num-traits = { version = "0.2.12", default-features = false }
 zerocopy = "0.6.1"
 
 [build-dependencies]
+build-util = {path = "../../build/util"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+serde = "1"

--- a/drv/auxflash-api/build.rs
+++ b/drv/auxflash-api/build.rs
@@ -2,10 +2,45 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use serde::Deserialize;
+use std::io::Write;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let global_config = build_util::config::<GlobalConfig>()?;
+    generate_auxflash_config(&global_config.auxflash)?;
+
     idol::client::build_client_stub(
         "../../idl/auxflash.idol",
         "client_stub.rs",
     )?;
+    Ok(())
+}
+
+/// This represents our _subset_ of global config and _must not_ be marked with
+/// `deny_unknown_fields`!
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct GlobalConfig {
+    auxflash: AuxFlashConfig,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+struct AuxFlashConfig {
+    memory_size: u32,
+    slot_count: u32,
+}
+
+fn generate_auxflash_config(
+    config: &AuxFlashConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = std::env::var("OUT_DIR")?;
+    let dest_path = std::path::Path::new(&out_dir).join("auxflash_config.rs");
+
+    let mut out = std::fs::File::create(&dest_path)?;
+
+    writeln!(out, "pub const MEMORY_SIZE: u32 = {};", config.memory_size)?;
+    writeln!(out, "pub const SLOT_COUNT: u32 = {};", config.slot_count)?;
+
     Ok(())
 }

--- a/drv/auxflash-api/build.rs
+++ b/drv/auxflash-api/build.rs
@@ -39,6 +39,23 @@ fn generate_auxflash_config(
 
     let mut out = std::fs::File::create(&dest_path)?;
 
+    // Check that the config is reasonable:
+    // a. We have at least 6 slots (see RFD 311)
+    assert!(config.slot_count >= 6, "auxflash requires at least 6 slots");
+    // b. Memory size is evenly divisible by the slot count
+    assert_eq!(
+        config.memory_size % config.slot_count,
+        0,
+        "auxflash memory must be evenly divisble by slot count"
+    );
+    // c. Slot offsets are page-aligned (assuming 64 KiB pages; we can update
+    //    this as needed)
+    assert_eq!(
+        config.memory_size / config.slot_count % (64 << 10),
+        0,
+        "auxflash slots must be page aligned"
+    );
+
     writeln!(out, "pub const MEMORY_SIZE: u32 = {};", config.memory_size)?;
     writeln!(out, "pub const SLOT_COUNT: u32 = {};", config.slot_count)?;
 

--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -177,3 +177,10 @@ where
 ////////////////////////////////////////////////////////////////////////////////
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
+
+mod config {
+    include!(concat!(env!("OUT_DIR"), "/auxflash_config.rs"));
+}
+
+pub use self::config::SLOT_COUNT;
+pub const SLOT_SIZE: usize = (self::config::MEMORY_SIZE / SLOT_COUNT) as usize;

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -19,7 +19,6 @@ stm32h7 = { version = "0.14", default-features = false }
 zerocopy = "0.6.1"
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -4,8 +4,6 @@
 use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_target_board();
-
     idol::server::build_server_support(
         "../../idl/auxflash.idol",
         "server_stub.rs",

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -7,26 +7,12 @@
 
 use drv_auxflash_api::{
     AuxFlashBlob, AuxFlashChecksum, AuxFlashError, AuxFlashId,
-    TlvcReadAuxFlash, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES,
+    TlvcReadAuxFlash, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES, SLOT_COUNT,
+    SLOT_SIZE,
 };
 use idol_runtime::{ClientError, Leased, RequestError, R, W};
 use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
 use userlib::*;
-
-cfg_if::cfg_if! {
-    if #[cfg(target_board="sidecar-a")] {
-        const MEMORY_SIZE: u32 = 16 << 20; // 16 MiB
-        const SLOT_COUNT: u32 = 8;
-        const SLOT_SIZE: usize = (MEMORY_SIZE / SLOT_COUNT) as usize;
-    } else {
-        compile_error!("No auxflash support for this board");
-        // Dummy values so that the error above is obvious; otherwise, the
-        // compiler throws out a bunch of other errors.
-        const MEMORY_SIZE: u32 = 0;
-        const SLOT_COUNT: u32 = 0;
-        const SLOT_SIZE: usize = 0;
-    }
-}
 
 #[cfg(feature = "h753")]
 use stm32h7::stm32h753 as device;


### PR DESCRIPTION
Allows clients to know the number and size of auxflash slots statically via constants exported from the API crate.