### PR TITLE
Support NVME BMC devices with bad mux

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -447,7 +447,7 @@ bus = "front"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
@@ -481,7 +481,7 @@ bus = "front"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
@@ -515,7 +515,7 @@ bus = "front"
 mux = 1
 segment = 3
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
@@ -549,7 +549,7 @@ bus = "front"
 mux = 1
 segment = 4
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
@@ -583,7 +583,7 @@ bus = "front"
 mux = 2
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
@@ -617,7 +617,7 @@ bus = "front"
 mux = 2
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
@@ -651,7 +651,7 @@ bus = "front"
 mux = 2
 segment = 3
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
@@ -685,7 +685,7 @@ bus = "front"
 mux = 2
 segment = 4
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
@@ -719,7 +719,7 @@ bus = "front"
 mux = 3
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
@@ -753,7 +753,7 @@ bus = "front"
 mux = 3
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
@@ -781,7 +781,7 @@ bus = "m2"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc_bad_mux"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
 sensors = { temperature = 1 }
@@ -792,7 +792,7 @@ bus = "m2"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc_bad_mux"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
 sensors = { temperature = 1 }

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -781,7 +781,7 @@ bus = "m2"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvme_bmc_bad_mux"
+device = "m2_hp_only"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
 sensors = { temperature = 1 }
@@ -792,7 +792,7 @@ bus = "m2"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvme_bmc_bad_mux"
+device = "m2_hp_only"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
 sensors = { temperature = 1 }

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -447,7 +447,7 @@ bus = "front"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
@@ -481,7 +481,7 @@ bus = "front"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
@@ -515,7 +515,7 @@ bus = "front"
 mux = 1
 segment = 3
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
@@ -549,7 +549,7 @@ bus = "front"
 mux = 1
 segment = 4
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
@@ -583,7 +583,7 @@ bus = "front"
 mux = 2
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
@@ -617,7 +617,7 @@ bus = "front"
 mux = 2
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
@@ -651,7 +651,7 @@ bus = "front"
 mux = 2
 segment = 3
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
@@ -685,7 +685,7 @@ bus = "front"
 mux = 2
 segment = 4
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
@@ -719,7 +719,7 @@ bus = "front"
 mux = 3
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
@@ -753,7 +753,7 @@ bus = "front"
 mux = 3
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc"
 description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
@@ -790,7 +790,7 @@ bus = "m2"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc_bad_mux"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
 sensors = { temperature = 1 }
@@ -801,7 +801,7 @@ bus = "m2"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvmebmc"
+device = "nvme_bmc_bad_mux"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
 sensors = { temperature = 1 }

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -790,7 +790,7 @@ bus = "m2"
 mux = 1
 segment = 1
 address = 0b110_1010
-device = "nvme_bmc_bad_mux"
+device = "m2_hp_only"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
 sensors = { temperature = 1 }
@@ -801,7 +801,7 @@ bus = "m2"
 mux = 1
 segment = 2
 address = 0b110_1010
-device = "nvme_bmc_bad_mux"
+device = "m2_hp_only"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
 sensors = { temperature = 1 }

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -18,6 +18,8 @@
 //! - [`mcp9808`]: MCP9808 temperature sensor
 //! - [`mwocp68`]: Murata power shelf
 //! - [`nvme_bmc`]: NVMe basic management control
+//! - [`nvme_bmc_bad_mux`]: NVMe basic management control, with a bad I2C mux
+//!   (communication is only allowed when the device is known to be powered)
 //! - [`pca9538`]: PCA9538 GPIO expander
 //! - [`pct2075`]: PCT2075 temperature sensor
 //! - [`raa229618`]: RAA229618 power controller
@@ -170,6 +172,7 @@ pub mod max6634;
 pub mod mcp9808;
 pub mod mwocp68;
 pub mod nvme_bmc;
+pub mod nvme_bmc_bad_mux;
 pub mod pca9538;
 pub mod pct2075;
 pub mod raa229618;

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -12,14 +12,15 @@
 //! - [`ds2482`]: DS2482-100 1-wire initiator
 //! - [`isl68224`]: ISL68224 power controller
 //! - [`m24c02`]: M24C02 EEPROM, used in MWOCP68 power shelf
