### PR TITLE
Move the thermal config from RAM into flash

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -120,8 +120,8 @@ task-slots = ["sys", "i2c_driver"]
 name = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
-max-sizes = {flash = 32768, ram = 16384 }
-stacksize = 8000
+max-sizes = {flash = 32768, ram = 8192 }
+stacksize = 4504
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -438,7 +438,8 @@ segment = 1
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 A NVMe Basic Management Command"
-sensors = { temperature = 1, names = ["U2_N0"] }
+sensors = { temperature = 1 }
+name = "U2_N0"
 refdes = "J206"
 removable = true
 
@@ -469,7 +470,8 @@ segment = 2
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 B NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N1"] }
+sensors = { temperature = 1 }
+name = "U2_N1"
 refdes = "J207"
 removable = true
 
@@ -500,7 +502,8 @@ segment = 3
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 C NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N2"] }
+sensors = { temperature = 1 }
+name = "U2_N2"
 refdes = "J208"
 removable = true
 
@@ -531,7 +534,8 @@ segment = 4
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 D NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N3"] }
+sensors = { temperature = 1 }
+name = "U2_N3"
 refdes = "J209"
 removable = true
 
@@ -562,7 +566,8 @@ segment = 1
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 E NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N4"] }
+sensors = { temperature = 1 }
+name = "U2_N4"
 refdes = "J210"
 removable = true
 
@@ -593,7 +598,8 @@ segment = 2
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 F NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N5"] }
+sensors = { temperature = 1 }
+name = "U2_N5"
 refdes = "J211"
 removable = true
 
@@ -624,7 +630,8 @@ segment = 3
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 G NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N6"] }
+sensors = { temperature = 1 }
+name = "U2_N6"
 refdes = "J212"
 removable = true
 
@@ -655,7 +662,8 @@ segment = 4
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 H NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N7"] }
+sensors = { temperature = 1 }
+name = "U2_N7"
 refdes = "J213"
 removable = true
 
@@ -686,7 +694,8 @@ segment = 1
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 I NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N8"] }
+sensors = { temperature = 1 }
+name = "U2_N8"
 refdes = "J214"
 removable = true
 
@@ -717,7 +726,8 @@ segment = 2
 address = 0b110_1010
 device = "nvmebmc"
 description = "U.2 J NVMe Basic Management Control"
-sensors = { temperature = 1, names = ["U2_N9"] }
+sensors = { temperature = 1 }
+name = "U2_N9"
 refdes = "J215"
 removable = true
 
@@ -753,6 +763,7 @@ mux = 1
 segment = 4
 address = 0x4c
 device = "tmp451"
+name = "t6"
 sensors = { temperature = 1 }
 description = "T6 temperature sensor"
 refdes = "U491"

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -966,24 +966,23 @@ impl ConfigGenerator {
                 label,
                 ids[0]
             )?;
-        }
-        // Always write the _SENSORS array as well, so that code doesn't have
-        // to special-case the situation with only one sensor of a type.
-        writeln!(
-            &mut self.output,
-            r##"
+        } else {
+            writeln!(
+                &mut self.output,
+                r##"
         #[allow(dead_code)]
         pub const {}_{}_SENSORS: [SensorId; {}] = [ "##,
-            device.to_uppercase(),
-            label,
-            ids.len(),
-        )?;
+                device.to_uppercase(),
+                label,
+                ids.len(),
+            )?;
 
-        for id in ids {
-            writeln!(&mut self.output, "            SensorId({}), ", id)?;
+            for id in ids {
+                writeln!(&mut self.output, "            SensorId({}), ", id)?;
+            }
+
+            writeln!(&mut self.output, "        ];")?;
         }
-
-        writeln!(&mut self.output, "        ];")?;
 
         Ok(())
     }

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -319,7 +319,7 @@ impl ConfigGenerator {
     }
 
     pub fn generate_header(&mut self) -> Result<()> {
-        writeln!(&mut self.output, "mod i2c_config {{")?;
+        writeln!(&mut self.output, "pub(crate) mod i2c_config {{")?;
         Ok(())
     }
 
