### PR TITLE
Always emit rerun-if-env-changed *before* reading var

### DIFF
--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -31,10 +31,10 @@ pub fn expose_m_profile() {
 /// Exposes the board type from the `HUBRIS_BOARD` envvar into
 /// `cfg(target_board="...")`.
 pub fn expose_target_board() {
+    println!("cargo:rerun-if-env-changed=HUBRIS_BOARD");
     if let Ok(board) = env::var("HUBRIS_BOARD") {
         println!("cargo:rustc-cfg=target_board=\"{}\"", board);
     }
-    println!("cargo:rerun-if-env-changed=HUBRIS_BOARD");
 }
 
 ///
@@ -134,6 +134,7 @@ impl TaskIds {
 /// - `Err(e)` if deserialization failed or the environment variable did not
 ///   contain UTF-8.
 fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
+    println!("cargo:rerun-if-env-changed={}", var);
     let config = match env::var(var) {
         Err(env::VarError::NotPresent) => return Ok(None),
         Err(e) => {
@@ -148,6 +149,5 @@ fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
     println!("{}", config);
     let rval = toml::from_slice(config.as_bytes())
         .context("deserializing configuration")?;
-    println!("cargo:rerun-if-env-changed={}", var);
     Ok(Some(rval))
 }

--- a/drv/sidecar-front-io/build.rs
+++ b/drv/sidecar-front-io/build.rs
@@ -24,8 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Pull the bitstream checksum from an environment variable
     // (injected by `xtask` itself as part of auxiliary flash packing)
-    let checksum = env!("HUBRIS_AUXFLASH_CHECKSUM_QSFP");
     println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM_QSFP");
+    let checksum = std::env::var("HUBRIS_AUXFLASH_CHECKSUM_QSFP").unwrap();
     writeln!(
         &mut file,
         "\npub const SIDECAR_IO_BITSTREAM_CHECKSUM: [u8; 32] = {};",

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -23,8 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Pull the bitstream checksum from an environment variable
     // (injected by `xtask` itself as part of auxiliary flash packing)
-    let checksum = env!("HUBRIS_AUXFLASH_CHECKSUM_FPGA");
     println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM_FPGA");
+    let checksum = env!("HUBRIS_AUXFLASH_CHECKSUM_FPGA");
     writeln!(
         &mut file,
         "\npub const SIDECAR_MAINBOARD_BITSTREAM_CHECKSUM: [u8; 32] = {};",

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Pull the bitstream checksum from an environment variable
     // (injected by `xtask` itself as part of auxiliary flash packing)
     println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM_FPGA");
-    let checksum = env!("HUBRIS_AUXFLASH_CHECKSUM_FPGA");
+    let checksum = std::env::var("HUBRIS_AUXFLASH_CHECKSUM_FPGA").unwrap();
     writeln!(
         &mut file,
         "\npub const SIDECAR_MAINBOARD_BITSTREAM_CHECKSUM: [u8; 32] = {};",

--- a/stage0/build.rs
+++ b/stage0/build.rs
@@ -11,8 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
-    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
     println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
+    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
 
     writeln!(const_file, "// See build.rs for details")?;
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -57,12 +57,12 @@ fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
-    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
     println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
+    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
 
+    println!("cargo:rerun-if-env-changed=HUBRIS_KCONFIG");
     let kconfig: KernelConfig =
         ron::de::from_str(&env::var("HUBRIS_KCONFIG")?)?;
-    println!("cargo:rerun-if-env-changed=HUBRIS_KCONFIG");
 
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut file = File::create(out.join("kconfig.rs")).unwrap();


### PR DESCRIPTION
If the build script decides the env var is missing, you still want to be re-run if it should change!