### PR TITLE
Add graph module to xtask to create task priority graphs

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -201,6 +201,43 @@ requires = {flash = 1024, ram = 1024}
 start = true
 ```
 
+## Graphing task relationships and priorities
+
+A graph can be generated that show the relationships of the various tasks
+and their priorities. The resulting file is in [Graphvis](https://grahviz.org)'s
+`dot` format. `Dot` source [can be included](https://docs.asciidoctor.org/diagram-extension/latest/) in [Asciidoctor](https://asciidoctor.org) source
+or rendered to a variety of formats.
+
+To create and view an SVG graph for `gimletlet` on Ubuntu, ensure that the `graphviz` package is installed. Then generate the graph:
+
+```console
+$ cargo xtask graph -o gimletlet.dot app/gimletlet/app.toml
+$ dot -Tsvg gimletlet.dot > gimletlet.svg
+$ xdg-open gimletlet.svg
+```
+
+### Generating all graphs under Linux
+
+Bash commands to generate all graphs:
+
+```console
+  APPS=( $(find app -name '*.toml' ! -name Cargo.toml) )
+  for app in "${APPS[@]}"
+  do
+    out=$(basename ${app//\//_} .toml).dot
+    svg=$(basename $out .dot).svg
+    cargo xtask graph -o $out $app
+    dot -Tsvg $out > $svg
+  done
+  first="${APPS[0]}"
+  out="$(basename ${first//\//_} .toml).dot"
+  svg="$(basename $out .dot).svg"
+  xdg-open "${svg}"
+```
+
+If `eog` is the default viewer, opening the first SVG in a directory will
+allow cycling through all of the available graphs using the same window.
+
 # Using Hubris
 Hubris is tightly coupled to its debugger,
 [Humility](https://github.com/oxidecomputer/humility),

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -1,11 +1,10 @@
 name = "gimletlet-sidecar-emulator"
 target = "thumbv7em-none-eabihf"
 board = "gimletlet-2"
-chip = "../../chips/stm32h7.toml"
+chip = "../../chips/stm32h7"
 stacksize = 896
 
 [kernel]
-path = "."
 name = "gimletlet"
 requires = {flash = 32768, ram = 4096}
 #
@@ -20,11 +19,7 @@ requires = {flash = 32768, ram = 4096}
 #
 features = ["itm"]
 
-[supervisor]
-notification = 1
-
 [tasks.jefe]
-path = "../../task/jefe"
 name = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
@@ -37,7 +32,6 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-path = "../../drv/stm32xx-sys"
 name = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
@@ -47,7 +41,6 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.i2c_driver]
-path = "../../drv/stm32xx-i2c-server"
 name = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 2
@@ -63,7 +56,6 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spi_driver]
-path = "../../drv/stm32h7-spi-server"
 name = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
@@ -78,7 +70,6 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.user_leds]
-path = "../../drv/user-leds"
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
@@ -87,7 +78,6 @@ start = true
 task-slots = ["sys"]
 
 [tasks.pong]
-path = "../../task/pong"
 name = "task-pong"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
@@ -95,7 +85,6 @@ start = true
 task-slots = ["user_leds"]
 
 [tasks.hiffy]
-path = "../../task/hiffy"
 name = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
@@ -105,7 +94,6 @@ start = true
 task-slots = ["sys", "i2c_driver", "user_leds"]
 
 [tasks.fpga]
-path = "../../drv/fpga-server"
 name = "drv-fpga-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
@@ -115,14 +103,12 @@ start = true
 task-slots = ["sys", "spi_driver"]
 
 [tasks.i2c_emulator]
-path = "../../drv/sidecar-mainboard-i2c-emulator"
 name = "drv-sidecar-mainboard-i2c-emulator"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 start = true
 
 [tasks.sequencer]
-path = "../../drv/sidecar-seq-server"
 name = "drv-sidecar-seq-server"
 features = []
 priority = 4
@@ -132,7 +118,6 @@ start = true
 task-slots = ["sys", {i2c_driver = "i2c_emulator"}, "fpga", "spi_driver"]
 
 [tasks.idle]
-path = "../../task/idle"
 name = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 256}
@@ -176,7 +161,6 @@ controller = 4
 [[config.i2c.controllers.ports.F.pins]]
 pins = [ 14, 15 ]
 af = 4
-
 
 [config.spi.spi3]
 controller = 3

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -51,9 +51,6 @@ struct PackageConfig {
     /// Run `cargo tree --edges` before compiling, to show dependencies
     edges: bool,
 
-    /// Generate a task priority graph in dot syntax.
-    graph: Option<PathBuf>,
-
     /// Directory where the build artifacts are placed, in the form
     /// `target/$NAME/dist`.
     dist_dir: PathBuf,
@@ -75,12 +72,7 @@ struct PackageConfig {
 }
 
 impl PackageConfig {
-    fn new(
-        app_toml_file: &Path,
-        verbose: bool,
-        edges: bool,
-        graph: Option<PathBuf>,
-    ) -> Result<Self> {
+    fn new(app_toml_file: &Path, verbose: bool, edges: bool) -> Result<Self> {
         let toml = Config::from_file(app_toml_file)?;
         let dist_dir = Path::new("target").join(&toml.name).join("dist");
         let app_src_dir = app_toml_file
@@ -115,18 +107,12 @@ impl PackageConfig {
             file_data.hash(&mut extra_hash);
         }
 
-        let graph = match graph {
-            Some(graph) => Some(graph.to_path_buf()),
-            None => None,
-        };
-
         Ok(Self {
             app_toml_file: app_toml_file.to_path_buf(),
             app_src_dir: app_src_dir.to_path_buf(),
             toml,
             verbose,
             edges,
-            graph,
             dist_dir,
             sysroot,
             host_triple,
@@ -213,16 +199,11 @@ type AllocationMap = (Allocations, IndexMap<String, Range<u32>>);
 pub fn package(
     verbose: bool,
     edges: bool,
-    graph: Option<PathBuf>,
     app_toml: &Path,
     tasks_to_build: Option<Vec<String>>,
     dirty_ok: bool,
 ) -> Result<BTreeMap<String, AllocationMap>> {
-    let cfg = PackageConfig::new(app_toml, verbose, edges, graph)?;
-
-    if cfg.graph.is_some() {
-        task_graph(&cfg.toml, cfg.graph.as_ref().unwrap().as_path())?;
-    }
+    let cfg = PackageConfig::new(app_toml, verbose, edges)?;
 
     // If we're using filters, we change behavior at the end. Record this in a
     // convenient flag, running other checks as well.
@@ -1147,73 +1128,6 @@ fn check_task_priorities(toml: &Config) -> Result<()> {
             bail!("Task {} is not the supervisor, but has priority 0", name,);
         }
     }
-
-    Ok(())
-}
-
-/// Prints warning messages about priority inversions
-fn task_graph(toml: &Config, path: &Path) -> Result<()> {
-    // Generate dot syntax for a graph of process priorities.
-    // Collect each task in a priority group
-    // Collect each edge
-    let mut priorities = BTreeMap::new();
-    let mut edges = Vec::new();
-    let mut dot = File::create(path)?;
-
-    #[derive(Debug)]
-    struct Edge<'a> {
-        from: &'a String,
-        to: &'a String,
-        inverted: bool,
-    }
-
-    // let idle_priority = toml.tasks["idle"].priority;
-    for (_i, (name, task)) in toml.tasks.iter().enumerate() {
-        if !priorities.contains_key(&task.priority) {
-            // priorities.insert(task.priority, &mut Box::<Vec::<String>>::new(Vec::<String>{}));
-            priorities.insert(task.priority, Vec::new());
-        }
-        if let Some(v) = priorities.get_mut(&task.priority) {
-            v.push(name.to_string());
-        }
-        for callee in task.task_slots.values() {
-            let p = toml
-                .tasks
-                .get(callee)
-                .ok_or_else(|| anyhow!("Invalid task-slot: {}", callee))?
-                .priority;
-            let inverted = p >= task.priority && name != callee;
-            edges.push(Edge {
-                from: &name,
-                to: &callee,
-                inverted,
-            });
-        }
-    }
-
-    write!(dot, "digraph tasks {{\n")?;
-    for key in priorities.keys() {
-        if let Some(v) = priorities.get(key) {
-            write!(dot, "  {{\n    edge [ style=invis ];\n    rank=same;\n")?;
-            for name in v {
-                write!(
-                    dot,
-                    "    {} [ label=\"{}\\n{}\", shape=box ];\n",
-                    name, name, key
-                )?;
-            }
-            write!(dot, "  }}\n")?;
-        }
-    }
-    for edge in edges {
-        let attr = if edge.inverted {
-            " [color=red, penwidth=3]"
-        } else {
-            " [color=green]"
-        };
-        write!(dot, "  {} -> {}{};\n", edge.from, edge.to, attr)?;
-    }
-    write!(dot, "}}\n")?;
 
     Ok(())
 }

--- a/build/xtask/src/graph.rs
+++ b/build/xtask/src/graph.rs
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs::File;
+use std::hash::Hash;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use crate::config::Config;
+
+/// Generate a directed graph of task priorities and task_slot
+/// dependencies.
+pub fn task_graph(app_toml: &Path, path: &Path) -> Result<()> {
+    // Generate dot syntax for a graph of process priorities.
+    // Collect each task in a priority group
+    // Collect each edge
+    let mut priorities = BTreeMap::new();
+    let mut edges = Vec::new();
+    let mut dot = File::create(path)?;
+    let mut ranks = HashSet::new();
+    let toml = Config::from_file(app_toml)?;
+
+    #[derive(Debug)]
+    struct Edge<'a> {
+        from: &'a String,
+        to: &'a String,
+        inverted: bool,
+    }
+
+    #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+    struct Rank {
+        from: u8,
+        to: u8,
+    }
+
+    for (_i, (name, task)) in toml.tasks.iter().enumerate() {
+        if !priorities.contains_key(&task.priority) {
+            priorities.insert(task.priority, Vec::new());
+        }
+        if let Some(v) = priorities.get_mut(&task.priority) {
+            v.push(name.to_string());
+        }
+        for callee in task.task_slots.values() {
+            let p = toml
+                .tasks
+                .get(callee)
+                .ok_or_else(|| anyhow!("Invalid task-slot: {}", callee))?
+                .priority;
+            let inverted = p >= task.priority && name != callee;
+            edges.push(Edge {
+                from: &name,
+                to: &callee,
+                inverted,
+            });
+            let rank = Rank {
+                from: task.priority,
+                to: p,
+            };
+            if !ranks.contains::<Rank>(&rank) {
+                ranks.insert(rank);
+            }
+        }
+    }
+
+    writeln!(dot, "digraph tasks {{")?;
+    writeln!(
+        dot,
+        "  labelloc=\"t\";\n  label=\"{}\";",
+        toml.app_toml_path.display()
+    )?;
+    for key in priorities.keys() {
+        if let Some(v) = priorities.get(key) {
+            writeln!(dot, "  {{\n    edge [ style=invis ];\n    rank=same;")?;
+            for name in v {
+                writeln!(
+                    dot,
+                    "    {} [ label=\"{}\\n{}\", shape=box ];",
+                    name, name, key
+                )?;
+            }
+            writeln!(dot, "  }}")?;
+        }
+    }
+    for edge in edges {
+        let attr = if edge.inverted {
+            " [color=red, penwidth=3]"
+        } else {
+            " [color=green]"
+        };
+        writeln!(dot, "  {} -> {}{};", edge.from, edge.to, attr)?;
+    }
+    let keys: Vec<&u8> = priorities.keys().collect();
+    let mut first = false;
+    for low_high in keys.windows(2) {
+        let low = low_high[0];
+        let high = low_high[1];
+        if !ranks.contains::<Rank>(&Rank {
+            from: *high,
+            to: *low,
+        }) {
+            if !first {
+                first = true;
+                writeln!(
+                    dot,
+                    "\n  # Force row ranking by priorities {:?}",
+                    keys
+                )?;
+            }
+            writeln!(dot, "  # Adding {} -> {}", high, low)?;
+            let high_name = &priorities.get(high).unwrap()[0];
+            let low_name = &priorities.get(low).unwrap()[0];
+            writeln!(dot, "  {} -> {} [style=invis];", high_name, low_name)?;
+        }
+    }
+    writeln!(dot, "}}")?;
+
+    Ok(())
+}


### PR DESCRIPTION
A graph of tasks is created. Each task is labeled with its name and priority in a box. Task slot relationships are represented by arrows. Priority inversions are noted with a red arrow. Normal dependencies are green arrows.

Use:

	cargo xtask dist --graph priority.dot $APP
	# There are several utilities to work with Graphviz's files.
	# On Ubuntu:
	sudo apt install graphviz xdg-utils eog
	dot -Tsvg priority.got
	xdg-open priority.svg