@@ -966,23 +966,24 @@ impl ConfigGenerator {
                 label,
                 ids[0]
             )?;
-        } else {
-            writeln!(
-                &mut self.output,
-                r##"
+        }
+        // Always write the _SENSORS array as well, so that code doesn't have
+        // to special-case the situation with only one sensor of a type.
+        writeln!(
+            &mut self.output,
+            r##"
         #[allow(dead_code)]
         pub const {}_{}_SENSORS: [SensorId; {}] = [ "##,
-                device.to_uppercase(),
-                label,
-                ids.len(),
-            )?;
+            device.to_uppercase(),
+            label,
+            ids.len(),
+        )?;
 
-            for id in ids {
-                writeln!(&mut self.output, "            SensorId({}), ", id)?;
-            }
-
-            writeln!(&mut self.output, "        ];")?;
+        for id in ids {
+            writeln!(&mut self.output, "            SensorId({}), ", id)?;
         }
+
+        writeln!(&mut self.output, "        ];")?;
 
         Ok(())
     }

--- a/drv/i2c-devices/src/tmp451.rs
+++ b/drv/i2c-devices/src/tmp451.rs
@@ -50,6 +50,7 @@ impl From<Error> for ResponseCode {
 }
 
 /// Selects whether this sensor reads the local or remote temperature
+#[derive(Copy, Clone)]
 pub enum Target {
     Local,
     Remote,

--- a/task/thermal/src/bsp/gimlet_b.rs
+++ b/task/thermal/src/bsp/gimlet_b.rs
@@ -177,7 +177,11 @@ const T6_THERMALS: ThermalProperties = ThermalProperties {
 
 const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
-        TemperatureSensor::new(Device::CPU, 0),
+        TemperatureSensor::new(
+            Device::CPU,
+            devices::sbtsi_cpu,
+            sensors::SBTSI_CPU_TEMPERATURE_SENSOR,
+        ),
         CPU_THERMALS,
         POWER_STATE_A0,
         false,
@@ -185,165 +189,270 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::Tmp451(drv_i2c_devices::tmp451::Target::Remote),
-            0,
+            devices::tmp451_t6,
+            sensors::TMP451_T6_TEMPERATURE_SENSOR,
         ),
         T6_THERMALS,
         POWER_STATE_A0,
         false,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 0),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_a0,
