### PR TITLE
Fetch host phase2 blocks from MGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,14 +376,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "corncobs"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603158882fa02a5f92b3ee716316f0495b962543141597751eaa5992a55f25b"
-
-[[package]]
-name = "corncobs"
-version = "0.1.2"
-source = "git+https://github.com/jgallagher/corncobs.git?branch=fix-encode-buf#3390268ef07a53be28156151b41ce12309ed4f28"
+checksum = "f9236877021b66ad90f833d8a73a7acb702b985b64c5986682d9f1f1a184f0fb"
 
 [[package]]
 name = "cortex-m"
@@ -735,7 +730,7 @@ name = "dice-mfg-msgs"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad#5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
 dependencies = [
- "corncobs 0.1.1",
+ "corncobs",
  "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-big-array",
@@ -3802,7 +3797,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if",
- "corncobs 0.1.2",
+ "corncobs",
  "cortex-m",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4603158882fa02a5f92b3ee716316f0495b962543141597751eaa5992a55f25b"
 
 [[package]]
+name = "corncobs"
+version = "0.1.2"
+source = "git+https://github.com/jgallagher/corncobs.git?branch=fix-encode-buf#3390268ef07a53be28156151b41ce12309ed4f28"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +735,7 @@ name = "dice-mfg-msgs"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad#5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
 dependencies = [
- "corncobs",
+ "corncobs 0.1.1",
  "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-big-array",
@@ -1911,7 +1916,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=d6c896c4e7af05860ad97b389cc72915084c9fd4#d6c896c4e7af05860ad97b389cc72915084c9fd4"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=07063d2e594d127452a96379dc082bef7439a924#07063d2e594d127452a96379dc082bef7439a924"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -3796,7 +3801,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if",
- "corncobs",
+ "corncobs 0.1.2",
  "cortex-m",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "fletcher",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
  "serde",
+ "serde-big-array",
  "serde_repr",
  "unwrap-lite",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=07063d2e594d127452a96379dc082bef7439a924#07063d2e594d127452a96379dc082bef7439a924"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=d7791e4d02571b8414b4c2976b0439234aa4d8c7#d7791e4d02571b8414b4c2976b0439234aa4d8c7"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -2137,10 +2137,12 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "fletcher",
+ "gateway-messages",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
  "serde",
  "serde-big-array",
  "serde_repr",
+ "static_assertions",
  "unwrap-lite",
  "zerocopy",
 ]
@@ -3732,6 +3734,7 @@ dependencies = [
  "drv-update-api",
  "gateway-messages",
  "heapless",
+ "host-sp-messages",
  "idol",
  "idol-runtime",
  "mutable-statics",
@@ -3754,8 +3757,11 @@ name = "task-control-plane-agent-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
+ "host-sp-messages",
  "idol",
  "num-traits",
+ "serde",
+ "ssmarshal",
  "userlib",
  "zerocopy",
 ]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -202,7 +202,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 7
-max-sizes = {flash = 16384, ram = 16384}
+max-sizes = {flash = 32768, ram = 16384}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -238,7 +238,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "usart1",

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -202,7 +202,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 7
-max-sizes = {flash = 16384, ram = 16384}
+max-sizes = {flash = 32768, ram = 16384}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -238,7 +238,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "usart1",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -131,7 +131,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 8
-max-sizes = {flash = 16384, ram = 16384}
+max-sizes = {flash = 32768, ram = 16384}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -192,7 +192,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "usart1",

--- a/idl/control-plane-agent.idol
+++ b/idl/control-plane-agent.idol
@@ -35,5 +35,28 @@ Interface(
                 err: CLike("ControlPlaneAgentError"),
             ),
         ),
