### PR TITLE
Add startup code to configure TMP451 THERM limit

### DIFF
--- a/drv/i2c-devices/src/tmp451.rs
+++ b/drv/i2c-devices/src/tmp451.rs
@@ -39,12 +39,14 @@ pub enum Register {
 #[derive(Debug)]
 pub enum Error {
     BadRegisterRead { reg: Register, code: ResponseCode },
+    BadRegisterWrite { reg: Register, code: ResponseCode },
 }
 
 impl From<Error> for ResponseCode {
     fn from(err: Error) -> Self {
         match err {
-            Error::BadRegisterRead { code, .. } => code,
+            Error::BadRegisterRead { code, .. }
+            | Error::BadRegisterWrite { code, .. } => code,
         }
     }
 }
@@ -81,6 +83,11 @@ impl Tmp451 {
         self.device
             .read_reg::<u8, u8>(reg as u8)
             .map_err(|code| Error::BadRegisterRead { reg, code })
+    }
+    pub fn write_reg(&self, reg: Register, value: u8) -> Result<(), Error> {
+        self.device
+            .write(&[reg as u8, value])
+            .map_err(|code| Error::BadRegisterWrite { reg, code })
     }
 }
 

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -567,6 +567,20 @@ fn main() -> ! {
         ringbuf_entry!(Trace::NoFrontIOBoardPresent);
     }
 
+    // Configure the TMP451 attached to the Tofino to trigger its THERM_B
+    // line at 90°C, rather than the default of 108°C.  The THERM_B line
+    // is monitored by the sequencer FPGA and will cut power to the system,
+    // because the Tofino doesn't have built-in protection against thermal
+    // overruns.
+    let i2c_task = I2C.get_task_id();
+    let tmp451 = drv_i2c_devices::tmp451::Tmp451::new(
+        &i2c_config::devices::tmp451_tf2(i2c_task),
+        drv_i2c_devices::tmp451::Target::Remote,
+    );
+    tmp451
+        .write_reg(drv_i2c_devices::tmp451::Register::RemoteTempThermBLimit, 90)
+        .unwrap();
+
     //
     // This will put our timer in the past, and should immediately kick us.
     //

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -114,6 +114,7 @@ impl From<drv_i2c_devices::tmp451::Error> for SensorReadError {
         use drv_i2c_devices::tmp451::Error::*;
         match s {
             BadRegisterRead { code, .. } => Self::I2cError(code),
+            BadRegisterWrite { .. } => panic!(),
         }
     }
 }


### PR DESCRIPTION
In the discussions at https://github.com/oxidecomputer/quartz/issues/24, Arjen suggested configuring the TMP451 to a lower cutoff point so that the sequencer can cut power if the Tofino overheats.  This PR does that configuration as part of Sidecar sequencer setup.