### PR TITLE
Move host startup options to control-plane-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=07063d2e594d127452a96379dc082bef7439a924#07063d2e594d127452a96379dc082bef7439a924"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=d7791e4d02571b8414b4c2976b0439234aa4d8c7#d7791e4d02571b8414b4c2976b0439234aa4d8c7"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -2137,10 +2137,12 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "fletcher",
+ "gateway-messages",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
  "serde",
  "serde-big-array",
  "serde_repr",
+ "static_assertions",
  "unwrap-lite",
  "zerocopy",
 ]
@@ -3732,6 +3734,7 @@ dependencies = [
  "drv-update-api",
  "gateway-messages",
  "heapless",
+ "host-sp-messages",
  "idol",
  "idol-runtime",
  "mutable-statics",
@@ -3754,8 +3757,11 @@ name = "task-control-plane-agent-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
+ "host-sp-messages",
  "idol",
  "num-traits",
+ "serde",
+ "ssmarshal",
  "userlib",
  "zerocopy",
 ]

--- a/idl/control-plane-agent.idol
+++ b/idl/control-plane-agent.idol
@@ -35,5 +35,28 @@ Interface(
                 err: CLike("ControlPlaneAgentError"),
             ),
         ),
+        "get_startup_options": (
+            doc: "Get the most-recently-provided startup options from MGS.",
+            encoding: Ssmarshal,
+            reply: Result(
+                ok: "HostStartupOptions",
+                err: CLike("ControlPlaneAgentError"),
+            ),
+        ),
+        "set_startup_options": (
+            doc: "Set the startup options word for use by host-sp-comms.",
+            args: {
+                // Arguably this should be `HostStartupOptions` (our bitflags
+                // type), but in practice we only call this function from hiffy,
+                // so it's easier to just use a plain `u64`. We convert it to a
+                // `HostStartupOptions` internally (returning an error if the
+                // supplied u64 contains any invalid bits).
+                "startup_options": "u64",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ControlPlaneAgentError"),
+            ),
+        ),
     },
 )

--- a/idl/host-sp-comms.idol
+++ b/idl/host-sp-comms.idol
@@ -24,26 +24,5 @@ Interface(
                 err: CLike("HostSpCommsError"),
             ),
         ),
-        "set_startup_options": (
-            doc: "Set the SP startup options word",
-            args: {
-                // Arguably this should be `StartupOptions` (our bitflags type),
-                // but in practice we only call this function from hiffy, so
-                // it's easier to just use a plain `u64`. We convert it to a
-                // `StartupOptions` internally (returning an error if the
-                // supplied u64 contains any invalid bits).
-                "startup_options": "u64",
-            },
-            reply: Result(
-                ok: "()",
-                err: CLike("HostSpCommsError"),
-            ),
-        ),
-        "get_startup_options": (
-            reply: Result(
-                ok: "StartupOptions",
-                err: CLike("HostSpCommsError"),
-            ),
-        ),
     },
 )

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -9,8 +9,10 @@ fletcher = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"
 serde_repr = "0.1"
+static_assertions = "1.1"
 zerocopy = "0.6.1"
 
 hubpack = { git = "https://github.com/cbiffle/hubpack" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
 
 unwrap-lite = { path = "../unwrap-lite" }

--- a/task/control-plane-agent-api/Cargo.toml
+++ b/task/control-plane-agent-api/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
 num-traits = { version = "0.2.12", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+ssmarshal = {version = "1", default-features = false}
 zerocopy = "0.6.1"
 
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+host-sp-messages = {path = "../../lib/host-sp-messages"}
 userlib = {path = "../../sys/userlib"}
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -7,11 +7,13 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
+pub use host_sp_messages::HostStartupOptions;
 use userlib::*;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ControlPlaneAgentError {
     DataUnavailable = 1,
+    InvalidStartupOptions,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -12,7 +12,6 @@ ssmarshal = {version = "1", default-features = false}
 static_assertions = "1.1"
 zerocopy = "0.6.1"
 
-task-control-plane-agent-api = {path = "../control-plane-agent-api"}
 drv-auxflash-api = {path = "../../drv/auxflash-api", optional = true}
 drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
 drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
@@ -20,15 +19,17 @@ drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
 drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"], optional = true}
 drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
 drv-update-api = {path = "../../drv/update-api"}
+host-sp-messages = {path = "../../lib/host-sp-messages"}
 mutable-statics = {path = "../../lib/mutable-statics"}
 ringbuf = {path = "../../lib/ringbuf"}
+task-control-plane-agent-api = {path = "../control-plane-agent-api"}
 task-jefe-api = {path = "../jefe-api"}
 task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
 task-validate-api = {path = "../validate-api"}
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 update-buffer = {path = "../../lib/update-buffer"}
 
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "07063d2e594d127452a96379dc082bef7439a924"}
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 
 [build-dependencies]

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -11,6 +11,7 @@ use gateway_messages::{
     IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
     SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
+use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::ControlPlaneAgentError;
@@ -95,6 +96,23 @@ impl MgsHandler {
         _data: Leased<idol_runtime::W, [u8]>,
     ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
         Err(ControlPlaneAgentError::DataUnavailable.into())
+    }
+
+    pub(crate) fn startup_options(
+        &self,
+    ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
+    }
+
+    pub(crate) fn set_startup_options(
+        &mut self,
+        _startup_options: HostStartupOptions,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 }
 
@@ -317,6 +335,27 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn get_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<gateway_messages::StartupOptions, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        options: gateway_messages::StartupOptions,
+    ) -> Result<(), SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn mgs_response_error(

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -11,6 +11,7 @@ use gateway_messages::{
     IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
     SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
+use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
 use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::ControlPlaneAgentError;
@@ -99,6 +100,23 @@ impl MgsHandler {
         _data: Leased<idol_runtime::W, [u8]>,
     ) -> Result<usize, RequestError<ControlPlaneAgentError>> {
         Err(ControlPlaneAgentError::DataUnavailable.into())
+    }
+
+    pub(crate) fn startup_options(
+        &self,
+    ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
+    }
+
+    pub(crate) fn set_startup_options(
+        &mut self,
+        _startup_options: HostStartupOptions,
+    ) -> Result<(), RequestError<ControlPlaneAgentError>> {
+        // We don't have a host to give startup options; no one should be
+        // calling this method.
+        Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 }
 
@@ -342,6 +360,27 @@ impl SpHandler for MgsHandler {
 
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
         self.common.inventory_device_description(index as usize)
+    }
+
+    fn get_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<gateway_messages::StartupOptions, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_startup_options(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        options: gateway_messages::StartupOptions,
+    ) -> Result<(), SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn mgs_response_error(

--- a/task/host-sp-comms-api/src/lib.rs
+++ b/task/host-sp-comms-api/src/lib.rs
@@ -9,7 +9,7 @@
 use derive_idol_err::IdolError;
 use userlib::*;
 
-pub use host_sp_messages::{StartupOptions, Status};
+pub use host_sp_messages::{HostStartupOptions, Status};
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum HostSpCommsError {


### PR DESCRIPTION
This allows them to be read and written by MGS.

Builds on #922 and should be merged after it.