### PR TITLE
Remove `Default` bound; use `new_zeroed` instead

### DIFF
--- a/drv/fpga-api/src/lib.rs
+++ b/drv/fpga-api/src/lib.rs
@@ -254,9 +254,9 @@ impl FpgaUserDesign {
 
     pub fn read<T>(&self, addr: impl Into<u16>) -> Result<T, FpgaError>
     where
-        T: AsBytes + Default + FromBytes,
+        T: AsBytes + FromBytes,
     {
-        let mut v = T::default();
+        let mut v = T::new_zeroed();
         self.server.user_design_read(
             self.device_index,
             addr.into(),

--- a/drv/fpga-devices/src/ecp5.rs
+++ b/drv/fpga-devices/src/ecp5.rs
@@ -234,11 +234,11 @@ impl<Driver: Ecp5Driver> Ecp5<Driver> {
 
     /// Send a command and read back a number of bytes given by the type T. Note
     /// that data is always returned in big endian order.
-    pub fn read<T: Default + AsBytes + FromBytes>(
+    pub fn read<T: AsBytes + FromBytes>(
         &self,
         c: Command,
     ) -> Result<T, Driver::Error> {
-        let mut buf = T::default();
+        let mut buf = T::new_zeroed();
 
         // Release of the lock happens implicit as we leave this function.
         let _lock = self.lock()?;

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -285,11 +285,11 @@ impl I2cDevice {
     ///
     /// On failure, a [`ResponseCode`] will indicate more detail.
     ///
-    pub fn read_reg<R: AsBytes, V: Default + AsBytes + FromBytes>(
+    pub fn read_reg<R: AsBytes, V: AsBytes + FromBytes>(
         &self,
         reg: R,
     ) -> Result<V, ResponseCode> {
-        let mut val = V::default();
+        let mut val = V::new_zeroed();
         let mut response = 0_usize;
 
         let (code, _) = sys_send(
@@ -388,11 +388,9 @@ impl I2cDevice {
     /// (And indeed, on these devices, attempting to read a register will
     /// in fact overwrite the contents of the first two registers.)
     ///
-    pub fn read<V: Default + AsBytes + FromBytes>(
-        &self,
-    ) -> Result<V, ResponseCode> {
+    pub fn read<V: AsBytes + FromBytes>(&self) -> Result<V, ResponseCode> {
         let empty = [0u8; 1];
-        let mut val = V::default();
+        let mut val = V::new_zeroed();
         let mut response = 0_usize;
 
         let (code, _) = sys_send(

--- a/drv/i2c-devices/src/at24csw080.rs
+++ b/drv/i2c-devices/src/at24csw080.rs
@@ -107,10 +107,7 @@ impl At24Csw080 {
     ///
     /// `addr` and `addr + sizeof(V)` must be below `EEPROM_SIZE`; otherwise
     /// this function will return an error.
-    pub fn read<V: Default + AsBytes + FromBytes>(
-        &self,
-        addr: u16,
-    ) -> Result<V, Error> {
+    pub fn read<V: AsBytes + FromBytes>(&self, addr: u16) -> Result<V, Error> {
         // Address validation
         if addr >= EEPROM_SIZE {
             return Err(Error::InvalidAddress(addr));
@@ -248,11 +245,7 @@ impl At24Csw080 {
     ///
     /// **Be careful** when using this value with integer literals:
     /// `write(addr, 0x01)` will write a 4-byte value!
-    pub fn write<V: Default + AsBytes + FromBytes>(
-        &self,
-        addr: u16,
-        val: V,
-    ) -> Result<(), Error> {
+    pub fn write<V: AsBytes>(&self, addr: u16, val: V) -> Result<(), Error> {
         self.write_buffer(addr, val.as_bytes())
     }
 

--- a/sys/userlib/src/hl.rs
+++ b/sys/userlib/src/hl.rs
@@ -369,11 +369,9 @@ impl Borrow<'_> {
     /// requirements is placed on the *client* side.
     pub fn read_at<T>(&self, offset: usize) -> Option<T>
     where
-        T: Default + FromBytes + AsBytes,
+        T: FromBytes + AsBytes,
     {
-        // NOTE: the default requirement could be lifted if we do some unsafe
-        // uninitialized buffer shenanigans.
-        let mut dest = T::default();
+        let mut dest = T::new_zeroed();
         let (rc, n) =
             sys_borrow_read(self.id, self.index, offset, dest.as_bytes_mut());
         if rc != 0 || n != core::mem::size_of::<T>() {


### PR DESCRIPTION
Since we require `FromBytes` anyways, the `Default` bound is superfluous.