### PR TITLE
Make TaskDesc/RegionDesc kernel implementation details

### DIFF
--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -7,12 +7,7 @@
 #![no_std]
 
 use serde::{Deserialize, Serialize};
-use zerocopy::{AsBytes, FromBytes, Unaligned};
-
-/// Number of region slots in a `TaskDesc` record. Needs to be less or equal to
-/// than the number of regions in the MPU; may be less to improve context switch
-/// performance. (Though note that changing this alters the ABI.)
-pub const REGIONS_PER_TASK: usize = 8;
+use zerocopy::{AsBytes, FromBytes};
 
 pub const TASK_ID_INDEX_BITS: usize = 10;
 
@@ -90,126 +85,6 @@ impl Generation {
 impl From<u8> for Generation {
     fn from(x: u8) -> Self {
         Self(x)
-    }
-}
-
-/// Indicates priority of a task.
-///
-/// Priorities are small numbers starting from zero. Numerically lower
-/// priorities are more important, so Priority 0 is the most likely to be
-/// scheduled, followed by 1, and so forth. (This keeps our logic simpler given
-/// that the number of priorities can be reconfigured.)
-///
-/// Note that this type *deliberately* does not implement `PartialOrd`/`Ord`, to
-/// keep us from confusing ourselves on whether `>` means numerically greater /
-/// less important, or more important / numerically smaller.
-#[derive(
-    Copy, Clone, Debug, Eq, PartialEq, FromBytes, AsBytes, Unaligned, Default,
-)]
-#[repr(transparent)]
-pub struct Priority(pub u8);
-
-impl Priority {
-    /// Checks if `self` is strictly more important than `other`.
-    ///
-    /// This is easier to read than comparing the numeric values of the
-    /// priorities, since lower numbers are more important.
-    pub fn is_more_important_than(self, other: Self) -> bool {
-        self.0 < other.0
-    }
-}
-
-/// Record describing a single task.
-#[derive(Clone, Debug, FromBytes, Serialize, Deserialize)]
-pub struct TaskDesc {
-    /// Identifies memory regions this task has access to, by index in the
-    /// `RegionDesc` table. If the task needs fewer than `REGIONS_PER_TASK`
-    /// regions, it should use remaining entries to name a region that confers
-    /// no access; by convention, this region is usually entry 0 in the table.
-    ///
-    /// Note: because these region indices are 8 bits, this is going to get
-    /// restrictive in applications that approach 128 tasks.
-    pub regions: [u8; REGIONS_PER_TASK],
-    /// Address of the task's entry point. This is the first instruction that
-    /// will be executed whenever the task is (re)started. It must be within one
-    /// of the task's memory regions (the kernel *will* check this).
-    pub entry_point: u32,
-    /// Address of the task's initial stack pointer, to be loaded at (re)start.
-    /// It must be pointing into or *just past* one of the task's memory
-    /// regions (the kernel *will* check this).
-    pub initial_stack: u32,
-    /// Initial priority of this task.
-    pub priority: u8,
-    /// Collection of boolean flags controlling task behavior.
-    pub flags: TaskFlags,
-    /// Index of this task within the task table.
-    ///
-    /// This field is here as an optimization for the kernel entry sequences. It
-    /// can contain an invalid index if you create an arbitrary invalid
-    /// `TaskDesc`; this will cause the kernel to behave strangely (if the index
-    /// is in range for the task table) or panic predictably (if not), but won't
-    /// violate safety. The build system is careful to generate correct indices
-    /// here.
-    ///
-    /// The index is a u16 to save space in the `TaskDesc` struct; in practice
-    /// other factors limit us to fewer than `2**16` tasks.
-    pub index: u16,
-}
-
-bitflags::bitflags! {
-    #[derive(FromBytes, Serialize, Deserialize)]
-    #[repr(transparent)]
-    pub struct TaskFlags: u8 {
-        const START_AT_BOOT = 1 << 0;
-        const RESERVED = !1;
-    }
-}
-
-/// Description of one memory region.
-///
-/// A memory region can be used by multiple tasks. This is mostly used to have
-/// tasks share a no-access region (often index 0) in unused region slots, but
-/// you could also use it for shared peripheral or RAM access.
-///
-/// Note that regions can overlap. This can be useful: for example, you can have
-/// two regions pointing to the same area of the address space, but one
-/// read-only and the other read-write.
-#[derive(Clone, Debug, FromBytes, Serialize, Deserialize)]
-pub struct RegionDesc {
-    /// Address of start of region. The platform likely has alignment
-    /// requirements for this; it must meet them. (For example, on ARMv7-M, it
-    /// must be naturally aligned for the size.)
-    pub base: u32,
-    /// Size of region, in bytes. The platform likely has alignment requirements
-    /// for this; it must meet them. (For example, on ARMv7-M, it must be a
-    /// power of two greater than 16.)
-    pub size: u32,
-    /// Flags describing what can be done with this region.
-    pub attributes: RegionAttributes,
-}
-
-bitflags::bitflags! {
-    #[derive(FromBytes, Serialize, Deserialize)]
-    #[repr(transparent)]
-    pub struct RegionAttributes: u32 {
-        /// Region can be read by tasks that include it.
-        const READ = 1 << 0;
-        /// Region can be written by tasks that include it.
-        const WRITE = 1 << 1;
-        /// Region can contain executable code for tasks that include it.
-        const EXECUTE = 1 << 2;
-        /// Region contains memory mapped registers. This affects cache behavior
-        /// on devices that include it, and discourages the kernel from using
-        /// `memcpy` in the region.
-        const DEVICE = 1 << 3;
-        /// Region can be used for DMA or communication with other processors.
-        /// This heavily restricts how this memory can be cached and will hurt
-        /// performance if overused.
-        ///
-        /// This is ignored for `DEVICE` memory, which is already not cached.
-        const DMA = 1 << 4;
-
-        const RESERVED = !((1 << 5) - 1);
     }
 }
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -94,14 +94,14 @@ fn process_config() -> Result<Generated> {
         // Work out the region indices for each of this task's regions.
         let mut regions = vec![
             // Always include the null region.
-            region_table.get_index_of(&RegionKey::Null).unwrap() as u8,
+            region_table.get_index_of(&RegionKey::Null).unwrap(),
         ];
 
         for name in task.owned_regions.keys() {
             regions.push(
                 region_table
                     .get_index_of(&RegionKey::Owned(i, name.clone()))
-                    .unwrap() as u8,
+                    .unwrap(),
             );
         }
 
@@ -109,14 +109,14 @@ fn process_config() -> Result<Generated> {
             regions.push(
                 region_table
                     .get_index_of(&RegionKey::Shared(name.clone()))
-                    .unwrap() as u8,
+                    .unwrap(),
             );
         }
 
         if regions.len() > 8 {
             bail!("too many regions ({}) for task {i}", regions.len());
         }
-        regions.resize(8, 0u8);
+        regions.resize(8, 0usize);
 
         // Translate abstract addresses in the task description into concrete
         // addresses.
@@ -134,7 +134,7 @@ fn process_config() -> Result<Generated> {
         };
         task_descs.push(quote::quote! {
             TaskDesc {
-                regions: [#(#regions),*],
+                regions: [#(&HUBRIS_REGION_DESCS[#regions]),*],
                 entry_point: #entry_point,
                 initial_stack: #initial_stack,
                 priority: #priority,
@@ -413,11 +413,6 @@ fn generate_statics(gen: &Generated) -> Result<()> {
             static mut HUBRIS_TASK_TABLE_SPACE:
                 core::mem::MaybeUninit<[crate::task::Task; HUBRIS_TASK_COUNT]> =
                 core::mem::MaybeUninit::uninit();
-
-            static mut HUBRIS_REGION_TABLE_SPACE:
-                core::mem::MaybeUninit<
-                    [[&'static RegionDesc; REGIONS_PER_TASK]; HUBRIS_TASK_COUNT],
-                > = core::mem::MaybeUninit::uninit();
         },
     )?;
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -128,12 +128,12 @@ fn process_config() -> Result<Generated> {
         let index = u16::try_from(i).expect("over 2**16 tasks??");
         let priority = task.priority;
         let flags = if task.start_at_boot {
-            quote::quote! { abi::TaskFlags::START_AT_BOOT }
+            quote::quote! { TaskFlags::START_AT_BOOT }
         } else {
-            quote::quote! { abi::TaskFlags::empty() }
+            quote::quote! { TaskFlags::empty() }
         };
         task_descs.push(quote::quote! {
-            abi::TaskDesc {
+            TaskDesc {
                 regions: [#(#regions),*],
                 entry_point: #entry_point,
                 initial_stack: #initial_stack,
@@ -321,22 +321,22 @@ fn fmt_region(region: &RegionConfig) -> TokenStream {
     }
 
     let atts = if atts.is_empty() {
-        quote::quote! { abi::RegionAttributes::empty() }
+        quote::quote! { RegionAttributes::empty() }
     } else {
         // We have to do the OR-ing on bits and then from_bits_unchecked it
         // because these operations are const, while OR-ing of the
         // RegionAttributes type itself is not (pending const impl stability)
         quote::quote! {
             unsafe {
-                abi::RegionAttributes::from_bits_unchecked(
-                    #(abi::RegionAttributes::#atts.bits())|*
+                RegionAttributes::from_bits_unchecked(
+                    #(RegionAttributes::#atts.bits())|*
                 )
             }
         }
     };
 
     quote::quote! {
-        abi::RegionDesc {
+        RegionDesc {
             base: #base,
             size: #size,
             attributes: #atts,
@@ -416,7 +416,7 @@ fn generate_statics(gen: &Generated) -> Result<()> {
 
             static mut HUBRIS_REGION_TABLE_SPACE:
                 core::mem::MaybeUninit<
-                    [[&'static abi::RegionDesc; abi::REGIONS_PER_TASK]; HUBRIS_TASK_COUNT],
+                    [[&'static RegionDesc; REGIONS_PER_TASK]; HUBRIS_TASK_COUNT],
                 > = core::mem::MaybeUninit::uninit();
         },
     )?;
@@ -429,7 +429,7 @@ fn generate_statics(gen: &Generated) -> Result<()> {
         file,
         "{}",
         quote::quote! {
-            static HUBRIS_TASK_DESCS: [abi::TaskDesc; HUBRIS_TASK_COUNT] = [
+            static HUBRIS_TASK_DESCS: [TaskDesc; HUBRIS_TASK_COUNT] = [
                 #(#task_descs,)*
             ];
 
@@ -445,7 +445,7 @@ fn generate_statics(gen: &Generated) -> Result<()> {
         file,
         "{}",
         quote::quote! {
-            static HUBRIS_REGION_DESCS: [abi::RegionDesc; #region_count] = [
+            static HUBRIS_REGION_DESCS: [RegionDesc; #region_count] = [
                 #(#regions,)*
             ];
         },

--- a/sys/kern/src/descs.rs
+++ b/sys/kern/src/descs.rs
@@ -35,14 +35,13 @@ impl Priority {
 /// Record describing a single task.
 #[derive(Clone, Debug)]
 pub struct TaskDesc {
-    /// Identifies memory regions this task has access to, by index in the
-    /// `RegionDesc` table. If the task needs fewer than `REGIONS_PER_TASK`
+    /// Identifies memory regions this task has access to, with references into
+    /// the `RegionDesc` table. If the task needs fewer than `REGIONS_PER_TASK`
     /// regions, it should use remaining entries to name a region that confers
     /// no access; by convention, this region is usually entry 0 in the table.
-    ///
-    /// Note: because these region indices are 8 bits, this is going to get
-    /// restrictive in applications that approach 128 tasks.
-    pub regions: [u8; REGIONS_PER_TASK],
+    /// (This is why we use pointers into a table, to avoid making many copies
+    /// of that region.)
+    pub regions: [&'static RegionDesc; REGIONS_PER_TASK],
     /// Address of the task's entry point. This is the first instruction that
     /// will be executed whenever the task is (re)started. It must be within one
     /// of the task's memory regions (the kernel *will* check this).
@@ -101,6 +100,19 @@ pub struct RegionDesc {
 }
 
 impl RegionDesc {
+    /// Tests whether `self` contains `addr`.
+    pub fn contains(&self, addr: usize) -> bool {
+        let next_addr = addr.wrapping_add(1);
+        if next_addr < addr {
+            return false;
+        };
+        // We don't allow regions to butt up against the end of the address
+        // space, so we can compute our off-by-one end address as follows:
+        let end = self.base.wrapping_add(self.size) as usize;
+
+        (self.base as usize) <= addr && next_addr <= end
+    }
+
     /// Tests whether `slice` is fully enclosed by `self`.
     pub fn covers<T>(&self, slice: &USlice<T>) -> bool {
         // We don't allow regions to butt up against the end of the address

--- a/sys/kern/src/descs.rs
+++ b/sys/kern/src/descs.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Descriptor types, used to statically define application resources.
+
+pub(crate) const REGIONS_PER_TASK: usize = 8;
+
+/// Indicates priority of a task.
+///
+/// Priorities are small numbers starting from zero. Numerically lower
+/// priorities are more important, so Priority 0 is the most likely to be
+/// scheduled, followed by 1, and so forth. (This keeps our logic simpler given
+/// that the number of priorities can be reconfigured.)
+///
+/// Note that this type *deliberately* does not implement `PartialOrd`/`Ord`, to
+/// keep us from confusing ourselves on whether `>` means numerically greater /
+/// less important, or more important / numerically smaller.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(transparent)]
+pub struct Priority(pub u8);
+
+impl Priority {
+    /// Checks if `self` is strictly more important than `other`.
+    ///
+    /// This is easier to read than comparing the numeric values of the
+    /// priorities, since lower numbers are more important.
+    pub fn is_more_important_than(self, other: Self) -> bool {
+        self.0 < other.0
+    }
+}
+
+/// Record describing a single task.
+#[derive(Clone, Debug)]
+pub struct TaskDesc {
+    /// Identifies memory regions this task has access to, by index in the
+    /// `RegionDesc` table. If the task needs fewer than `REGIONS_PER_TASK`
+    /// regions, it should use remaining entries to name a region that confers
+    /// no access; by convention, this region is usually entry 0 in the table.
+    ///
+    /// Note: because these region indices are 8 bits, this is going to get
+    /// restrictive in applications that approach 128 tasks.
+    pub regions: [u8; REGIONS_PER_TASK],
+    /// Address of the task's entry point. This is the first instruction that
+    /// will be executed whenever the task is (re)started. It must be within one
+    /// of the task's memory regions (the kernel *will* check this).
+    pub entry_point: u32,
+    /// Address of the task's initial stack pointer, to be loaded at (re)start.
+    /// It must be pointing into or *just past* one of the task's memory
+    /// regions (the kernel *will* check this).
+    pub initial_stack: u32,
+    /// Initial priority of this task.
+    pub priority: u8,
+    /// Collection of boolean flags controlling task behavior.
+    pub flags: TaskFlags,
+    /// Index of this task within the task table.
+    ///
+    /// This field is here as an optimization for the kernel entry sequences. It
+    /// can contain an invalid index if you create an arbitrary invalid
+    /// `TaskDesc`; this will cause the kernel to behave strangely (if the index
+    /// is in range for the task table) or panic predictably (if not), but won't
+    /// violate safety. The build system is careful to generate correct indices
+    /// here.
+    ///
+    /// The index is a u16 to save space in the `TaskDesc` struct; in practice
+    /// other factors limit us to fewer than `2**16` tasks.
+    pub index: u16,
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    pub struct TaskFlags: u8 {
+        const START_AT_BOOT = 1 << 0;
+        const RESERVED = !1;
+    }
+}
+
+/// Description of one memory region.
+///
+/// A memory region can be used by multiple tasks. This is mostly used to have
+/// tasks share a no-access region (often index 0) in unused region slots, but
+/// you could also use it for shared peripheral or RAM access.
+///
+/// Note that regions can overlap. This can be useful: for example, you can have
+/// two regions pointing to the same area of the address space, but one
+/// read-only and the other read-write.
+#[derive(Clone, Debug)]
+pub struct RegionDesc {
+    /// Address of start of region. The platform likely has alignment
+    /// requirements for this; it must meet them. (For example, on ARMv7-M, it
+    /// must be naturally aligned for the size.)
+    pub base: u32,
+    /// Size of region, in bytes. The platform likely has alignment requirements
+    /// for this; it must meet them. (For example, on ARMv7-M, it must be a
+    /// power of two greater than 16.)
+    pub size: u32,
+    /// Flags describing what can be done with this region.
+    pub attributes: RegionAttributes,
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    pub struct RegionAttributes: u32 {
+        /// Region can be read by tasks that include it.
+        const READ = 1 << 0;
+        /// Region can be written by tasks that include it.
+        const WRITE = 1 << 1;
+        /// Region can contain executable code for tasks that include it.
+        const EXECUTE = 1 << 2;
+        /// Region contains memory mapped registers. This affects cache behavior
+        /// on devices that include it, and discourages the kernel from using
+        /// `memcpy` in the region.
+        const DEVICE = 1 << 3;
+        /// Region can be used for DMA or communication with other processors.
+        /// This heavily restricts how this memory can be cached and will hurt
+        /// performance if overused.
+        ///
+        /// This is ignored for `DEVICE` memory, which is already not cached.
+        const DMA = 1 << 4;
+
+        const RESERVED = !((1 << 5) - 1);
+    }
+}

--- a/sys/kern/src/descs.rs
+++ b/sys/kern/src/descs.rs
@@ -4,6 +4,8 @@
 
 //! Descriptor types, used to statically define application resources.
 
+use crate::umem::USlice;
+
 pub(crate) const REGIONS_PER_TASK: usize = 8;
 
 /// Indicates priority of a task.
@@ -96,6 +98,17 @@ pub struct RegionDesc {
     pub size: u32,
     /// Flags describing what can be done with this region.
     pub attributes: RegionAttributes,
+}
+
+impl RegionDesc {
+    /// Tests whether `slice` is fully enclosed by `self`.
+    pub fn covers<T>(&self, slice: &USlice<T>) -> bool {
+        // We don't allow regions to butt up against the end of the address
+        // space, so we can compute our off-by-one end address as follows:
+        let end = self.base.wrapping_add(self.size) as usize;
+
+        (self.base as usize) <= slice.base_addr() && slice.end_addr() <= end
+    }
 }
 
 bitflags::bitflags! {

--- a/sys/kern/src/lib.rs
+++ b/sys/kern/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod arch;
 
 pub mod atomic;
+mod descs;
 pub mod err;
 pub mod header;
 pub mod kipc;

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -5,6 +5,7 @@
 //! Kernel startup.
 
 use crate::atomic::AtomicExt;
+use crate::descs::{RegionDesc, REGIONS_PER_TASK};
 use crate::task::Task;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -69,7 +70,7 @@ pub unsafe fn start_kernel(tick_divisor: u32) -> ! {
     // these.
 
     // Safety: MaybeUninit<[T]> -> [MaybeUninit<T>] is defined as safe.
-    let region_tables: &mut [[MaybeUninit<&'static abi::RegionDesc>; abi::REGIONS_PER_TASK];
+    let region_tables: &mut [[MaybeUninit<&'static RegionDesc>; REGIONS_PER_TASK];
              HUBRIS_TASK_COUNT] =
         unsafe { &mut *(region_tables as *mut _ as *mut _) };
 
@@ -81,7 +82,7 @@ pub unsafe fn start_kernel(tick_divisor: u32) -> ! {
 
     // Safety: we have fully initialized this and can shed the uninit part.
     // We're also dropping &mut.
-    let region_tables: &[[&'static abi::RegionDesc; abi::REGIONS_PER_TASK];
+    let region_tables: &[[&'static RegionDesc; REGIONS_PER_TASK];
          HUBRIS_TASK_COUNT] = unsafe { &*(region_tables as *mut _ as *mut _) };
 
     // Now, generate the task table.
@@ -145,4 +146,5 @@ pub(crate) fn with_task_table<R>(body: impl FnOnce(&mut [Task]) -> R) -> R {
     r
 }
 
+use crate::descs::*;
 include!(concat!(env!("OUT_DIR"), "/kconfig.rs"));

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -183,7 +183,7 @@ impl Task {
             return true;
         }
         self.region_table.iter().any(|region| {
-            region_covers(region, slice)
+            region.covers(slice)
                 && region.attributes.contains(atts)
                 && !region.attributes.contains(RegionAttributes::DEVICE)
                 && !region.attributes.contains(RegionAttributes::DMA)
@@ -859,14 +859,4 @@ pub fn force_fault(
 /// `tasks[index]`.
 pub fn current_id(tasks: &[Task], index: usize) -> TaskId {
     TaskId::for_index_and_gen(index, tasks[index].generation())
-}
-
-/// Tests whether `slice` is fully enclosed by `region`.
-fn region_covers<T>(region: &RegionDesc, slice: &USlice<T>) -> bool {
-    // We don't allow regions to butt up against the end of the address space,
-    // so we can compute our off-by-one end address as follows:
-    let region_end = region.base.wrapping_add(region.size) as usize;
-
-    (region.base as usize) <= slice.base_addr()
-        && slice.end_addr() <= region_end
 }

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -7,12 +7,14 @@
 use core::convert::TryFrom;
 
 use abi::{
-    FaultInfo, FaultSource, Generation, Priority, RegionAttributes, RegionDesc,
-    ReplyFaultReason, SchedState, TaskDesc, TaskFlags, TaskId, TaskState,
-    ULease, UsageError,
+    FaultInfo, FaultSource, Generation, ReplyFaultReason, SchedState, TaskId,
+    TaskState, ULease, UsageError,
 };
 use zerocopy::FromBytes;
 
+use crate::descs::{
+    Priority, RegionAttributes, RegionDesc, TaskDesc, TaskFlags,
+};
 use crate::err::UserError;
 use crate::startup::HUBRIS_FAULT_NOTIFICATION;
 use crate::time::Timestamp;
@@ -59,7 +61,7 @@ impl Task {
         region_table: &'static [&'static RegionDesc],
     ) -> Self {
         Task {
-            priority: abi::Priority(descriptor.priority),
+            priority: Priority(descriptor.priority),
             state: if descriptor.flags.contains(TaskFlags::START_AT_BOOT) {
                 TaskState::Healthy(SchedState::Runnable)
             } else {
@@ -860,7 +862,7 @@ pub fn current_id(tasks: &[Task], index: usize) -> TaskId {
 }
 
 /// Tests whether `slice` is fully enclosed by `region`.
-fn region_covers<T>(region: &abi::RegionDesc, slice: &USlice<T>) -> bool {
+fn region_covers<T>(region: &RegionDesc, slice: &USlice<T>) -> bool {
     // We don't allow regions to butt up against the end of the address space,
     // so we can compute our off-by-one end address as follows:
     let region_end = region.base.wrapping_add(region.size) as usize;


### PR DESCRIPTION
Since the Early Days, we've had these `TaskDesc`/`RegionDesc` structs in the `abi` crate, giving the static definition of tasks in a Hubris application. Originally this was because they got deposited, by a separate tool, into an array at a predictable location in Flash; the kernel would then interpret them at runtime to set things up. This made it almost impossible to notice when you were running out of kernel RAM, since it depended on the results of that interpretation, rather than (say) the linker.

So about a year ago I fixed that.

The fact that the structs were still public has been gnawing at me, and recently I ran into some cases where I wanted to make changes to the structs that simply wouldn't work if they were in abi. This is because the remaining out-of-kernel use of the structs was by the build system, and it needed `Serialize`/`Deserialize` on the structs, which limits which types they can contain. It also introduced weird coupling between the build system (specifically the ever-growing `build/xtask/src/dist.rs`) and the _internal task structure used by the kernel,_ which seemed grody. Anyway, that part was fixed recently with the introduction of the `build/kconfig` crate.

These commits finish the job, by removing the `Desc` structs from `abi` _completely,_ recognizing them as the kernel-internal implementation detail that they are. I then take advantage of this fact to optimize their layout a bit, saving 40 bytes of RAM per task and excising a considerable chunk of unsafe code from the startup routine.