### PR TITLE
Use path attr instead of giant cfg_if trees for BSPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,7 +3556,6 @@ version = "0.1.0"
 dependencies = [
  "build-net",
  "build-util",
- "cfg-if",
  "cortex-m",
  "drv-gimlet-seq-api",
  "drv-sidecar-seq-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,6 @@ dependencies = [
  "anyhow",
  "build-i2c",
  "build-util",
- "cfg-if",
  "cortex-m",
  "drv-gimlet-seq-api",
  "drv-i2c-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,6 @@ name = "drv-gimlet-hf-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "cfg-if",
  "drv-gimlet-hf-api",
  "drv-hash-api",
  "drv-stm32h7-qspi",

--- a/app/donglet/app-g030.toml
+++ b/app/donglet/app-g030.toml
@@ -25,6 +25,7 @@ max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
 start = true
 features = ["g030"]
+task-slots = ["jefe"]
 stacksize = 256
 
 [tasks.pong]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1330,6 +1330,12 @@ fn build(
         ),
     );
     cmd.arg("--");
+
+    // We use attributes to conditionally import based on feature flags;
+    // invalid combinations of features often create duplicate attributes,
+    // which causes the later one to go unused.  Let's detect this explicitly!
+    cmd.arg("-Dunused_attributes");
+
     cmd.arg("-C")
         .arg("link-arg=-Tlink.x")
         .arg("-L")

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -10,7 +10,6 @@ userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 stm32h7 = { version = "0.14", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
 drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
-cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
 drv-hash-api = {path = "../hash-api", default-features = false}

--- a/drv/gimlet-hf-server/src/bsp.rs
+++ b/drv/gimlet-hf-server/src/bsp.rs
@@ -2,22 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// We deliberately build every possible BSP here; the linker will strip them,
-// and this prevents us from accidentally introducing breaking changes.
-mod gemini_bu_1;
-mod gimlet_b;
-mod gimletlet_2;
-mod nucleo_h7x;
-
-cfg_if::cfg_if! {
-    if #[cfg(target_board = "gimlet-b")] {
-        pub(crate) use gimlet_b::*;
-    } else if #[cfg(target_board = "gemini-bu-1")] {
-        pub(crate) use gemini_bu_1::*;
-    } else if #[cfg(target_board = "gimletlet-2")] {
-        pub(crate) use gimletlet_2::*;
-    } else if #[cfg(any(target_board = "nucleo-h743zi2",
-                        target_board = "nucleo-h753zi"))] {
-        pub(crate) use nucleo_h7x::*;
-    }
-}
+// This file should never be included; if it is, the build configuration is bad
+compile_error!("no BSP for the given target board");

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -10,7 +10,6 @@
 #![no_std]
 #![no_main]
 
-#[deny(unused_attributes)]
 #[cfg_attr(target_board = "gimlet-b", path = "bsp/gimlet_b.rs")]
 #[cfg_attr(target_board = "gemini-bu-1", path = "bsp/gemini_bu_1.rs")]
 #[cfg_attr(target_board = "gimletlet-2", path = "bsp/gimletlet_2.rs")]

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -10,6 +10,14 @@
 #![no_std]
 #![no_main]
 
+#[deny(unused_attributes)]
+#[cfg_attr(target_board = "gimlet-b", path = "bsp/gimlet_b.rs")]
+#[cfg_attr(target_board = "gemini-bu-1", path = "bsp/gemini_bu_1.rs")]
+#[cfg_attr(target_board = "gimletlet-2", path = "bsp/gimletlet_2.rs")]
+#[cfg_attr(
+    any(target_board = "nucleo-h743zi2", target_board = "nucleo-h753zi"),
+    path = "bsp/nucleo_h7x.rs"
+)]
 mod bsp;
 
 use userlib::*;
