### PR TITLE
Standardize on a safe wrapper around std::env::var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
 name = "drv-auxflash-server"
 version = "0.1.0"
 dependencies = [
+ "build-util",
  "cfg-if",
  "drv-auxflash-api",
  "drv-stm32h7-qspi",
@@ -2017,6 +2018,9 @@ dependencies = [
 [[package]]
 name = "hubris-num-tasks"
 version = "0.1.0"
+dependencies = [
+ "build-util",
+]
 
 [[package]]
 name = "hypocalls"
@@ -3276,6 +3280,7 @@ name = "stage0"
 version = "0.1.0"
 dependencies = [
  "abi",
+ "build-util",
  "cortex-m",
  "cortex-m-rt",
  "dice",
@@ -3607,6 +3612,7 @@ name = "task-net-api"
 version = "0.1.0"
 dependencies = [
  "build-net",
+ "build-util",
  "derive-idol-err",
  "drv-spi-api",
  "idol",

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -8,10 +8,8 @@ use indexmap::IndexMap;
 use multimap::MultiMap;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
-use std::env;
 use std::fmt::Write;
 use std::fs::File;
-use std::path::Path;
 
 //
 // Our definition of the `Config` type.  We share this type with all other
@@ -1136,8 +1134,8 @@ impl ConfigGenerator {
 pub fn codegen(disposition: Disposition) -> Result<()> {
     use std::io::Write;
 
-    let out_dir = env::var("OUT_DIR")?;
-    let dest_path = Path::new(&out_dir).join("i2c_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("i2c_config.rs");
     let mut file = File::create(&dest_path)?;
 
     let mut g = ConfigGenerator::new(disposition);

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -14,5 +14,3 @@ convert_case = "0.4"
 syn = {version = "1", features = ["parsing"]}
 proc-macro2 = "1"
 quote = "1"
-
-[features]

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -117,8 +117,8 @@ impl ToTokens for PinConfig {
 }
 
 pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("pin_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("pin_config.rs");
     let mut file = std::fs::File::create(&dest_path)?;
 
     let mut buf = BufWriter::new(Vec::new());

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -14,9 +14,22 @@ pub fn env_var(key: &str) -> Result<String, std::env::VarError> {
     std::env::var(key)
 }
 
-/// Reads the `OUT_DIR` environment variable, marking that it's used
+/// Reads the `OUT_DIR` environment variable
+///
+/// This function goes through `std::env::var` directly, rather than our own
+/// `env_var`, because Cargo should know when `OUT_DIR` changes.
 pub fn out_dir() -> std::path::PathBuf {
-    std::path::PathBuf::from(env_var("OUT_DIR").expect("Could not get OUT_DIR"))
+    std::path::PathBuf::from(
+        std::env::var("OUT_DIR").expect("Could not get OUT_DIR"),
+    )
+}
+
+/// Reads the `TARGET` environment variable
+///
+/// This function goes through `std::env::var` directly, rather than our own
+/// `env_var`, because Cargo should know when `OUT_DIR` changes.
+pub fn target() -> String {
+    std::env::var("TARGET").unwrap()
 }
 
 /// Exposes the CPU's M-profile architecture version. This isn't available in
@@ -25,7 +38,7 @@ pub fn out_dir() -> std::path::PathBuf {
 /// This will set one of `cfg(armv6m`), `cfg(armv7m)`, or `cfg(armv8m)`
 /// depending on the value of the `TARGET` environment variable.
 pub fn expose_m_profile() {
-    let target = env_var("TARGET").unwrap();
+    let target = target();
 
     if target.starts_with("thumbv6m") {
         println!("cargo:rustc-cfg=armv6m");

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -55,7 +55,7 @@ pub fn has_feature(s: &str) -> bool {
 /// This will set one of `cfg(armv6m`), `cfg(armv7m)`, or `cfg(armv8m)`
 /// depending on the value of the `TARGET` environment variable.
 pub fn expose_m_profile() {
-    let target = target();
+    let target = crate::target();
 
     if target.starts_with("thumbv6m") {
         println!("cargo:rustc-cfg=armv6m");

--- a/drv/auxflash-api/build.rs
+++ b/drv/auxflash-api/build.rs
@@ -34,8 +34,8 @@ struct AuxFlashConfig {
 fn generate_auxflash_config(
     config: &AuxFlashConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("auxflash_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("auxflash_config.rs");
 
     let mut out = std::fs::File::create(&dest_path)?;
 

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -19,8 +19,8 @@ stm32h7 = { version = "0.14", default-features = false }
 zerocopy = "0.6.1"
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 build-util = { path = "../../build/util" }
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -20,6 +20,7 @@ zerocopy = "0.6.1"
 
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -10,11 +10,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         idol::server::ServerStyle::InOrder,
     )?;
 
-    println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM");
-    match std::env::var("HUBRIS_AUXFLASH_CHECKSUM") {
+    match build_util::env_var("HUBRIS_AUXFLASH_CHECKSUM") {
         Ok(e) => {
-            let out_dir = std::env::var("OUT_DIR")?;
-            let dest_path = std::path::Path::new(&out_dir).join("checksum.rs");
+            let out_dir = build_util::out_dir();
+            let dest_path = out_dir.join("checksum.rs");
             let mut file = std::fs::File::create(&dest_path)?;
             writeln!(&mut file, "const AUXI_CHECKSUM: [u8; 32] = {};", e)?;
         }

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -5,7 +5,7 @@
 use build_fpga_regmap::fpga_regs;
 use serde::Deserialize;
 use sha2::Digest;
-use std::{convert::TryInto, env, fs, io::Write, path::PathBuf};
+use std::{convert::TryInto, fs, io::Write, path::PathBuf};
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fpga_image = fs::read(&fpga_image_path)?;
     let compressed = gnarle::compress_to_vec(&fpga_image);
 
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let compressed_path = out.join(fpga_image_path.with_extension("bin.rle"));
     fs::write(&compressed_path, &compressed)?;
     println!("cargo:rerun-if-changed={}", config.fpga_image);

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -8,6 +8,7 @@
 #![no_std]
 #![no_main]
 
+use drv_lpc55_gpio_api::Pin;
 use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -8,7 +8,6 @@
 #![no_std]
 #![no_main]
 
-use drv_lpc55_gpio_api::Pin;
 use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;

--- a/drv/lpc55-swd/build.rs
+++ b/drv/lpc55-swd/build.rs
@@ -17,8 +17,8 @@ struct TaskConfig {
 }
 
 fn generate_swd_functions(config: &TaskConfig) -> Result<()> {
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("swd.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("swd.rs");
     let mut file = std::fs::File::create(&dest_path)?;
 
     let out_cfg = &config.out_cfg;

--- a/drv/sidecar-front-io/build.rs
+++ b/drv/sidecar-front-io/build.rs
@@ -7,12 +7,12 @@ use std::{fs, io::Write};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
-    let out_dir = build_util::out_dir();
 
     if build_util::env_var("HUBRIS_BOARD")? != "sidecar-a" {
         panic!("unknown target board");
     }
 
+    let out_dir = build_util::out_dir();
     let out_file = out_dir.join("sidecar_qsfp_x32_controller.rs");
     let mut file = fs::File::create(out_file)?;
     write!(

--- a/drv/sidecar-front-io/build.rs
+++ b/drv/sidecar-front-io/build.rs
@@ -3,14 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use build_fpga_regmap::fpga_regs;
-use std::{env, fs, io::Write, path::PathBuf};
+use std::{fs, io::Write};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
+    let out_dir = build_util::out_dir();
 
-    let out_dir = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    if env::var("HUBRIS_BOARD")? != "sidecar-a" {
+    if build_util::env_var("HUBRIS_BOARD")? != "sidecar-a" {
         panic!("unknown target board");
     }
 
@@ -24,8 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Pull the bitstream checksum from an environment variable
     // (injected by `xtask` itself as part of auxiliary flash packing)
-    println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM_QSFP");
-    let checksum = std::env::var("HUBRIS_AUXFLASH_CHECKSUM_QSFP").unwrap();
+    let checksum =
+        build_util::env_var("HUBRIS_AUXFLASH_CHECKSUM_QSFP").unwrap();
     writeln!(
         &mut file,
         "\npub const SIDECAR_IO_BITSTREAM_CHECKSUM: [u8; 32] = {};",

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -3,12 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use build_fpga_regmap::fpga_regs;
-use std::{env, fs, io::Write};
+use std::{fs, io::Write};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
 
-    if env::var("HUBRIS_BOARD")? != "sidecar-a" {
+    if build_util::env_var("HUBRIS_BOARD")? != "sidecar-a" {
         panic!("unknown target board");
     }
 

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use build_fpga_regmap::fpga_regs;
-use std::{env, fs, io::Write, path::PathBuf};
+use std::{env, fs, io::Write};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_target_board();
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!("unknown target board");
     }
 
-    let out_dir = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out_dir = build_util::out_dir();
     let out_file = out_dir.join("sidecar_mainboard_controller.rs");
     let mut file = fs::File::create(out_file)?;
     write!(
@@ -23,8 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Pull the bitstream checksum from an environment variable
     // (injected by `xtask` itself as part of auxiliary flash packing)
-    println!("cargo:rerun-if-env-changed=HUBRIS_AUXFLASH_CHECKSUM_FPGA");
-    let checksum = std::env::var("HUBRIS_AUXFLASH_CHECKSUM_FPGA").unwrap();
+    let checksum =
+        build_util::env_var("HUBRIS_AUXFLASH_CHECKSUM_FPGA").unwrap();
     writeln!(
         &mut file,
         "\npub const SIDECAR_MAINBOARD_BITSTREAM_CHECKSUM: [u8; 32] = {};",

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -169,8 +169,8 @@ fn generate_spi_config(
         )
     })?;
 
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("spi_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("spi_config.rs");
 
     let mut out = std::fs::File::create(&dest_path)?;
 

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -32,6 +32,9 @@ path = "../lib/dice"
 default-features = false
 optional = true
 
+[build-dependencies]
+build-util = { path = "../build/util" }
+
 #[build-dependencies]
 #hubpack = "0.1"
 #

--- a/stage0/build.rs
+++ b/stage0/build.rs
@@ -2,17 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
-    println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
-    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
+    let image_id: u64 = build_util::env_var("HUBRIS_IMAGE_ID")?.parse()?;
 
     writeln!(const_file, "// See build.rs for details")?;
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -181,7 +181,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let target = build_util::env_var("TARGET").unwrap();
+    let target = build_util::target();
     if target.starts_with("thumbv6m") {
         let task_irq_map =
             phash_gen::OwnedSortedList::build(task_irq_map).unwrap();

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -3,10 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
-use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 
 use serde::Deserialize;
 
@@ -20,10 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
-    println!("cargo:rerun-if-env-changed=HUBRIS_SECURE");
     writeln!(
         const_file,
         "// See build.rs for an explanation of this constant"
@@ -35,7 +32,7 @@ fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
     // bit 0 = ES = the security domain the exception was taken to
     // These need to be consistent! The failure mode is a secure fault
     // otherwise
-    if let Ok(secure) = env::var("HUBRIS_SECURE") {
+    if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
         if secure == "0" {
             writeln!(
                 const_file,
@@ -57,14 +54,11 @@ fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-env-changed=HUBRIS_IMAGE_ID");
-    let image_id: u64 = env::var("HUBRIS_IMAGE_ID")?.parse()?;
-
-    println!("cargo:rerun-if-env-changed=HUBRIS_KCONFIG");
+    let image_id: u64 = build_util::env_var("HUBRIS_IMAGE_ID")?.parse()?;
     let kconfig: KernelConfig =
-        ron::de::from_str(&env::var("HUBRIS_KCONFIG")?)?;
+        ron::de::from_str(&build_util::env_var("HUBRIS_KCONFIG")?)?;
 
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let mut file = File::create(out.join("kconfig.rs")).unwrap();
 
     writeln!(file, "// See build.rs for details")?;
@@ -187,7 +181,7 @@ fn generate_statics() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let target = env::var("TARGET").unwrap();
+    let target = build_util::env_var("TARGET").unwrap();
     if target.starts_with("thumbv6m") {
         let task_irq_map =
             phash_gen::OwnedSortedList::build(task_irq_map).unwrap();

--- a/sys/num-tasks/Cargo.toml
+++ b/sys/num-tasks/Cargo.toml
@@ -3,7 +3,8 @@ name = "hubris-num-tasks"
 version = "0.1.0"
 edition = "2018"
 
-[dependencies]
+[build-dependencies]
+build-util = { path = "../../build/util" }
 
 [features]
 task-enum = []

--- a/sys/num-tasks/build.rs
+++ b/sys/num-tasks/build.rs
@@ -2,17 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
 
-    println!("cargo:rerun-if-env-changed=HUBRIS_TASKS");
     let mut task_enum = vec![];
-    if let Ok(task_names) = env::var("HUBRIS_TASKS") {
+    if let Ok(task_names) = build_util::env_var("HUBRIS_TASKS") {
         println!("HUBRIS_TASKS = {}", task_names);
         for (i, name) in task_names.split(',').enumerate() {
             task_enum.push(format!("    {} = {},", name, i));
@@ -24,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut task_file = File::create(out.join("tasks.rs")).unwrap();
 
-    if env::var_os("CARGO_FEATURE_TASK_ENUM").is_some() {
+    if build_util::env_var("CARGO_FEATURE_TASK_ENUM").is_ok() {
         writeln!(task_file, "#[allow(non_camel_case_types)]").unwrap();
         writeln!(task_file, "pub enum Task {{").unwrap();
         for line in task_enum {

--- a/sys/num-tasks/build.rs
+++ b/sys/num-tasks/build.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut task_file = File::create(out.join("tasks.rs")).unwrap();
 
-    if build_util::env_var("CARGO_FEATURE_TASK_ENUM").is_ok() {
+    if build_util::has_feature("task-enum") {
         writeln!(task_file, "#[allow(non_camel_case_types)]").unwrap();
         writeln!(task_file, "pub enum Task {{").unwrap();
         for line in task_enum {

--- a/sys/userlib/build.rs
+++ b/sys/userlib/build.rs
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::env;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
 
     // Do an architecture check.
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "none" {
+    if build_util::env_var("CARGO_CFG_TARGET_OS").unwrap() != "none" {
         eprintln!("***********************************************");
         eprintln!("Hi!");
         eprintln!("You appear to be building this natively,");

--- a/sys/userlib/build.rs
+++ b/sys/userlib/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
 
     // Do an architecture check.
-    if build_util::env_var("CARGO_CFG_TARGET_OS").unwrap() != "none" {
+    if build_util::target_os() != "none" {
         eprintln!("***********************************************");
         eprintln!("Hi!");
         eprintln!("You appear to be building this natively,");

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -23,8 +23,8 @@ fn main() -> Result<()> {
 
     build_util::expose_m_profile();
 
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("jefe_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("jefe_config.rs");
     let mut out =
         std::fs::File::create(&dest_path).context("creating jefe_config.rs")?;
 

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 
 [build-dependencies]
 build-net = {path = "../../build/net"}
+build-util = {path = "../../build/util"}
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/net-api/build.rs
+++ b/task/net-api/build.rs
@@ -5,14 +5,15 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     idol::client::build_client_stub("../../idl/net.idol", "client_stub.rs")?;
 
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("net_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("net_config.rs");
     let net_config = build_net::load_net_config()?;
 
     let mut out = std::fs::File::create(dest_path)?;
 
-    #[cfg(feature = "vlan")]
-    build_net::generate_vlan_consts(&net_config, &mut out)?;
+    if build_util::env_var("CARGO_FEATURE_VLAN").is_ok() {
+        build_net::generate_vlan_consts(&net_config, &mut out)?;
+    }
 
     build_net::generate_socket_enum(&net_config, &mut out)?;
     Ok(())

--- a/task/net-api/build.rs
+++ b/task/net-api/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut out = std::fs::File::create(dest_path)?;
 
-    if build_util::env_var("CARGO_FEATURE_VLAN").is_ok() {
+    if build_util::has_feature("vlan") {
         build_net::generate_vlan_consts(&net_config, &mut out)?;
     }
 

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -24,8 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn generate_net_config(
     config: &NetConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("net_config.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("net_config.rs");
 
     let mut out = std::fs::File::create(&dest_path)?;
 
@@ -41,8 +41,9 @@ fn generate_net_config(
         }
     )?;
 
-    #[cfg(feature = "vlan")]
-    build_net::generate_vlan_consts(config, &mut out)?;
+    if build_util::env_var("CARGO_FEATURE_VLAN").is_ok() {
+        build_net::generate_vlan_consts(config, &mut out)?;
+    }
 
     for (name, socket) in &config.sockets {
         writeln!(

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -41,7 +41,7 @@ fn generate_net_config(
         }
     )?;
 
-    if build_util::env_var("CARGO_FEATURE_VLAN").is_ok() {
+    if build_util::has_feature("vlan") {
         build_net::generate_vlan_consts(config, &mut out)?;
     }
 

--- a/task/ping/build.rs
+++ b/task/ping/build.rs
@@ -4,7 +4,6 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();

--- a/task/ping/build.rs
+++ b/task/ping/build.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -16,13 +15,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
     // If hubris is non-secure (i.e. TZ is enabled) we need to use a
     // different address for our bad address testing since NULL will
     // trigger a secure fault
-    if let Ok(secure) = env::var("HUBRIS_SECURE") {
+    if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
         if secure == "0" {
             // This corresponds to USB SRAM on the LPC55
             writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")

--- a/task/sp_measure/build.rs
+++ b/task/sp_measure/build.rs
@@ -15,8 +15,8 @@ struct TaskConfig {
 const TEST_SIZE: usize = 0x0010_0000;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = std::env::var("OUT_DIR")?;
-    let dest_path = std::path::Path::new(&out_dir).join("expected.rs");
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("expected.rs");
     let mut file = std::fs::File::create(&dest_path)?;
 
     let task_config = build_util::task_config::<TaskConfig>()?;

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -18,13 +17,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out = build_util::out_dir();
     let mut const_file = File::create(out.join("consts.rs")).unwrap();
 
     // If hubris is non-secure (i.e. TZ is enabled) we need to use a
     // different address for our bad address testing since NULL will
     // trigger a secure fault
-    if let Ok(secure) = env::var("HUBRIS_SECURE") {
+    if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
         if secure == "0" {
             // This corresponds to USB SRAM on the LPC55
             writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")


### PR DESCRIPTION
This switches all uses of `std::env::var` to `build_env::env_var`, which ensures that Cargo will rebuild if the environment variable changes.

In addition, I added `build_util::out_dir`, which is a very common case.