+//! - [`m2_hp_only`]: M.2 drive; identical to `nvme_bmc`, with the limitation
+//!   that communication is **only allowed** when the device is known to be
+//!   powered (at the cost of locking up the I2C bus if you get it wrong).
 //! - [`max5970`]: MAX5970 hot swap controller
 //! - [`max6634`]: MAX6634 temperature sensor
 //! - [`max31790`]: MAX31790 fan controller
 //! - [`mcp9808`]: MCP9808 temperature sensor
 //! - [`mwocp68`]: Murata power shelf
 //! - [`nvme_bmc`]: NVMe basic management control
-//! - [`nvme_bmc_bad_mux`]: NVMe basic management control, with a bad I2C mux
-//!   (communication is only allowed when the device is known to be powered)
 //! - [`pca9538`]: PCA9538 GPIO expander
 //! - [`pct2075`]: PCT2075 temperature sensor
 //! - [`raa229618`]: RAA229618 power controller
@@ -166,13 +167,13 @@ pub mod bmr491;
 pub mod ds2482;
 pub mod isl68224;
 pub mod m24c02;
+pub mod m2_hp_only;
 pub mod max31790;
 pub mod max5970;
 pub mod max6634;
 pub mod mcp9808;
 pub mod mwocp68;
 pub mod nvme_bmc;
-pub mod nvme_bmc_bad_mux;
 pub mod pca9538;
 pub mod pct2075;
 pub mod raa229618;

--- a/drv/i2c-devices/src/m2_hp_only.rs
+++ b/drv/i2c-devices/src/m2_hp_only.rs
@@ -9,12 +9,14 @@ use userlib::units::Celsius;
 pub use crate::nvme_bmc::{Error, NvmeBmc};
 
 /// Wrapper for an NVME BMC device on the far end of an I2C mux that exhibits