@@ -321,65 +329,65 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         }
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "hash")] {
-            fn hash(
-                &mut self,
-                _: &RecvMessage,
-                addr: u32,
-                len: u32,
-            ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
-                self.check_muxed_to_sp()?;
-                let hash_driver = hash_api::Hash::from(HASH.get_task_id());
-                if hash_driver.init_sha256().is_err() {
-                    return Err(HfError::HashError.into());
-                }
-                let begin = addr as usize;
-                // TODO: Begin may be an address beyond physical end of
-                // flash part and may wrap around.
-                let end = match begin.checked_add(len as usize) {
-                    Some(end) => {
-                        // Check end > maximum 4-byte address.
-                        // TODO: End may be beyond physical end of flash part.
-                        //       Use that limit rather than maximum 4-byte address.
-                        if end > u32::MAX as usize {
-                            return Err(HfError::HashBadRange.into());
-                        } else {
-                            end
-                        }
-                    },
-                    None => {
-                        return Err(HfError::HashBadRange.into());
-                    },
-                };
-                // If we knew the flash part size, we'd check against those limits.
-                for addr in (begin..end).step_by(self.block.len()) {
-                    let size = if self.block.len() < (end - addr) {
-                        self.block.len()
-                    } else {
-                        end - addr
-                    };
-                    self.qspi.read_memory(addr as u32, &mut self.block[..size]);
-                    if hash_driver.update(
-                        size as u32, &self.block[..size]).is_err() {
-                        return Err(HfError::HashError.into());
-                    }
-                }
-                match hash_driver.finalize_sha256() {
-                    Ok(sum) => Ok(sum),
-                    Err(_) => Err(HfError::HashError.into()),   // XXX losing info
+    #[cfg(feature = "hash")]
+    fn hash(
+        &mut self,
+        _: &RecvMessage,
+        addr: u32,
+        len: u32,
+    ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
+        self.check_muxed_to_sp()?;
+        let hash_driver = hash_api::Hash::from(HASH.get_task_id());
+        if hash_driver.init_sha256().is_err() {
+            return Err(HfError::HashError.into());
+        }
+        let begin = addr as usize;
+        // TODO: Begin may be an address beyond physical end of
+        // flash part and may wrap around.
+        let end = match begin.checked_add(len as usize) {
+            Some(end) => {
+                // Check end > maximum 4-byte address.
+                // TODO: End may be beyond physical end of flash part.
+                //       Use that limit rather than maximum 4-byte address.
+                if end > u32::MAX as usize {
+                    return Err(HfError::HashBadRange.into());
+                } else {
+                    end
                 }
             }
-        } else {
-            fn hash(
-                &mut self,
-                _: &RecvMessage,
-                _addr: u32,
-                _len: u32,
-            ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
-                Err(HfError::HashNotConfigured.into())
+            None => {
+                return Err(HfError::HashBadRange.into());
+            }
+        };
+        // If we knew the flash part size, we'd check against those limits.
+        for addr in (begin..end).step_by(self.block.len()) {
+            let size = if self.block.len() < (end - addr) {
+                self.block.len()
+            } else {
+                end - addr
+            };
+            self.qspi.read_memory(addr as u32, &mut self.block[..size]);
+            if hash_driver
+                .update(size as u32, &self.block[..size])
+                .is_err()
+            {
+                return Err(HfError::HashError.into());
             }
         }
+        match hash_driver.finalize_sha256() {
+            Ok(sum) => Ok(sum),
+            Err(_) => Err(HfError::HashError.into()), // XXX losing info
+        }
+    }
+
+    #[cfg(not(feature = "hash"))]
+    fn hash(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _len: u32,
+    ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
+        Err(HfError::HashNotConfigured.into())
     }
 }
 

--- a/task/mgmt-gateway/src/main.rs
+++ b/task/mgmt-gateway/src/main.rs
@@ -21,10 +21,9 @@ mod mgs_common;
 mod update;
 
 // If the build system enables multiple of the gimlet/sidecar/psc features, this
-// sequence of `cfg_attr`s will trigger an unused_attributes warning. We can
-// turn this into a hard error via this `deny`, which will catch any such build
-// system misconfiguration.
-#[deny(unused_attributes)]
+// sequence of `cfg_attr`s will trigger an unused_attributes warning.  We build
+// everything with -Dunused_attributes, which will catch any such build system
+// misconfiguration.
 #[cfg_attr(feature = "gimlet", path = "mgs_gimlet.rs")]
 #[cfg_attr(feature = "sidecar", path = "mgs_sidecar.rs")]
 #[cfg_attr(feature = "psc", path = "mgs_psc.rs")]

--- a/task/monorail-server/src/bsp.rs
+++ b/task/monorail-server/src/bsp.rs
@@ -2,21 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// These modules are exported so that we don't have warnings about unused code,
-// but you should import Bsp instead, which is autoselected based on board.
-
-cfg_if::cfg_if! {
-    // We use the vsc7448_dev Bsp for both Gemini-BU and Gimletlet hosts.
-    // In both cases, these are driving a VSC7448 dev kit on someone's desk,
-    // connected over wires to the Hubris board.
-    if #[cfg(any(target_board = "gemini-bu-1",
-                 target_board = "gimletlet-2"))] {
-        mod vsc7448_dev;
-        pub use vsc7448_dev::*;
-    } else if #[cfg(target_board = "sidecar-a")] {
-        mod sidecar_1;
-        pub use sidecar_1::*;
-    } else {
-        compile_error!("No BSP available for this board");
-    }
-}
+// This file should never be included; if it is, the build configuration is bad
+compile_error!("no BSP for the given target board");

