### PR TITLE
SPD power interlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,6 +3887,7 @@ dependencies = [
  "build-util",
  "cfg-if",
  "cortex-m",
+ "drv-gimlet-state",
  "drv-i2c-api",
  "drv-stm32xx-i2c",
  "drv-stm32xx-sys-api",
@@ -3894,6 +3895,7 @@ dependencies = [
  "ringbuf",
  "spd",
  "stm32h7",
+ "task-jefe-api",
  "userlib",
 ]
 

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -57,19 +57,6 @@ task-slots = ["sys"]
 "i2c4.event" = 0b0000_1000
 "i2c4.error" = 0b0000_1000
 
-[tasks.spd]
-name = "task-spd"
-features = ["h753", "itm"]
-priority = 3
-max-sizes = {flash = 16384, ram = 16384 }
-uses = ["i2c2"]
-start = true
-task-slots = ["sys", "i2c_driver"]
-
-[tasks.spd.interrupts]
-"i2c2.event" = 0b0000_0010
-"i2c2.error" = 0b0000_0010
-
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -31,6 +31,7 @@ stacksize = 1536
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}
+spd = {bit-number = 8}
 
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
@@ -110,7 +111,7 @@ priority = 2
 max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
-task-slots = ["sys", "i2c_driver"]
+task-slots = ["sys", "i2c_driver", "jefe"]
 
 [tasks.spd.interrupts]
 "i2c1.event" = 0b0000_0001

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -31,6 +31,7 @@ stacksize = 1536
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}
+spd = {bit-number = 8}
 
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
@@ -110,7 +111,7 @@ priority = 2
 max-sizes = {flash = 16384, ram = 16384}
 uses = ["i2c1"]
 start = true
-task-slots = ["sys", "i2c_driver"]
+task-slots = ["sys", "i2c_driver", "jefe"]
 
 [tasks.spd.interrupts]
 "i2c1.event" = 0b0000_0001

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -10,6 +10,8 @@ spd = { git = "https://github.com/oxidecomputer/spd" }
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false}
 drv-stm32xx-i2c = {path = "../../drv/stm32xx-i2c", features = ["amd_erratum_1394"]}
+drv-gimlet-state = {path = "../../drv/gimlet-state"}
+task-jefe-api = {path = "../jefe-api"}
 drv-i2c-api = {path = "../../drv/i2c-api", default-features = false}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cfg-if = "1"

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -24,12 +24,14 @@
 use core::cell::Cell;
 use core::cell::RefCell;
 use drv_gimlet_state::PowerState;
-use drv_i2c_api::*;
-use drv_stm32xx_i2c::*;
-use drv_stm32xx_sys_api::*;
-use ringbuf::*;
+use drv_i2c_api::{Controller, I2cDevice, Mux, Segment};
+use drv_stm32xx_i2c::{I2cControl, I2cPin};
+use drv_stm32xx_sys_api::{OutputType, Pull, Speed, Sys};
+use ringbuf::{ringbuf, ringbuf_entry};
 use task_jefe_api::Jefe;
-use userlib::*;
+use userlib::{
+    sys_irq_control, sys_recv_closed, task_slot, FromPrimitive, TaskId,
+};
 
 task_slot!(SYS, sys);
 task_slot!(I2C, i2c_driver);


### PR DESCRIPTION
Previously, the spd proxy would treat it as "good enough" if it could
read at least one SPD EEPROM in a given pass. I believe this was causing
issue https://github.com/oxidecomputer/hubris/issues/657, where occasionally a board would come up missing a DIMM or
two.

This commit has the SPD task wait patiently until the power sequencing
task has declared A2, which should imply that the DIMM SPD EEPROMs are
ready to go.