### PR TITLE
Reduce stack and flash usage of `power` task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +3707,7 @@ name = "task-power"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "array-init",
  "build-i2c",
  "build-util",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-init"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,7 +3701,6 @@ name = "task-power"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "array-init",
  "build-i2c",
  "build-util",
  "cfg-if",
@@ -3716,6 +3709,7 @@ dependencies = [
  "drv-i2c-api",
  "drv-i2c-devices",
  "drv-sidecar-seq-api",
+ "mutable-statics",
  "paste",
  "ringbuf",
  "task-sensor-api",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -130,7 +130,7 @@ name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 4776
+stacksize = 1000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -130,7 +130,7 @@ name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 4774
+stacksize = 4776
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -129,8 +129,8 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
-max-sizes = {flash = 32768, ram = 16384 }
-stacksize = 14000
+max-sizes = {flash = 32768, ram = 8192 }
+stacksize = 4774
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -129,8 +129,8 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
-max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 5000
+max-sizes = {flash = 32768, ram = 16384 }
+stacksize = 14000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -130,7 +130,7 @@ name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 5000
+stacksize = 4776
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -130,7 +130,7 @@ name = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 4776
+stacksize = 1000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 

--- a/lib/mutable-statics/src/lib.rs
+++ b/lib/mutable-statics/src/lib.rs
@@ -11,8 +11,9 @@
 /// &mut references to statics, which are declared within the macro.
 ///
 /// The macro accepts definitions of one or more mutable static arrays. It will
-/// arrange for them to be initialized a per-array lambda function, and return a
-/// tuple containing mutable references to each, in the order they're declared.
+/// arrange for them to be initialized by a per-array lambda function, and
+/// return a tuple containing mutable references to each, in the order they're
+/// declared.
 #[macro_export]
 macro_rules! mutable_statics {
     (

--- a/lib/mutable-statics/src/lib.rs
+++ b/lib/mutable-statics/src/lib.rs
@@ -11,8 +11,8 @@
 /// &mut references to statics, which are declared within the macro.
 ///
 /// The macro accepts definitions of one or more mutable static arrays. It will
-/// arrange for them to be initialized, and return a tuple containing mutable
-/// references to each, in the order they're declared.
+/// arrange for them to be initialized a per-array lambda function, and return a
+/// tuple containing mutable references to each, in the order they're declared.
 #[macro_export]
 macro_rules! mutable_statics {
     (
@@ -48,7 +48,7 @@ macro_rules! mutable_statics {
                             &mut *(__ref as *mut _ as *mut _)
                         };
                     for __u in __ref.iter_mut() {
-                        *__u = core::mem::MaybeUninit::new($init);
+                        *__u = core::mem::MaybeUninit::new($init());
                     }
                     // Safety: unsafe because of dereference of a raw pointer
                     // (after we cast it) -- safe because we are casting here

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -145,10 +145,10 @@ impl NetHandler {
     fn claim_static_resources() -> Self {
         let (tx_buf, rx_buf) = mutable_statics! {
             static mut NET_TX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
-                [0; _];
+                [|| 0; _];
 
             static mut NET_RX_BUF: [u8; gateway_messages::MAX_SERIALIZED_SIZE] =
-                [0; _];
+                [|| 0; _];
         };
         Self {
             net: Net::from(NET.get_task_id()),

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -119,8 +119,8 @@ struct ServerImpl {
 impl ServerImpl {
     fn claim_static_resources() -> Self {
         let (tx_msg_buf, tx_pkt_buf) = mutable_statics! {
-                static mut UART_TX_MSG_BUF: [u8; MAX_MESSAGE_SIZE] = [0; _];
-                static mut UART_TX_PKT_BUF: [u8; MAX_PACKET_SIZE] = [0; _];
+                static mut UART_TX_MSG_BUF: [u8; MAX_MESSAGE_SIZE] = [|| 0; _];
+                static mut UART_TX_PKT_BUF: [u8; MAX_PACKET_SIZE] = [|| 0; _];
         };
         let sys = sys_api::Sys::from(SYS.get_task_id());
         let uart = configure_uart_device(&sys);

--- a/task/net/src/buf.rs
+++ b/task/net/src/buf.rs
@@ -16,10 +16,10 @@ pub fn claim_tx_statics() -> (
     mutable_statics! {
         #[link_section = ".eth_bulk"]
         static mut TX_DESC: [eth::ring::TxDesc; TX_RING_SZ] =
-            [eth::ring::TxDesc::new(); _];
+            [|| eth::ring::TxDesc::new(); _];
         #[link_section = ".eth_bulk"]
         static mut TX_BUF: [eth::ring::Buffer; TX_RING_SZ] =
-            [eth::ring::Buffer::new(); _];
+            [|| eth::ring::Buffer::new(); _];
     }
 }
 /// Grabs references to the static descriptor/buffer receive rings. Can only be
@@ -31,15 +31,15 @@ pub fn claim_rx_statics() -> (
     mutable_statics! {
         #[link_section = ".eth_bulk"]
         static mut RX_DESC: [eth::ring::RxDesc; RX_RING_SZ] =
-            [eth::ring::RxDesc::new(); _];
+            [|| eth::ring::RxDesc::new(); _];
         #[link_section = ".eth_bulk"]
         static mut RX_BUF: [eth::ring::Buffer; RX_RING_SZ] =
-            [eth::ring::Buffer::new(); _];
+            [|| eth::ring::Buffer::new(); _];
     }
 }
 /// Grabs references to the MAC address buffer.  Can only be called once.
 pub fn claim_mac_address() -> &'static mut [u8; 6] {
     mutable_statics! {
-        static mut MAC_ADDRESS: [u8; 6] = [0; _];
+        static mut MAC_ADDRESS: [u8; 6] = [|| 0; _];
     }
 }

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -38,7 +38,7 @@ pub fn claim_server_storage_statics() -> (
             [|| Default::default(); _];
         static mut SOCKET_STORAGE: [SocketStorage<'static>; SOCKET_COUNT] =
             [|| Default::default(); _];
-        static mut IPV6_NET: [IpCidr; 1] = [Ipv6Cidr::default().into(); _];
+        static mut IPV6_NET: [IpCidr; 1] = [|| Ipv6Cidr::default().into(); _];
     }
 }
 

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -35,9 +35,9 @@ pub fn claim_server_storage_statics() -> (
 ) {
     mutable_statics! {
         static mut NEIGHBOR_CACHE_STORAGE: [NeighborStorage; NEIGHBORS] =
-            [Default::default(); _];
+            [|| Default::default(); _];
         static mut SOCKET_STORAGE: [SocketStorage<'static>; SOCKET_COUNT] =
-            [Default::default(); _];
+            [|| Default::default(); _];
         static mut IPV6_NET: [IpCidr; 1] = [Ipv6Cidr::default().into(); _];
     }
 }

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -37,12 +37,12 @@ pub fn claim_server_storage_statics() -> (
     mutable_statics! {
         static mut NEIGHBOR_CACHE_STORAGE:
             [[NeighborStorage; NEIGHBORS]; VLAN_COUNT] =
-            [Default::default(); _];
+            [|| Default::default(); _];
         static mut SOCKET_STORAGE:
             [[SocketStorage<'static>; SOCKET_COUNT]; VLAN_COUNT] =
-            [Default::default(); _];
+            [|| Default::default(); _];
         static mut IPV6_NET: [IpCidr; VLAN_COUNT] =
-            [Ipv6Cidr::default().into(); _];
+            [|| Ipv6Cidr::default().into(); _];
     }
 }
 

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-array-init = "2"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 zerocopy = "0.6.1"
 cfg-if = "1"
-drv-i2c-devices = { path = "../../drv/i2c-devices" }
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
+drv-i2c-devices = { path = "../../drv/i2c-devices" }
 drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
+mutable-statics = {path = "../../lib/mutable-statics"}
 task-sensor-api = {path = "../sensor-api"}
 paste = "1.0.6"
 

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+array-init = "2"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 drv-i2c-api = {path = "../../drv/i2c-api"}

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -71,81 +71,39 @@ enum Device {
 
 impl Device {
     fn read_temperature(&self) -> Result<Celsius, ResponseCode> {
-        match &self {
-            Device::Bmr491(dev) => read_temperature(dev),
-            Device::Raa229618(dev) => read_temperature(dev),
-            Device::Isl68224(dev) => read_temperature(dev),
-            Device::Tps546B24A(dev) => read_temperature(dev),
-            Device::Adm1272(dev) => read_temperature(dev),
-            Device::Max5970(_dev) => Err(ResponseCode::NoDevice),
-        }
+        let r = match &self {
+            Device::Bmr491(dev) => dev.read_temperature()?,
+            Device::Raa229618(dev) => dev.read_temperature()?,
+            Device::Isl68224(dev) => dev.read_temperature()?,
+            Device::Tps546B24A(dev) => dev.read_temperature()?,
+            Device::Adm1272(dev) => dev.read_temperature()?,
+            Device::Max5970(_dev) => return Err(ResponseCode::NoDevice),
+        };
+        Ok(r)
     }
 
     fn read_iout(&self) -> Result<Amperes, ResponseCode> {
-        match &self {
-            Device::Bmr491(dev) => read_current(dev),
-            Device::Raa229618(dev) => read_current(dev),
-            Device::Isl68224(dev) => read_current(dev),
-            Device::Tps546B24A(dev) => read_current(dev),
-            Device::Adm1272(dev) => read_current(dev),
-            Device::Max5970(dev) => read_current(dev),
-        }
+        let r = match &self {
+            Device::Bmr491(dev) => dev.read_iout()?,
+            Device::Raa229618(dev) => dev.read_iout()?,
+            Device::Isl68224(dev) => dev.read_iout()?,
+            Device::Tps546B24A(dev) => dev.read_iout()?,
+            Device::Adm1272(dev) => dev.read_iout()?,
+            Device::Max5970(dev) => dev.read_iout()?,
+        };
+        Ok(r)
     }
 
     fn read_vout(&self) -> Result<Volts, ResponseCode> {
-        match &self {
-            Device::Bmr491(dev) => read_voltage(dev),
-            Device::Raa229618(dev) => read_voltage(dev),
-            Device::Isl68224(dev) => read_voltage(dev),
-            Device::Tps546B24A(dev) => read_voltage(dev),
-            Device::Adm1272(dev) => read_voltage(dev),
-            Device::Max5970(dev) => read_voltage(dev),
-        }
-    }
-}
-
-fn read_temperature<E, T: TempSensor<E>>(
-    device: &T,
-) -> Result<Celsius, ResponseCode>
-where
-    ResponseCode: From<E>,
-{
-    match device.read_temperature() {
-        Ok(reading) => Ok(reading),
-        Err(err) => {
-            let err: ResponseCode = err.into();
-            Err(err)
-        }
-    }
-}
-
-fn read_current<E, T: CurrentSensor<E>>(
-    device: &T,
-) -> Result<Amperes, ResponseCode>
-where
-    ResponseCode: From<E>,
-{
-    match device.read_iout() {
-        Ok(reading) => Ok(reading),
-        Err(err) => {
-            let err: ResponseCode = err.into();
-            Err(err)
-        }
-    }
-}
-
-fn read_voltage<E, T: VoltageSensor<E>>(
-    device: &T,
-) -> Result<Volts, ResponseCode>
-where
-    ResponseCode: From<E>,
-{
-    match device.read_vout() {
-        Ok(reading) => Ok(reading),
-        Err(err) => {
-            let err: ResponseCode = err.into();
-            Err(err)
-        }
+        let r = match &self {
+            Device::Bmr491(dev) => dev.read_vout()?,
+            Device::Raa229618(dev) => dev.read_vout()?,
+            Device::Isl68224(dev) => dev.read_vout()?,
+            Device::Tps546B24A(dev) => dev.read_vout()?,
+            Device::Adm1272(dev) => dev.read_vout()?,
+            Device::Max5970(dev) => dev.read_vout()?,
+        };
+        Ok(r)
     }
 }
 

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use core::mem::MaybeUninit;
-
 use drv_i2c_devices::adm1272::*;
 use drv_i2c_devices::bmr491::*;
 use drv_i2c_devices::isl68224::*;
@@ -346,13 +344,8 @@ fn main() -> ! {
 
     let i2c_task = I2C.get_task_id();
 
-    let mut devices: [MaybeUninit<Device>; CONTROLLER_CONFIG.len()] =
-        unsafe { MaybeUninit::uninit().assume_init() };
-    for (dev, config) in devices.iter_mut().zip(CONTROLLER_CONFIG.iter()) {
-        dev.write(config.get_device(i2c_task));
-    }
     let mut devices: [Device; CONTROLLER_CONFIG.len()] =
-        unsafe { core::mem::transmute(devices) };
+        array_init::array_init(|i| CONTROLLER_CONFIG[i].get_device(i2c_task));
 
     loop {
         hl::sleep_for(1000);

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -110,16 +110,19 @@ impl Device {
 impl PowerControllerConfig {
     fn get_device(&self, task: TaskId) -> Device {
         let (dev, rail) = (self.builder)(task);
-        use DeviceType::*;
         match &self.device {
-            IBC => Device::Bmr491(Bmr491::new(&dev, rail)),
-            Core | Mem => Device::Raa229618(Raa229618::new(&dev, rail)),
-            MemVpp | SerDes => Device::Isl68224(Isl68224::new(&dev, rail)),
-            Sys => Device::Tps546B24A(Tps546B24A::new(&dev, rail)),
-            HotSwap(sense) | Fan(sense) => {
+            DeviceType::IBC => Device::Bmr491(Bmr491::new(&dev, rail)),
+            DeviceType::Core | DeviceType::Mem => {
+                Device::Raa229618(Raa229618::new(&dev, rail))
+            }
+            DeviceType::MemVpp | DeviceType::SerDes => {
+                Device::Isl68224(Isl68224::new(&dev, rail))
+            }
+            DeviceType::Sys => Device::Tps546B24A(Tps546B24A::new(&dev, rail)),
+            DeviceType::HotSwap(sense) | DeviceType::Fan(sense) => {
                 Device::Adm1272(Adm1272::new(&dev, *sense))
             }
-            HotSwapIO(sense) => {
+            DeviceType::HotSwapIO(sense) => {
                 Device::Max5970(Max5970::new(&dev, rail, *sense))
             }
         }

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -10,6 +10,8 @@
 #![no_std]
 #![no_main]
 
+use core::mem::MaybeUninit;
+
 use drv_i2c_devices::adm1272::*;
 use drv_i2c_devices::bmr491::*;
 use drv_i2c_devices::isl68224::*;
@@ -39,24 +41,69 @@ include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 use i2c_config::sensors;
 
 #[allow(dead_code, clippy::upper_case_acronyms)]
-enum Device {
-    IBC(Bmr491),
-    Core(Raa229618),
-    SerDes(Isl68224),
-    Mem(Raa229618),
-    MemVpp(Isl68224),
-    Sys(Tps546B24A),
-    HotSwap(Adm1272),
-    Fan(Adm1272),
-    HotSwapIO(Max5970),
+enum DeviceType {
+    IBC,
+    Core,
+    SerDes,
+    Mem,
+    MemVpp,
+    Sys,
+    HotSwap(Ohms),
+    Fan(Ohms),
+    HotSwapIO(Ohms),
 }
 
-struct PowerController {
+struct PowerControllerConfig {
     state: PowerState,
-    device: Device,
+    device: DeviceType,
+    builder: fn(TaskId) -> (drv_i2c_api::I2cDevice, u8), // device, rail
     voltage: SensorId,
     current: SensorId,
     temperature: Option<SensorId>,
+}
+
+enum Device {
+    Bmr491(Bmr491),
+    Raa229618(Raa229618),
+    Isl68224(Isl68224),
+    Tps546B24A(Tps546B24A),
+    Adm1272(Adm1272),
+    Max5970(Max5970),
+}
+
+impl Device {
+    fn read_temperature(&self) -> Result<Celsius, ResponseCode> {
+        match &self {
+            Device::Bmr491(dev) => read_temperature(dev),
+            Device::Raa229618(dev) => read_temperature(dev),
+            Device::Isl68224(dev) => read_temperature(dev),
+            Device::Tps546B24A(dev) => read_temperature(dev),
+            Device::Adm1272(dev) => read_temperature(dev),
+            Device::Max5970(_dev) => Err(ResponseCode::NoDevice),
+        }
+    }
+
+    fn read_iout(&self) -> Result<Amperes, ResponseCode> {
+        match &self {
+            Device::Bmr491(dev) => read_current(dev),
+            Device::Raa229618(dev) => read_current(dev),
+            Device::Isl68224(dev) => read_current(dev),
+            Device::Tps546B24A(dev) => read_current(dev),
+            Device::Adm1272(dev) => read_current(dev),
+            Device::Max5970(dev) => read_current(dev),
+        }
+    }
+
+    fn read_vout(&self) -> Result<Volts, ResponseCode> {
+        match &self {
+            Device::Bmr491(dev) => read_voltage(dev),
+            Device::Raa229618(dev) => read_voltage(dev),
+            Device::Isl68224(dev) => read_voltage(dev),
+            Device::Tps546B24A(dev) => read_voltage(dev),
+            Device::Adm1272(dev) => read_voltage(dev),
+            Device::Max5970(dev) => read_voltage(dev),
+        }
+    }
 }
 
 fn read_temperature<E, T: TempSensor<E>>(
@@ -104,52 +151,32 @@ where
     }
 }
 
-impl PowerController {
-    fn read_temperature(&self) -> Result<Celsius, ResponseCode> {
+impl PowerControllerConfig {
+    fn get_device(&self, task: TaskId) -> Device {
+        let (dev, rail) = (self.builder)(task);
+        use DeviceType::*;
         match &self.device {
-            Device::IBC(dev) => read_temperature(dev),
-            Device::Core(dev) | Device::Mem(dev) => read_temperature(dev),
-            Device::SerDes(dev) => read_temperature(dev),
-            Device::Sys(dev) => read_temperature(dev),
-            Device::HotSwap(dev) | Device::Fan(dev) => read_temperature(dev),
-            _ => panic!(),
-        }
-    }
-
-    fn read_iout(&self) -> Result<Amperes, ResponseCode> {
-        match &self.device {
-            Device::IBC(dev) => read_current(dev),
-            Device::Core(dev) | Device::Mem(dev) => read_current(dev),
-            Device::MemVpp(dev) => read_current(dev),
-            Device::SerDes(dev) => read_current(dev),
-            Device::Sys(dev) => read_current(dev),
-            Device::HotSwap(dev) | Device::Fan(dev) => read_current(dev),
-            Device::HotSwapIO(dev) => read_current(dev),
-        }
-    }
-
-    fn read_vout(&self) -> Result<Volts, ResponseCode> {
-        match &self.device {
-            Device::IBC(dev) => read_voltage(dev),
-            Device::Core(dev) | Device::Mem(dev) => read_voltage(dev),
-            Device::MemVpp(dev) => read_voltage(dev),
-            Device::SerDes(dev) => read_voltage(dev),
-            Device::Sys(dev) => read_voltage(dev),
-            Device::HotSwap(dev) | Device::Fan(dev) => read_voltage(dev),
-            Device::HotSwapIO(dev) => read_voltage(dev),
+            IBC => Device::Bmr491(Bmr491::new(&dev, rail)),
+            Core | Mem => Device::Raa229618(Raa229618::new(&dev, rail)),
+            MemVpp | SerDes => Device::Isl68224(Isl68224::new(&dev, rail)),
+            Sys => Device::Tps546B24A(Tps546B24A::new(&dev, rail)),
+            HotSwap(sense) | Fan(sense) => {
+                Device::Adm1272(Adm1272::new(&dev, *sense))
+            }
+            HotSwapIO(sense) => {
+                Device::Max5970(Max5970::new(&dev, rail, *sense))
+            }
         }
     }
 }
 
 macro_rules! rail_controller {
-    ($task:expr, $which:ident, $dev:ident, $rail:ident, $state:ident) => {
+    ($which:ident, $dev:ident, $rail:ident, $state:ident) => {
         paste::paste! {
-            PowerController {
+            PowerControllerConfig {
                 state: PowerState::$state,
-                device: Device::$which({
-                    let (device, rail) = i2c_config::pmbus::$rail($task);
-                    [<$dev:camel>]::new(&device, rail)
-                }),
+                device: DeviceType::$which,
+                builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
                 current: sensors::[<$dev:upper _ $rail:upper _CURRENT_SENSOR>],
                 temperature: Some(
@@ -162,14 +189,12 @@ macro_rules! rail_controller {
 
 #[allow(unused_macros)]
 macro_rules! rail_controller_notemp {
-    ($task:expr, $which:ident, $dev:ident, $rail:ident, $state:ident) => {
+    ($which:ident, $dev:ident, $rail:ident, $state:ident) => {
         paste::paste! {
-            PowerController {
+            PowerControllerConfig {
                 state: PowerState::$state,
-                device: Device::$which({
-                    let (device, rail) = i2c_config::pmbus::$rail($task);
-                    [<$dev:camel>]::new(&device, rail)
-                }),
+                device: DeviceType::$which,
+                builder:i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
                 current: sensors::[<$dev:upper _ $rail:upper _CURRENT_SENSOR>],
                 temperature: None,
@@ -180,14 +205,12 @@ macro_rules! rail_controller_notemp {
 
 #[allow(unused_macros)]
 macro_rules! adm1272_controller {
-    ($task:expr, $which:ident, $rail:ident, $state:ident, $rsense:expr) => {
+    ($which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
-            PowerController {
+            PowerControllerConfig {
                 state: PowerState::$state,
-                device: Device::$which({
-                    let (device, _) = i2c_config::pmbus::$rail($task);
-                    Adm1272::new(&device, $rsense)
-                }),
+                device: DeviceType::$which($rsense),
+                builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<ADM1272_ $rail:upper _VOLTAGE_SENSOR>],
                 current: sensors::[<ADM1272_ $rail:upper _CURRENT_SENSOR>],
                 temperature: Some(
@@ -200,14 +223,12 @@ macro_rules! adm1272_controller {
 
 #[allow(unused_macros)]
 macro_rules! max5970_controller {
-    ($task:expr, $which:ident, $rail:ident, $state:ident, $rsense:expr) => {
+    ($which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
-            PowerController {
+            PowerControllerConfig {
                 state: PowerState::$state,
-                device: Device::$which({
-                    let (device, rail) = i2c_config::power::$rail($task);
-                    Max5970::new(&device, rail, $rsense)
-                }),
+                device: DeviceType::$which($rsense),
+                builder: i2c_config::power::$rail,
                 voltage: sensors::[<MAX5970_ $rail:upper _VOLTAGE_SENSOR>],
                 current: sensors::[<MAX5970_ $rail:upper _CURRENT_SENSOR>],
                 temperature: None,
@@ -216,71 +237,49 @@ macro_rules! max5970_controller {
     };
 }
 
-#[cfg(target_board = "gimlet-a")]
-fn controllers() -> [PowerController; 13] {
-    let task = I2C.get_task_id();
-
-    [
-        rail_controller!(task, IBC, bmr491, v12_sys_a2, A2),
-        rail_controller!(task, Core, raa229618, vdd_vcore, A0),
-        rail_controller!(task, Core, raa229618, vddcr_soc, A0),
-        rail_controller!(task, Mem, raa229618, vdd_mem_abcd, A0),
-        rail_controller!(task, Mem, raa229618, vdd_mem_efgh, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, vpp_abcd, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, vpp_efgh, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, v3p3_sys, A0),
-        rail_controller!(task, Sys, tps546B24A, v3p3_sp_a2, A2),
-        rail_controller!(task, Sys, tps546B24A, v1p8_sp3, A0),
-        rail_controller!(task, Sys, tps546B24A, v5_sys_a2, A2),
-        adm1272_controller!(task, HotSwap, v54_hs_output, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_fan, A2, Ohms(0.002)),
-    ]
-}
+#[cfg(any(target_board = "gimlet-b", target_board = "gimlet-c"))]
+const CONTROLLER_CONFIG_LEN: usize = 37;
 
 #[cfg(any(target_board = "gimlet-b", target_board = "gimlet-c"))]
-fn controllers() -> [PowerController; 37] {
-    let task = I2C.get_task_id();
-
-    [
-        rail_controller!(task, IBC, bmr491, v12_sys_a2, A2),
-        rail_controller!(task, Core, raa229618, vdd_vcore, A0),
-        rail_controller!(task, Core, raa229618, vddcr_soc, A0),
-        rail_controller!(task, Mem, raa229618, vdd_mem_abcd, A0),
-        rail_controller!(task, Mem, raa229618, vdd_mem_efgh, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, vpp_abcd, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, vpp_efgh, A0),
-        rail_controller_notemp!(task, MemVpp, isl68224, v1p8_sp3, A0),
-        rail_controller!(task, Sys, tps546B24A, v3p3_sp_a2, A2),
-        rail_controller!(task, Sys, tps546B24A, v3p3_sys_a0, A0),
-        rail_controller!(task, Sys, tps546B24A, v5_sys_a2, A2),
-        rail_controller!(task, Sys, tps546B24A, v1p8_sys_a2, A2),
-        rail_controller!(task, Sys, tps546B24A, v0p96_nic_vdd_a0hp, A0),
-        adm1272_controller!(task, HotSwap, v54_hs_output, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_fan, A2, Ohms(0.002)),
-        max5970_controller!(task, HotSwapIO, v3p3_m2a_a0hp, A0, Ohms(0.004)),
-        max5970_controller!(task, HotSwapIO, v3p3_m2b_a0hp, A0, Ohms(0.004)),
-        max5970_controller!(task, HotSwapIO, v12_u2a_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2a_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2b_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2b_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2c_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2c_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2d_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2d_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2e_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2e_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2f_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2f_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2g_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2g_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2h_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2h_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2i_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2i_a0, A0, Ohms(0.008)),
-        max5970_controller!(task, HotSwapIO, v12_u2j_a0, A0, Ohms(0.005)),
-        max5970_controller!(task, HotSwapIO, v3p3_u2j_a0, A0, Ohms(0.008)),
-    ]
-}
+static CONTROLLER_CONFIG: [PowerControllerConfig; CONTROLLER_CONFIG_LEN] = [
+    rail_controller!(IBC, bmr491, v12_sys_a2, A2),
+    rail_controller!(Core, raa229618, vdd_vcore, A0),
+    rail_controller!(Core, raa229618, vddcr_soc, A0),
+    rail_controller!(Mem, raa229618, vdd_mem_abcd, A0),
+    rail_controller!(Mem, raa229618, vdd_mem_efgh, A0),
+    rail_controller_notemp!(MemVpp, isl68224, vpp_abcd, A0),
+    rail_controller_notemp!(MemVpp, isl68224, vpp_efgh, A0),
+    rail_controller_notemp!(MemVpp, isl68224, v1p8_sp3, A0),
+    rail_controller!(Sys, tps546B24A, v3p3_sp_a2, A2),
+    rail_controller!(Sys, tps546B24A, v3p3_sys_a0, A0),
+    rail_controller!(Sys, tps546B24A, v5_sys_a2, A2),
+    rail_controller!(Sys, tps546B24A, v1p8_sys_a2, A2),
+    rail_controller!(Sys, tps546B24A, v0p96_nic_vdd_a0hp, A0),
+    adm1272_controller!(HotSwap, v54_hs_output, A2, Ohms(0.001)),
+    adm1272_controller!(Fan, v54_fan, A2, Ohms(0.002)),
+    max5970_controller!(HotSwapIO, v3p3_m2a_a0hp, A0, Ohms(0.004)),
+    max5970_controller!(HotSwapIO, v3p3_m2b_a0hp, A0, Ohms(0.004)),
+    max5970_controller!(HotSwapIO, v12_u2a_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2a_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2b_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2b_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2c_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2c_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2d_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2d_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2e_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2e_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2f_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2f_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2g_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2g_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2h_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2h_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2i_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2i_a0, A0, Ohms(0.008)),
+    max5970_controller!(HotSwapIO, v12_u2j_a0, A0, Ohms(0.005)),
+    max5970_controller!(HotSwapIO, v3p3_u2j_a0, A0, Ohms(0.008)),
+];
 
 #[cfg(feature = "gimlet")]
 fn get_state() -> PowerState {
@@ -306,27 +305,26 @@ fn get_state() -> PowerState {
 }
 
 #[cfg(any(target_board = "sidecar-a", target_board = "sidecar-b"))]
-fn controllers() -> [PowerController; 15] {
-    let task = I2C.get_task_id();
+const CONTROLLER_CONFIG_LEN: usize = 15;
 
-    [
-        rail_controller!(task, IBC, bmr491, v12p0_sys, A2),
-        adm1272_controller!(task, Fan, v54_fan0, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_fan1, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_fan2, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_fan3, A2, Ohms(0.001)),
-        adm1272_controller!(task, Fan, v54_hsc, A2, Ohms(0.001)),
-        rail_controller!(task, Core, raa229618, v0p8_tf2_vdd_core, A0),
-        rail_controller!(task, Sys, tps546B24A, v3p3_sys, A2),
-        rail_controller!(task, Sys, tps546B24A, v5p0_sys, A2),
-        rail_controller!(task, Core, raa229618, v1p5_tf2_vdda, A0),
-        rail_controller!(task, Core, raa229618, v0p9_tf2_vddt, A0),
-        rail_controller!(task, SerDes, isl68224, v1p8_tf2_vdda, A0),
-        rail_controller!(task, SerDes, isl68224, v1p8_tf2_vdd, A0),
-        rail_controller!(task, Sys, tps546B24A, v1p0_mgmt, A2),
-        rail_controller!(task, Sys, tps546B24A, v1p8_sys, A2),
-    ]
-}
+#[cfg(any(target_board = "sidecar-a", target_board = "sidecar-b"))]
+static CONTROLLER_CONFIG: [PowerControllerConfig; CONTROLLER_CONFIG_LEN] = [
+    rail_controller!(IBC, bmr491, v12p0_sys, A2),
+    adm1272_controller!(Fan, v54_fan0, A2, Ohms(0.001)),
+    adm1272_controller!(Fan, v54_fan1, A2, Ohms(0.001)),
+    adm1272_controller!(Fan, v54_fan2, A2, Ohms(0.001)),
+    adm1272_controller!(Fan, v54_fan3, A2, Ohms(0.001)),
+    adm1272_controller!(Fan, v54_hsc, A2, Ohms(0.001)),
+    rail_controller!(Core, raa229618, v0p8_tf2_vdd_core, A0),
+    rail_controller!(Sys, tps546B24A, v3p3_sys, A2),
+    rail_controller!(Sys, tps546B24A, v5p0_sys, A2),
+    rail_controller!(Core, raa229618, v1p5_tf2_vdda, A0),
+    rail_controller!(Core, raa229618, v0p9_tf2_vddt, A0),
+    rail_controller!(SerDes, isl68224, v1p8_tf2_vdda, A0),
+    rail_controller!(SerDes, isl68224, v1p8_tf2_vdd, A0),
+    rail_controller!(Sys, tps546B24A, v1p0_mgmt, A2),
+    rail_controller!(Sys, tps546B24A, v1p8_sys, A2),
+];
 
 #[cfg(any(target_board = "sidecar-a", target_board = "sidecar-b"))]
 fn get_state() -> PowerState {
@@ -349,14 +347,22 @@ fn get_state() -> PowerState {
 fn main() -> ! {
     let sensor = sensor_api::Sensor::from(SENSOR.get_task_id());
 
-    let mut controllers = controllers();
+    let i2c_task = I2C.get_task_id();
+
+    let mut devices: [MaybeUninit<Device>; CONTROLLER_CONFIG_LEN] =
+        unsafe { MaybeUninit::uninit().assume_init() };
+    for (dev, config) in devices.iter_mut().zip(CONTROLLER_CONFIG.iter()) {
+        dev.write(config.get_device(i2c_task));
+    }
+    let mut devices: [Device; CONTROLLER_CONFIG_LEN] =
+        unsafe { core::mem::transmute(devices) };
 
     loop {
         hl::sleep_for(1000);
 
         let state = get_state();
 
-        for c in &mut controllers {
+        for (c, dev) in CONTROLLER_CONFIG.iter().zip(devices.iter_mut()) {
             if c.state == PowerState::A0 && state != PowerState::A0 {
                 sensor.nodata(c.voltage, NoData::DeviceOff).unwrap();
                 sensor.nodata(c.current, NoData::DeviceOff).unwrap();
@@ -369,7 +375,7 @@ fn main() -> ! {
             }
 
             if let Some(id) = c.temperature {
-                match c.read_temperature() {
+                match dev.read_temperature() {
                     Ok(reading) => {
                         sensor.post(id, reading.0).unwrap();
                     }
@@ -379,7 +385,7 @@ fn main() -> ! {
                 }
             }
 
-            match c.read_iout() {
+            match dev.read_iout() {
                 Ok(reading) => {
                     sensor.post(c.current, reading.0).unwrap();
                 }
@@ -388,7 +394,7 @@ fn main() -> ! {
                 }
             }
 
-            match c.read_vout() {
+            match dev.read_vout() {
                 Ok(reading) => {
                     sensor.post(c.voltage, reading.0).unwrap();
                 }

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -238,10 +238,7 @@ macro_rules! max5970_controller {
 }
 
 #[cfg(any(target_board = "gimlet-b", target_board = "gimlet-c"))]
-const CONTROLLER_CONFIG_LEN: usize = 37;
-
-#[cfg(any(target_board = "gimlet-b", target_board = "gimlet-c"))]
-static CONTROLLER_CONFIG: [PowerControllerConfig; CONTROLLER_CONFIG_LEN] = [
+const CONTROLLER_CONFIG: [PowerControllerConfig; 37] = [
     rail_controller!(IBC, bmr491, v12_sys_a2, A2),
     rail_controller!(Core, raa229618, vdd_vcore, A0),
     rail_controller!(Core, raa229618, vddcr_soc, A0),
@@ -349,12 +346,12 @@ fn main() -> ! {
 
     let i2c_task = I2C.get_task_id();
 
-    let mut devices: [MaybeUninit<Device>; CONTROLLER_CONFIG_LEN] =
+    let mut devices: [MaybeUninit<Device>; CONTROLLER_CONFIG.len()] =
         unsafe { MaybeUninit::uninit().assume_init() };
     for (dev, config) in devices.iter_mut().zip(CONTROLLER_CONFIG.iter()) {
         dev.write(config.get_device(i2c_task));
     }
-    let mut devices: [Device; CONTROLLER_CONFIG_LEN] =
+    let mut devices: [Device; CONTROLLER_CONFIG.len()] =
         unsafe { core::mem::transmute(devices) };
 
     loop {

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -258,10 +258,7 @@ fn get_state() -> PowerState {
 }
 
 #[cfg(any(target_board = "sidecar-a", target_board = "sidecar-b"))]
-const CONTROLLER_CONFIG_LEN: usize = 15;
-
-#[cfg(any(target_board = "sidecar-a", target_board = "sidecar-b"))]
-static CONTROLLER_CONFIG: [PowerControllerConfig; CONTROLLER_CONFIG_LEN] = [
+const CONTROLLER_CONFIG: [PowerControllerConfig; 15] = [
     rail_controller!(IBC, bmr491, v12p0_sys, A2),
     adm1272_controller!(Fan, v54_fan0, A2, Ohms(0.001)),
     adm1272_controller!(Fan, v54_fan1, A2, Ohms(0.001)),


### PR DESCRIPTION
Same basic idea as #830 , except that many power devices have a local state cache, so we keep the devices in RAM (moving the configuration to flash).

It's not _as big_ of a win, but is still non-trivial:
- Flash goes from 17804 -> 16588 bytes
- Stack depth goes from 4160 -> 3880

Alas, neither of these changes pushes us below a power of two, but they're still probably worthwhile.