--- a/task/monorail-server/src/bsp/sidecar_1.rs
+++ b/task/monorail-server/src/bsp/sidecar_1.rs
@@ -288,7 +288,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         // Tune QSGMII link from the front IO board's PHY
         // These values are captured empirically with an oscilloscope
         if let Some(phy) = self.vsc8562.as_mut() {
-            use vsc85xx::vsc8562::{Sd6gObCfg, Sd6gObCfg1, Vsc8562Phy};
+            use vsc85xx::vsc8562::{Sd6gObCfg, Sd6gObCfg1};
             let mut p = vsc85xx::Phy::new(0, phy); // port 0
             let mut v = Vsc8562Phy { phy: &mut p };
             v.tune_sd6g_ob_cfg(Sd6gObCfg {

--- a/task/monorail-server/src/main.rs
+++ b/task/monorail-server/src/main.rs
@@ -5,6 +5,11 @@
 #![no_std]
 #![no_main]
 
+#[cfg_attr(target_board = "sidecar-a", path = "bsp/sidecar_1.rs")]
+#[cfg_attr(
+    any(target_board = "gemini-bu-1", target_board = "gimletlet-2"),
+    path = "bsp/vsc7448_dev.rs"
+)]
 mod bsp;
 mod server;
 

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 num-traits = {version = "0.2.12", default-features = false}
 serde = {version = "1", default-features = false, features = ["derive"]}

--- a/task/net/src/bsp.rs
+++ b/task/net/src/bsp.rs
@@ -2,30 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// These modules are exported so that we don't have warnings about unused code,
-// but you should import Bsp instead, which is autoselected based on board.
-
-cfg_if::cfg_if! {
-    if #[cfg(any(target_board = "nucleo-h743zi2", target_board = "nucleo-h753zi"))] {
-        mod nucleo_h7;
-        pub use nucleo_h7::*;
-    } else if #[cfg(target_board = "sidecar-a")] {
-        mod sidecar_a;
-        pub use sidecar_a::*;
-    } else if #[cfg(any(target_board="gimlet-b"))] {
-        mod gimlet_b;
-        pub use gimlet_b::*;
-    } else if #[cfg(target_board = "psc-a")] {
-        mod psc_a;
-        pub use psc_a::*;
-    } else if #[cfg(target_board = "gimletlet-1")] {
-        mod gimletlet_mgmt;
-        pub use gimletlet_mgmt::*;
-    } else if #[cfg(all(feature = "gimletlet-nic",
-                        target_board = "gimletlet-2"))] {
-        mod gimletlet_nic;
-        pub use gimletlet_nic::*;
-    } else {
-        compile_error!("Board is not supported by the task/net");
-    }
-}
+// This file should never be included; if it is, the build configuration is bad
+compile_error!("set one of the relevant features");

--- a/task/net/src/bsp.rs
+++ b/task/net/src/bsp.rs
@@ -3,4 +3,4 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // This file should never be included; if it is, the build configuration is bad
-compile_error!("set one of the relevant features");
+compile_error!("no BSP for the given target board");

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -5,28 +5,36 @@
 #![no_std]
 #![no_main]
 
-mod bsp;
+pub mod pins;
+
 mod buf;
 mod miim_bridge;
 mod server;
 
