### PR TITLE
kern: use captured identifiers in format strings

### DIFF
--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -114,7 +114,7 @@ fn process_config() -> Result<Generated> {
         }
 
         if regions.len() > 8 {
-            bail!("too many regions ({}) for task {}", regions.len(), i);
+            bail!("too many regions ({}) for task {i}", regions.len());
         }
         regions.resize(8, 0u8);
 
@@ -277,7 +277,7 @@ fn process_config() -> Result<Generated> {
             #map2
         }
     } else {
-        panic!("Don't know the target {}", target);
+        panic!("Don't know the target {target}");
     };
 
     Ok(Generated {

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1130,7 +1130,7 @@ pub unsafe extern "C" fn DefaultHandler() {
             let irq_num = exception_num - 16;
             let owner = crate::startup::HUBRIS_IRQ_TASK_LOOKUP
                 .get(abi::InterruptNum(irq_num))
-                .unwrap_or_else(|| panic!("unhandled IRQ {}", irq_num));
+                .unwrap_or_else(|| panic!("unhandled IRQ {irq_num}"));
 
             let switch = with_task_table(|tasks| {
                 disable_irq(irq_num);
@@ -1145,7 +1145,7 @@ pub unsafe extern "C" fn DefaultHandler() {
             }
         }
 
-        _ => panic!("unknown exception {}", exception_num),
+        _ => panic!("unknown exception {exception_num}"),
     }
     crate::profiling::event_isr_exit();
 }
@@ -1417,7 +1417,7 @@ unsafe extern "C" fn handle_fault(task: *mut task::Task) {
         };
 
         if next == idx {
-            panic!("attempt to return to Task #{} after fault", idx);
+            panic!("attempt to return to Task #{idx} after fault");
         }
 
         let next = &mut tasks[next];
@@ -1594,7 +1594,7 @@ unsafe extern "C" fn handle_fault(
         };
 
         if next == idx {
-            panic!("attempt to return to Task #{} after fault", idx);
+            panic!("attempt to return to Task #{idx} after fault");
         }
 
         let next = &mut tasks[next];


### PR DESCRIPTION
Now that we're Rust 2021 we can do this!