### PR TITLE
Get our hubpacks from one place: the crates.io registry.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "drv-sprot-api",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol-runtime",
  "if_chain",
  "lpc55-pac",
@@ -1408,7 +1408,7 @@ dependencies = [
  "crc",
  "derive-idol-err",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "if_chain",
  "memoffset",
@@ -1566,7 +1566,7 @@ dependencies = [
  "drv-sprot-api",
  "drv-stm32xx-sys-api",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "idol-runtime",
  "num-traits",
@@ -1722,7 +1722,7 @@ name = "drv-update-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "num-traits",
  "serde",
@@ -2137,7 +2137,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "fletcher",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_repr",
  "unwrap-lite",
@@ -2164,15 +2164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hubpack"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
-dependencies = [
- "hubpack_derive 0.1.0 (git+https://github.com/cbiffle/hubpack)",
- "serde",
-]
-
-[[package]]
 name = "hubpack_derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,16 +2178,6 @@ dependencies = [
 name = "hubpack_derive"
 version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "hubpack_derive"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -19,7 +19,7 @@ lpc55_romapi = { path = "../../lib/lpc55-romapi" }
 crc = "3.0.0"
 sprockets-common = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
 sprockets-rot = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
-hubpack = { rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25", git = "https://github.com/cbiffle/hubpack.git"}
+hubpack = "0.1"
 salty = "0.2.0"
 if_chain = "1"
 

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
+hubpack = "0.1"
 ssmarshal = {version = "1", default-features = false}
 
 [build-dependencies]

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -15,7 +15,7 @@ drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-s
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 cfg-if = "1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
+hubpack = "0.1"
 ssmarshal = {version = "1", default-features = false}
 
 [build-dependencies]

--- a/drv/update-api/Cargo.toml
+++ b/drv/update-api/Cargo.toml
@@ -8,7 +8,7 @@ derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
+hubpack = "0.1"
 serde = {version = "1.0.145", default-features = false, features = ["derive"]}
 serde_repr = "0.1"
 

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -10,6 +10,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_repr = "0.1"
 zerocopy = "0.6.1"
 
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
+hubpack = "0.1"
 
 unwrap-lite = { path = "../unwrap-lite" }


### PR DESCRIPTION
This is minor cleanup. These toml files were probably created before hubpack was published to the registry.