+            sensors::TSE2004AV_DIMM_A0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 1),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_a1,
+            sensors::TSE2004AV_DIMM_A1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 2),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_b0,
+            sensors::TSE2004AV_DIMM_B0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 3),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_b1,
+            sensors::TSE2004AV_DIMM_B1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 4),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_c0,
+            sensors::TSE2004AV_DIMM_C0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 5),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_c1,
+            sensors::TSE2004AV_DIMM_C1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 6),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_d0,
+            sensors::TSE2004AV_DIMM_D0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 7),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_d1,
+            sensors::TSE2004AV_DIMM_D1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 8),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_e0,
+            sensors::TSE2004AV_DIMM_E0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 9),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_e1,
+            sensors::TSE2004AV_DIMM_E1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 10),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_f0,
+            sensors::TSE2004AV_DIMM_F0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 11),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_f1,
+            sensors::TSE2004AV_DIMM_F1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 12),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_g0,
+            sensors::TSE2004AV_DIMM_G0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 13),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_g1,
+            sensors::TSE2004AV_DIMM_G1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 14),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_h0,
+            sensors::TSE2004AV_DIMM_H0_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::Dimm, 15),
+        TemperatureSensor::new(
+            Device::Dimm,
+            devices::tse2004av_dimm_h1,
+            sensors::TSE2004AV_DIMM_H1_TEMPERATURE_SENSOR,
+        ),
         DIMM_THERMALS,
         POWER_STATE_A0 | POWER_STATE_A2,
         true,
     ),
     // U.2 drives
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 0),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n0,
+            sensors::NVMEBMC_U2_N0_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 1),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n1,
+            sensors::NVMEBMC_U2_N1_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 2),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n2,
+            sensors::NVMEBMC_U2_N2_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 3),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n3,
+            sensors::NVMEBMC_U2_N3_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 4),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n4,
+            sensors::NVMEBMC_U2_N4_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 5),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n5,
+            sensors::NVMEBMC_U2_N5_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 6),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n6,
+            sensors::NVMEBMC_U2_N6_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 7),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n7,
+            sensors::NVMEBMC_U2_N7_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 8),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n8,
+            sensors::NVMEBMC_U2_N8_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
     ),
     InputChannel::new(
-        TemperatureSensor::new(Device::U2, 9),
+        TemperatureSensor::new(
+            Device::U2,
+            devices::nvmebmc_u2_n9,
+            sensors::NVMEBMC_U2_N9_TEMPERATURE_SENSOR,
+        ),
         U2_THERMALS,
         POWER_STATE_A0,
         true,
@@ -351,10 +460,34 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
 ];
 
 const MISC_SENSORS: [TemperatureSensor; NUM_TEMPERATURE_SENSORS] = [
-    TemperatureSensor::new(Device::Tmp117, 0),
-    TemperatureSensor::new(Device::Tmp117, 1),
-    TemperatureSensor::new(Device::Tmp117, 2),
-    TemperatureSensor::new(Device::Tmp117, 3),
-    TemperatureSensor::new(Device::Tmp117, 4),
-    TemperatureSensor::new(Device::Tmp117, 5),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_southwest,
+        sensors::TMP117_SOUTHWEST_TEMPERATURE_SENSOR,
+    ),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_southeast,
+        sensors::TMP117_SOUTHEAST_TEMPERATURE_SENSOR,
+    ),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_northwest,
+        sensors::TMP117_NORTHWEST_TEMPERATURE_SENSOR,
+    ),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_northeast,
+        sensors::TMP117_NORTHEAST_TEMPERATURE_SENSOR,
+    ),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_north,
+        sensors::TMP117_NORTH_TEMPERATURE_SENSOR,
+    ),
+    TemperatureSensor::new(
+        Device::Tmp117,
+        devices::tmp117_south,
+        sensors::TMP117_SOUTH_TEMPERATURE_SENSOR,
+    ),
 ];

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -39,9 +39,11 @@ pub enum Device {
     U2,
 }
 
-/// Represents a sensor and an associated index.  The index is used both as
-/// the device index (e.g. `devices::tse2004av(i2c_task)[index]`) and the
-/// sensors index (`sensors::TSE2004AV_TEMPERATURE_SENSORS[index]`).
+/// Represents a sensor in the system.
+///
+/// The sensor includes a device type, used to decide how to read it;
+/// a free function that returns the raw `I2cDevice`, so that this can be
+/// `const`); and the sensor ID, to post data to the `sensors` task.
 pub struct TemperatureSensor {
     device: Device,
     builder: fn(TaskId) -> drv_i2c_api::I2cDevice,

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -264,6 +264,8 @@ impl<'a> NotificationHandler for ServerImpl<'a> {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 #[export_name = "main"]
 fn main() -> ! {
     let i2c_task = I2C.get_task_id();
@@ -272,7 +274,7 @@ fn main() -> ! {
     ringbuf_entry!(Trace::Start);
 
     let bsp = Bsp::new(i2c_task);
-    let control = ThermalControl::new(&bsp, sensor_api);
+    let control = ThermalControl::new(&bsp, i2c_task, sensor_api);
 
     // This will put our timer in the past, and should immediately kick us.
     let deadline = sys_get_timer().now;
@@ -295,8 +297,11 @@ fn main() -> ! {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 mod idl {
     use super::{ThermalAutoState, ThermalError, ThermalMode};
-
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
+
+include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));


### PR DESCRIPTION
This brings the `thermal` task from 18648 to 17720 bytes of flash (a small improvement)

More importantly, it drops the stack usage from 7392 to 3560, meaning we can shrink the RAM usage by 8192!