+        "get_startup_options": (
+            doc: "Get the most-recently-provided startup options from MGS.",
+            encoding: Ssmarshal,
+            reply: Result(
+                ok: "HostStartupOptions",
+                err: CLike("ControlPlaneAgentError"),
+            ),
+        ),
+        "set_startup_options": (
+            doc: "Set the startup options word for use by host-sp-comms.",
+            args: {
+                // Arguably this should be `HostStartupOptions` (our bitflags
+                // type), but in practice we only call this function from hiffy,
+                // so it's easier to just use a plain `u64`. We convert it to a
+                // `HostStartupOptions` internally (returning an error if the
+                // supplied u64 contains any invalid bits).
+                "startup_options": "u64",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ControlPlaneAgentError"),
+            ),
+        ),
     },
 )

--- a/idl/host-sp-comms.idol
+++ b/idl/host-sp-comms.idol
@@ -24,26 +24,5 @@ Interface(
                 err: CLike("HostSpCommsError"),
             ),
         ),
-        "set_startup_options": (
-            doc: "Set the SP startup options word",
-            args: {
-                // Arguably this should be `StartupOptions` (our bitflags type),
-                // but in practice we only call this function from hiffy, so
-                // it's easier to just use a plain `u64`. We convert it to a
-                // `StartupOptions` internally (returning an error if the
-                // supplied u64 contains any invalid bits).
-                "startup_options": "u64",
-            },
-            reply: Result(
-                ok: "()",
-                err: CLike("HostSpCommsError"),
-            ),
-        ),
-        "get_startup_options": (
-            reply: Result(
-                ok: "StartupOptions",
-                err: CLike("HostSpCommsError"),
-            ),
-        ),
     },
 )

--- a/idl/host-sp-comms.idol
+++ b/idl/host-sp-comms.idol
@@ -24,24 +24,24 @@ Interface(
                 err: CLike("HostSpCommsError"),
             ),
         ),
