### PR TITLE
Redesign build system kernel config structs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-kconfig"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "build-lpc55pins"
 version = "0.1.0"
 dependencies = [
@@ -1887,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heapless"
@@ -2095,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2132,11 +2140,13 @@ dependencies = [
  "abi",
  "anyhow",
  "bitflags",
+ "build-kconfig",
  "build-util",
  "byteorder",
  "call_rustfmt",
  "cfg-if",
  "cortex-m",
+ "indexmap",
  "phash",
  "phash-gen",
  "proc-macro2",
@@ -3143,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -3161,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4476,6 +4486,7 @@ dependencies = [
  "abi",
  "anyhow",
  "atty",
+ "build-kconfig",
  "byteorder",
  "cargo_metadata",
  "clap",

--- a/build/kconfig/Cargo.toml
+++ b/build/kconfig/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "build-kconfig"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitflags = "1.3.2"
+serde = { version = "1.0.147", features = ["derive"] }

--- a/build/kconfig/README.mkdn
+++ b/build/kconfig/README.mkdn
@@ -1,0 +1,8 @@
+# Kernel configuration data structures
+
+This module provides types used within the build system to transfer the
+kernel/image configuration from the image builder into the kernel's own build
+script, from which kernel tables and data structures can be generated.
+
+This exists to decouple the kernel's internal representation of these data
+structures from the build system.

--- a/build/kconfig/src/lib.rs
+++ b/build/kconfig/src/lib.rs
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Application configuration passed into the kernel build.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KernelConfig {
+    /// Tasks in the app image. The order of tasks is significant.
+    pub tasks: Vec<TaskConfig>,
+
+    /// Regions that tasks have shared access to, keyed by the name the task
+    /// config used to grant access (often peripheral name). These are typically
+    /// memory mapped peripherals.
+    pub shared_regions: BTreeMap<String, RegionConfig>,
+
+    /// Interrupts hooked by the application, keyed by IRQ number.
+    pub irqs: BTreeMap<u32, InterruptConfig>,
+}
+
+/// Configuration for a single hooked interrupt.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Hash,
+    Ord,
+    PartialOrd,
+)]
+pub struct InterruptConfig {
+    /// Index of task (in the application task array) that receives this
+    /// interrupt.
+    pub task_index: usize,
+    /// Notification bits that are posted to the task when the interrupt fires.
+    /// Note that this is a mask and can have multiple (or zero!) bits set; the
+    /// kernel doesn't really care.
+    pub notification: u32,
+}
+
+/// Record describing a single task.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskConfig {
+    /// Named memory regions that this task has exclusive access to, keyed by
+    /// name.
+    ///
+    /// The name is the "output" assignment that generated this region,
+    /// typically (but not necessarily!) either `"ram"` or `"flash"`.
+    pub owned_regions: BTreeMap<String, RegionConfig>,
+
+    /// Names of regions (in the app-level `shared_regions`) that this task
+    /// needs access to.
+    pub shared_regions: BTreeSet<String>,
+
+    /// Address of the task's entry point. This is the first instruction that
+    /// will be executed whenever the task is (re)started.
+    pub entry_point: OwnedAddress,
+
+    /// Address of the task's initial stack pointer, to be loaded at (re)start.
+    /// It must be pointing into or *just past* one of the task's memory
+    /// regions.
+    pub initial_stack: OwnedAddress,
+
+    /// Initial priority of this task.
+    pub priority: u8,
+
+    /// Should this task be started automatically on boot?
+    pub start_at_boot: bool,
+}
+
+/// An address within an owned region of memory.
+///
+/// Certain analyses benefit from being able to tell that an address like a
+/// stack pointer points into a particular class of memory region. While we
+/// could determine this by e.g. comparing the address to all memory regions,
+/// this type explicitly encodes the intended relationship between an address
+/// and region, simplifying the analysis.
+///
+/// Note that an `OwnedAddress` can encode an offset that is out of range for
+/// the region. This is an error and should be rejected. As a special case,
+/// certain applications (particularly stack pointers) accept an "off the end"
+/// address in a region, since the address will not be directly dereferenced.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OwnedAddress {
+    /// Name of region in the task's `owned_regions` table.
+    pub region_name: String,
+    /// Offset within the region.
+    pub offset: u32,
+}
+
+/// Description of one memory region.
+///
+/// A memory region spans a range of physical addresses, and applies access
+/// permissions to whatever lies in that range. Despite our use of the term
+/// "memory" here, the region may not describe RAM -- ROM and memory-mapped
+/// peripherals are also described by memory regions.
+///
+/// A memory region can be used by multiple tasks. This is mostly used to have
+/// tasks share a no-access region (often index 0) in unused region slots, but
+/// you could also use it for shared peripheral or RAM access.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct RegionConfig {
+    /// Address of start of region. The platform likely has alignment
+    /// requirements for this; it must meet them. (For example, on ARMv7-M, it
+    /// must be naturally aligned for the size.)
+    pub base: u32,
+    /// Size of region, in bytes. The platform likely has alignment requirements
+    /// for this; it must meet them. (For example, on ARMv7-M, it must be a
+    /// power of two greater than 16.)
+    pub size: u32,
+    /// Flags describing what can be done with this region.
+    pub attributes: RegionAttributes,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct RegionAttributes {
+    /// Region can be read by tasks that include it.
+    pub read: bool,
+    /// Region can be written by tasks that include it.
+    pub write: bool,
+    /// Region can contain executable code for tasks that include it.
+    pub execute: bool,
+    /// Special role assigned to this region, if any. This controls cache
+    /// behavior, among other things.
+    pub special_role: Option<SpecialRole>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum SpecialRole {
+    /// Region contains memory mapped registers. This affects cache behavior
+    /// on devices that include it, and discourages the kernel from using
+    /// `memcpy` in the region.
+    Device,
+    /// Region can be used for DMA or communication with other processors.
+    /// This heavily restricts how this memory can be cached and will hurt
+    /// performance if overused.
+    Dma,
+}

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -30,6 +30,7 @@ tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
 tlvc-text = {git = "https://github.com/oxidecomputer/tlvc"}
 gnarle = {path = "../../lib/gnarle", features=["std"]}
 sha3 = {version = "0.10", default-features = false}
+build-kconfig = {path = "../kconfig"}
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
 # on the version that works for us
 zip = "=0.5.6"

--- a/lib/phash/src/lib.rs
+++ b/lib/phash/src/lib.rs
@@ -11,6 +11,12 @@ pub trait PerfectHash {
     fn phash(&self, b: u32) -> usize;
 }
 
+impl PerfectHash for u32 {
+    fn phash(&self, b: u32) -> usize {
+        self.wrapping_mul(b) as usize
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct PerfectHashMap<'a, K, V> {

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kern"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 abi = {path = "../abi"}
@@ -26,6 +26,8 @@ proc-macro2 = "1.0.32"
 syn = { version = "1.0.94", features = ["parsing"] }
 quote = "1.0.10"
 call_rustfmt = {path = "../../build/call_rustfmt"}
+build-kconfig = {path = "../../build/kconfig"}
+indexmap = "1.9.1"
 
 [lib]
 test = false

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -6,18 +6,342 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 
-use abi::{InterruptNum, InterruptOwner};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use build_kconfig::{
+    InterruptConfig, KernelConfig, OwnedAddress, RegionAttributes,
+    RegionConfig, SpecialRole,
+};
+use indexmap::IndexMap;
 use proc_macro2::TokenStream;
-use serde::Deserialize;
 
 fn main() -> Result<()> {
     build_util::expose_m_profile();
 
+    let g = process_config()?;
+
     generate_consts()?;
-    generate_statics()?;
+    generate_statics(&g)?;
 
     Ok(())
+}
+
+struct Generated {
+    tasks: Vec<TokenStream>,
+    regions: Vec<TokenStream>,
+    irq_code: TokenStream,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+enum RegionKey {
+    Null,
+    Shared(String),
+    Owned(usize, String),
+}
+
+fn process_config() -> Result<Generated> {
+    let kconfig: KernelConfig =
+        ron::de::from_str(&build_util::env_var("HUBRIS_KCONFIG")?)
+            .context("parsing kconfig from HUBRIS_KCONFIG")?;
+
+    // The kconfig data structure keeps things somewhat abstract to give us, the
+    // kernel, more freedom about our internal implementation choices. However,
+    // this means we have to do some preprocessing before it's useful.
+
+    // The kernel currently uses a flat region descriptor table, and tasks get
+    // pointers into that table. Let's assemble that flat table. By putting the
+    // regions into an IndexMap, we make their locations findable (using a
+    // RegionKey) while also creating a predictable ordering.
+
+    let mut region_table = IndexMap::new();
+
+    // We reserve the first entry (index 0) for the "null" region. This gives no
+    // access, and plays the important role of intercepting null pointer
+    // dereferences _in the kernel._
+    region_table.insert(
+        RegionKey::Null,
+        RegionConfig {
+            base: 0,
+            size: 32,
+            attributes: RegionAttributes {
+                read: false,
+                write: false,
+                execute: false,
+                special_role: None,
+            },
+        },
+    );
+
+    // We'll do the shared bits next.
+    for (name, region) in &kconfig.shared_regions {
+        region_table.insert(RegionKey::Shared(name.clone()), *region);
+    }
+
+    // Finally, the task-specific regions.
+    for (i, task) in kconfig.tasks.iter().enumerate() {
+        for (name, region) in &task.owned_regions {
+            region_table.insert(RegionKey::Owned(i, name.clone()), *region);
+        }
+    }
+
+    // We are done mutating this.
+    let region_table = region_table;
+
+    // Now, generate the TaskDesc literals. These rely on the region table
+    // because they address it by index at the moment.
+    let mut task_descs = vec![];
+
+    for (i, task) in kconfig.tasks.iter().enumerate() {
+        // Work out the region indices for each of this task's regions.
+        let mut regions = vec![
+            // Always include the null region.
+            region_table.get_index_of(&RegionKey::Null).unwrap() as u8,
+        ];
+
+        for name in task.owned_regions.keys() {
+            regions.push(
+                region_table
+                    .get_index_of(&RegionKey::Owned(i, name.clone()))
+                    .unwrap() as u8,
+            );
+        }
+
+        for name in &task.shared_regions {
+            regions.push(
+                region_table
+                    .get_index_of(&RegionKey::Shared(name.clone()))
+                    .unwrap() as u8,
+            );
+        }
+
+        if regions.len() > 8 {
+            bail!("too many regions ({}) for task {}", regions.len(), i);
+        }
+        regions.resize(8, 0u8);
+
+        // Translate abstract addresses in the task description into concrete
+        // addresses.
+        let entry_point =
+            translate_address(&region_table, i, task.entry_point.clone());
+        let initial_stack =
+            translate_address(&region_table, i, task.initial_stack.clone());
+
+        let index = u16::try_from(i).expect("over 2**16 tasks??");
+        let priority = task.priority;
+        let flags = if task.start_at_boot {
+            quote::quote! { abi::TaskFlags::START_AT_BOOT }
+        } else {
+            quote::quote! { abi::TaskFlags::empty() }
+        };
+        task_descs.push(quote::quote! {
+            abi::TaskDesc {
+                regions: [#(#regions),*],
+                entry_point: #entry_point,
+                initial_stack: #initial_stack,
+                priority: #priority,
+                index: #index,
+                flags: #flags,
+            }
+        });
+    }
+
+    let region_descs = region_table
+        .into_iter()
+        .map(|(_k, region)| fmt_region(&region))
+        .collect();
+
+    // Now, we generate two mappings:
+    //  irq num => abi::Interrupt
+    //  (task, notifications) => abi::InterruptSet
+    //
+    // The first table allows for efficient implementation of the default
+    // interrupt handler, which needs to look up the task corresponding with a
+    // given interrupt.
+    //
+    // The second table allows for efficient implementation of `irq_control`,
+    // where a task enables or disables one or more IRQS based on notification
+    // masks.
+    //
+    // The form of the mapping will depend on the target architecture, below.
+    let irq_task_map = kconfig
+        .irqs
+        .iter()
+        .map(|(&k, &v)| (k, v))
+        .collect::<Vec<_>>();
+
+    let mut per_task_irqs: HashMap<_, Vec<_>> = HashMap::new();
+    for (irq, cfg) in &kconfig.irqs {
+        let o = abi::InterruptOwner {
+            task: cfg.task_index as u32,
+            notification: cfg.notification,
+        };
+        per_task_irqs.entry(o).or_default().push(*irq)
+    }
+    let task_irq_map = per_task_irqs.into_iter().collect::<Vec<_>>();
+
+    let target = build_util::target();
+    let irq_code = if target.starts_with("thumbv6m") {
+        // On ARMv6-M we have no hardware division, which the perfect hash table
+        // relies on (to get efficient integer remainder). Fall back to a good
+        // old sorted list with binary search instead.
+        //
+        // This means our dispatch time for interrupts on ARMv6-M is O(log N)
+        // instead of O(1), but these parts also tend to have few interrupts,
+        // so, not the end of the world.
+
+        let task_irq_map = phash_gen::OwnedSortedList::build(task_irq_map)
+            .context("building task-to-IRQ map")?;
+        let irq_task_map = phash_gen::OwnedSortedList::build(irq_task_map)
+            .context("building IRQ-to-task map")?;
+
+        // Generate text for the Interrupt and InterruptSet tables stored in the
+        // sorted lists
+        let irq_task_literal = fmt_sorted_list(&irq_task_map, fmt_irq_task);
+        let task_irq_literal = fmt_sorted_list(&task_irq_map, fmt_task_irq);
+
+        quote::quote! {
+            pub const HUBRIS_IRQ_TASK_LOOKUP:
+                phash::SortedList<abi::InterruptNum, abi::InterruptOwner>
+                = #irq_task_literal;
+            pub const HUBRIS_TASK_IRQ_LOOKUP:
+                phash::SortedList<
+                abi::InterruptOwner,
+                &'static [abi::InterruptNum],
+                > = #task_irq_literal;
+        }
+    } else if target.starts_with("thumbv7m")
+        || target.starts_with("thumbv7em")
+        || target.starts_with("thumbv8m")
+    {
+        // First, try to build it as a single-level perfect hash map, which is
+        // cheaper but won't always succeed.
+        let map1 = if let Ok(task_irq_map) =
+            phash_gen::OwnedPerfectHashMap::build(task_irq_map.clone())
+        {
+            let map_literal =
+                fmt_perfect_hash_map(&task_irq_map, fmt_opt_task_irq);
+            quote::quote! {
+                pub const HUBRIS_TASK_IRQ_LOOKUP:
+                    phash::PerfectHashMap<
+                    '_,
+                    abi::InterruptOwner,
+                    &'static [abi::InterruptNum],
+                    > = #map_literal;
+            }
+        } else {
+            // Single-level perfect hash failed, make it work with a nested map.
+            let task_irq_map =
+                phash_gen::OwnedNestedPerfectHashMap::build(task_irq_map)
+                    .context("building task-to-IRQ perfect hash")?;
+            let task_irq_literal =
+                fmt_nested_perfect_hash_map(&task_irq_map, fmt_opt_task_irq);
+            quote::quote! {
+                pub const HUBRIS_TASK_IRQ_LOOKUP:
+                    phash::NestedPerfectHashMap<
+                    abi::InterruptOwner,
+                    &'static [abi::InterruptNum],
+                    > = #task_irq_literal;
+            }
+        };
+
+        // And now repeat the process for the IRQ-to-task direction.
+        let map2 = if let Ok(irq_task_map) =
+            phash_gen::OwnedPerfectHashMap::build(irq_task_map.clone())
+        {
+            let map_literal =
+                fmt_perfect_hash_map(&irq_task_map, fmt_opt_irq_task);
+            quote::quote! {
+                pub const HUBRIS_IRQ_TASK_LOOKUP:
+                    phash::PerfectHashMap<
+                    '_,
+                    abi::InterruptNum,
+                    abi::InterruptOwner,
+                    > = #map_literal;
+            }
+        } else {
+            let irq_task_map =
+                phash_gen::OwnedNestedPerfectHashMap::build(irq_task_map)
+                    .context("building IRQ-to-task perfect hash")?;
+            let map_literal =
+                fmt_nested_perfect_hash_map(&irq_task_map, fmt_opt_irq_task);
+            quote::quote! {
+                pub const HUBRIS_IRQ_TASK_LOOKUP:
+                    phash::NestedPerfectHashMap<
+                    abi::InterruptNum,
+                    abi::InterruptOwner,
+                    > = #map_literal;
+            }
+        };
+
+        quote::quote! {
+            #map1
+            #map2
+        }
+    } else {
+        panic!("Don't know the target {}", target);
+    };
+
+    Ok(Generated {
+        tasks: task_descs,
+        regions: region_descs,
+        irq_code,
+    })
+}
+
+fn translate_address(
+    region_table: &IndexMap<RegionKey, RegionConfig>,
+    task_index: usize,
+    address: OwnedAddress,
+) -> u32 {
+    let key = RegionKey::Owned(task_index, address.region_name);
+    region_table[&key].base + address.offset
+}
+
+fn fmt_region(region: &RegionConfig) -> TokenStream {
+    let RegionConfig {
+        base,
+        size,
+        attributes,
+    } = region;
+
+    let mut atts = vec![];
+    if attributes.read {
+        atts.push(quote::quote! { READ });
+    }
+    if attributes.write {
+        atts.push(quote::quote! { WRITE });
+    }
+    if attributes.execute {
+        atts.push(quote::quote! { EXECUTE });
+    }
+    if let Some(role) = attributes.special_role {
+        atts.push(match role {
+            SpecialRole::Device => quote::quote! { DEVICE },
+            SpecialRole::Dma => quote::quote! { DMA },
+        });
+    }
+
+    let atts = if atts.is_empty() {
+        quote::quote! { abi::RegionAttributes::empty() }
+    } else {
+        // We have to do the OR-ing on bits and then from_bits_unchecked it
+        // because these operations are const, while OR-ing of the
+        // RegionAttributes type itself is not (pending const impl stability)
+        quote::quote! {
+            unsafe {
+                abi::RegionAttributes::from_bits_unchecked(
+                    #(abi::RegionAttributes::#atts.bits())|*
+                )
+            }
+        }
+    };
+
+    quote::quote! {
+        abi::RegionDesc {
+            base: #base,
+            size: #size,
+            attributes: #atts,
+        }
+    }
 }
 
 fn generate_consts() -> Result<()> {
@@ -62,13 +386,10 @@ fn generate_consts() -> Result<()> {
     Ok(())
 }
 
-fn generate_statics() -> Result<()> {
+fn generate_statics(gen: &Generated) -> Result<()> {
     let image_id: u64 = build_util::env_var("HUBRIS_IMAGE_ID")?
         .parse()
         .context("parsing HUBRIS_IMAGE_ID")?;
-    let kconfig: KernelConfig =
-        ron::de::from_str(&build_util::env_var("HUBRIS_KCONFIG")?)
-            .context("parsing kconfig from HUBRIS_KCONFIG")?;
 
     let out = build_util::out_dir();
     let kconfig_path = out.join("kconfig.rs");
@@ -80,14 +401,14 @@ fn generate_statics() -> Result<()> {
     /////////////////////////////////////////////////////////
     // Basic constants and empty space
 
-    let task_count = kconfig.tasks.len();
+    let task_count = gen.tasks.len();
     writeln!(
         file,
         "{}",
         quote::quote! {
+            const HUBRIS_TASK_COUNT: usize = #task_count;
             #[no_mangle]
             pub static HUBRIS_IMAGE_ID: u64 = #image_id;
-            const HUBRIS_TASK_COUNT: usize = #task_count;
 
             static mut HUBRIS_TASK_TABLE_SPACE:
                 core::mem::MaybeUninit<[crate::task::Task; HUBRIS_TASK_COUNT]> =
@@ -103,31 +424,7 @@ fn generate_statics() -> Result<()> {
     /////////////////////////////////////////////////////////
     // Task descriptors
 
-    let mut task_descs = vec![];
-    for task in &kconfig.tasks {
-        let abi::TaskDesc {
-            regions,
-            entry_point,
-            initial_stack,
-            priority,
-            index,
-            ..
-        } = task;
-        let flags_bits = task.flags.bits();
-        task_descs.push(quote::quote! {
-            abi::TaskDesc {
-                regions: [
-                    #(#regions,)*
-                ],
-                entry_point: #entry_point,
-                initial_stack: #initial_stack,
-                priority: #priority,
-                index: #index,
-                flags: unsafe { abi::TaskFlags::from_bits_unchecked(#flags_bits) },
-            }
-        });
-    }
-
+    let task_descs = &gen.tasks;
     writeln!(
         file,
         "{}",
@@ -142,31 +439,14 @@ fn generate_statics() -> Result<()> {
     /////////////////////////////////////////////////////////
     // Region descriptors
 
-    let mut region_descs = vec![];
-    for region in &kconfig.regions {
-        let abi::RegionDesc {
-            base,
-            size,
-            attributes,
-        } = region;
-        let attbits = attributes.bits();
-        region_descs.push(quote::quote! {
-            abi::RegionDesc {
-                base: #base,
-                size: #size,
-                attributes: unsafe {
-                    abi::RegionAttributes::from_bits_unchecked(#attbits)
-                },
-            }
-        });
-    }
-    let region_count = kconfig.regions.len();
+    let regions = &gen.regions;
+    let region_count = regions.len();
     writeln!(
         file,
         "{}",
         quote::quote! {
             static HUBRIS_REGION_DESCS: [abi::RegionDesc; #region_count] = [
-                #(#region_descs,)*
+                #(#regions,)*
             ];
         },
     )?;
@@ -174,147 +454,7 @@ fn generate_statics() -> Result<()> {
     /////////////////////////////////////////////////////////
     // Interrupt table
 
-    // Now, we generate two mappings:
-    //  irq num => abi::Interrupt
-    //  (task, notifications) => abi::InterruptSet
-    //
-    // The first table allows for efficient implementation of the default
-    // interrupt handler, which needs to look up the task corresponding with a
-    // given interrupt.
-    //
-    // The second table allows for efficient implementation of `irq_control`,
-    // where a task enables or disables one or more IRQS based on notification
-    // masks.
-    //
-    // The form of the mapping will depend on the target architecture, below.
-    let irq_task_map = kconfig
-        .irqs
-        .iter()
-        .map(|irq| (irq.irq, irq.owner))
-        .collect::<Vec<_>>();
-
-    let mut per_task_irqs: HashMap<_, Vec<_>> = HashMap::new();
-    for irq in &kconfig.irqs {
-        per_task_irqs.entry(irq.owner).or_default().push(irq.irq)
-    }
-    let task_irq_map = per_task_irqs.into_iter().collect::<Vec<_>>();
-
-    let target = build_util::target();
-    if target.starts_with("thumbv6m") {
-        // On ARMv6-M we have no hardware division, which the perfect hash table
-        // relies on (to get efficient integer remainder). Fall back to a good
-        // old sorted list with binary search instead.
-        //
-        // This means our dispatch time for interrupts on ARMv6-M is O(log N)
-        // instead of O(1), but these parts also tend to have few interrupts,
-        // so, not the end of the world.
-
-        let task_irq_map = phash_gen::OwnedSortedList::build(task_irq_map)
-            .context("building task-to-IRQ map")?;
-        let irq_task_map = phash_gen::OwnedSortedList::build(irq_task_map)
-            .context("building IRQ-to-task map")?;
-
-        // Generate text for the Interrupt and InterruptSet tables stored in the
-        // sorted lists
-        let irq_task_literal = fmt_sorted_list(&irq_task_map, fmt_irq_task);
-        let task_irq_literal = fmt_sorted_list(&task_irq_map, fmt_task_irq);
-
-        write!(
-            file,
-            "{}",
-            quote::quote! {
-                pub const HUBRIS_IRQ_TASK_LOOKUP:
-                    phash::SortedList<abi::InterruptNum, abi::InterruptOwner>
-                    = #irq_task_literal;
-                pub const HUBRIS_TASK_IRQ_LOOKUP:
-                    phash::SortedList<
-                        abi::InterruptOwner,
-                        &'static [abi::InterruptNum],
-                    > = #task_irq_literal;
-            }
-        )?;
-    } else if target.starts_with("thumbv7m")
-        || target.starts_with("thumbv7em")
-        || target.starts_with("thumbv8m")
-    {
-        // First, try to build it as a single-level perfect hash map, which is
-        // cheaper but won't always succeed.
-        if let Ok(task_irq_map) =
-            phash_gen::OwnedPerfectHashMap::build(task_irq_map.clone())
-        {
-            let map_literal =
-                fmt_perfect_hash_map(&task_irq_map, fmt_opt_task_irq);
-            writeln!(
-                file,
-                "{}",
-                quote::quote! {
-                    pub const HUBRIS_TASK_IRQ_LOOKUP:
-                        phash::PerfectHashMap<
-                            '_,
-                            abi::InterruptOwner,
-                            &'static [abi::InterruptNum],
-                        > = #map_literal;
-                },
-            )?;
-        } else {
-            // Single-level perfect hash failed, make it work with a nested map.
-            let task_irq_map =
-                phash_gen::OwnedNestedPerfectHashMap::build(task_irq_map)
-                    .context("building task-to-IRQ perfect hash")?;
-            let task_irq_literal =
-                fmt_nested_perfect_hash_map(&task_irq_map, fmt_opt_task_irq);
-            writeln!(
-                file,
-                "{}",
-                quote::quote! {
-                    pub const HUBRIS_TASK_IRQ_LOOKUP:
-                        phash::NestedPerfectHashMap<
-                            abi::InterruptOwner,
-                            &'static [abi::InterruptNum],
-                        > = #task_irq_literal;
-                },
-            )?;
-        }
-
-        // And now repeat the process for the IRQ-to-task direction.
-        if let Ok(irq_task_map) =
-            phash_gen::OwnedPerfectHashMap::build(irq_task_map.clone())
-        {
-            let map_literal =
-                fmt_perfect_hash_map(&irq_task_map, fmt_opt_irq_task);
-            writeln!(
-                file,
-                "{}",
-                quote::quote! {
-                    pub const HUBRIS_IRQ_TASK_LOOKUP:
-                        phash::PerfectHashMap<
-                            '_,
-                            abi::InterruptNum,
-                            abi::InterruptOwner,
-                        > = #map_literal;
-                },
-            )?;
-        } else {
-            let irq_task_map =
-                phash_gen::OwnedNestedPerfectHashMap::build(irq_task_map)
-                    .context("building IRQ-to-task perfect hash")?;
-            let map_literal =
-                fmt_nested_perfect_hash_map(&irq_task_map, fmt_opt_irq_task);
-            writeln!(
-                file,
-                "{}",
-                quote::quote! {
-                    pub const HUBRIS_IRQ_TASK_LOOKUP:
-                        phash::NestedPerfectHashMap<
-                            abi::InterruptNum,
-                            abi::InterruptOwner,
-                        > = #map_literal;
-                },
-            )?;
-        }
-    } else {
-        panic!("Don't know the target {}", target);
-    }
+    writeln!(file, "{}", gen.irq_code)?;
 
     drop(file);
     call_rustfmt::rustfmt(kconfig_path)?;
@@ -323,7 +463,7 @@ fn generate_statics() -> Result<()> {
 }
 
 fn fmt_opt_task_irq(
-    v: Option<&(InterruptOwner, Vec<InterruptNum>)>,
+    v: Option<&(abi::InterruptOwner, Vec<u32>)>,
 ) -> TokenStream {
     match v {
         Some((owner, irqs)) => fmt_task_irq(owner, irqs),
@@ -333,11 +473,7 @@ fn fmt_opt_task_irq(
     }
 }
 
-fn fmt_task_irq(
-    owner: &InterruptOwner,
-    irqs: &Vec<InterruptNum>,
-) -> TokenStream {
-    let irqs = irqs.iter().map(|irqnum| irqnum.0);
+fn fmt_task_irq(owner: &abi::InterruptOwner, irqs: &Vec<u32>) -> TokenStream {
     let (task, not) = (owner.task, owner.notification);
     quote::quote! {
         (
@@ -347,7 +483,7 @@ fn fmt_task_irq(
     }
 }
 
-fn fmt_opt_irq_task(v: Option<&(InterruptNum, InterruptOwner)>) -> TokenStream {
+fn fmt_opt_irq_task(v: Option<&(u32, InterruptConfig)>) -> TokenStream {
     match v {
         Some((irq, owner)) => fmt_irq_task(irq, owner),
         None => quote::quote! {
@@ -356,11 +492,11 @@ fn fmt_opt_irq_task(v: Option<&(InterruptNum, InterruptOwner)>) -> TokenStream {
     }
 }
 
-fn fmt_irq_task(irq: &InterruptNum, owner: &InterruptOwner) -> TokenStream {
-    let (irqnum, task, not) = (irq.0, owner.task, owner.notification);
+fn fmt_irq_task(irq: &u32, owner: &InterruptConfig) -> TokenStream {
+    let (task, not) = (owner.task_index as u32, owner.notification);
     quote::quote! {
         (
-            abi::InterruptNum(#irqnum),
+            abi::InterruptNum(#irq),
             abi::InterruptOwner { task: #task, notification: #not },
         )
     }
@@ -411,11 +547,4 @@ fn fmt_nested_perfect_hash_map<K, V>(
             values: &[#(#values,)*],
         }
     }
-}
-
-#[derive(Deserialize)]
-struct KernelConfig {
-    tasks: Vec<abi::TaskDesc>,
-    regions: Vec<abi::RegionDesc>,
-    irqs: Vec<abi::Interrupt>,
 }


### PR DESCRIPTION
This insulates xtask dist from a bunch of kernel implementation decisions, removing (for example) the region table construction code from xtask and moving it into kern/build.rs. This should let us iterate on the kernel's internal representations more easily.