### PR TITLE
Allow for naming individual LPC55 GPIO pins.

### DIFF
--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -102,6 +102,10 @@ pins = [
 { pin = { port = 1, pin = 2}, alt = 6},
 # HS_SSEL1 = P1_1 = FUN5
 { pin = { port = 1, pin = 1}, alt = 5},
+# ROT_IRQ = P0_18 = FUN0
+{ name = "ROT_IRQ", pin = { port = 0, pin = 18}, alt = 0, mode = "NoPull", direction = "output"},
+# SP_RESET = P0_9 = FUN0
+{ name = "SP_RESET", pin = { port = 0, pin = 9}, alt = 0, mode = "NoPull", direction = "input"},
 ]
 
 [tasks.swd]

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use proc_macro2::TokenStream;
 use quote::{format_ident, ToTokens, TokenStreamExt};
 use serde::Deserialize;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -46,6 +46,7 @@ pub struct PinConfig {
     digimode: Option<String>,
     opendrain: Option<String>,
     direction: Option<String>,
+    name: Option<String>,
 }
 
 impl PinConfig {
@@ -120,6 +121,7 @@ pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
     let dest_path = std::path::Path::new(&out_dir).join("pin_config.rs");
     let mut file = std::fs::File::create(&dest_path)?;
 
+    let mut buf = BufWriter::new(Vec::new());
     writeln!(
         &mut file,
         "fn setup_pins(task : TaskId) -> Result<(), ()> {{"
@@ -143,10 +145,23 @@ pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
                 writeln!(&mut file, ").unwrap_lite();")?;
             }
         }
+        match p.name {
+            None => (),
+            Some(name) => {
+                let pin = p.pin.get_port_pin();
+                writeln!(&mut buf, "#[allow(unused)]")?;
+                writeln!(
+                    &mut buf,
+                    "const {}: Pin = Pin::PIO{}_{};",
+                    name, pin.0, pin.1
+                )?;
+            }
+        }
     }
 
     writeln!(&mut file, "Ok(())")?;
     writeln!(&mut file, "}}")?;
+    write!(file, "{}", String::from_utf8(buf.into_inner()?).unwrap())?;
 
     Ok(())
 }

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -8,6 +8,7 @@
 #![no_std]
 #![no_main]
 
+use drv_lpc55_gpio_api::Pin;
 use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;


### PR DESCRIPTION
Used for ROT_IRQ and SP_RESET in later PRs.