-pub mod pins;
+// Select the BSP based on the target board
+#[deny(unused_attributes)]
+#[cfg_attr(
+    any(target_board = "nucleo-h743zi2", target_board = "nucleo-h753zi"),
+    path = "bsp/nucleo_h7.rs"
+)]
+#[cfg_attr(target_board = "sidecar-a", path = "bsp/sidecar_a.rs")]
+#[cfg_attr(target_board = "gimlet-b", path = "bsp/gimlet_b.rs")]
+#[cfg_attr(target_board = "psc-a", path = "bsp/psc_a.rs")]
+#[cfg_attr(target_board = "gimletlet-1", path = "bsp/gimletlet_mgmt.rs")]
+#[cfg_attr(
+    all(target_board = "gimletlet-2", feature = "gimletlet-nic"),
+    path = "bsp/gimletlet_nic.rs"
+)]
+mod bsp;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "vlan")] {
-        mod server_vlan;
-        use server_vlan::ServerImpl;
-    } else {
-        mod server_basic;
-        use server_basic::ServerImpl;
-    }
-}
+#[deny(unused_attributes)]
+#[cfg_attr(feature = "vlan", path = "server_vlan.rs")]
+#[cfg_attr(not(feature = "vlan"), path = "server_basic.rs")]
+mod server_impl;
+use server_impl::ServerImpl;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "mgmt")] {
-        pub(crate) mod mgmt;
-    }
-}
+#[cfg(feature = "mgmt")]
+pub(crate) mod mgmt;
 
 mod idl {
     use task_net_api::{

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -12,7 +12,6 @@ mod miim_bridge;
 mod server;
 
 // Select the BSP based on the target board
-#[deny(unused_attributes)]
 #[cfg_attr(
     any(target_board = "nucleo-h743zi2", target_board = "nucleo-h753zi"),
     path = "bsp/nucleo_h7.rs"
@@ -27,7 +26,6 @@ mod server;
 )]
 mod bsp;
 
-#[deny(unused_attributes)]
 #[cfg_attr(feature = "vlan", path = "server_vlan.rs")]
 #[cfg_attr(not(feature = "vlan"), path = "server_basic.rs")]
 mod server_impl;

--- a/task/net/src/miim_bridge.rs
+++ b/task/net/src/miim_bridge.rs
@@ -13,6 +13,7 @@ pub struct MiimBridge<'a> {
 }
 
 impl<'a> MiimBridge<'a> {
+    #[allow(dead_code)]
     pub fn new(eth: &'a eth::Ethernet) -> Self {
         Self { eth }
     }

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -11,7 +11,6 @@ ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
-cfg-if = "1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
 drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
@@ -26,7 +25,6 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-util = {path = "../../build/util"}
 build-i2c = {path = "../../build/i2c"}
 anyhow = "1.0.31"
-cfg-if = "1"
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]

--- a/task/thermal/src/bsp.rs
+++ b/task/thermal/src/bsp.rs
@@ -2,14 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-cfg_if::cfg_if! {
-    if #[cfg(target_board = "gimlet-b")] {
-        mod gimlet_b;
-        pub(crate) use gimlet_b::*;
-    } else if #[cfg(target_board = "sidecar-a")] {
-        mod sidecar_a;
-        pub(crate) use sidecar_a::*;
-    } else {
-        compile_error!("No BSP for the given board");
-    }
-}
+// This file should never be included; if it is, the build configuration is bad
+compile_error!("no BSP for the given target board");

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -12,7 +12,6 @@
 #![no_std]
 #![no_main]
 
-#[deny(unused_attributes)]
 #[cfg_attr(target_board = "gimlet-b", path = "bsp/gimlet_b.rs")]
 #[cfg_attr(target_board = "sidecar-a", path = "bsp/sidecar_a.rs")]
 mod bsp;

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -12,6 +12,9 @@
 #![no_std]
 #![no_main]
 
+#[deny(unused_attributes)]
+#[cfg_attr(target_board = "gimlet-b", path = "bsp/gimlet_b.rs")]
+#[cfg_attr(target_board = "sidecar-a", path = "bsp/sidecar_a.rs")]
 mod bsp;
 mod control;
 


### PR DESCRIPTION
Also includes two drive-by fixes:
- Missing task slot in G030
- Warning about unused function in `gimlet/app.toml`