-/// lock-up behavior; see `hardware-gimlet#1804`
-pub struct NvmeBmcBadMux {
+/// lock-up behavior; see `hardware-gimlet#1804`.  The end result is that we can
+/// only talk to the device when we know _for sure_ that it is powered; the `Hp`
+/// in its name is our standard abbreviation for "hot-plug".
+pub struct M2HpOnly {
     dev: NvmeBmc,
 }
 
-impl NvmeBmcBadMux {
+impl M2HpOnly {
     pub fn new(device: &I2cDevice) -> Self {
         Self {
             dev: NvmeBmc::new(device),
@@ -26,7 +28,7 @@ impl NvmeBmcBadMux {
     }
 }
 
-impl Validate<ResponseCode> for NvmeBmcBadMux {
+impl Validate<ResponseCode> for M2HpOnly {
     fn validate(
         _device: &drv_i2c_api::I2cDevice,
     ) -> Result<bool, ResponseCode> {

--- a/task/thermal/src/bsp/gimlet_bc.rs
+++ b/task/thermal/src/bsp/gimlet_bc.rs
@@ -29,7 +29,7 @@ pub const NUM_TEMPERATURE_INPUTS: usize = sensors::NUM_SBTSI_TEMPERATURE_SENSORS
     + sensors::NUM_TMP451_TEMPERATURE_SENSORS
     + sensors::NUM_TSE2004AV_TEMPERATURE_SENSORS
     + sensors::NUM_NVME_BMC_TEMPERATURE_SENSORS
-    + sensors::NUM_NVME_BMC_BAD_MUX_TEMPERATURE_SENSORS;
+    + sensors::NUM_M2_HP_ONLY_TEMPERATURE_SENSORS;
 
 // We've got 6 fans, driven from a single MAX31790 IC
 const NUM_FANS: usize = drv_i2c_devices::max31790::MAX_FANS as usize;
@@ -245,8 +245,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::M2,
-            devices::nvme_bmc_bad_mux_m2_a,
-            sensors::NVME_BMC_BAD_MUX_M2_A_TEMPERATURE_SENSOR,
+            devices::m2_hp_only_m2_a,
+            sensors::M2_HP_ONLY_M2_A_TEMPERATURE_SENSOR,
         ),
         M2_THERMALS,
         PowerBitmask::M2A,
@@ -255,8 +255,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::M2,
-            devices::nvme_bmc_bad_mux_m2_b,
-            sensors::NVME_BMC_BAD_MUX_M2_B_TEMPERATURE_SENSOR,
+            devices::m2_hp_only_m2_b,
+            sensors::M2_HP_ONLY_M2_B_TEMPERATURE_SENSOR,
         ),
         M2_THERMALS,
         PowerBitmask::M2B,

--- a/task/thermal/src/bsp/gimlet_bc.rs
+++ b/task/thermal/src/bsp/gimlet_bc.rs
@@ -28,7 +28,8 @@ const NUM_TEMPERATURE_SENSORS: usize = sensors::NUM_TMP117_TEMPERATURE_SENSORS;
 pub const NUM_TEMPERATURE_INPUTS: usize = sensors::NUM_SBTSI_TEMPERATURE_SENSORS
     + sensors::NUM_TMP451_TEMPERATURE_SENSORS
     + sensors::NUM_TSE2004AV_TEMPERATURE_SENSORS
-    + sensors::NUM_NVMEBMC_TEMPERATURE_SENSORS;
+    + sensors::NUM_NVME_BMC_TEMPERATURE_SENSORS
+    + sensors::NUM_NVME_BMC_BAD_MUX_TEMPERATURE_SENSORS;
 
 // We've got 6 fans, driven from a single MAX31790 IC
 const NUM_FANS: usize = drv_i2c_devices::max31790::MAX_FANS as usize;
@@ -244,8 +245,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::M2,
-            devices::nvmebmc_m2_a,
-            sensors::NVMEBMC_M2_A_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_bad_mux_m2_a,
+            sensors::NVME_BMC_BAD_MUX_M2_A_TEMPERATURE_SENSOR,
         ),
         M2_THERMALS,
         PowerBitmask::M2A,
@@ -254,8 +255,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::M2,
-            devices::nvmebmc_m2_b,
-            sensors::NVMEBMC_M2_B_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_bad_mux_m2_b,
+            sensors::NVME_BMC_BAD_MUX_M2_B_TEMPERATURE_SENSOR,
         ),
         M2_THERMALS,
         PowerBitmask::M2B,
@@ -445,8 +446,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n0,
-            sensors::NVMEBMC_U2_N0_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n0,
+            sensors::NVME_BMC_U2_N0_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -455,8 +456,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n1,
-            sensors::NVMEBMC_U2_N1_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n1,
+            sensors::NVME_BMC_U2_N1_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -465,8 +466,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n2,
-            sensors::NVMEBMC_U2_N2_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n2,
+            sensors::NVME_BMC_U2_N2_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -475,8 +476,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n3,
-            sensors::NVMEBMC_U2_N3_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n3,
+            sensors::NVME_BMC_U2_N3_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -485,8 +486,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n4,
-            sensors::NVMEBMC_U2_N4_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n4,
+            sensors::NVME_BMC_U2_N4_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -495,8 +496,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n5,
-            sensors::NVMEBMC_U2_N5_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n5,
+            sensors::NVME_BMC_U2_N5_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -505,8 +506,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n6,
-            sensors::NVMEBMC_U2_N6_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n6,
+            sensors::NVME_BMC_U2_N6_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -515,8 +516,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n7,
-            sensors::NVMEBMC_U2_N7_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n7,
+            sensors::NVME_BMC_U2_N7_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -525,8 +526,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n8,
-            sensors::NVMEBMC_U2_N8_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n8,
+            sensors::NVME_BMC_U2_N8_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,
@@ -535,8 +536,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     InputChannel::new(
         TemperatureSensor::new(
             Device::U2,
-            devices::nvmebmc_u2_n9,
-            sensors::NVMEBMC_U2_N9_TEMPERATURE_SENSOR,
+            devices::nvme_bmc_u2_n9,
+            sensors::NVME_BMC_U2_N9_TEMPERATURE_SENSOR,
         ),
         U2_THERMALS,
         PowerBitmask::A0,


### PR DESCRIPTION
Due to https://github.com/oxidecomputer/hardware-gimlet/issues/1804, we can't talk to M.2s when they are unpowered.  We work around this in the `thermal` task by asking the `MAX5970` for its status; however, `humility validate` doesn't have any support for that kind of special-casing.

This PR adds a new `nvme_bmc_bad_mux`, which is ignored during `humility validate`.

In addition, it renames `nvmebmc` -> `nvme_bmc` so that the existing driver is used for `humility validate` (on good devices).