### PR TITLE
netstack refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2099,15 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3664,9 +3679,11 @@ dependencies = [
  "drv-stm32xx-uid",
  "drv-user-leds-api",
  "enum-map",
+ "heapless",
  "hubris-num-tasks",
  "idol",
  "idol-runtime",
+ "itertools",
  "ksz8463",
  "multitimer",
  "mutable-statics",

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -31,6 +31,8 @@ task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448"}
 vsc85xx = { path = "../../drv/vsc85xx"}
+itertools = { version = "0.10.5", default-features = false }
+heapless = { version = "0.7.16", default-features = false }
 
 [dependencies.smoltcp]
 version = "0.8.0"

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::pins;
+#[cfg(not(feature = "ksz8463"))]
+compile_error!("this BSP requires the ksz8463 feature");
+
+use crate::{bsp_support, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
@@ -29,35 +32,31 @@ enum Trace {
 }
 ringbuf!(Trace, 32, Trace::None);
 
-// This system wants to be woken periodically to do logging
-pub const WAKE_INTERVAL: Option<u64> = Some(5000);
-
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn preinit() {
-    // Nothing to do here
-}
-
-pub fn configure_ethernet_pins(sys: &Sys) {
-    pins::RmiiPins {
-        refclk: Port::A.pin(1),
-        crs_dv: Port::A.pin(7),
-        tx_en: Port::B.pin(11),
-        txd0: Port::B.pin(12),
-        txd1: Port::B.pin(13),
-        rxd0: Port::C.pin(4),
-        rxd1: Port::C.pin(5),
-        af: Alternate::AF11,
-    }
-    .configure(sys);
-}
-
-pub struct Bsp {
+pub struct BspImpl {
     ksz8463: Ksz8463,
 }
 
-impl Bsp {
-    pub fn new(_eth: &eth::Ethernet, sys: &Sys) -> Self {
+impl bsp_support::Bsp for BspImpl {
+    // This system wants to be woken periodically to do logging
+    const WAKE_INTERVAL: Option<u64> = Some(5000);
+
+    fn configure_ethernet_pins(sys: &Sys) {
+        pins::RmiiPins {
+            refclk: Port::A.pin(1),
+            crs_dv: Port::A.pin(7),
+            tx_en: Port::B.pin(11),
+            txd0: Port::B.pin(12),
+            txd1: Port::B.pin(13),
+            rxd0: Port::C.pin(4),
+            rxd1: Port::C.pin(5),
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+    }
+
+    fn new(_eth: &eth::Ethernet, sys: &Sys) -> Self {
         let ksz8463 = loop {
             // SPI device is based on ordering in app.toml
             let ksz8463_spi = Spi::from(SPI.get_task_id()).device(0);
@@ -84,7 +83,7 @@ impl Bsp {
         Self { ksz8463 }
     }
 
-    pub fn wake(&self, _eth: &eth::Ethernet) {
+    fn wake(&self, _eth: &eth::Ethernet) {
         for port in [1, 2] {
             ringbuf_entry!(
                 match self.ksz8463.read(KszRegister::PxMBSR(port)) {
@@ -109,7 +108,7 @@ impl Bsp {
     }
 
     /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_read(
+    fn phy_read(
         &mut self,
         _port: u8,
         _reg: PhyRegisterAddress<u16>,
@@ -119,17 +118,17 @@ impl Bsp {
     }
 
     /// Calls a function on a `Phy` associated with the given port.
-    pub fn phy_write(
+    fn phy_write(
         &mut self,
         _port: u8,
         _reg: PhyRegisterAddress<u16>,
         _value: u16,
         _eth: &eth::Ethernet,
-    ) -> Result<u16, PhyError> {
+    ) -> Result<(), PhyError> {
         Err(PhyError::NotImplemented)
     }
 
-    pub fn ksz8463(&self) -> &Ksz8463 {
+    fn ksz8463(&self) -> &Ksz8463 {
         &self.ksz8463
     }
 }

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -15,38 +15,32 @@ use vsc85xx::PhyRw;
 /// become configurable.
 const PHYADDR: u8 = 0x0;
 
-// The Nucleo dev board doesn't do any periodic logging
-pub const WAKE_INTERVAL: Option<u64> = None;
-
-pub fn configure_ethernet_pins(sys: &Sys) {
-    pins::RmiiPins {
-        refclk: Port::A.pin(1),
-        crs_dv: Port::A.pin(7),
-        tx_en: Port::G.pin(11),
-        txd0: Port::G.pin(13),
-        txd1: Port::B.pin(13),
-        rxd0: Port::C.pin(4),
-        rxd1: Port::C.pin(5),
-        af: Alternate::AF11,
-    }
-    .configure(sys);
-
-    pins::MdioPins {
-        mdio: Port::A.pin(2),
-        mdc: Port::C.pin(1),
-        af: Alternate::AF11,
-    }
-    .configure(sys);
-}
-
-pub fn preinit() {
-    // Nothing to do here
-}
-
 // Empty handle
-pub struct Bsp;
-impl Bsp {
-    pub fn new(eth: &eth::Ethernet, _sys: &Sys) -> Self {
+pub struct BspImpl;
+
+impl crate::bsp_support::Bsp for BspImpl {
+    fn configure_ethernet_pins(sys: &Sys) {
+        pins::RmiiPins {
+            refclk: Port::A.pin(1),
+            crs_dv: Port::A.pin(7),
+            tx_en: Port::G.pin(11),
+            txd0: Port::G.pin(13),
+            txd1: Port::B.pin(13),
+            rxd0: Port::C.pin(4),
+            rxd1: Port::C.pin(5),
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+
+        pins::MdioPins {
+            mdio: Port::A.pin(2),
+            mdc: Port::C.pin(1),
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+    }
+
+    fn new(eth: &eth::Ethernet, _sys: &Sys) -> Self {
         // Unlike most Microchip PHYs, the LAN8742A-CZ-TR does not use register
         // 31 to switch between register pages (since it only uses page 0).
         // This means that we use the _raw read and write functions, since the
@@ -64,11 +58,7 @@ impl Bsp {
         Self {}
     }
 
-    pub fn wake(&self, _eth: &eth::Ethernet) {
-        panic!("Wake should never be called, because WAKE_INTERVAL is None");
-    }
-
-    pub fn phy_read(
+    fn phy_read(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -84,7 +74,7 @@ impl Bsp {
         Ok(out)
     }
 
-    pub fn phy_write(
+    fn phy_write(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,

--- a/task/net/src/bsp/psc_a.rs
+++ b/task/net/src/bsp/psc_a.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{mgmt, pins};
+#[cfg(not(all(feature = "ksz8463", feature = "mgmt")))]
+compile_error!("this BSP requires the ksz8463 and mgmt features");
+
+use crate::{bsp_support, mgmt, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
@@ -14,42 +17,38 @@ use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 
-// This system wants to be woken periodically to do logging
-pub const WAKE_INTERVAL: Option<u64> = Some(500);
-
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Stateless function to configure ethernet pins before the Bsp struct
-/// is actually constructed
-pub fn configure_ethernet_pins(sys: &Sys) {
-    pins::RmiiPins {
-        refclk: Port::A.pin(1),
-        crs_dv: Port::A.pin(7),
-        tx_en: Port::G.pin(11),
-        txd0: Port::G.pin(13),
-        txd1: Port::G.pin(12),
-        rxd0: Port::C.pin(4),
-        rxd1: Port::C.pin(5),
-        af: Alternate::AF11,
+pub struct BspImpl(mgmt::Bsp);
+
+impl bsp_support::Bsp for BspImpl {
+    // This system wants to be woken periodically to do logging
+    const WAKE_INTERVAL: Option<u64> = Some(500);
+
+    /// Stateless function to configure ethernet pins before the Bsp struct
+    /// is actually constructed
+    fn configure_ethernet_pins(sys: &Sys) {
+        pins::RmiiPins {
+            refclk: Port::A.pin(1),
+            crs_dv: Port::A.pin(7),
+            tx_en: Port::G.pin(11),
+            txd0: Port::G.pin(13),
+            txd1: Port::G.pin(12),
+            rxd0: Port::C.pin(4),
+            rxd1: Port::C.pin(5),
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+
+        pins::MdioPins {
+            mdio: Port::A.pin(2),
+            mdc: Port::C.pin(1),
+            af: Alternate::AF11,
+        }
+        .configure(sys);
     }
-    .configure(sys);
 
-    pins::MdioPins {
-        mdio: Port::A.pin(2),
-        mdc: Port::C.pin(1),
-        af: Alternate::AF11,
-    }
-    .configure(sys);
-}
-
-pub struct Bsp(mgmt::Bsp);
-
-pub fn preinit() {
-    // Nothing to do here
-}
-
-impl Bsp {
-    pub fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
+    fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let bsp = mgmt::Config {
             // SP_TO_MGMT_V1P0_EN / SP_TO_MGMT_V2P5_EN
             // (note that the latter also enables the MGMT_PHY_REFCLK)
@@ -81,11 +80,11 @@ impl Bsp {
         Self(bsp)
     }
 
-    pub fn wake(&self, eth: &eth::Ethernet) {
+    fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
     }
 
-    pub fn phy_read(
+    fn phy_read(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -94,7 +93,7 @@ impl Bsp {
         self.0.phy_read(port, reg, eth)
     }
 
-    pub fn phy_write(
+    fn phy_write(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -104,18 +103,18 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+    fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
     }
 
-    pub fn management_link_status(
+    fn management_link_status(
         &self,
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
     }
 
-    pub fn management_counters(
+    fn management_counters(
         &self,
         eth: &crate::eth::Ethernet,
     ) -> Result<ManagementCounters, MgmtError> {

--- a/task/net/src/bsp/psc_b.rs
+++ b/task/net/src/bsp/psc_b.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{mgmt, pins};
+#[cfg(not(all(feature = "ksz8463", feature = "mgmt")))]
+compile_error!("this BSP requires the ksz8463 and mgmt features");
+
+use crate::{bsp_support, mgmt, pins};
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
@@ -14,42 +17,38 @@ use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SPI, spi_driver);
 
-// This system wants to be woken periodically to do logging
-pub const WAKE_INTERVAL: Option<u64> = Some(500);
-
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Stateless function to configure ethernet pins before the Bsp struct
-/// is actually constructed
-pub fn configure_ethernet_pins(sys: &Sys) {
-    pins::RmiiPins {
-        refclk: Port::A.pin(1), // CLK_50MHZ_SP_RMII_REFCLK
-        crs_dv: Port::A.pin(7), // RMII_MGMT_SW_TO_SP_CRS_DV
-        tx_en: Port::G.pin(11), // RMII_SP_TO_MGMT_SW_TX_EN
-        txd0: Port::G.pin(13),  // RMII_SP_TO_MGMT_SW_TXD0
-        txd1: Port::G.pin(12),  // RMII_SP_TO_MGMT_SW_TXD1
-        rxd0: Port::C.pin(4),   // RMII_MGMT_SW_TO_SP_RXD0
-        rxd1: Port::C.pin(5),   // RMII_MGMT_SW_TO_SP_RXD1
-        af: Alternate::AF11,
+pub struct BspImpl(mgmt::Bsp);
+
+impl bsp_support::Bsp for BspImpl {
+    // This system wants to be woken periodically to do logging
+    const WAKE_INTERVAL: Option<u64> = Some(500);
+
+    /// Stateless function to configure ethernet pins before the Bsp struct
+    /// is actually constructed
+    fn configure_ethernet_pins(sys: &Sys) {
+        pins::RmiiPins {
+            refclk: Port::A.pin(1), // CLK_50MHZ_SP_RMII_REFCLK
+            crs_dv: Port::A.pin(7), // RMII_MGMT_SW_TO_SP_CRS_DV
+            tx_en: Port::G.pin(11), // RMII_SP_TO_MGMT_SW_TX_EN
+            txd0: Port::G.pin(13),  // RMII_SP_TO_MGMT_SW_TXD0
+            txd1: Port::G.pin(12),  // RMII_SP_TO_MGMT_SW_TXD1
+            rxd0: Port::C.pin(4),   // RMII_MGMT_SW_TO_SP_RXD0
+            rxd1: Port::C.pin(5),   // RMII_MGMT_SW_TO_SP_RXD1
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+
+        pins::MdioPins {
+            mdio: Port::A.pin(2), // SP_TO_MGMT_PHY_MDIO_SP_DOMAIN
+            mdc: Port::C.pin(1),  // SP_TO_MGMT_PHY_MDC_SP_DOMAIN
+            af: Alternate::AF11,
+        }
+        .configure(sys);
     }
-    .configure(sys);
 
-    pins::MdioPins {
-        mdio: Port::A.pin(2), // SP_TO_MGMT_PHY_MDIO_SP_DOMAIN
-        mdc: Port::C.pin(1),  // SP_TO_MGMT_PHY_MDC_SP_DOMAIN
-        af: Alternate::AF11,
-    }
-    .configure(sys);
-}
-
-pub struct Bsp(mgmt::Bsp);
-
-pub fn preinit() {
-    // Nothing to do here
-}
-
-impl Bsp {
-    pub fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
+    fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let bsp = mgmt::Config {
             // SP_TO_MGMT_PHY_A2_PWR_EN
             power_en: Some(Port::I.pin(10)),
@@ -80,11 +79,11 @@ impl Bsp {
         Self(bsp)
     }
 
-    pub fn wake(&self, eth: &eth::Ethernet) {
+    fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
     }
 
-    pub fn phy_read(
+    fn phy_read(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -93,7 +92,7 @@ impl Bsp {
         self.0.phy_read(port, reg, eth)
     }
 
-    pub fn phy_write(
+    fn phy_write(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -103,18 +102,18 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+    fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
     }
 
-    pub fn management_link_status(
+    fn management_link_status(
         &self,
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
     }
 
-    pub fn management_counters(
+    fn management_counters(
         &self,
         eth: &crate::eth::Ethernet,
     ) -> Result<ManagementCounters, MgmtError> {

--- a/task/net/src/bsp/sidecar_b.rs
+++ b/task/net/src/bsp/sidecar_b.rs
@@ -7,7 +7,10 @@
 //! Right now, this is identical to the rev A BSP, but that may change in the
 //! future, so they're kept separate.
 
-use crate::{mgmt, miim_bridge::MiimBridge, pins};
+#[cfg(not(all(feature = "ksz8463", feature = "mgmt")))]
+compile_error!("this BSP requires the ksz8463 and mgmt features");
+
+use crate::{bsp_support, mgmt, miim_bridge::MiimBridge, pins};
 use drv_sidecar_seq_api::Sequencer;
 use drv_spi_api::Spi;
 use drv_stm32h7_eth as eth;
@@ -21,46 +24,46 @@ use vsc7448_pac::types::PhyRegisterAddress;
 task_slot!(SPI, spi_driver);
 task_slot!(SEQ, seq);
 
-// This system wants to be woken periodically to do logging
-pub const WAKE_INTERVAL: Option<u64> = Some(500);
-
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Stateless function to configure ethernet pins before the Bsp struct
-/// is actually constructed
-pub fn configure_ethernet_pins(sys: &Sys) {
-    pins::RmiiPins {
-        refclk: Port::A.pin(1), // CLK_50M_SP_RMII_REFCLK
-        crs_dv: Port::A.pin(7), // RMII_SP_TO_EPE_RX_DV
-        tx_en: Port::G.pin(11), // RMII_SP_TO_EPE_TX_EN
-        txd0: Port::G.pin(13),  // RMII_SP_TO_EPE_TXD0
-        txd1: Port::G.pin(12),  // RMII_SP_TO_EPE_TXD1
-        rxd0: Port::C.pin(4),   // RMII_SP_TO_EPE_RDX0 (typo in schematic)
-        rxd1: Port::C.pin(5),   // RMII_SP_TO_EPE_RXD1
-        af: Alternate::AF11,
+pub struct BspImpl(mgmt::Bsp);
+
+impl bsp_support::Bsp for BspImpl {
+    // This system wants to be woken periodically to do logging
+    const WAKE_INTERVAL: Option<u64> = Some(500);
+
+    /// Stateless function to configure ethernet pins before the Bsp struct
+    /// is actually constructed
+    fn configure_ethernet_pins(sys: &Sys) {
+        pins::RmiiPins {
+            refclk: Port::A.pin(1), // CLK_50M_SP_RMII_REFCLK
+            crs_dv: Port::A.pin(7), // RMII_SP_TO_EPE_RX_DV
+            tx_en: Port::G.pin(11), // RMII_SP_TO_EPE_TX_EN
+            txd0: Port::G.pin(13),  // RMII_SP_TO_EPE_TXD0
+            txd1: Port::G.pin(12),  // RMII_SP_TO_EPE_TXD1
+            rxd0: Port::C.pin(4),   // RMII_SP_TO_EPE_RDX0 (typo in schematic)
+            rxd1: Port::C.pin(5),   // RMII_SP_TO_EPE_RXD1
+            af: Alternate::AF11,
+        }
+        .configure(sys);
+
+        pins::MdioPins {
+            mdio: Port::A.pin(2), // MIIM_SP_TO_PHY_MDIO_3V3
+            mdc: Port::C.pin(1),  // MIIM_SP_TO_PHY_MDC_3V3
+            af: Alternate::AF11,
+        }
+        .configure(sys);
     }
-    .configure(sys);
 
-    pins::MdioPins {
-        mdio: Port::A.pin(2), // MIIM_SP_TO_PHY_MDIO_3V3
-        mdc: Port::C.pin(1),  // MIIM_SP_TO_PHY_MDC_3V3
-        af: Alternate::AF11,
+    fn preinit() {
+        // Wait for the sequencer to turn on the clock
+        let seq = Sequencer::from(SEQ.get_task_id());
+        while !seq.is_clock_config_loaded().unwrap_or(false) {
+            sleep_for(10);
+        }
     }
-    .configure(sys);
-}
 
-pub struct Bsp(mgmt::Bsp);
-
-pub fn preinit() {
-    // Wait for the sequencer to turn on the clock
-    let seq = Sequencer::from(SEQ.get_task_id());
-    while !seq.is_clock_config_loaded().unwrap_or(false) {
-        sleep_for(10);
-    }
-}
-
-impl Bsp {
-    pub fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
+    fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let bsp = mgmt::Config {
             // SP_TO_LDO_PHY2_EN (turns on both P2V5 and P1V0)
             power_en: Some(Port::I.pin(11)),
@@ -95,11 +98,11 @@ impl Bsp {
         Self(bsp)
     }
 
-    pub fn wake(&self, eth: &eth::Ethernet) {
+    fn wake(&self, eth: &eth::Ethernet) {
         self.0.wake(eth);
     }
 
-    pub fn phy_read(
+    fn phy_read(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -108,7 +111,7 @@ impl Bsp {
         self.0.phy_read(port, reg, eth)
     }
 
-    pub fn phy_write(
+    fn phy_write(
         &mut self,
         port: u8,
         reg: PhyRegisterAddress<u16>,
@@ -118,18 +121,18 @@ impl Bsp {
         self.0.phy_write(port, reg, value, eth)
     }
 
-    pub fn ksz8463(&self) -> &ksz8463::Ksz8463 {
+    fn ksz8463(&self) -> &ksz8463::Ksz8463 {
         &self.0.ksz8463
     }
 
-    pub fn management_link_status(
+    fn management_link_status(
         &self,
         eth: &eth::Ethernet,
     ) -> Result<ManagementLinkStatus, MgmtError> {
         self.0.management_link_status(eth)
     }
 
-    pub fn management_counters(
+    fn management_counters(
         &self,
         eth: &crate::eth::Ethernet,
     ) -> Result<ManagementCounters, MgmtError> {

--- a/task/net/src/bsp_support.rs
+++ b/task/net/src/bsp_support.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Common bits for Board Support Packages (BSPs).
+//!
+//! This would be named `bsp` but the BSP infrastructure squats on that name.
+//!
+//! # How the BSP stuff works
+//!
+//! The netstack defines a `bsp` module, but chooses which source file to use
+//! based on the board ID/rev, selecting among options in `src/bsp/`.
+//!
+//! A BSP module is expected to export a single type, called `BspImpl`, which
+//! implements the `Bsp` trait from this module.
+
+use drv_stm32h7_eth as eth;
+use drv_stm32xx_sys_api::Sys;
+use task_net_api::PhyError;
+use vsc7448_pac::types::PhyRegisterAddress;
+
+#[cfg(feature = "mgmt")]
+use task_net_api::MgmtError;
+
+/// Operations that must be provided by a BSP for the netstack.
+///
+/// A module implementing a BSP is expected to expose a type called `BspImpl`
+/// that implements this trait.
+pub trait Bsp: Sized {
+    /// How long to wait between calls to `wake`. `None` tells the netstack to
+    /// never call `wake`.
+    ///
+    /// The default is `None`, which goes along with the default impl for
+    /// `wake`. If you change one, change the other.
+    const WAKE_INTERVAL: Option<u64> = None;
+
+    /// Opportunity to do any work before the Ethernet peripheral is turned on.
+    /// By default this does nothing, override it if necessary.
+    fn preinit() {}
+    /// Stateless function to configure ethernet pins before the Bsp struct
+    /// is actually constructed
+    fn configure_ethernet_pins(sys: &Sys);
+
+    fn new(eth: &eth::Ethernet, sys: &Sys) -> Self;
+
+    /// Pokes the board-specific code to do some sort of action periodically.
+    /// The interval between calls to `wake` is defined by `WAKE_INTERVAL`; if
+    /// it's `None`, this function won't be called.
+    ///
+    /// The default implementation of this function panics, which goes great
+    /// with a `WAKE_INTERVAL` of `None`.
+    fn wake(&self, _eth: &eth::Ethernet) {
+        panic!();
+    }
+
+    fn phy_read(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        eth: &eth::Ethernet,
+    ) -> Result<u16, PhyError>;
+
+    fn phy_write(
+        &mut self,
+        port: u8,
+        reg: PhyRegisterAddress<u16>,
+        value: u16,
+        eth: &eth::Ethernet,
+    ) -> Result<(), PhyError>;
+
+    #[cfg(feature = "ksz8463")]
+    fn ksz8463(&self) -> &ksz8463::Ksz8463;
+
+    #[cfg(feature = "mgmt")]
+    fn management_link_status(
+        &self,
+        eth: &eth::Ethernet,
+    ) -> Result<task_net_api::ManagementLinkStatus, MgmtError>;
+
+    #[cfg(feature = "mgmt")]
+    fn management_counters(
+        &self,
+        eth: &crate::eth::Ethernet,
+    ) -> Result<task_net_api::ManagementCounters, MgmtError>;
+}

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -177,7 +177,7 @@ fn main() -> ! {
     // Board-dependant initialization (e.g. bringing up the PHYs)
     let bsp = BspImpl::new(&eth, &sys);
 
-    let mut server = ServerImpl::new(&eth, ipv6_addr, mac, bsp);
+    let mut server = server_impl::new(&eth, ipv6_addr, mac, bsp);
 
     // Turn on our IRQ.
     userlib::sys_irq_control(ETH_IRQ, true);

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -33,7 +33,6 @@ mod bsp;
 #[cfg_attr(feature = "vlan", path = "server_vlan.rs")]
 #[cfg_attr(not(feature = "vlan"), path = "server_basic.rs")]
 mod server_impl;
-use server_impl::ServerImpl;
 
 #[cfg(feature = "mgmt")]
 pub(crate) mod mgmt;
@@ -245,7 +244,7 @@ fn main() -> ! {
                     Timers::Watchdog => panic!("MAC RX watchdog"),
                 }
             }
-            let mut msgbuf = [0u8; ServerImpl::<BspImpl>::INCOMING_SIZE];
+            let mut msgbuf = [0u8; idl::INCOMING_SIZE];
             idol_runtime::dispatch_n(&mut msgbuf, &mut server);
         }
     }

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::idl;
+use crate::{bsp_support, bsp_support::Bsp, idl};
 use drv_stm32h7_eth as eth;
 use idol_runtime::RequestError;
 use smoltcp::wire::EthernetAddress;
@@ -15,6 +15,8 @@ use task_net_api::{
 /// Abstraction trait to reduce code duplication between VLAN and non-VLAN
 /// server implementations.
 pub trait NetServer {
+    type Bsp: bsp_support::Bsp;
+
     fn net_recv_packet(
         &mut self,
         msg: &userlib::RecvMessage,
@@ -31,7 +33,7 @@ pub trait NetServer {
         payload: idol_runtime::Leased<idol_runtime::R, [u8]>,
     ) -> Result<(), RequestError<SendError>>;
 
-    fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut crate::bsp::Bsp);
+    fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut Self::Bsp);
 
     /// Returns the MAC address for port 0
     fn base_mac_address(&self) -> &EthernetAddress;

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -8,164 +8,52 @@
 
 use drv_stm32h7_eth as eth;
 
+use crate::bsp_support;
+use crate::generated;
+use crate::server::{DeviceExt, GenServerImpl, NetServer, Storage};
 use core::cell::Cell;
-use idol_runtime::{ClientError, NotificationHandler, RequestError};
+use idol_runtime::{ClientError, RequestError};
 use mutable_statics::mutable_statics;
-use smoltcp::iface::{Interface, Neighbor, SocketHandle, SocketStorage};
-use smoltcp::socket::UdpSocket;
-use smoltcp::wire::{
-    EthernetAddress, IpAddress, IpCidr, Ipv6Address, Ipv6Cidr,
-};
+use smoltcp::wire::{EthernetAddress, Ipv6Address};
 use task_net_api::{
     LargePayloadBehavior, RecvError, SendError, SocketName, UdpMetadata,
 };
-use userlib::{sys_post, sys_refresh_task_id};
-
-use crate::generated::{self, SOCKET_COUNT};
-use crate::server::NetServer;
-use crate::{bsp_support, idl, ETH_IRQ, NEIGHBORS, WAKE_IRQ_BIT};
-
-type NeighborStorage = Option<(IpAddress, Neighbor)>;
 
 /// Grabs references to the server storage arrays.  Can only be called once!
-fn claim_server_storage_statics() -> (
-    &'static mut [NeighborStorage; NEIGHBORS],
-    &'static mut [SocketStorage<'static>; SOCKET_COUNT],
-    &'static mut [IpCidr; 1],
-) {
+fn claim_server_storage_statics() -> &'static mut [Storage; 1] {
     mutable_statics! {
-        static mut NEIGHBOR_CACHE_STORAGE: [NeighborStorage; NEIGHBORS] =
-            [|| Default::default(); _];
-        static mut SOCKET_STORAGE: [SocketStorage<'static>; SOCKET_COUNT] =
-            [|| Default::default(); _];
-        static mut IPV6_NET: [IpCidr; 1] = [|| Ipv6Cidr::default().into(); _];
+        static mut STORAGE: [Storage; 1] = [|| Default::default(); _];
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// State for the running network server.
-pub struct ServerImpl<'a, B> {
-    socket_handles: [SocketHandle; SOCKET_COUNT],
-    client_waiting_to_send: [bool; SOCKET_COUNT],
-    iface: Interface<'static, Smol<'a>>,
-    bsp: B,
+pub type ServerImpl<'a, B> = GenServerImpl<'a, B, Smol<'a>, 1>;
+
+pub fn new<'a, B>(
+    eth: &'a eth::Ethernet,
+    ipv6_addr: Ipv6Address,
     mac: EthernetAddress,
+    bsp: B,
+) -> ServerImpl<'a, B>
+where
+    B: bsp_support::Bsp,
+{
+    ServerImpl::new(
+        eth,
+        ipv6_addr,
+        mac,
+        bsp,
+        claim_server_storage_statics(),
+        generated::construct_sockets(),
+        |_| Smol::from(eth),
+    )
 }
 
-impl<'a, B: bsp_support::Bsp> ServerImpl<'a, B> {
-    /// Size of buffer that must be allocated to use `dispatch`.
-    pub const INCOMING_SIZE: usize = idl::INCOMING_SIZE;
-
-    /// Builds a new `ServerImpl`, using the provided storage space.
-    pub fn new(
-        eth: &'a eth::Ethernet,
-        ipv6_addr: Ipv6Address,
-        mac: EthernetAddress,
-        bsp: B,
-    ) -> Self {
-        let eth = Smol::from(eth);
-        let (neighbor_cache_storage, socket_storage, ipv6_net) =
-            claim_server_storage_statics();
-        ipv6_net[0] = Ipv6Cidr::new(ipv6_addr, 64).into();
-        let neighbor_cache =
-            smoltcp::iface::NeighborCache::new(&mut neighbor_cache_storage[..]);
-        let mut iface =
-            smoltcp::iface::InterfaceBuilder::new(eth, &mut socket_storage[..])
-                .hardware_addr(mac.into())
-                .neighbor_cache(neighbor_cache)
-                .ip_addrs(&mut ipv6_net[..])
-                .finalize();
-
-        // Create sockets and associate them with the interface.
-        let sockets = generated::construct_sockets();
-        let mut socket_handles = [None; generated::SOCKET_COUNT];
-        for (socket, h) in sockets.0.into_iter().zip(&mut socket_handles) {
-            *h = Some(iface.add_socket(socket));
-        }
-        let socket_handles = socket_handles.map(|h| h.unwrap());
-        // Bind sockets to their ports.
-        for (&h, &port) in socket_handles.iter().zip(&generated::SOCKET_PORTS) {
-            iface
-                .get_socket::<UdpSocket>(h)
-                .bind((ipv6_addr, port))
-                .map_err(|_| ())
-                .unwrap();
-        }
-
-        Self {
-            socket_handles,
-            client_waiting_to_send: [false; SOCKET_COUNT],
-            iface,
-            bsp,
-            mac,
-        }
-    }
-
-    /// Calls `smoltcp`'s internal poll function on our interface
-    pub(crate) fn poll(&mut self, t: u64) -> smoltcp::Result<crate::Activity> {
-        let ip = self
-            .iface
-            .poll(smoltcp::time::Instant::from_millis(t as i64))?;
-
-        // Test and clear our receive activity flag.
-        let mac_rx = self.iface.device().mac_rx.take();
-
-        Ok(crate::Activity { ip, mac_rx })
-    }
-
-    /// Iterate over sockets, waking any that can do work.
-    pub fn wake_sockets(&mut self) {
-        // There's something to do! Iterate over sockets looking for work.
-        // TODO making every packet O(n) in the number of sockets is super
-        // lame; provide a Waker to fix this.
-        for i in 0..SOCKET_COUNT {
-            let want_to_send = self.client_waiting_to_send[i];
-            let socket = self.get_socket_mut(i).unwrap();
-            if socket.can_recv() || (want_to_send && socket.can_send()) {
-                // Make sure the owner knows about this. This can
-                // technically cause spurious wakeups if the owner is
-                // already waiting in our incoming queue to recv. Maybe we
-                // fix this later.
-                let (task_id, notification) = generated::SOCKET_OWNERS[i];
-                let task_id = sys_refresh_task_id(task_id);
-                sys_post(task_id, notification);
-            }
-        }
-    }
-
-    /// Gets the socket handle for socket `index`. If `index` is out of range,
-    /// returns `BadMessage`.
-    ///
-    /// You often want `get_socket_mut` instead of this, but since it claims
-    /// `self` mutably, it is sometimes useful to inline it by calling this
-    /// followed by `eth.get_socket`.
-    fn get_handle(&self, index: usize) -> Result<SocketHandle, ClientError> {
-        self.socket_handles
-            .get(index)
-            .cloned()
-            .ok_or(ClientError::BadMessageContents)
-    }
-
-    /// Gets the socket `index`. If `index` is out of range, returns
-    /// `BadMessage`.
-    ///
-    /// Sockets are currently assumed to be UDP.
-    fn get_socket_mut(
-        &mut self,
-        index: usize,
-    ) -> Result<&mut UdpSocket<'static>, ClientError> {
-        Ok(self.iface.get_socket::<UdpSocket>(self.get_handle(index)?))
-    }
-
-    /// Calls the `wake` function on the BSP, which handles things like
-    /// periodic logging and monitoring of ports.
-    pub fn wake(&self) {
-        self.bsp.wake(&self.iface.device().eth);
-    }
-}
-
-impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
+impl<B: bsp_support::Bsp> NetServer for GenServerImpl<'_, B, Smol<'_>, 1>
+where
+    B: bsp_support::Bsp,
+{
     type Bsp = B;
 
     /// Requests that a packet waiting in the rx queue of `socket` be delivered
@@ -191,8 +79,8 @@ impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
         }
 
         let socket = self
-            .get_socket_mut(socket_index)
-            .map_err(RequestError::Fail)?;
+            .get_socket_mut(0, socket_index)
+            .ok_or(RequestError::Fail(ClientError::BadMessageContents))?;
         loop {
             match socket.recv() {
                 Ok((body, endp)) => {
@@ -242,18 +130,18 @@ impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
         }
 
         let socket = self
-            .get_socket_mut(socket_index)
-            .map_err(RequestError::Fail)?;
+            .get_socket_mut(0, socket_index)
+            .ok_or(RequestError::Fail(ClientError::BadMessageContents))?;
         match socket.send(payload.len(), metadata.into()) {
             Ok(buf) => {
                 payload
                     .read_range(0..payload.len(), buf)
                     .map_err(|_| RequestError::went_away())?;
-                self.client_waiting_to_send[socket_index] = false;
+                self.set_client_waiting_to_send(socket_index, false);
                 Ok(())
             }
             Err(smoltcp::Error::Exhausted) => {
-                self.client_waiting_to_send[socket_index] = true;
+                self.set_client_waiting_to_send(socket_index, true);
                 Err(SendError::QueueFull.into())
             }
             Err(_e) => {
@@ -261,30 +149,6 @@ impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
                 Err(SendError::Other.into())
             }
         }
-    }
-
-    fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut Self::Bsp) {
-        (&self.iface.device().eth, &mut self.bsp)
-    }
-
-    fn base_mac_address(&self) -> &EthernetAddress {
-        &self.mac
-    }
-}
-
-impl<B> NotificationHandler for ServerImpl<'_, B> {
-    fn current_notification_mask(&self) -> u32 {
-        // We're always listening for our interrupt or the wake (timer) irq
-        ETH_IRQ | 1 << WAKE_IRQ_BIT
-    }
-
-    fn handle_notification(&mut self, bits: u32) {
-        // Interrupt dispatch.
-        if bits & ETH_IRQ != 0 {
-            self.iface.device().eth.on_interrupt();
-            userlib::sys_irq_control(ETH_IRQ, true);
-        }
-        // The wake IRQ is handled in the main `net` loop
     }
 }
 
@@ -294,7 +158,7 @@ impl<B> NotificationHandler for ServerImpl<'_, B> {
 // We gotta newtype the Ethernet driver since we're not in its crate. (This
 // implementation was once in its crate but that became a little gross.)
 
-struct Smol<'d> {
+pub struct Smol<'d> {
     eth: &'d eth::Ethernet,
     mac_rx: Cell<bool>,
 }
@@ -308,7 +172,7 @@ impl<'d> From<&'d eth::Ethernet> for Smol<'d> {
     }
 }
 
-struct OurRxToken<'d>(&'d Smol<'d>);
+pub struct OurRxToken<'d>(&'d Smol<'d>);
 impl<'d> smoltcp::phy::RxToken for OurRxToken<'d> {
     fn consume<R, F>(
         self,
@@ -322,7 +186,7 @@ impl<'d> smoltcp::phy::RxToken for OurRxToken<'d> {
     }
 }
 
-struct OurTxToken<'d>(&'d Smol<'d>);
+pub struct OurTxToken<'d>(&'d Smol<'d>);
 impl<'d> smoltcp::phy::TxToken for OurTxToken<'d> {
     fn consume<R, F>(
         self,
@@ -375,5 +239,11 @@ impl<'d> smoltcp::phy::Device<'d> for Smol<'_> {
 
     fn capabilities(&self) -> smoltcp::phy::DeviceCapabilities {
         crate::ethernet_capabilities(self.eth)
+    }
+}
+
+impl DeviceExt for Smol<'_> {
+    fn read_and_clear_activity_flag(&self) -> bool {
+        self.mac_rx.take()
     }
 }

--- a/task/net/src/server_basic.rs
+++ b/task/net/src/server_basic.rs
@@ -10,14 +10,11 @@ use drv_stm32h7_eth as eth;
 
 use crate::bsp_support;
 use crate::generated;
-use crate::server::{DeviceExt, GenServerImpl, NetServer, Storage};
+use crate::server::{DeviceExt, GenServerImpl, Storage};
 use core::cell::Cell;
-use idol_runtime::{ClientError, RequestError};
 use mutable_statics::mutable_statics;
 use smoltcp::wire::{EthernetAddress, Ipv6Address};
-use task_net_api::{
-    LargePayloadBehavior, RecvError, SendError, SocketName, UdpMetadata,
-};
+use task_net_api::UdpMetadata;
 
 /// Grabs references to the server storage arrays.  Can only be called once!
 fn claim_server_storage_statics() -> &'static mut [Storage; 1] {
@@ -48,108 +45,6 @@ where
         generated::construct_sockets(),
         |_| Smol::from(eth),
     )
-}
-
-impl<B: bsp_support::Bsp> NetServer for GenServerImpl<'_, B, Smol<'_>, 1>
-where
-    B: bsp_support::Bsp,
-{
-    type Bsp = B;
-
-    /// Requests that a packet waiting in the rx queue of `socket` be delivered
-    /// into loaned memory at `payload`.
-    ///
-    /// If a packet is available and fits, copies it into `payload` and returns
-    /// its `UdpMetadata`. Otherwise, leaves `payload` untouched and returns an
-    /// error.
-    fn net_recv_packet(
-        &mut self,
-        msg: &userlib::RecvMessage,
-        socket: SocketName,
-        large_payload_behavior: LargePayloadBehavior,
-        payload: idol_runtime::Leased<idol_runtime::W, [u8]>,
-    ) -> Result<UdpMetadata, RequestError<RecvError>> {
-        let socket_index = socket as usize;
-
-        // Check that the task owns the socket.
-        if generated::SOCKET_OWNERS[socket_index].0.index()
-            != msg.sender.index()
-        {
-            return Err(RecvError::NotYours.into());
-        }
-
-        let socket = self
-            .get_socket_mut(0, socket_index)
-            .ok_or(RequestError::Fail(ClientError::BadMessageContents))?;
-        loop {
-            match socket.recv() {
-                Ok((body, endp)) => {
-                    if payload.len() < body.len() {
-                        match large_payload_behavior {
-                            LargePayloadBehavior::Discard => continue,
-                            // If we add a `::Fail` case, we will need to
-                            // allow for caller retries (possibly by peeking
-                            // on the socket instead of recving)
-                        }
-                    }
-                    payload
-                        .write_range(0..body.len(), body)
-                        .map_err(|_| RequestError::went_away())?;
-
-                    return Ok(UdpMetadata {
-                        port: endp.port,
-                        size: body.len() as u32,
-                        addr: endp.addr.try_into().map_err(|_| ()).unwrap(),
-                    });
-                }
-                Err(smoltcp::Error::Exhausted) => {
-                    return Err(RecvError::QueueEmpty.into());
-                }
-                Err(_) => {
-                    // uhhhh TODO
-                    return Err(RecvError::QueueEmpty.into());
-                }
-            }
-        }
-    }
-
-    /// Requests to copy a packet into the tx queue of socket `socket`,
-    /// described by `metadata` and containing the bytes loaned in `payload`.
-    fn net_send_packet(
-        &mut self,
-        msg: &userlib::RecvMessage,
-        socket: SocketName,
-        metadata: UdpMetadata,
-        payload: idol_runtime::Leased<idol_runtime::R, [u8]>,
-    ) -> Result<(), RequestError<SendError>> {
-        let socket_index = socket as usize;
-        if generated::SOCKET_OWNERS[socket_index].0.index()
-            != msg.sender.index()
-        {
-            return Err(SendError::NotYours.into());
-        }
-
-        let socket = self
-            .get_socket_mut(0, socket_index)
-            .ok_or(RequestError::Fail(ClientError::BadMessageContents))?;
-        match socket.send(payload.len(), metadata.into()) {
-            Ok(buf) => {
-                payload
-                    .read_range(0..payload.len(), buf)
-                    .map_err(|_| RequestError::went_away())?;
-                self.set_client_waiting_to_send(socket_index, false);
-                Ok(())
-            }
-            Err(smoltcp::Error::Exhausted) => {
-                self.set_client_waiting_to_send(socket_index, true);
-                Err(SendError::QueueFull.into())
-            }
-            Err(_e) => {
-                // uhhhh TODO
-                Err(SendError::Other.into())
-            }
-        }
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -245,5 +140,18 @@ impl<'d> smoltcp::phy::Device<'d> for Smol<'_> {
 impl DeviceExt for Smol<'_> {
     fn read_and_clear_activity_flag(&self) -> bool {
         self.mac_rx.take()
+    }
+
+    fn make_meta(
+        &self,
+        port: u16,
+        size: usize,
+        addr: task_net_api::Address,
+    ) -> UdpMetadata {
+        UdpMetadata {
+            port,
+            size: size as u32,
+            addr,
+        }
     }
 }

--- a/task/net/src/server_vlan.rs
+++ b/task/net/src/server_vlan.rs
@@ -10,41 +10,16 @@
 use drv_stm32h7_eth as eth;
 
 use core::cell::Cell;
-use core::iter::zip;
-use heapless::Vec;
-use idol_runtime::{ClientError, NotificationHandler, RequestError};
+use idol_runtime::{ClientError, RequestError};
 use mutable_statics::mutable_statics;
-use smoltcp::iface::{Interface, Neighbor, SocketHandle, SocketStorage};
-use smoltcp::socket::UdpSocket;
-use smoltcp::wire::{
-    EthernetAddress, IpAddress, IpCidr, Ipv6Address, Ipv6Cidr,
-};
+use smoltcp::wire::{EthernetAddress, Ipv6Address};
 use task_net_api::{
     LargePayloadBehavior, RecvError, SendError, SocketName, UdpMetadata,
 };
-use userlib::{sys_post, sys_refresh_task_id, UnwrapLite};
 
-use crate::generated::{self, SOCKET_COUNT, VLAN_COUNT, VLAN_RANGE};
-use crate::server::NetServer;
-use crate::{bsp_support, idl, ETH_IRQ, NEIGHBORS, WAKE_IRQ_BIT};
-
-type NeighborStorage = Option<(IpAddress, Neighbor)>;
-
-struct Storage {
-    neighbors: [NeighborStorage; NEIGHBORS],
-    sockets: [SocketStorage<'static>; SOCKET_COUNT],
-    net: IpCidr,
-}
-
-impl Default for Storage {
-    fn default() -> Self {
-        Self {
-            neighbors: Default::default(),
-            sockets: Default::default(),
-            net: Ipv6Cidr::default().into(),
-        }
-    }
-}
+use crate::bsp_support;
+use crate::generated::{self, VLAN_COUNT, VLAN_RANGE};
+use crate::server::{DeviceExt, GenServerImpl, NetServer, Storage};
 
 /// Grabs references to the server storage arrays.  Can only be called once!
 fn claim_server_storage_statics() -> &'static mut [Storage; VLAN_COUNT] {
@@ -88,6 +63,12 @@ impl<'a, 'b> smoltcp::phy::Device<'a> for VLanEthernet<'b> {
     }
 }
 
+impl DeviceExt for VLanEthernet<'_> {
+    fn read_and_clear_activity_flag(&self) -> bool {
+        self.mac_rx.take()
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct VLanRxToken<'a>(&'a eth::Ethernet, u16);
@@ -123,170 +104,37 @@ impl<'a> smoltcp::phy::TxToken for VLanTxToken<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// State for the running network server
-pub struct ServerImpl<'a, B> {
+pub type ServerImpl<'a, B> = GenServerImpl<'a, B, VLanEthernet<'a>, VLAN_COUNT>;
+
+pub fn new<'a, B>(
     eth: &'a eth::Ethernet,
-
-    vlan_state: [VLanState<'a>; VLAN_COUNT],
-    client_waiting_to_send: [bool; SOCKET_COUNT],
-    bsp: B,
-
+    ipv6_addr: Ipv6Address,
     mac: EthernetAddress,
-}
-
-struct VLanState<'a> {
-    socket_handles: [SocketHandle; SOCKET_COUNT],
-    iface: Interface<'static, VLanEthernet<'a>>,
-}
-
-impl<'a, B: bsp_support::Bsp> ServerImpl<'a, B> {
-    /// Size of buffer that must be allocated to use `dispatch`.
-    pub const INCOMING_SIZE: usize = idl::INCOMING_SIZE;
-
-    /// Builds a new `ServerImpl`, using the provided storage space.
-    pub fn new(
-        eth: &'a eth::Ethernet,
-        mut ipv6_addr: Ipv6Address,
-        mut mac: EthernetAddress,
-        bsp: B,
-    ) -> Self {
-        // Local storage; this will end up owned by the returned ServerImpl.
-        let mut vlan_state: Vec<VLanState, VLAN_COUNT> = Vec::new();
-        let storage = claim_server_storage_statics();
-
-        // Socket definitions from generated code:
-        let sockets: [_; VLAN_COUNT] = generated::construct_sockets().0;
-
-        let start_mac = mac;
-        // Each of these is replicated once per VID. Loop over them in lockstep.
-        for (sockets, storage, vid) in
-            itertools::izip!(sockets, storage, generated::VLAN_RANGE)
-        {
-            // Make some types explicit to try and make this clearer.
-            let sockets: [UdpSocket<'_>; SOCKET_COUNT] = sockets;
-
-            let neighbor_cache =
-                smoltcp::iface::NeighborCache::new(&mut storage.neighbors[..]);
-
-            let builder = smoltcp::iface::InterfaceBuilder::new(
-                VLanEthernet {
-                    eth,
-                    vid,
-                    mac_rx: Cell::new(false),
-                },
-                &mut storage.sockets[..],
-            );
-
-            storage.net = Ipv6Cidr::new(ipv6_addr, 64).into();
-            let mut iface = builder
-                .hardware_addr(mac.into())
-                .neighbor_cache(neighbor_cache)
-                .ip_addrs(core::slice::from_mut(&mut storage.net))
-                .finalize();
-
-            // Associate sockets with this interface.
-            let socket_handles = sockets.map(|s| iface.add_socket(s));
-            // Bind sockets to their ports.
-            for (&h, port) in zip(&socket_handles, generated::SOCKET_PORTS) {
-                iface
-                    .get_socket::<UdpSocket<'_>>(h)
-                    .bind((ipv6_addr, port))
-                    .unwrap_lite();
-            }
-
-            vlan_state
-                .push(VLanState {
-                    socket_handles,
-                    iface,
-                })
-                .unwrap_lite();
-
-            // Increment the MAC and IP addresses so that each VLAN has
-            // a unique address.
-            ipv6_addr.0[15] += 1;
-            mac.0[5] += 1;
-        }
-
-        Self {
+    bsp: B,
+) -> ServerImpl<'a, B>
+where
+    B: bsp_support::Bsp,
+{
+    ServerImpl::new(
+        eth,
+        ipv6_addr,
+        mac,
+        bsp,
+        claim_server_storage_statics(),
+        generated::construct_sockets(),
+        |i| VLanEthernet {
             eth,
-            client_waiting_to_send: [false; SOCKET_COUNT],
-            vlan_state: vlan_state.into_array().unwrap_lite(),
-            bsp,
-            mac: start_mac,
-        }
-    }
-
-    pub(crate) fn poll(&mut self, t: u64) -> smoltcp::Result<crate::Activity> {
-        let t = smoltcp::time::Instant::from_millis(t as i64);
-        // Do not be tempted to use `Iterator::any` here, it short circuits and
-        // we really do want to poll all of them.
-        let mut ip = false;
-        let mut mac_rx = false;
-        for vlan in &mut self.vlan_state {
-            ip |= vlan.iface.poll(t)?;
-            // Test and clear our receive activity flag.
-            mac_rx |= vlan.iface.device().mac_rx.take();
-        }
-
-        Ok(crate::Activity { ip, mac_rx })
-    }
-
-    /// Iterate over sockets, waking any that can do work.  A task can do work
-    /// if all of the (internal) VLAN sockets can receive a packet, since
-    /// we don't know which VLAN it will write to.
-    pub fn wake_sockets(&mut self) {
-        for i in 0..SOCKET_COUNT {
-            if (0..VLAN_COUNT).any(|v| {
-                let want_to_send = self.client_waiting_to_send[i];
-                let socket = self.get_socket_mut(i, v).unwrap();
-                socket.can_recv() || (want_to_send && socket.can_send())
-            }) {
-                let (task_id, notification) = generated::SOCKET_OWNERS[i];
-                let task_id = sys_refresh_task_id(task_id);
-                sys_post(task_id, notification);
-            }
-        }
-    }
-
-    pub fn wake(&self) {
-        self.bsp.wake(self.eth)
-    }
-
-    fn get_handle(
-        &self,
-        index: usize,
-        vlan_index: usize,
-    ) -> Option<SocketHandle> {
-        self.vlan_state
-            .get(vlan_index)?
-            .socket_handles
-            .get(index)
-            .cloned()
-    }
-
-    /// Gets the socket `index`. If `index` is out of range, returns
-    /// `None`. Panics if `vlan_index` is out of range, which should
-    /// never happen (because messages with invalid VIDs are dropped in
-    /// RxRing).
-    ///
-    /// Sockets are currently assumed to be UDP.
-    fn get_socket_mut(
-        &mut self,
-        index: usize,
-        vlan_index: usize,
-    ) -> Option<&mut UdpSocket<'static>> {
-        Some(
-            self.vlan_state[vlan_index]
-                .iface
-                .get_socket::<UdpSocket<'_>>(
-                    self.get_handle(index, vlan_index)?,
-                ),
-        )
-    }
+            vid: generated::VLAN_RANGE.start + i as u16,
+            mac_rx: Cell::new(false),
+        },
+    )
 }
 
 /// Implementation of the Net Idol interface.
-impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
+impl<B> NetServer for ServerImpl<'_, B>
+where
+    B: bsp_support::Bsp,
+{
     type Bsp = B;
 
     /// Requests that a packet waiting in the rx queue of `socket` be delivered
@@ -383,11 +231,11 @@ impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
                 payload
                     .read_range(0..payload.len(), buf)
                     .map_err(|_| RequestError::went_away())?;
-                self.client_waiting_to_send[socket_index] = false;
+                self.set_client_waiting_to_send(socket_index, false);
                 Ok(())
             }
             Err(smoltcp::Error::Exhausted) => {
-                self.client_waiting_to_send[socket_index] = true;
+                self.set_client_waiting_to_send(socket_index, true);
                 Err(SendError::QueueFull.into())
             }
             Err(_e) => {
@@ -395,29 +243,5 @@ impl<B: bsp_support::Bsp> NetServer for ServerImpl<'_, B> {
                 Err(SendError::Other.into())
             }
         }
-    }
-
-    fn eth_bsp(&mut self) -> (&eth::Ethernet, &mut Self::Bsp) {
-        (self.eth, &mut self.bsp)
-    }
-
-    fn base_mac_address(&self) -> &EthernetAddress {
-        &self.mac
-    }
-}
-
-impl<B> NotificationHandler for ServerImpl<'_, B> {
-    fn current_notification_mask(&self) -> u32 {
-        // We're always listening for our interrupt or the wake (timer) irq
-        ETH_IRQ | 1 << WAKE_IRQ_BIT
-    }
-
-    fn handle_notification(&mut self, bits: u32) {
-        // Interrupt dispatch.
-        if bits & ETH_IRQ != 0 {
-            self.eth.on_interrupt();
-            userlib::sys_irq_control(ETH_IRQ, true);
-        }
-        // The wake IRQ is handled in the main `net` loop
     }
 }


### PR DESCRIPTION
These commits...

- Formalize the relationship of the BSP modules with the rest of the netstack by defining a `Bsp` trait
- Simplify the `server_vlan` setup code to do less parallel array iteration and asserting
- Make the `server_vlan` implementation the sole implementation, by treating the VLAN-less case as a degenerate single-network case of the VLAN server.

This reduces code duplication and opportunities for divergence, and makes it easier to reason about whether non-target-specific code (like `src/main.rs`) will work with all the various platform-specific bits (since it only needs to be checked against traits and concrete implementations now).