### PR TITLE
lpc55-sprot-server: Pin repo hash to current HEAD.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "sprockets-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git#77df31efa5619d0767ffc837ef7468101608aee9"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "derive_more",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "sprockets-rot"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git#77df31efa5619d0767ffc837ef7468101608aee9"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "corncobs",
  "derive_more",

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -17,8 +17,8 @@ idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 ringbuf = {path = "../../lib/ringbuf"}
 lpc55_romapi = { path = "../../lib/lpc55-romapi" }
 crc = "3.0.0"
-sprockets-common = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
-sprockets-rot = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
+sprockets-common = {git = "https://github.com/oxidecomputer/sprockets.git", rev = "77df31efa5619d0767ffc837ef7468101608aee9", default-features = false}
+sprockets-rot = {git = "https://github.com/oxidecomputer/sprockets.git", rev = "77df31efa5619d0767ffc837ef7468101608aee9", default-features = false}
 hubpack = { rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25", git = "https://github.com/cbiffle/hubpack.git"}
 salty = "0.2.0"
 if_chain = "1"


### PR DESCRIPTION
This should allow us to make incompatible changes upstream w/o breaking stuff.