### PR TITLE
thermal: add PID term to apply offset to output values

### DIFF
--- a/idl/thermal.idol
+++ b/idl/thermal.idol
@@ -60,6 +60,7 @@ Interface(
         ),
         "set_pid": (
             args: {
+                "z": "f32",
                 "p": "f32",
                 "i": "f32",
                 "d": "f32",

--- a/task/thermal/src/bsp/gimlet_bc.rs
+++ b/task/thermal/src/bsp/gimlet_bc.rs
@@ -163,6 +163,7 @@ impl Bsp {
             pid_config: PidConfig {
                 // If we're > 10 degrees from the target temperature, fans
                 // should be on at full power.
+                zero: 0.0,
                 gain_p: 10.0,
                 gain_i: 0.5,
                 gain_d: 10.0,

--- a/task/thermal/src/bsp/sidecar_ab.rs
+++ b/task/thermal/src/bsp/sidecar_ab.rs
@@ -151,6 +151,7 @@ impl Bsp {
             pid_config: PidConfig {
                 // If we're > 10 degrees from the target temperature, fans
                 // should be on at full power.
+                zero: 0.0,
                 gain_p: 10.0,
                 gain_i: 0.0,
                 gain_d: 0.0,

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -292,6 +292,7 @@ enum TemperatureReading {
 /// Configuration for a PID controller
 #[derive(Copy, Clone)]
 pub struct PidConfig {
+    pub zero: f32,
     pub gain_p: f32,
     pub gain_i: f32,
     pub gain_d: f32,
@@ -330,7 +331,7 @@ impl OneSidedPidState {
         // Calculate the P+D contribution separately, which is used to clamp the
         // integral term.
         let pd_contribution = p_contribution + d_contribution;
-        let out = pd_contribution + self.integral;
+        let out = cfg.zero + pd_contribution + self.integral;
 
         if out > output_limit {
             // Clamp the integral to the maximum value at which it can
@@ -456,6 +457,7 @@ impl<'a> ThermalControl<'a> {
 
     pub fn set_pid(
         &mut self,
+        z: f32,
         p: f32,
         i: f32,
         d: f32,
@@ -479,6 +481,7 @@ impl<'a> ThermalControl<'a> {
             }
         }
 
+        self.pid_config.zero = z;
         self.pid_config.gain_p = p;
         self.pid_config.gain_i = i;
         self.pid_config.gain_d = d;

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -200,6 +200,7 @@ impl<'a> idl::InOrderThermalImpl for ServerImpl<'a> {
     fn set_pid(
         &mut self,
         _: &RecvMessage,
+        z: f32,
         p: f32,
         i: f32,
         d: f32,
@@ -207,7 +208,7 @@ impl<'a> idl::InOrderThermalImpl for ServerImpl<'a> {
         if self.mode != ThermalMode::Auto {
             return Err(ThermalError::NotInAutoMode.into());
         }
-        self.control.set_pid(p, i, d)?;
+        self.control.set_pid(z, p, i, d)?;
         Ok(())
     }
 


### PR DESCRIPTION
When output value is used as fan duty cycle directly, only positive error values are meaningful.  This prevents the PID loop from engaging until the set point is already reached.  By offsetting the output values, negative errors are meaningful and the PID loop can engage control during the initial rise toward the set point.