### PR TITLE
thermal: more gimlet PID tuning

### DIFF
--- a/task/thermal/src/bsp/gimlet_bc.rs
+++ b/task/thermal/src/bsp/gimlet_bc.rs
@@ -162,12 +162,10 @@ impl Bsp {
 
             // Based on experimental tuning!
             pid_config: PidConfig {
-                // If we're > 10 degrees from the target temperature, fans
-                // should be on at full power.
                 zero: 35.0,
-                gain_p: 6.75,
-                gain_i: 0.17,
-                gain_d: 4.5,
+                gain_p: 6.1,
+                gain_i: 0.09,
+                gain_d: 2.75,
             },
 
             inputs: &INPUTS,


### PR DESCRIPTION
With integral clamping working properly, previous PID terms seem to create oscillations when tracking the set point under load tests.  While these new PID terms don't completely resolve that problem, they do seem to tame the variations to be less annoying.