### PR TITLE
Change how the LPC55 calcuates the clock speed

### DIFF
--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -32,7 +32,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
-uses = ["rom", "secure_syscon", "flash"]
+uses = ["rom", "secure_syscon", "syscon", "flash"]
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"


### PR DESCRIPTION
On targets with TrustZone, the secure world has access to the entire address space. On targets without TrustZone we have to explicitly give access. Since the ROM programming APIs already require access to syscon switch to calculating the clock speed using syscon instead.