### PR TITLE
Introduce new command, xtask print

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -78,7 +78,8 @@ pub struct Config {
 
 impl Config {
     pub fn from_file(cfg: &Path) -> Result<Self> {
-        let cfg_contents = std::fs::read(&cfg)?;
+        let cfg_contents = std::fs::read(&cfg)
+            .with_context(|| format!("could not read {}", cfg.display()))?;
         let toml: RawConfig = toml::from_slice(&cfg_contents)?;
         if toml.tasks.contains_key("kernel") {
             bail!("'kernel' is reserved and cannot be used as a task name");

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_KERNEL_STACK: u32 = 1024;
 ///
 /// It should be trivial to calculate and kept constant during the build;
 /// mutable build information should be accumulated elsewhere.
-struct PackageConfig {
+pub struct PackageConfig {
     /// Path to the `app.toml` file being built
     app_toml_file: PathBuf,
 
@@ -43,7 +43,7 @@ struct PackageConfig {
     app_src_dir: PathBuf,
 
     /// Loaded configuration
-    toml: Config,
+    pub toml: Config,
 
     /// Add `-v` to various build commands
     verbose: bool,
@@ -72,7 +72,11 @@ struct PackageConfig {
 }
 
 impl PackageConfig {
-    fn new(app_toml_file: &Path, verbose: bool, edges: bool) -> Result<Self> {
+    pub fn new(
+        app_toml_file: &Path,
+        verbose: bool,
+        edges: bool,
+    ) -> Result<Self> {
         let toml = Config::from_file(app_toml_file)?;
         let dist_dir = Path::new("target").join(&toml.name).join("dist");
         let app_src_dir = app_toml_file
@@ -125,11 +129,11 @@ impl PackageConfig {
         self.dist_dir.join(img_name)
     }
 
-    fn img_file(&self, name: impl AsRef<Path>, img_name: &str) -> PathBuf {
+    pub fn img_file(&self, name: impl AsRef<Path>, img_name: &str) -> PathBuf {
         self.img_dir(img_name).join(name)
     }
 
-    fn dist_file(&self, name: impl AsRef<Path>) -> PathBuf {
+    pub fn dist_file(&self, name: impl AsRef<Path>) -> PathBuf {
         self.dist_dir.join(name)
     }
 

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 
 use crate::config::Config;
@@ -17,6 +17,7 @@ mod elf;
 mod flash;
 mod graph;
 mod humility;
+mod print;
 mod sizes;
 mod task_slot;
 
@@ -162,6 +163,22 @@ enum Xtask {
         output: PathBuf,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
+    },
+
+    /// Print out information related to the build.
+    ///
+    /// Currently only useful to print the archive path, but may grow over time.
+    Print {
+        /// Path to the image configuration file, in TOML.
+        cfg: PathBuf,
+
+        /// Print the path to the archive
+        #[clap(long)]
+        archive: bool,
+
+        /// If there are multiple possible images, print this one
+        #[clap(long)]
+        image_name: Option<String>,
     },
 }
 
@@ -319,6 +336,14 @@ fn run(xtask: Xtask) -> Result<()> {
         }
         Xtask::Graph { output, cfg } => {
             graph::task_graph(&cfg, &output)?;
+        }
+        Xtask::Print {
+            cfg,
+            archive,
+            image_name,
+        } => {
+            print::run(&cfg, archive, image_name)
+                .context("could not print information about the build")?;
         }
     }
 

--- a/build/xtask/src/print.rs
+++ b/build/xtask/src/print.rs
@@ -1,0 +1,34 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Error, Result};
+
+use crate::dist::PackageConfig;
+
+pub fn run(
+    cfg: &Path,
+    archive: bool,
+    image_name: Option<String>,
+) -> Result<()> {
+    if archive {
+        let config = PackageConfig::new(cfg, false, false)
+            .context("could not create build configuration")?;
+
+        let image_name = image_name.unwrap_or(String::from("default"));
+
+        let image_name = config
+            .toml
+            .image_names
+            .iter()
+            .find(|name| name == &&image_name)
+            .ok_or(Error::msg(format!("cannot find image {}", image_name)))?;
+
+        let final_path = config
+            .img_file(format!("build-{}.zip", config.toml.name), image_name);
+
+        println!("{}", final_path.display());
+    } else {
+        bail!("I'm not sure what to print. Currently supported: --archive");
+    }
+
+    Ok(())
+}

--- a/build/xtask/src/print.rs
+++ b/build/xtask/src/print.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::path::Path;
 
 use anyhow::{bail, Context, Error, Result};


### PR DESCRIPTION
This command can print out information about the build. Currently, it only supports one option, --archive, which prints out the final build archive. This is useful in scripting.

Example:

```
〉cargo xtask print .\app\demo-stm32f4-discovery\app.toml --archive
    Finished dev [optimized + debuginfo] target(s) in 1.68s
     Running `target\debug\xtask.exe print .\app\demo-stm32f4-discovery\app.toml --archive`
target\demo-stm32f4-discovery\dist\default\build-demo-stm32f4-discovery.zip
```

Additonally, I wanted to make the errors nice for this, and so I ended up adding some contexts inside of the other commands, which will also make them slightly better. Example:

```
〉cargo xtask print .\app\demo-stm32f4-discovery\app.tom --archive
    Finished dev [optimized + debuginfo] target(s) in 1.52s
     Running `target\debug\xtask.exe print .\app\demo-stm32f4-discovery\app.tom --archive`
Error: could not print information about the build

Caused by:
    0: could not create build configuration
    1: could not read .\app\demo-stm32f4-discovery\app.tom
    2: The system cannot find the file specified. (os error 2)
```

This feature was requested by @rmustacc and @jclulow , so I'd love to make sure that this satisfies their needs.

I could make the command just `print-archive` (suggested by @mkeeter) and remove some of the machinery here, but I feel like we've wanted to print other stuff in the past? IIRC @cbiffle was talking about something with environment variables? maybe that was just setting them, not examining them.