-        "set_debug": (
-            doc: "Set the SP debug word",
+        "set_startup_options": (
+            doc: "Set the SP startup options word",
             args: {
-		// Arguably this should be `DebugReg` (our bitflags type), but
-		// in practice we only call this function from hiffy, so it's
-		// easier to just use a plain `u64`. We convert it to a
-		// `DebugReg` internally (returning an error if the supplied
-		// u64 contains any invalid bits).
-                "debug": "u64",
+                // Arguably this should be `StartupOptions` (our bitflags type),
+                // but in practice we only call this function from hiffy, so
+                // it's easier to just use a plain `u64`. We convert it to a
+                // `StartupOptions` internally (returning an error if the
+                // supplied u64 contains any invalid bits).
+                "startup_options": "u64",
             },
             reply: Result(
                 ok: "()",
                 err: CLike("HostSpCommsError"),
             ),
         ),
-        "get_debug": (
+        "get_startup_options": (
             reply: Result(
-                ok: "DebugReg",
+                ok: "StartupOptions",
                 err: CLike("HostSpCommsError"),
             ),
         ),

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 bitflags = "1.3"
 fletcher = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde-big-array = "0.4"
 serde_repr = "0.1"
 zerocopy = "0.6.1"
 

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -9,8 +9,10 @@ fletcher = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"
 serde_repr = "0.1"
+static_assertions = "1.1"
 zerocopy = "0.6.1"
 
 hubpack = { git = "https://github.com/cbiffle/hubpack" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
 
 unwrap-lite = { path = "../unwrap-lite" }

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -108,7 +108,7 @@ pub enum SpToHost {
     BootStorageUnit(Bsu),
     Identity {
         model: [u8; 11], // TODO model format?
-        revision: u8,
+        revision: u32,
         serial: [u8; 11], // TODO serial format?
     },
     MacAddresses {
@@ -177,8 +177,13 @@ bitflags::bitflags! {
     pub struct Status: u64 {
         const SP_TASK_RESTARTED = 1 << 0;
         const ALERTS_AVAILABLE  = 1 << 1;
+
         // Resync is a WIP; omit for now.
         // const READY_FOR_RESYNC  = 1 << 2;
+
+        // Instruct the host to go into recovery mode and fetch its phase2 image
+        // from the SP.
+        const PHASE2_RECOVERY = 1 << 3;
     }
 
     #[derive(Serialize, Deserialize, SerializedSize, FromBytes, AsBytes)]

--- a/task/control-plane-agent-api/Cargo.toml
+++ b/task/control-plane-agent-api/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
 num-traits = { version = "0.2.12", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+ssmarshal = {version = "1", default-features = false}
 zerocopy = "0.6.1"
 
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+host-sp-messages = {path = "../../lib/host-sp-messages"}
 userlib = {path = "../../sys/userlib"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -7,11 +7,13 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
+pub use host_sp_messages::HostStartupOptions;
 use userlib::*;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ControlPlaneAgentError {
     DataUnavailable = 1,
+    InvalidStartupOptions,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -28,7 +28,7 @@ task-validate-api = {path = "../validate-api"}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 update-buffer = {path = "../../lib/update-buffer"}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d6c896c4e7af05860ad97b389cc72915084c9fd4"}
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "07063d2e594d127452a96379dc082bef7439a924"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -12,7 +12,6 @@ ssmarshal = {version = "1", default-features = false}
 static_assertions = "1.1"
 zerocopy = "0.6.1"
 
-task-control-plane-agent-api = {path = "../control-plane-agent-api"}
 drv-auxflash-api = {path = "../../drv/auxflash-api", optional = true}
 drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
@@ -20,15 +19,17 @@ drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"], optional = true}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
 drv-update-api = {path = "../../drv/update-api"}
+host-sp-messages = {path = "../../lib/host-sp-messages"}
 mutable-statics = {path = "../../lib/mutable-statics"}
 ringbuf = {path = "../../lib/ringbuf"}
+task-control-plane-agent-api = {path = "../control-plane-agent-api"}
 task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 task-validate-api = {path = "../validate-api"}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 update-buffer = {path = "../../lib/update-buffer"}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "07063d2e594d127452a96379dc082bef7439a924"}
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -6,7 +6,8 @@
 #![no_main]
 
 use gateway_messages::{
-    sp_impl, IgnitionCommand, PowerState, SpComponent, SpPort, UpdateId, MgsError,
+    sp_impl, IgnitionCommand, MgsError, PowerState, SpComponent, SpPort,
+    UpdateId,
 };
 use idol_runtime::{Leased, NotificationHandler, RequestError};
 use mutable_statics::mutable_statics;

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -14,14 +14,23 @@ use drv_stm32h7_usart::Usart;
 use gateway_messages::sp_impl::{DeviceDescription, SocketAddrV6, SpHandler};
 use gateway_messages::{
     BulkIgnitionState, ComponentUpdatePrepare, DiscoverResponse, Header,
-    IgnitionCommand, IgnitionState, Message, MessageKind, PowerState,
+    IgnitionCommand, IgnitionState, Message, MessageKind, MgsError, PowerState,
     SpComponent, SpError, SpPort, SpRequest, SpState, SpUpdatePrepare,
     UpdateChunk, UpdateId, UpdateStatus,
 };
 use heapless::Deque;
+use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
+use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::{Address, UdpMetadata};
 use userlib::{sys_get_timer, sys_irq_control, UnwrapLite};
+
+// We're included under a special `path` cfg from main.rs, which confuses rustc
+// about where our submodules live. Pass explicit paths to correct it.
+#[path = "mgs_gimlet/host_phase2.rs"]
+mod host_phase2;
+
+use host_phase2::HostPhase2Requester;
 
 // How big does our shared update buffer need to be? Has to be able to handle SP
 // update blocks or host flash pages.
@@ -66,6 +75,7 @@ pub(crate) struct MgsHandler {
     sequencer: Sequencer,
     sp_update: SpUpdate,
     host_flash_update: HostFlashUpdate,
+    host_phase2: HostPhase2Requester,
     usart: UsartHandler,
     attached_serial_console_mgs: Option<(SocketAddrV6, SpPort)>,
     serial_console_write_offset: u64,
@@ -80,6 +90,7 @@ impl MgsHandler {
         Self {
             common: MgsCommon::claim_static_resources(),
             host_flash_update: HostFlashUpdate::new(),
+            host_phase2: HostPhase2Requester::claim_static_resources(),
             sp_update: SpUpdate::new(),
             sequencer: Sequencer::from(GIMLET_SEQ.get_task_id()),
             usart,
@@ -103,7 +114,15 @@ impl MgsHandler {
         {
             Some(sys_get_timer().now + 1)
         } else {
-            self.usart.from_rx_flush_deadline
+            match (
+                self.usart.from_rx_flush_deadline,
+                self.host_phase2.timer_deadline(),
+            ) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            }
         }
     }
 
@@ -114,9 +133,10 @@ impl MgsHandler {
         self.host_flash_update.step_preparation();
         self.sp_update.step_preparation();
         // Even though `timer_deadline()` can return a timer related to usart
-        // flushing, we don't need to do anything here; `NetHandler` in main.rs
-        // will call `wants_to_send_packet_to_mgs()` below when it's ready to
-        // grab any data we want to flush.
+        // flushing or host phase2 data handling, we don't need to do anything
+        // here; `NetHandler` in main.rs will call
+        // `wants_to_send_packet_to_mgs()` below when it's ready to grab any
+        // data we want to send.
     }
 
     pub(crate) fn drive_usart(&mut self) {
@@ -127,10 +147,10 @@ impl MgsHandler {
         // Do we have an attached serial console session MGS?
         if self.attached_serial_console_mgs.is_none() {
             self.usart.clear_rx_data();
-            return false;
         }
 
         self.usart.should_flush_to_mgs()
+            || self.host_phase2.wants_to_send_packet()
     }
 
     fn next_message_id(&mut self) -> u32 {
@@ -143,6 +163,16 @@ impl MgsHandler {
         &mut self,
         tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     ) -> Option<UdpMetadata> {
+        // Do we need to request host phase2 data?
+        if self.host_phase2.wants_to_send_packet() {
+            let message_id = self.next_message_id();
+            if let Some(meta) =
+                self.host_phase2.packet_to_mgs(message_id, tx_buf)
+            {
+                return Some(meta);
+            }
+        }
+
         // Should we flush any buffered usart data out to MGS?
         if !self.usart.should_flush_to_mgs() {
             return None;
@@ -193,6 +223,31 @@ impl MgsHandler {
             size: n as u32,
             vid: vlan_id_from_sp_port(sp_port),
         })
+    }
+
+    pub(crate) fn fetch_host_phase2_data(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        image_hash: [u8; 32],
+        offset: u64,
+        notification_bit: u8,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        self.host_phase2.start_fetch(
+            msg.sender,
+            notification_bit,
+            image_hash,
+            offset,
+        );
+        Ok(())
+    }
+
+    pub(crate) fn get_host_phase2_data(
+        &mut self,
+        image_hash: [u8; 32],
+        offset: u64,
+        data: Leased<idol_runtime::W, [u8]>,
+    ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
+        self.host_phase2.get_data(image_hash, offset, data)
     }
 }
 
@@ -516,6 +571,37 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn mgs_response_error(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        message_id: u32,
+        err: MgsError,
+    ) {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
+            message_id,
+            err
+        }));
+    }
+
+    fn mgs_response_host_phase2_data(
+        &mut self,
+        _sender: SocketAddrV6,
+        port: SpPort,
+        _message_id: u32,
+        hash: [u8; 32],
+        offset: u64,
+        data: &[u8],
+    ) {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+            hash,
+            offset,
+            data_len: data.len(),
+        }));
+
+        self.host_phase2.ingest_incoming_data(port, hash, offset, data);
     }
 }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -601,7 +601,8 @@ impl SpHandler for MgsHandler {
             data_len: data.len(),
         }));
 
-        self.host_phase2.ingest_incoming_data(port, hash, offset, data);
+        self.host_phase2
+            .ingest_incoming_data(port, hash, offset, data);
     }
 }
 

--- a/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
@@ -1,0 +1,285 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::vlan_id_from_sp_port;
+use core::sync::atomic::{AtomicBool, Ordering};
+use gateway_messages::{Header, Message, MessageKind, SpPort, SpRequest};
+use heapless::Vec;
+use idol_runtime::{Leased, RequestError};
+use task_control_plane_agent_api::ControlPlaneAgentError;
+use task_net_api::{Address, Ipv6Address, UdpMetadata};
+use userlib::{sys_get_timer, sys_post, TaskId, UnwrapLite};
+
+const ALL_NODES_MULTICAST: Address = Address::Ipv6(Ipv6Address([
+    0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+]));
+const MGS_UDP_PORT: u16 = 22222;
+
+// We only support a single in-flight host phase 2 request at a time (i.e., we
+// do not support any pipelining). When the host makes a request of us (via
+// `host-sp-comms`, which calls our idol interface on its behalf), we may not
+// know _which_ MGS instance is able to provide the data it wants, and given
+// we're using UDP, we need to support a small number of retries. Our constants
+// here control how long we wait before we try "the other" MGS (assuming we've
+// picked one to start with), and then how long we wait before switching back
+// and retrying both. Assuming no successful replies from either MGS instance,
+// our timeline for a request will be:
+//
+// 1. Start in `State::NeedToSendFirstMgs(port)`.
+// 2. We send a request on our currently-selected port and update our state to
+//    `State::WaitingForFirstMgs { .. }`.
+// 2. If we have not received a successful response after `DELAY_TRY_OTHER_MGS`
+//    ticks, we will switch to the other port, send a request, and update our
+//    state to `State::WaitingForSecondMgs { .. }`.
+// 3. If we have not received a successful response after `DELAY_RETRY` _and_ we
+//    have attempted fewer than `MAX_ATTEMPTS`, we will switch back to the first
+//    port and go to step 2. If we have exceeded `MAX_ATTEMPTS`, we'll notify
+//    our caller (and give them an error when they request the data).
+const DELAY_TRY_OTHER_MGS: u64 = 500;
+const DELAY_RETRY: u64 = 1_000;
+const MAX_ATTEMPTS: u8 = 3;
+
+pub(crate) struct HostPhase2Requester {
+    current: Option<CurrentRequest>,
+    last_responsive_mgs: SpPort,
+    buffer: &'static mut Vec<u8, { gateway_messages::MAX_SERIALIZED_SIZE }>,
+}
+
+impl HostPhase2Requester {
+    pub(crate) fn claim_static_resources() -> Self {
+        Self {
+            current: None,
+            last_responsive_mgs: SpPort::One,
+            buffer: claim_phase2_buffer(),
+        }
+    }
+
+    pub(crate) fn start_fetch(
+        &mut self,
+        requesting_task: TaskId,
+        requesting_task_notification_bit: u8,
+        hash: [u8; 32],
+        offset: u64,
+    ) {
+        self.current = Some(CurrentRequest {
+            requesting_task,
+            requesting_task_notification_bit,
+            hash,
+            offset,
+            state: State::NeedToSendFirstMgs(self.last_responsive_mgs),
+            retry_count: 0,
+        });
+        self.buffer.clear();
+    }
+
+    pub(crate) fn timer_deadline(&self) -> Option<u64> {
+        self.current
+            .as_ref()
+            .and_then(|current| current.state.timer_deadline())
+    }
+
+    pub(crate) fn wants_to_send_packet(&self) -> bool {
+        self.current
+            .as_ref()
+            .and_then(|c| c.state.port_to_send_packet())
+            .is_some()
+    }
+
+    pub(crate) fn packet_to_mgs(
+        &mut self,
+        message_id: u32,
+        tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Option<UdpMetadata> {
+        let current = self.current.as_mut()?;
+
+        let now = sys_get_timer().now;
+
+        // Are we in a state where we should send a packet? If so, extract which
+        // port we should use, and update `current.state` assuming that packet
+        // will be sent imminently (which will be true as long as there's room
+        // in our outgoing net task queue).
+        let port = match current.state {
+            State::NeedToSendFirstMgs(port) => {
+                current.state = State::WaitingForFirstMgs {
+                    port,
+                    deadline: now + DELAY_TRY_OTHER_MGS,
+                };
+                port
+            }
+            State::WaitingForFirstMgs { port, deadline } => {
+                if now < deadline {
+                    return None;
+                }
+                // Timed out waiting for a response from the first MGS we tried;
+                // flip to the other one.
+                let port = match port {
+                    SpPort::One => SpPort::Two,
+                    SpPort::Two => SpPort::One,
+                };
+                current.state = State::WaitingForSecondMgs {
+                    port,
+                    deadline: now + DELAY_RETRY,
+                };
+                port
+            }
+            State::WaitingForSecondMgs { port, deadline } => {
+                if now < deadline {
+                    return None;
+                }
+                // Timed out waiting for a response from the second MGS we
+                // tried; flip back to the first and retry.
+                current.retry_count += 1;
+                if current.retry_count >= MAX_ATTEMPTS {
+                    current.notify_calling_task();
+                    self.current = None;
+                    return None;
+                }
+                let port = match port {
+                    SpPort::One => SpPort::Two,
+                    SpPort::Two => SpPort::One,
+                };
+                current.state = State::WaitingForFirstMgs {
+                    port,
+                    deadline: now + DELAY_TRY_OTHER_MGS,
+                };
+                port
+            }
+            State::Fetched => return None,
+        };
+
+        let message = Message {
+            header: Header {
+                version: gateway_messages::version::V2,
+                message_id,
+            },
+            kind: MessageKind::SpRequest(SpRequest::HostPhase2Data {
+                hash: current.hash,
+                offset: current.offset,
+            }),
+        };
+
+        let n = gateway_messages::serialize(tx_buf, &message).unwrap_lite();
+
+        Some(UdpMetadata {
+            addr: ALL_NODES_MULTICAST,
+            port: MGS_UDP_PORT,
+            size: n as u32,
+            vid: vlan_id_from_sp_port(port),
+        })
+    }
+
+    pub(crate) fn ingest_incoming_data(
+        &mut self,
+        port: SpPort,
+        hash: [u8; 32],
+        offset: u64,
+        data: &[u8],
+    ) {
+        let current = match self.current.as_mut() {
+            Some(current)
+                if hash == current.hash && offset == current.offset =>
+            {
+                current
+            }
+            _ => return,
+        };
+
+        self.buffer.clear();
+        let n = usize::min(self.buffer.capacity(), data.len());
+        self.buffer.extend_from_slice(&data[..n]).unwrap_lite();
+
+        current.state = State::Fetched;
+        current.notify_calling_task();
+        self.last_responsive_mgs = port;
+    }
+
+    pub(crate) fn get_data(
+        &self,
+        hash: [u8; 32],
+        offset: u64,
+        data: Leased<idol_runtime::W, [u8]>,
+    ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
+        match self.current.as_ref() {
+            Some(current)
+                if hash == current.hash && offset == current.offset =>
+            {
+                let n = usize::min(data.len(), self.buffer.len());
+                data.write_range(0..n, &self.buffer[..n])
+                    .map_err(|()| RequestError::went_away())?;
+                Ok(n)
+            }
+            _ => Err(ControlPlaneAgentError::DataUnavailable.into()),
+        }
+    }
+}
+
+struct CurrentRequest {
+    requesting_task: TaskId,
+    requesting_task_notification_bit: u8,
+    hash: [u8; 32],
+    offset: u64,
+    state: State,
+    retry_count: u8,
+}
+
+impl CurrentRequest {
+    fn notify_calling_task(&self) {
+        sys_post(
+            self.requesting_task,
+            1 << self.requesting_task_notification_bit,
+        );
+    }
+}
+
+enum State {
+    NeedToSendFirstMgs(SpPort),
+    WaitingForFirstMgs { port: SpPort, deadline: u64 },
+    WaitingForSecondMgs { port: SpPort, deadline: u64 },
+    Fetched,
+}
+
+impl State {
+    // If we want to send a packet, returns `Some(port)` on which we want to
+    // send that packet.
+    fn port_to_send_packet(&self) -> Option<SpPort> {
+        match self {
+            State::NeedToSendFirstMgs(port) => Some(*port),
+            State::Fetched => None,
+            State::WaitingForFirstMgs { deadline, port }
+            | State::WaitingForSecondMgs { deadline, port } => {
+                if sys_get_timer().now >= *deadline {
+                    Some(*port)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn timer_deadline(&self) -> Option<u64> {
+        match self {
+            State::NeedToSendFirstMgs(_) => Some(sys_get_timer().now + 1),
+            State::Fetched => None,
+            State::WaitingForFirstMgs { deadline, .. }
+            | State::WaitingForSecondMgs { deadline, .. } => Some(*deadline),
+        }
+    }
+}
+
+fn claim_phase2_buffer(
+) -> &'static mut Vec<u8, { gateway_messages::MAX_SERIALIZED_SIZE }> {
+    static mut PHASE2_BUF: Vec<u8, { gateway_messages::MAX_SERIALIZED_SIZE }> =
+        Vec::new();
+
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::Relaxed) {
+        panic!()
+    }
+
+    // Safety: unsafe because of references to mutable statics; safe because of
+    // the AtomicBool swap above, combined with the lexical scoping of
+    // `PHASE2_BUF`, means that this reference can't be aliased by any
+    // other reference in the program.
+    unsafe { &mut PHASE2_BUF }
+}

--- a/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
@@ -11,8 +11,8 @@ use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::{Address, Ipv6Address, UdpMetadata};
 use userlib::{sys_get_timer, sys_post, TaskId, UnwrapLite};
 
-const ALL_NODES_MULTICAST: Address = Address::Ipv6(Ipv6Address([
-    0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+const SP_TO_MGS_MULTICAST_ADDR: Address = Address::Ipv6(Ipv6Address([
+    0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0xde, 0, 1,
 ]));
 const MGS_UDP_PORT: u16 = 22222;
 
@@ -162,7 +162,7 @@ impl HostPhase2Requester {
         let n = gateway_messages::serialize(tx_buf, &message).unwrap_lite();
 
         Some(UdpMetadata {
-            addr: ALL_NODES_MULTICAST,
+            addr: SP_TO_MGS_MULTICAST_ADDR,
             port: MGS_UDP_PORT,
             size: n as u32,
             vid: vlan_id_from_sp_port(port),

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -11,6 +11,7 @@ use gateway_messages::{
     IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
     SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
+use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::ControlPlaneAgentError;
@@ -95,6 +96,23 @@ impl MgsHandler {
         _data: Leased<idol_runtime::W, [u8]>,
     ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
         Err(ControlPlaneAgentError::DataUnavailable.into())
+    }
+
+    pub(crate) fn startup_options(
+        &self,
+    ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
+    }
+
+    pub(crate) fn set_startup_options(
+        &mut self,
+        _startup_options: HostStartupOptions,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 }
 
@@ -317,6 +335,27 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn get_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<gateway_messages::StartupOptions, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        options: gateway_messages::StartupOptions,
+    ) -> Result<(), SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn mgs_response_error(

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -8,10 +8,12 @@ use crate::{mgs_common::MgsCommon, update::sp::SpUpdate, Log, MgsMessage};
 use gateway_messages::sp_impl::{DeviceDescription, SocketAddrV6, SpHandler};
 use gateway_messages::{
     BulkIgnitionState, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, PowerState, SpComponent, SpError, SpPort,
-    SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
+    SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
+use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
+use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::UdpMetadata;
 use userlib::sys_get_timer;
 
@@ -74,6 +76,25 @@ impl MgsHandler {
         _tx_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     ) -> Option<UdpMetadata> {
         None
+    }
+
+    pub(crate) fn fetch_host_phase2_data(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        _image_hash: [u8; 32],
+        _offset: u64,
+        _notification_bit: u8,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        Err(ControlPlaneAgentError::DataUnavailable.into())
+    }
+
+    pub(crate) fn get_host_phase2_data(
+        &mut self,
+        _image_hash: [u8; 32],
+        _offset: u64,
+        _data: Leased<idol_runtime::W, [u8]>,
+    ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
+        Err(ControlPlaneAgentError::DataUnavailable.into())
     }
 }
 
@@ -296,5 +317,34 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn mgs_response_error(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        message_id: u32,
+        err: MgsError,
+    ) {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
+            message_id,
+            err
+        }));
+    }
+
+    fn mgs_response_host_phase2_data(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        _message_id: u32,
+        hash: [u8; 32],
+        offset: u64,
+        data: &[u8],
+    ) {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+            hash,
+            offset,
+            data_len: data.len(),
+        }));
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -11,6 +11,7 @@ use gateway_messages::{
     IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
     SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
+use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::ControlPlaneAgentError;
@@ -99,6 +100,23 @@ impl MgsHandler {
         _data: Leased<idol_runtime::W, [u8]>,
     ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
         Err(ControlPlaneAgentError::DataUnavailable.into())
+    }
+
+    pub(crate) fn startup_options(
+        &self,
+    ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
+    }
+
+    pub(crate) fn set_startup_options(
+        &mut self,
+        _startup_options: HostStartupOptions,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 }
 
@@ -342,6 +360,27 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn get_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<gateway_messages::StartupOptions, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        options: gateway_messages::StartupOptions,
+    ) -> Result<(), SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn mgs_response_error(

--- a/task/host-sp-comms-api/src/lib.rs
+++ b/task/host-sp-comms-api/src/lib.rs
@@ -9,7 +9,7 @@
 use derive_idol_err::IdolError;
 use userlib::*;
 
-pub use host_sp_messages::{StartupOptions, Status};
+pub use host_sp_messages::{HostStartupOptions, Status};
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum HostSpCommsError {

--- a/task/host-sp-comms-api/src/lib.rs
+++ b/task/host-sp-comms-api/src/lib.rs
@@ -9,12 +9,12 @@
 use derive_idol_err::IdolError;
 use userlib::*;
 
-pub use host_sp_messages::{DebugReg, Status};
+pub use host_sp_messages::{StartupOptions, Status};
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum HostSpCommsError {
     InvalidStatus = 1,
-    InvalidDebug,
+    InvalidStartupOptions,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1"
-#corncobs = "0.1.1"
-corncobs = {git = "https://github.com/jgallagher/corncobs.git", branch = "fix-encode-buf"}
+corncobs = "0.1.3"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 enum-map = "2.4.1"
 heapless = "0.7.16"

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1"
-corncobs = "0.1.1"
+#corncobs = "0.1.1"
+corncobs = {git = "https://github.com/jgallagher/corncobs.git", branch = "fix-encode-buf"}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 enum-map = "2.4.1"
 heapless = "0.7.16"

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -625,8 +625,9 @@ impl ServerImpl {
             }),
             HostToSp::AckSpStart => {
                 ringbuf_entry!(Trace::AckSpStart);
-                action =
-                    Some(Action::ClearStatusBits(Status::SP_TASK_RESTARTED));
+                action = Some(Action::ClearStatusBits(
+                    Status::SP_TASK_RESTARTED | Status::PHASE2_RECOVERY,
+                ));
                 Some(SpToHost::Ack)
             }
             HostToSp::GetAlert => {


### PR DESCRIPTION
The bulk of this PR is in the new `host_phase2` module, which is responsible for sending requests to MGS (potentially on both ports) to ask for phase 2 data in response to `host-sp-comms` asking `control-plane-agent` to do so. There are a handful of minor changes to `host-sp-messages` to track the latest RFD 316 updates (some of which may be so new to have not even landed yet!).