### PR TITLE
Switch to using workspace dependencies for _everything_

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
  "lib-lpc55-usart",
  "lpc55-pac",
  "nb 1.0.0",
- "salty 0.2.0 (git+https://github.com/oxidecomputer/salty?rev=eb3c31858f631a7fb9934246c8efdef080d05726)",
+ "salty 0.2.0 (git+https://github.com/oxidecomputer/salty)",
  "serde",
  "serde-big-array",
  "sha3",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad#5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
+source = "git+https://github.com/oxidecomputer/dice-util#5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
 dependencies = [
  "corncobs",
  "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1908,7 +1908,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=d7791e4d02571b8414b4c2976b0439234aa4d8c7#d7791e4d02571b8414b4c2976b0439234aa4d8c7"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#d7791e4d02571b8414b4c2976b0439234aa4d8c7"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?rev=5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23#5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
+source = "git+https://github.com/oxidecomputer/lpc55_support#5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?rev=5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23#5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
+source = "git+https://github.com/oxidecomputer/lpc55_support#5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "salty"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/salty?rev=eb3c31858f631a7fb9934246c8efdef080d05726#eb3c31858f631a7fb9934246c8efdef080d05726"
+source = "git+https://github.com/oxidecomputer/salty#eb3c31858f631a7fb9934246c8efdef080d05726"
 dependencies = [
  "ed25519",
  "subtle",
@@ -3555,7 +3555,7 @@ dependencies = [
  "p256",
  "panic-halt",
  "panic-semihosting",
- "salty 0.2.0 (git+https://github.com/oxidecomputer/salty?rev=eb3c31858f631a7fb9934246c8efdef080d05726)",
+ "salty 0.2.0 (git+https://github.com/oxidecomputer/salty)",
  "serde",
  "sha3",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,11 +302,8 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
- "time",
- "winapi",
 ]
 
 [[package]]
@@ -2521,9 +2518,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "multitimer"
@@ -3010,7 +3004,6 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
  "rand_hc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.14.0",
+ "stm32g0",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.14.0",
+ "stm32g0",
 ]
 
 [[package]]
@@ -1135,7 +1135,7 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "drv-sprot-api",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol-runtime",
  "if_chain",
  "lpc55-pac",
@@ -1408,7 +1408,7 @@ dependencies = [
  "crc",
  "derive-idol-err",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "if_chain",
  "memoffset",
@@ -1451,7 +1451,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "drv-stm32xx-sys-api",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "userlib",
  "zerocopy",
 ]
@@ -1566,7 +1566,7 @@ dependencies = [
  "drv-sprot-api",
  "drv-stm32xx-sys-api",
  "drv-update-api",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "idol-runtime",
  "num-traits",
@@ -1601,7 +1601,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "stm32h7",
  "userlib",
  "zerocopy",
@@ -1617,7 +1617,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "stm32g0 0.15.1",
+ "stm32g0",
  "stm32h7",
  "userlib",
  "zerocopy",
@@ -1638,7 +1638,7 @@ dependencies = [
  "fixedmap",
  "num-traits",
  "ringbuf",
- "stm32g0 0.15.1",
+ "stm32g0",
  "stm32h7",
  "userlib",
 ]
@@ -1654,7 +1654,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "stm32h7",
  "task-jefe-api",
  "userlib",
@@ -1722,7 +1722,7 @@ name = "drv-update-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
  "num-traits",
  "serde",
@@ -3631,16 +3631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stm32g0"
-version = "0.15.1"
-source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-update#9bb993b07a5906ac4503d702e7ff507f229d1b44"
-dependencies = [
- "bare-metal 1.0.0",
- "cortex-m",
- "vcell",
-]
-
-[[package]]
 name = "stm32h7"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,7 +4429,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.14.0",
+ "stm32g0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
  "bitflags",
  "fletcher",
  "gateway-messages",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-big-array",
  "serde_repr",
@@ -2167,15 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hubpack"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
-dependencies = [
- "hubpack_derive 0.1.0 (git+https://github.com/cbiffle/hubpack)",
- "serde",
-]
-
-[[package]]
 name = "hubpack_derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,16 +2181,6 @@ dependencies = [
 name = "hubpack_derive"
 version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "hubpack_derive"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,8 +3602,8 @@ dependencies = [
 
 [[package]]
 name = "stm32g0"
-version = "0.14.0"
-source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-initial-support#19280bfc90cce3020482abc1d0c57d7d2a3bf162"
+version = "0.15.1"
+source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-update#9bb993b07a5906ac4503d702e7ff507f229d1b44"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.15.1",
+ "stm32g0 0.14.0",
 ]
 
 [[package]]
@@ -3637,7 +3637,6 @@ source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
- "cortex-m-rt",
  "vcell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,21 +112,21 @@ zerocopy = { version = "0.6.1", default-features = false }
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
 
 # Oxide forks and repos
-dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", rev = "5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad" }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
-ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726" }
-spd = { git = "https://github.com/oxidecomputer/spd" }
+dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
+idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
+ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
+salty = { git = "https://github.com/oxidecomputer/salty", default-features = false }
+spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false }
-tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
-tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
+tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
+tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
+vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["resolver", "named-profiles"]
+cargo-features = ["resolver", "named-profiles", "workspace-inheritance"]
 
 [workspace]
 members = [
@@ -30,3 +30,70 @@ path = "sys/userlib"
 [patch."https://github.com/oxidecomputer/hubris".abi]
 path = "sys/abi"
 
+[workspace.dependencies]
+anyhow = "1.0.31"
+atty = "0.2"
+bitfield = "0.13"
+bitflags = "1.2.1"
+bstringify = "0.1.2"
+byteorder = { version = "1.3.4", default-features = false }
+cargo_metadata = "0.12.0"
+cfg-if = "1"
+clap = { version = "3.0.14", features = ["derive"] }
+colored = "2.0"
+convert_case = "0.4"
+cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m-rt = "0.6.12"
+ctrlc = "3.1.5"
+digest = "0.10"
+dunce = "1.0.2"
+ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
+filetime = "0.2.12"
+fnv = "1.0.7"
+goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
+hmac = { version = "0.10.1", default-features = false }
+hubpack = "0.1"
+indexmap = { version = "1.4.0", features = ["serde-1"] }
+lpc55-pac = { version = "0.4" }
+memchr = "2.4"
+multimap = "0.8.3"
+nb = "1"
+num-traits = { version = "0.2.12", default-features = false }
+p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
+panic-halt = "0.2.0"
+panic-itm = "0.4.1"
+panic-semihosting = "0.5.3"
+paste = "1"
+path-slash = "0.1.3"
+proc-macro2 = "1"
+quote = "1"
+rand = "0.8"
+rand_chacha = "0.3"
+ron = "0.7"
+scroll = "0.10"
+serde = { version = "1.0.114", default_features = false, features = ["derive"] }
+serde_json = "1.0"
+sha2 = { version = "0.9", default-features = false }
+sha3 = { version = "0.10", default-features = false }
+srec = "0.2.0"
+ssmarshal = { version = "1.0.0", default-features = false }
+static_assertions = { version = "1" }
+stm32f3 = "0.13.0"
+stm32f4 = "0.13.0"
+stm32h7 = { version = "0.14", default-features = false }
+strsim = "0.10.0"
+syn = { version = "1", features = ["parsing"] }
+toml = "0.5.6"
+walkdir = "2.0.0"
+zerocopy = "0.6.1"
+
+# Oxide forks and repos
+salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726" }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
+tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
+tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
+idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ ron = { version = "0.7", default-features = false }
 scroll = { version = "0.10", default-features = false }
 serde = { version = "1.0.114", default_features = false, features = ["derive"] }
 serde-big-array = { version = "0.4", default-features = false }
-serde_json = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_repr = { version = "0.1", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["resolver", "named-profiles", "workspace-inheritance"]
+cargo-features = ["resolver", "named-profiles"]
 
 [workspace]
 members = [
@@ -44,20 +44,28 @@ colored = "2.0"
 convert_case = "0.4"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 cortex-m-rt = "0.6.12"
+cortex-m-semihosting = "0.5.0"
+crc = "3.0.0"
 ctrlc = "3.1.5"
+derive_more = "0.99"
 digest = "0.10"
 dunce = "1.0.2"
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
 filetime = "0.2.12"
 fnv = "1.0.7"
+getrandom = { version = "0.2", default-features = false }
 goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
 hmac = { version = "0.10.1", default-features = false }
 hubpack = "0.1"
+if_chain = "1"
 indexmap = { version = "1.4.0", features = ["serde-1"] }
 lpc55-pac = { version = "0.4" }
 memchr = "2.4"
+memoffset = { version = "0.6.5", default-features = false }
 multimap = "0.8.3"
 nb = "1"
+num = { version = "0.4", default-features = false }
+num-derive = { version = "0.3.3", features = ["full-syntax"] }
 num-traits = { version = "0.2.12", default-features = false }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 panic-halt = "0.2.0"
@@ -68,13 +76,16 @@ path-slash = "0.1.3"
 proc-macro2 = "1"
 quote = "1"
 rand = "0.8"
-rand_chacha = "0.3"
+rand_chacha = { version = "0.3", default_features = false }
+rand_core = "0.6"
 ron = "0.7"
 scroll = "0.10"
 serde = { version = "1.0.114", default_features = false, features = ["derive"] }
 serde_json = "1.0"
+serde_repr = "0.1"
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
+smbus-pec = "1.0.1"
 srec = "0.2.0"
 ssmarshal = { version = "1.0.0", default-features = false }
 static_assertions = { version = "1" }
@@ -85,15 +96,20 @@ strsim = "0.10.0"
 syn = { version = "1", features = ["parsing"] }
 toml = "0.5.6"
 walkdir = "2.0.0"
+vcell = "0.1.2"
 zerocopy = "0.6.1"
 
 # Oxide forks and repos
-salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726" }
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
-ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
-tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
-tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
+ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
+salty = "0.2.0"
+sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
+sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
+tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
+vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bstringify = "0.1.2"
 byteorder = { version = "1.3.4", default-features = false }
 cargo_metadata = "0.12.0"
 cfg-if = "1"
+chrono = "0.4"
 clap = { version = "3.0.14", features = ["derive"] }
 colored = "2.0"
 convert_case = "0.4"
@@ -65,6 +66,7 @@ hmac = { version = "0.10.1", default-features = false }
 hubpack = "0.1"
 if_chain = "1"
 indexmap = { version = "1.4.0", features = ["serde-1"] }
+itertools = { version = "0.10.5", default-features = false }
 lpc55-pac = { version = "0.4" }
 memchr = "2.4"
 memoffset = { version = "0.6.5", default-features = false }
@@ -93,6 +95,7 @@ serde_repr = "0.1"
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 smbus-pec = "1.0.1"
+smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
 spin = {version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
 srec = "0.2.0"
 ssmarshal = { version = "1.0.0", default-features = false }
@@ -102,13 +105,11 @@ stm32f4 = "0.13.0"
 stm32h7 = { version = "0.14", default-features = false }
 strsim = "0.10.0"
 syn = { version = "1", features = ["parsing"] }
-smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
 toml = "0.5.6"
 vcell = "0.1.2"
 walkdir = "2.0.0"
 zerocopy = "0.6.1"
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
-itertools = { version = "0.10.5", default-features = false }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", rev = "5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad" }
@@ -121,11 +122,10 @@ lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5f
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
 salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726" }
+spd = { git = "https://github.com/oxidecomputer/spd" }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
-spd = { git = "https://github.com/oxidecomputer/spd" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,8 @@ salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7
 spd = { git = "https://github.com/oxidecomputer/spd" }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cortex-m-rt = { version = "0.6.12", default-features = false }
 cortex-m-semihosting = { version = "0.5.0", default-features = false }
 crc = { version = "3.0.0", default-features = false }
 ctrlc = { version = "3.1.5", default-features = false }
-derive_more = { version = "0.99", default-features = false }
+derive_more = { version = "0.99", default-features = false, features = ["from"] }
 digest = { version = "0.10", default-features = false }
 dunce = { version = "1.0.2", default-features = false }
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,84 +31,84 @@ path = "sys/userlib"
 path = "sys/abi"
 
 [workspace.dependencies]
-anyhow = "1.0.31"
-atty = "0.2"
-bitfield = "0.13"
-bitflags = "1.2.1"
-bstringify = "0.1.2"
+anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
+atty = { version = "0.2", default-features = false }
+bitfield = { version = "0.13", default-features = false }
+bitflags = { version = "1.2.1", default-features = false }
+bstringify = { version = "0.1.2", default-features = false }
 byteorder = { version = "1.3.4", default-features = false }
-cargo_metadata = "0.12.0"
-cfg-if = "1"
-chrono = "0.4"
+cargo_metadata = { version = "0.12.0", default-features = false }
+cfg-if = { version = "1", default-features = false }
+chrono = { version = "0.4", default-features = false }
 clap = { version = "3.0.14", features = ["derive"] }
-colored = "2.0"
-convert_case = "0.4"
-corncobs = "0.1.1"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-cortex-m-semihosting = "0.5.0"
-crc = "3.0.0"
-ctrlc = "3.1.5"
-derive_more = "0.99"
-digest = "0.10"
-dunce = "1.0.2"
+colored = { version = "2.0", default-features = false }
+convert_case = { version = "0.4", default-features = false }
+corncobs = { version = "0.1.1", default-features = false }
+cortex-m = { version = "0.7", features = ["inline-asm"]}
+cortex-m-rt = { version = "0.6.12", default-features = false }
+cortex-m-semihosting = { version = "0.5.0", default-features = false }
+crc = { version = "3.0.0", default-features = false }
+ctrlc = { version = "3.1.5", default-features = false }
+derive_more = { version = "0.99", default-features = false }
+digest = { version = "0.10", default-features = false }
+dunce = { version = "1.0.2", default-features = false }
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
-embedded-hal = "0.2"
-enum-map = "2.4.1"
-filetime = "0.2.12"
-fletcher = "0.3"
-fnv = "1.0.7"
+embedded-hal = { version = "0.2", default-features = false }
+enum-map = { version = "2.4.1", default-features = false }
+filetime = { version = "0.2.12", default-features = false }
+fletcher = { version = "0.3", default-features = false }
+fnv = { version = "1.0.7", default-features = false }
 getrandom = { version = "0.2", default-features = false }
 goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
-heapless = "0.7.16"
+heapless = { version = "0.7.16", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.10.1", default-features = false }
-hubpack = "0.1"
-if_chain = "1"
+hubpack = { version = "0.1", default-features = false }
+if_chain = {version = "1", default-features = false }
 indexmap = { version = "1.4.0", features = ["serde-1"] }
 itertools = { version = "0.10.5", default-features = false }
 lpc55-pac = { version = "0.4" }
-memchr = "2.4"
+memchr = { version = "2.4", default-features = false }
 memoffset = { version = "0.6.5", default-features = false }
-multimap = "0.8.3"
-nb = "1"
+multimap = { version = "0.8.3", default-features = false }
+nb = { version = "1", default-features = false }
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.3.3", features = ["full-syntax"] }
 num-traits = { version = "0.2.12", default-features = false }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
-panic-halt = "0.2.0"
-panic-itm = "0.4.1"
-panic-semihosting = "0.5.3"
-paste = "1"
-path-slash = "0.1.3"
-proc-macro2 = "1"
-quote = "1"
-rand = "0.8"
+panic-halt = { version = "0.2.0", default-features = false }
+panic-itm = { version = "0.4.1", default-features = false }
+panic-semihosting = { version = "0.5.3", default-features = false }
+paste = { version = "1", default-features = false }
+path-slash = { version = "0.1.3", default-features = false }
+proc-macro2 = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3", default_features = false }
-rand_core = "0.6"
-ron = "0.7"
-scroll = "0.10"
+rand_core = { version = "0.6", default-features = false }
+ron = { version = "0.7", default-features = false }
+scroll = { version = "0.10", default-features = false }
 serde = { version = "1.0.114", default_features = false, features = ["derive"] }
-serde-big-array = "0.4"
-serde_json = "1.0"
-serde_repr = "0.1"
+serde-big-array = { version = "0.4", default-features = false }
+serde_json = { version = "1.0", default-features = false }
+serde_repr = { version = "0.1", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-smbus-pec = "1.0.1"
+smbus-pec = { version = "1.0.1", default-features = false }
 smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
-spin = {version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
-srec = "0.2.0"
+spin = { version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
+srec = { version = "0.2.0", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
 static_assertions = { version = "1" }
-stm32f3 = "0.13.0"
-stm32f4 = "0.13.0"
+stm32f3 = { version = "0.13.0", default-features = false }
+stm32f4 = { version = "0.13.0", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }
-strsim = "0.10.0"
+strsim = { version = "0.10.0", default-features = false }
 syn = { version = "1", features = ["parsing"] }
-toml = "0.5.6"
-vcell = "0.1.2"
-walkdir = "2.0.0"
-zerocopy = "0.6.1"
+toml = { version = "0.5.6", default-features = false }
+vcell = { version = "0.1.2", default-features = false }
+walkdir = { version = "2.0.0", default-features = false }
+zerocopy = { version = "0.6.1", default-features = false }
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
 
 # Oxide forks and repos

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ byteorder = { version = "1.3.4", default-features = false }
 cargo_metadata = { version = "0.12.0", default-features = false }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false }
-clap = { version = "3.0.14", features = ["derive"] }
+clap = { version = "3.0.14", default-features = false, features = ["derive"] }
 colored = { version = "2.0", default-features = false }
 convert_case = { version = "0.4", default-features = false }
 corncobs = { version = "0.1.1", default-features = false }
-cortex-m = { version = "0.7", features = ["inline-asm"]}
+cortex-m = { version = "0.7", default-features = false, features = ["inline-asm"]}
 cortex-m-rt = { version = "0.6.12", default-features = false }
 cortex-m-semihosting = { version = "0.5.0", default-features = false }
 crc = { version = "3.0.0", default-features = false }
@@ -59,21 +59,21 @@ filetime = { version = "0.2.12", default-features = false }
 fletcher = { version = "0.3", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 getrandom = { version = "0.2", default-features = false }
-goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
+goblin = { version = "0.4.3", default-features = true } # goblin::Object doesn't work without everything enabled
 heapless = { version = "0.7.16", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.10.1", default-features = false }
 hubpack = { version = "0.1", default-features = false }
 if_chain = {version = "1", default-features = false }
-indexmap = { version = "1.4.0", features = ["serde-1"] }
+indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"] }
 itertools = { version = "0.10.5", default-features = false }
-lpc55-pac = { version = "0.4" }
+lpc55-pac = { version = "0.4", default-features = false }
 memchr = { version = "2.4", default-features = false }
 memoffset = { version = "0.6.5", default-features = false }
 multimap = { version = "0.8.3", default-features = false }
 nb = { version = "1", default-features = false }
 num = { version = "0.4", default-features = false }
-num-derive = { version = "0.3.3", features = ["full-syntax"] }
+num-derive = { version = "0.3.3", default-features = false, features = ["full-syntax"] }
 num-traits = { version = "0.2.12", default-features = false }
 p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 panic-halt = { version = "0.2.0", default-features = false }
@@ -84,11 +84,11 @@ path-slash = { version = "0.1.3", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
-rand_chacha = { version = "0.3", default_features = false }
+rand_chacha = { version = "0.3", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 ron = { version = "0.7", default-features = false }
 scroll = { version = "0.10", default-features = false }
-serde = { version = "1.0.114", default_features = false, features = ["derive"] }
+serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.4", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_repr = { version = "0.1", default-features = false }
@@ -99,12 +99,12 @@ smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6
 spin = { version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
 srec = { version = "0.2.0", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
-static_assertions = { version = "1" }
+static_assertions = { version = "1", default-features = false }
 stm32f3 = { version = "0.13.0", default-features = false }
 stm32f4 = { version = "0.13.0", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }
 strsim = { version = "0.10.0", default-features = false }
-syn = { version = "1", features = ["parsing"] }
+syn = { version = "1", default-features = false, features = ["parsing"] }
 toml = { version = "0.5.6", default-features = false }
 vcell = { version = "0.1.2", default-features = false }
 walkdir = { version = "2.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ cfg-if = "1"
 clap = { version = "3.0.14", features = ["derive"] }
 colored = "2.0"
 convert_case = "0.4"
+corncobs = "0.1.1"
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.5.0"
@@ -51,10 +52,15 @@ derive_more = "0.99"
 digest = "0.10"
 dunce = "1.0.2"
 ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
+embedded-hal = "0.2"
+enum-map = "2.4.1"
 filetime = "0.2.12"
+fletcher = "0.3"
 fnv = "1.0.7"
 getrandom = { version = "0.2", default-features = false }
 goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
+heapless = "0.7.16"
+hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.10.1", default-features = false }
 hubpack = "0.1"
 if_chain = "1"
@@ -81,11 +87,13 @@ rand_core = "0.6"
 ron = "0.7"
 scroll = "0.10"
 serde = { version = "1.0.114", default_features = false, features = ["derive"] }
+serde-big-array = "0.4"
 serde_json = "1.0"
 serde_repr = "0.1"
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 smbus-pec = "1.0.1"
+spin = {version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
 srec = "0.2.0"
 ssmarshal = { version = "1.0.0", default-features = false }
 static_assertions = { version = "1" }
@@ -94,22 +102,30 @@ stm32f4 = "0.13.0"
 stm32h7 = { version = "0.14", default-features = false }
 strsim = "0.10.0"
 syn = { version = "1", features = ["parsing"] }
+smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
 toml = "0.5.6"
-walkdir = "2.0.0"
 vcell = "0.1.2"
+walkdir = "2.0.0"
 zerocopy = "0.6.1"
+zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
+itertools = { version = "0.10.5", default-features = false }
 
 # Oxide forks and repos
+dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", rev = "5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
+hif = { git = "https://github.com/oxidecomputer/hif" }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23" }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml" }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-salty = "0.2.0"
+salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726" }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
+spd = { git = "https://github.com/oxidecomputer/spd" }
+

--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "demo-stm32f4-discovery"
 version = "0.1.0"

--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,25 +11,15 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32f3 = { workspace = true, optional = true, features = ["stm32f303", "rt"] }
+stm32f4 = { workspace = true, optional = true, features = ["stm32f407", "rt"] }
 
-[dependencies.stm32f3]
-features = ["stm32f303", "rt"]
-version = "0.13.0"
-optional = true
-
-[dependencies.stm32f4]
-features = ["stm32f407", "rt"]
-version = "0.13.0"
-optional = true
-
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -17,7 +17,7 @@ panic-semihosting = { workspace = true, optional = true }
 stm32f3 = { workspace = true, optional = true, features = ["stm32f303", "rt"] }
 stm32f4 = { workspace = true, optional = true, features = ["stm32f407", "rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -13,17 +15,15 @@ g070 = ["stm32g0/stm32g070"]
 g0b1 = ["stm32g0/stm32g0b1"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+cfg-if = { workspace = true }
+stm32g0 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "demo-stm32g0-nucleo"
 version = "0.1.0"

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -21,7 +21,7 @@ panic-semihosting = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 stm32g0 = { workspace = true, features = ["rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -20,7 +20,7 @@ panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt"] }
 
 drv-stm32h7-startup = {path = "../../drv/stm32h7-startup"}
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -11,18 +13,16 @@ h743 = ["stm32h7/stm32h743", "drv-stm32h7-startup/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32h7-startup/h753"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup"}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace = true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = {path = "../../drv/stm32h7-startup"}
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "demo-stm32h7-nucleo"
 version = "0.1.0"

--- a/app/donglet/Cargo.toml
+++ b/app/donglet/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/donglet/Cargo.toml
+++ b/app/donglet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "app-donglet"
 version = "0.1.0"

--- a/app/donglet/Cargo.toml
+++ b/app/donglet/Cargo.toml
@@ -19,7 +19,7 @@ panic-semihosting = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 stm32g0 = { workspace = true, features = ["rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/donglet/Cargo.toml
+++ b/app/donglet/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -11,17 +13,15 @@ g030 = ["stm32g0/stm32g030"]
 g031 = ["stm32g0/stm32g031"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+cfg-if = { workspace = true }
+stm32g0 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -18,7 +18,7 @@ panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
 drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "gemini-bu"
 version = "0.1.0"

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace = true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.4", features = ["rt"]}
-cfg-if = "1"
-abi = { path = "../../sys/abi"}
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+lpc55-pac = { workspace = true, features = ["rt"]}
+cfg-if = { workspace = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+abi = { path = "../../sys/abi"}
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -18,7 +18,7 @@ lpc55-pac = { workspace = true, features = ["rt"]}
 cfg-if = { workspace = true }
 
 abi = { path = "../../sys/abi"}
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/gimlet-rot/Cargo.toml
+++ b/app/gimlet-rot/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "gimlet-rot"
 version = "0.1.0"

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { workspace = true }
 stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
 drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "gimlet"
 version = "0.1.0"

--- a/app/gimlet/Cargo.toml
+++ b/app/gimlet/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,17 +11,15 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
+cortex-m = { workspace = true }
+cortex-m-rt ={ workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+cfg-if = { workspace = true }
+stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+cfg-if = { workspace = true }
+stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { workspace = true }
 stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
 drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "gimletlet"
 version = "0.1.0"

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.4", features = ["rt"]}
-cfg-if = "1"
-abi = { path = "../../sys/abi"}
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+lpc55-pac = { workspace = true, features = ["rt"]}
+cfg-if = { workspace = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+abi = { path = "../../sys/abi"}
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "lpc55xpresso"
 version = "0.1.0"

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -18,7 +18,7 @@ lpc55-pac = { workspace = true, features = ["rt"]}
 cfg-if = { workspace = true }
 
 abi = { path = "../../sys/abi"}
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "psc"
 version = "0.1.0"

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,16 +11,14 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -16,7 +16,7 @@ panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
 drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "rot-carrier"
 version = "0.1.0"

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -18,7 +18,7 @@ lpc55-pac = { workspace = true, features = ["rt"]}
 cfg-if = { workspace = true }
 
 abi = { path = "../../sys/abi"}
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = {version = "0.4", features = ["rt"]}
-cfg-if = "1"
-abi = { path = "../../sys/abi"}
+cortex-m = {version = "0.7"}
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+lpc55-pac = { workspace = true, features = ["rt"]}
+cfg-if = { workspace = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+abi = { path = "../../sys/abi"}
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 edition = "2018"
 readme = "README.md"

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2018"
 readme = "README.md"
@@ -9,18 +11,16 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt", "stm32h753"] }
-drv-stm32h7-startup = {path = "../../drv/stm32h7-startup", features = ["h753"]}
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+cfg-if = { workspace = true }
+stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { workspace = true }
 stm32h7 = { workspace = true, features = ["rt", "stm32h753"] }
 
 drv-stm32h7-startup = { path = "../../drv/stm32h7-startup", features = ["h753"] }
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "sidecar"
 version = "0.1.0"

--- a/build/call_rustfmt/Cargo.toml
+++ b/build/call_rustfmt/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "call_rustfmt"
 version = "0.1.0"

--- a/build/call_rustfmt/Cargo.toml
+++ b/build/call_rustfmt/Cargo.toml
@@ -3,7 +3,5 @@ name = "call_rustfmt"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = { workspace = true }

--- a/build/call_rustfmt/Cargo.toml
+++ b/build/call_rustfmt/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "call_rustfmt"
 version = "0.1.0"
@@ -6,4 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }

--- a/build/fpga-regmap/Cargo.toml
+++ b/build/fpga-regmap/Cargo.toml
@@ -1,8 +1,10 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-fpga-regmap"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/build/fpga-regmap/Cargo.toml
+++ b/build/fpga-regmap/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-fpga-regmap"
 version = "0.1.0"

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-i2c"
 version = "0.1.0"

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-i2c"
 version = "0.1.0"
@@ -5,13 +7,13 @@ edition = "2018"
 
 [dependencies]
 build-util = {path = "../util"}
-serde = { version = "1.0.114", features = ["derive"] }
-indexmap = { version = "1.4.0", features = ["serde-1"] }
-anyhow = "1.0.31"
-cfg-if = "1"
-multimap = "0.8.3"
-convert_case = "0.4"
-cargo_metadata = "0.12.0"
+anyhow = { workspace = true }
+cargo_metadata = { workspace = true }
+cfg-if = { workspace = true }
+convert_case = { workspace = true }
+indexmap = { workspace = true }
+multimap = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 h743 = []

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "build-i2c"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 build-util = {path = "../util"}

--- a/build/i2c/Cargo.toml
+++ b/build/i2c/Cargo.toml
@@ -11,7 +11,7 @@ cfg-if = { workspace = true }
 convert_case = { workspace = true }
 indexmap = { workspace = true }
 multimap = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 
 [features]
 h743 = []

--- a/build/kconfig/Cargo.toml
+++ b/build/kconfig/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-kconfig"
 version = "0.1.0"

--- a/build/kconfig/Cargo.toml
+++ b/build/kconfig/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-kconfig"
 version = "0.1.0"
@@ -6,5 +8,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3.2"
-serde = { version = "1.0.147", features = ["derive"] }
+bitflags = { workspace = true }
+serde = { workspace = true }

--- a/build/kconfig/Cargo.toml
+++ b/build/kconfig/Cargo.toml
@@ -3,8 +3,6 @@ name = "build-kconfig"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bitflags = { workspace = true }
 serde = { workspace = true }

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "build-lpc55pins"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-lpc55pins"
 version = "0.1.0"

--- a/build/lpc55pins/Cargo.toml
+++ b/build/lpc55pins/Cargo.toml
@@ -1,16 +1,19 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-lpc55pins"
 version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-build-util = {path = "../util"}
-serde = { version = "1", features = ["derive"] }
-indexmap = { version = "1.4.0", features = ["serde-1"] }
-anyhow = "1.0.31"
-cfg-if = "1"
-multimap = "0.8.3"
-convert_case = "0.4"
-syn = {version = "1", features = ["parsing"]}
-proc-macro2 = "1"
-quote = "1"
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+convert_case = { workspace = true }
+indexmap = { workspace = true }
+multimap = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+
+build-util = { path = "../util" }

--- a/build/net/Cargo.toml
+++ b/build/net/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-net"
 version = "0.1.0"
@@ -8,4 +10,4 @@ vlan = []
 
 [dependencies]
 build-util = {path = "../util"}
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }

--- a/build/net/Cargo.toml
+++ b/build/net/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-net"
 version = "0.1.0"

--- a/build/phash-gen/Cargo.toml
+++ b/build/phash-gen/Cargo.toml
@@ -3,8 +3,6 @@ name = "phash-gen"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = { workspace = true }
 rand = { workspace = true }

--- a/build/phash-gen/Cargo.toml
+++ b/build/phash-gen/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "phash-gen"
 version = "0.1.0"
@@ -6,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.32"
-rand = "0.8"
-rand_chacha = "0.3"
+anyhow = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 phash = { path = "../../lib/phash" }

--- a/build/phash-gen/Cargo.toml
+++ b/build/phash-gen/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "phash-gen"
 version = "0.1.0"

--- a/build/util/Cargo.toml
+++ b/build/util/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "build-util"
 version = "0.1.0"

--- a/build/util/Cargo.toml
+++ b/build/util/Cargo.toml
@@ -1,11 +1,13 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "build-util"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.114", features = ["derive"] }
-toml = "0.5.6"
-indexmap = { version = "1.4.0", features = ["serde-1"] }
-serde_json = "1.0.56"
-anyhow = "1.0.31"
+anyhow = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -3,8 +3,6 @@ name = "xtask"
 version = "1.0.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = { workspace = true }
 atty = { workspace = true }

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "xtask"
 version = "1.0.0"
@@ -6,47 +8,44 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2"
-colored = "2.0"
-clap = { version = "3.0.14", features = ["derive"] }
-anyhow = "1.0.32"
-cargo_metadata = "0.12.0"
-ordered-toml = {git = "https://github.com/oxidecomputer/ordered-toml"}
-strsim = "0.10.0"
-memchr = "2.4"
+anyhow = { workspace = true }
+atty = { workspace = true }
+cargo_metadata = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+memchr = { workspace = true }
+ordered-toml = { workspace = true }
+strsim = { workspace = true }
 
 # for dist
-serde = { version = "1.0.114", features = ["derive"] }
-toml = "0.5.6"
-ron = "0.7"
-indexmap = { version = "1.4.0", features = ["serde-1"] }
-srec = "0.2.0"
-goblin = { version = "0.4.3", features = ["std", "elf32", "endian_fd"] }
-serde_json = "1.0.56"
-path-slash = "0.1.3"
-ctrlc = "3.1.5"
-dunce = "1.0.2"
-tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
-tlvc-text = {git = "https://github.com/oxidecomputer/tlvc"}
-gnarle = {path = "../../lib/gnarle", features=["std"]}
-sha3 = {version = "0.10", default-features = false}
-build-kconfig = {path = "../kconfig"}
+serde = { workspace = true }
+toml = { workspace = true }
+ron = { workspace = true }
+indexmap = { workspace = true }
+srec = { workspace = true }
+goblin = { workspace = true }
+serde_json = { workspace = true }
+path-slash = { workspace = true }
+ctrlc = { workspace = true }
+dunce = { workspace = true }
+tlvc = { workspace = true }
+tlvc-text = { workspace = true }
+sha3 = { workspace = true }
+byteorder = { workspace = true }
+filetime = { workspace = true }
+scroll = { workspace = true }
+walkdir = { workspace = true }
+fnv = { workspace = true }
+zerocopy = { workspace = true }
+
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
 # on the version that works for us
 zip = "=0.5.6"
+
+gnarle = { path = "../../lib/gnarle", features = ["std"] }
+build-kconfig = { path = "../kconfig" }
 abi = { path = "../../sys/abi" }
-byteorder = "1.3.4"
-filetime = "0.2.12"
-scroll = "0.10"
-walkdir = "2.0.0"
-fnv = "1.0.7"
-zerocopy = "0.6.1"
 
 # For NXP signing
-[dependencies.lpc55_sign]
-git = "https://github.com/oxidecomputer/lpc55_support"
-rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
-
-[dependencies.lpc55_areas]
-git = "https://github.com/oxidecomputer/lpc55_support"
-rev = "5fe64fda52c218cd8d7b31f95a445d8d4ce2cb23"
+lpc55_sign = { workspace = true }
+lpc55_areas = { workspace = true }

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "xtask"
 version = "1.0.0"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -708,7 +708,6 @@ impl BuildConfig<'_> {
             "cmse_nonsecure_entry",
             "naked_functions",
             "named-profiles",
-            "workspace-inheritance",
         ]);
         // nightly features that our dependencies use:
         nightly_features.extend([

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -708,6 +708,7 @@ impl BuildConfig<'_> {
             "cmse_nonsecure_entry",
             "naked_functions",
             "named-profiles",
+            "workspace-inheritance",
         ]);
         // nightly features that our dependencies use:
         nightly_features.extend([

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-auxflash-api"
 version = "0.1.0"

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-auxflash-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 num-traits = { workspace = true }

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -1,20 +1,21 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-auxflash-api"
 version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-drv-qspi-api = {path = "../qspi-api"}
-userlib = {path = "../../sys/userlib"}
+num-traits = { workspace = true }
+sha3 = { workspace = true }
+tlvc = { workspace = true }
+zerocopy = { workspace = true }
 
-tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
-
-sha3 = {version = "0.10", default-features = false}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-qspi-api = { path = "../qspi-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-serde = "1"
+idol = { workspace = true }
+serde = { workspace = true }

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-auxflash-server"
 version = "0.1.0"

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-auxflash-server"
 version = "0.1.0"
@@ -5,22 +7,21 @@ authors = ["Matt Keeter <matt@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
-drv-auxflash-api = {path = "../auxflash-api", default-features = false}
-drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+tlvc = { workspace = true }
+zerocopy = { workspace = true }
 
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
-
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
-stm32h7 = { version = "0.14", default-features = false }
-zerocopy = "0.6.1"
+drv-auxflash-api = { path = "../auxflash-api", default-features = false }
+drv-stm32h7-qspi = { path = "../stm32h7-qspi", default-features = false }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -12,9 +12,9 @@ stm32h7 = { workspace = true }
 tlvc = { workspace = true }
 zerocopy = { workspace = true }
 
-drv-auxflash-api = { path = "../auxflash-api", default-features = false }
-drv-stm32h7-qspi = { path = "../stm32h7-qspi", default-features = false }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-auxflash-api = { path = "../auxflash-api" }
+drv-stm32h7-qspi = { path = "../stm32h7-qspi" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]

--- a/drv/eeprom/Cargo.toml
+++ b/drv/eeprom/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-eeprom"
 version = "0.1.0"

--- a/drv/eeprom/Cargo.toml
+++ b/drv/eeprom/Cargo.toml
@@ -1,17 +1,20 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-eeprom"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 drv-i2c-api = {path = "../i2c-api"}
 drv-i2c-devices = { path = "../i2c-devices" }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
-num-traits = { version = "0.2.12", default-features = false }
 userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
 
 [build-dependencies]
 build-i2c = {path = "../../build/i2c"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/fpga-api/Cargo.toml
+++ b/drv/fpga-api/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-fpga-api"
 version = "0.1.0"

--- a/drv/fpga-api/Cargo.toml
+++ b/drv/fpga-api/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-fpga-api"
 version = "0.1.0"
@@ -8,16 +10,15 @@ hiffy = []
 auxflash = ["drv-auxflash-api", "tlvc", "sha3"]
 
 [dependencies]
-drv-auxflash-api = {path = "../../drv/auxflash-api", optional = true}
-drv-spi-api = {path = "../../drv/spi-api"}
-userlib = {path = "../../sys/userlib"}
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+sha3 = { workspace = true, optional = true }
+tlvc = { workspace = true, optional = true}
+zerocopy = { workspace = true }
 
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-tlvc = {git = "https://github.com/oxidecomputer/tlvc.git", optional = true}
-
-num-traits = {version = "0.2.12", default-features = false}
-sha3 = {version = "0.10", default-features = false, optional = true}
-zerocopy = "0.6.1"
+drv-auxflash-api = { path = "../../drv/auxflash-api", optional = true }
+drv-spi-api = { path = "../../drv/spi-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/fpga-devices/Cargo.toml
+++ b/drv/fpga-devices/Cargo.toml
@@ -1,20 +1,23 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-fpga-devices"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-ringbuf = {path = "../../lib/ringbuf"}
-drv-i2c-api = {path = "../../drv/i2c-api"}
-drv-i2c-devices = {path = "../../drv/i2c-devices"}
-drv-fpga-api = {path = "../../drv/fpga-api"}
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}
-num-traits = {version = "0.2.12", default-features = false}
-cfg-if = "1"
-bitfield = "0.13"
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+cfg-if = { workspace = true }
+bitfield = { workspace = true }
+zerocopy = { workspace = true }
+
+userlib = { path = "../../sys/userlib" }
+ringbuf = { path = "../../lib/ringbuf" }
+drv-i2c-api = { path = "../../drv/i2c-api" }
+drv-i2c-devices = { path = "../../drv/i2c-devices" }
+drv-fpga-api = { path = "../../drv/fpga-api" }
+drv-spi-api = { path = "../../drv/spi-api" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/fpga-devices/Cargo.toml
+++ b/drv/fpga-devices/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-fpga-devices"
 version = "0.1.0"

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -1,27 +1,30 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-fpga-server"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf" }
-gnarle = {path = "../../lib/gnarle"}
-drv-fpga-api = {path = "../../drv/fpga-api"}
-drv-fpga-devices = {path = "../../drv/fpga-devices"}
-drv-i2c-api = {path = "../../drv/i2c-api", optional = true}
-drv-i2c-devices = {path = "../../drv/i2c-devices", optional = true}
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"]}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-fpga-api = { path = "../../drv/fpga-api" }
+drv-fpga-devices = { path = "../../drv/fpga-devices" }
+drv-i2c-api = { path = "../../drv/i2c-api", optional = true }
+drv-i2c-devices = { path = "../../drv/i2c-devices", optional = true }
+drv-spi-api = { path = "../../drv/spi-api" }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
+gnarle = { path = "../../lib/gnarle" }
+ringbuf = { path = "../../lib/ringbuf"  }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-i2c = {path = "../../build/i2c"}
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 mainboard = []

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-fpga-server"
 version = "0.1.0"

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -1,17 +1,18 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-gimlet-hf-api"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
-drv-qspi-api = {path = "../qspi-api"}
-drv-hash-api = {path = "../hash-api"}
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-hash-api = { path = "../hash-api" }
+drv-qspi-api = { path = "../qspi-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-gimlet-hf-api"
 version = "0.1.0"

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -1,24 +1,25 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-gimlet-hf-server"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32h7 = { version = "0.14", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-stm32h7-qspi = {path = "../stm32h7-qspi", default-features = false}
-num-traits = { version = "0.2.12", default-features = false }
-drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
-drv-hash-api = {path = "../hash-api", default-features = false}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-zerocopy = "0.6.1"
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
+drv-hash-api = { path = "../hash-api", default-features = false }
+drv-stm32h7-qspi = { path = "../stm32h7-qspi", default-features = false }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [features]
 host_access = []

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-gimlet-hf-server"
 version = "0.1.0"

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -10,9 +10,9 @@ stm32h7 = { workspace = true }
 zerocopy = { workspace = true }
 
 drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
-drv-hash-api = { path = "../hash-api", default-features = false }
-drv-stm32h7-qspi = { path = "../stm32h7-qspi", default-features = false }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-hash-api = { path = "../hash-api" }
+drv-stm32h7-qspi = { path = "../stm32h7-qspi" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-gimlet-seq-api"
 version = "0.1.0"

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -1,14 +1,17 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-gimlet-seq-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
-drv-gimlet-state = {path = "../gimlet-state"}
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-gimlet-state = { path = "../gimlet-state" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -10,8 +10,8 @@ drv-i2c-api = { path = "../i2c-api" }
 drv-i2c-devices = { path = "../i2c-devices" }
 drv-ice40-spi-program = { path = "../ice40-spi-program" }
 drv-spi-api = { path = "../spi-api" }
-drv-stm32h7-spi = { path = "../stm32h7-spi", default-features = false  }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-stm32h7-spi = { path = "../stm32h7-spi" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 gnarle = { path = "../../lib/gnarle" }
 ringbuf = { path = "../../lib/ringbuf" }
 task-jefe-api = { path = "../../task/jefe-api" }

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "drv-gimlet-seq-server"
 version = "0.1.0"

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -3,8 +3,6 @@ name = "drv-gimlet-seq-server"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
 drv-gimlet-seq-api = { path = "../gimlet-seq-api" }

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -1,39 +1,43 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "drv-gimlet-seq-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-byteorder = {version = "1.4", default-features = false}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-spi-api = {path = "../spi-api"}
-task-jefe-api = {path = "../../task/jefe-api"}
-drv-ice40-spi-program = {path = "../ice40-spi-program"}
-drv-i2c-api = {path = "../i2c-api"}
-drv-i2c-devices = {path = "../i2c-devices"}
-drv-gimlet-hf-api = {path = "../gimlet-hf-api"}
-drv-gimlet-seq-api = {path = "../gimlet-seq-api"}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "1"
-gnarle = {path = "../../lib/gnarle"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
+drv-gimlet-seq-api = { path = "../gimlet-seq-api" }
+drv-i2c-api = { path = "../i2c-api" }
+drv-i2c-devices = { path = "../i2c-devices" }
+drv-ice40-spi-program = { path = "../ice40-spi-program" }
+drv-spi-api = { path = "../spi-api" }
+drv-stm32h7-spi = { path = "../stm32h7-spi", default-features = false  }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+gnarle = { path = "../../lib/gnarle" }
+ringbuf = { path = "../../lib/ringbuf" }
+task-jefe-api = { path = "../../task/jefe-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-fpga-regmap = {path = "../../build/fpga-regmap"}
-build-i2c = {path = "../../build/i2c"}
-build-util = {path = "../../build/util"}
-gnarle = {path = "../../lib/gnarle", features=["std"]}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0"
-sha2 = { version = "0.9", default-features = false }
+build-fpga-regmap = { path = "../../build/fpga-regmap" }
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
+gnarle = { path = "../../lib/gnarle", features=["std"] }
+
+idol = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [features]
 h753 = ["drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]

--- a/drv/gimlet-state/Cargo.toml
+++ b/drv/gimlet-state/Cargo.toml
@@ -3,9 +3,7 @@ name = "drv-gimlet-state"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
+userlib = { path = "../../sys/userlib" }
+zerocopy = { workspace = true }
+num-traits = { workspace = true }

--- a/drv/hash-api/Cargo.toml
+++ b/drv/hash-api/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "drv-hash-api"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "drv-i2c-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-num-traits = { version = "0.2.12", default-features = false }
-ringbuf = {path = "../../lib/ringbuf"}
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-bitfield = "0.13"
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-drv-i2c-api = {path = "../i2c-api"}
-drv-onewire = {path = "../onewire"}
-num-traits = { version = "0.2.12", default-features = false }
-num-derive = "0.3.3"
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-ringbuf = {path = "../../lib/ringbuf" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
+bitfield = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+pmbus = { workspace = true }
+smbus-pec = { workspace = true }
+zerocopy = { workspace = true }
 
-smbus-pec = "1.0.1"
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-i2c-api = { path = "../i2c-api" }
+drv-onewire = { path = "../onewire" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-i2c-devices"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bitfield = { workspace = true }

--- a/drv/ice40-spi-program/Cargo.toml
+++ b/drv/ice40-spi-program/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "drv-ice40-spi-program"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-drv-spi-api = {path = "../spi-api"}
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}
+drv-spi-api = { path = "../spi-api" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
+userlib = { path = "../../sys/userlib" }

--- a/drv/ignition-api/Cargo.toml
+++ b/drv/ignition-api/Cargo.toml
@@ -4,20 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-bitfield = "0.13"
-derive_more = "0.99"
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-drv-fpga-api = {path = "../fpga-api", optional = true}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git", optional = true}
-num-traits = {version = "0.2.12", default-features = false}
-num-derive = {version = "0.3.0", features = [ "full-syntax" ]}
-userlib = {path = "../../sys/userlib", optional = true}
-zerocopy = "0.6.1"
+bitfield = { workspace = true }
+cfg-if = { workspace = true }
+derive_more = { workspace = true }
+idol-runtime = { workspace = true, optional = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-fpga-api = { path = "../fpga-api", optional = true }
+userlib = { path = "../../sys/userlib", optional = true }
 
 [features]
 default = ["idol-client"]
 idol-client = ["drv-fpga-api", "idol-runtime", "userlib"]
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/ignition-server/Cargo.toml
+++ b/drv/ignition-server/Cargo.toml
@@ -4,16 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-drv-fpga-api = {path = "../fpga-api"}
-drv-ignition-api = {path = "../ignition-api"}
-drv-sidecar-mainboard-controller = {path = "../../drv/sidecar-mainboard-controller"}
-drv-sidecar-seq-api = {path = "../sidecar-seq-api", optional = true}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-num-traits = { version = "0.2.12", default-features = false }
-ringbuf = {path = "../../lib/ringbuf" }
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-fpga-api = { path = "../fpga-api" }
+drv-ignition-api = { path = "../ignition-api" }
+drv-sidecar-mainboard-controller = { path = "../../drv/sidecar-mainboard-controller" }
+drv-sidecar-seq-api = { path = "../sidecar-seq-api", optional = true }
+ringbuf = { path = "../../lib/ringbuf"  }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 sequencer = ["dep:drv-sidecar-seq-api"]

--- a/drv/ksz8463/Cargo.toml
+++ b/drv/ksz8463/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+num-traits = { workspace = true }
+
 drv-spi-api = {path = "../../drv/spi-api"}
 ringbuf = {path = "../../lib/ringbuf" }
 userlib = {path = "../../sys/userlib" }
-
-num-traits = { version = "0.2.12", default-features = false }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/local-vpd/Cargo.toml
+++ b/drv/local-vpd/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
-zerocopy = "0.6.1"
+tlvc = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 userlib = { path = "../../sys/userlib" }
-drv-i2c-api = { path = "../../drv/i2c-api" }
 
 [build-dependencies]
+serde = { workspace = true }
 build-i2c = {path = "../../build/i2c" }
 build-util = {path = "../../build/util"}
-serde = { version = "1.0.114", features = ["derive"] }

--- a/drv/lpc55-gpio-api/Cargo.toml
+++ b/drv/lpc55-gpio-api/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "drv-lpc55-gpio-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-cfg-if = "1"
-derive-idol-err = {path = "../../lib/derive-idol-err" }
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }

--- a/drv/lpc55-gpio/Cargo.toml
+++ b/drv/lpc55-gpio/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "drv-lpc55-gpio"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-lpc55-pac = "0.4"
-num-traits = { version = "0.2.12", default-features = false }
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-zerocopy = "0.6.1"
+idol-runtime = { workspace = true }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "drv-lpc55-i2c"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-num-traits = { version = "0.2.12", default-features = false }
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-iocon-gen/Cargo.toml
+++ b/drv/lpc55-iocon-gen/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "lpc55-iocon-gen"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-zerocopy = "0.6.1"
-quote = "1.0.9"
-cfg-if = "1"
-proc-macro2 = "1.0.9"
+cfg-if = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [lib]
 proc-macro = true

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-num-traits = { version = "0.2.12", default-features = false }
-cfg-if = "1"
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+rand_chacha = { workspace = true }
+rand_core = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
 drv-rng-api = { path = "../rng-api" }
-rand_chacha = { version = "0.3", default-features = false }
-rand_core = { version = "0.6" }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "drv-lpc55-spi-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-drv-lpc55-spi = {path = "../lpc55-spi"}
-num-traits = { version = "0.2.12", default-features = false }
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
-ringbuf = {path = "../../lib/ringbuf"}
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-spi = { path = "../lpc55-spi" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-lpc55pins = {path = "../../build/lpc55pins"}
-serde = "1"
+build-lpc55pins = { path = "../../build/lpc55pins" }
+build-util = { path = "../../build/util" }
+serde = { workspace = true }
 
 [features]
 spi0 = []

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "drv-lpc55-spi"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-num-traits = { version = "0.2.12", default-features = false }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+userlib = { path = "../../sys/userlib" }

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -10,10 +10,12 @@ idol-runtime = { workspace = true }
 if_chain = { workspace = true }
 lpc55-pac = { workspace = true }
 num-traits = { workspace = true }
-salty = { workspace = true }
 sprockets-common = { workspace = true }
 sprockets-rot = { workspace = true }
 zerocopy = { workspace = true }
+
+# Special-case for Sprockets (for now)
+salty = "0.2.0"
 
 drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
 drv-lpc55-spi = { path = "../lpc55-spi" }

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -1,33 +1,34 @@
 [package]
 name = "drv-lpc55-sprot-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-drv-lpc55-spi = {path = "../lpc55-spi"}
-drv-sprot-api = {path = "../sprot-api"}
-drv-update-api = {path = "../update-api"}
-num-traits = { version = "0.2.12", default-features = false }
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-ringbuf = {path = "../../lib/ringbuf"}
+crc = { workspace = true }
+hubpack = { workspace = true }
+idol-runtime = { workspace = true }
+if_chain = { workspace = true }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+salty = { workspace = true }
+sprockets-common = { workspace = true }
+sprockets-rot = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-spi = { path = "../lpc55-spi" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+drv-sprot-api = { path = "../sprot-api" }
+drv-update-api = { path = "../update-api" }
 lpc55_romapi = { path = "../../lib/lpc55-romapi" }
-crc = "3.0.0"
-sprockets-common = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
-sprockets-rot = {git = "https://github.com/oxidecomputer/sprockets.git", default-features = false}
-hubpack = { rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25", git = "https://github.com/cbiffle/hubpack.git"}
-salty = "0.2.0"
-if_chain = "1"
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-lpc55pins = {path = "../../build/lpc55pins"}
-serde = "1"
-quote = "1"
+build-lpc55pins = { path = "../../build/lpc55pins" }
+build-util = { path = "../../build/util" }
+serde = { workspace = true }
+quote = { workspace = true }
 
 [features]
 spi0 = []

--- a/drv/lpc55-swd/Cargo.toml
+++ b/drv/lpc55-swd/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "drv-lpc55-swd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-lpc55-pac = "0.4"
-drv-lpc55-spi = {path = "../lpc55-spi"}
-ringbuf = {path = "../../lib/ringbuf"}
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
-drv-sp-ctrl-api = {path = "../sp-ctrl-api"}
-num-traits = { version = "0.2.12", default-features = false }
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-zerocopy = "0.6.1"
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-spi = { path = "../lpc55-spi" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+drv-sp-ctrl-api = { path = "../sp-ctrl-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-build-lpc55pins = {path = "../../build/lpc55pins"}
-anyhow = "1.0.31"
-serde = "1"
-quote = "1"
+build-lpc55pins = { path = "../../build/lpc55pins" }
+build-util = { path = "../../build/util" }
+anyhow = { workspace = true }
+idol = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-syscon-api/Cargo.toml
+++ b/drv/lpc55-syscon-api/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "drv-lpc55-syscon-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-derive-idol-err = {path = "../../lib/derive-idol-err" }
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
+
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "drv-lpc55-syscon"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-num-traits = { version = "0.2.12", default-features = false }
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
-task-jefe-api = {path = "../../task/jefe-api"}
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+lpc55-pac = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+task-jefe-api = { path = "../../task/jefe-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "lpc55-update-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
+drv-update-api = {  path = "../update-api/"  }
+hypocalls = { path = "../../lib/hypocalls" }
+ringbuf = { path = "../../lib/ringbuf" }
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-drv-update-api = { path = "../update-api/" }
-ringbuf = {path = "../../lib/ringbuf"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
-hypocalls = {path = "../../lib/hypocalls"}
-cfg-if = "1"
+
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 name = "drv-lpc55-usart"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-lib-lpc55-usart = {path = "../../lib/lpc55-usart"}
-nb = "1.0"
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-zerocopy = "0.6.1"
-lpc55-pac = "0.4"
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api"}
-drv-lpc55-syscon-api = {path = "../lpc55-syscon-api"}
+lpc55-pac = { workspace = true }
+nb = { workspace = true }
+zerocopy = { workspace = true }
 
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
+drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
+lib-lpc55-usart = { path = "../../lib/lpc55-usart" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-lpc55pins = {path = "../../build/lpc55pins"}
-serde = "1"
-anyhow = "1.0.31"
+anyhow = { workspace = true }
+serde = { workspace = true }
+
+build-lpc55pins = { path = "../../build/lpc55pins" }
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/meanwell-api/Cargo.toml
+++ b/drv/meanwell-api/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "drv-meanwell-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-derive-idol-err = {path = "../../lib/derive-idol-err" }
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
+
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -16,5 +17,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
+idol = { workspace = true }

--- a/drv/meanwell/Cargo.toml
+++ b/drv/meanwell/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "drv-meanwell"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-drv-user-leds-api = {path = "../../drv/user-leds-api"}
-drv-meanwell-api = {path = "../../drv/meanwell-api"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", optional = true}
-cfg-if = "1"
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-meanwell-api = { path = "../../drv/meanwell-api" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", optional = true }
+drv-user-leds-api = { path = "../../drv/user-leds-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 stm32g0 = ["drv-stm32xx-sys-api/family-stm32g0"]

--- a/drv/mock-gimlet-seq-server/Cargo.toml
+++ b/drv/mock-gimlet-seq-server/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-gimlet-seq-api = {path = "../gimlet-seq-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
-task-jefe-api = {path = "../../task/jefe-api"}
+drv-gimlet-seq-api = { path = "../gimlet-seq-api" }
+task-jefe-api = { path = "../../task/jefe-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -3,16 +3,14 @@ name = "monorail-api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-vsc7448 = {path = "../vsc7448"}
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
+vsc7448 = { path = "../vsc7448" }
 
-num-traits = {version = "0.2", default-features = false}
-serde = { version = "1", features = ["derive"], default-features = false}
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+serde = { workspace = true }
+zerocopy = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/onewire-devices/Cargo.toml
+++ b/drv/onewire-devices/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "drv-onewire-devices"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-onewire = {path = "../onewire"}
+drv-onewire = { path = "../onewire" }
+userlib = { path = "../../sys/userlib" }
+
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/onewire/Cargo.toml
+++ b/drv/onewire/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "drv-onewire"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/rng-api/Cargo.toml
+++ b/drv/rng-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-rng-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 getrandom = { workspace = true, optional = true }

--- a/drv/rng-api/Cargo.toml
+++ b/drv/rng-api/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-abi = { path = "../../sys/abi" }
-userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
-num = { version = "0.4", default-features = false }
-num-traits = { version = "0.2.12", default-features = false }
-getrandom = { version = "0.2", default-features = false, optional = true}
-rand_core = { version = "0.6" }
-zerocopy = "0.6.1"
+getrandom = { workspace = true, optional = true }
+num = { workspace = true }
+num-traits = { workspace = true }
+rand_core = { workspace = true }
+zerocopy = { workspace = true }
+
+abi = {  path = "../../sys/abi"  }
+userlib = {  path = "../../sys/userlib", features = ["panic-messages"]  }
 
 [features]
 custom-getrandom = ["getrandom/custom"]
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [lib]
 name = "drv_rng_api"

--- a/drv/sidecar-front-io/Cargo.toml
+++ b/drv/sidecar-front-io/Cargo.toml
@@ -4,18 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-drv-auxflash-api = {path = "../../drv/auxflash-api"}
-drv-fpga-api = {path = "../../drv/fpga-api", features = ["auxflash"]}
-drv-i2c-api = {path = "../i2c-api"}
-drv-i2c-devices = {path = "../i2c-devices"}
-vsc85xx = {path = "../../drv/vsc85xx", optional = true}
-vsc7448-pac = {git = "https://github.com/oxidecomputer/vsc7448", optional = true}
-drv-transceivers-api = {path = "../../drv/transceivers-api"}
-ringbuf = {path = "../../lib/ringbuf"}
-userlib = {path = "../../sys/userlib"}
-num-traits = {version = "0.2.12", default-features = false}
-zerocopy = "0.6.1"
-cfg-if = "1"
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+vsc7448-pac = { workspace = true, optional = true }
+zerocopy = { workspace = true }
+
+drv-auxflash-api = { path = "../../drv/auxflash-api" }
+drv-fpga-api = { path = "../../drv/fpga-api", features = ["auxflash"] }
+drv-i2c-api = { path = "../i2c-api" }
+drv-i2c-devices = { path = "../i2c-devices" }
+drv-transceivers-api = { path = "../../drv/transceivers-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
+vsc85xx = { path = "../../drv/vsc85xx", optional = true }
 
 [features]
 controller = []
@@ -24,6 +25,6 @@ transceivers = []
 leds = []
 
 [build-dependencies]
-build-fpga-regmap = {path = "../../build/fpga-regmap"}
-build-util = {path = "../../build/util"}
-gnarle = {path = "../../lib/gnarle", features=["std"]}
+build-fpga-regmap = { path = "../../build/fpga-regmap" }
+build-util = { path = "../../build/util" }
+gnarle = { path = "../../lib/gnarle", features=["std"] }

--- a/drv/sidecar-mainboard-controller/Cargo.toml
+++ b/drv/sidecar-mainboard-controller/Cargo.toml
@@ -4,20 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitfield = "0.13"
-drv-auxflash-api = {path = "../auxflash-api", optional = true}
-drv-fpga-api = {path = "../fpga-api"}
-drv-ignition-api = {path = "../ignition-api"}
-num-traits = { version = "0.2.12", default-features = false }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
+bitfield = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-auxflash-api = { path = "../auxflash-api", optional = true }
+drv-fpga-api = { path = "../fpga-api" }
+drv-ignition-api = { path = "../ignition-api" }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 bitstream = ["dep:drv-auxflash-api", "drv-fpga-api/auxflash"]
 
 [build-dependencies]
-build-fpga-regmap = {path = "../../build/fpga-regmap"}
-build-util = {path = "../../build/util"}
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0"
-gnarle = {path = "../../lib/gnarle", features=["std"]}
+build-fpga-regmap = { path = "../../build/fpga-regmap" }
+build-util = { path = "../../build/util" }
+gnarle = { path = "../../lib/gnarle", features=["std"] }
+
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
+++ b/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ringbuf = {path = "../../lib/ringbuf"}
-userlib = {path = "../../sys/userlib"}
-drv-i2c-api = {path = "../i2c-api"}
+drv-i2c-api = { path = "../i2c-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
-drv-fpga-api = {path = "../fpga-api"}
-drv-sidecar-mainboard-controller = {path = "../sidecar-mainboard-controller"}
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-fpga-api = { path = "../fpga-api" }
+drv-sidecar-mainboard-controller = { path = "../sidecar-mainboard-controller" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/sidecar-seq-server/Cargo.toml
+++ b/drv/sidecar-seq-server/Cargo.toml
@@ -3,31 +3,30 @@ name = "drv-sidecar-seq-server"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-byteorder = {version = "1.4", default-features = false}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-i2c-api = {path = "../i2c-api"}
-drv-i2c-devices = {path = "../i2c-devices"}
-drv-fpga-api = {path = "../fpga-api", features = ["auxflash"]}
-drv-sidecar-seq-api = {path = "../sidecar-seq-api"}
-drv-sidecar-mainboard-controller = {path = "../sidecar-mainboard-controller", features = ["bitstream"]}
-drv-sidecar-front-io = {path = "../sidecar-front-io", features = ["controller", "phy_smi"]}
-cortex-m = { version = "0.7", features = ["inline-asm"]}
-cfg-if = "1"
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-fpga-api = { path = "../fpga-api", features = ["auxflash"] }
+drv-i2c-api = { path = "../i2c-api" }
+drv-i2c-devices = { path = "../i2c-devices" }
+drv-sidecar-front-io = { path = "../sidecar-front-io", features = ["controller", "phy_smi"] }
+drv-sidecar-mainboard-controller = { path = "../sidecar-mainboard-controller", features = ["bitstream"] }
+drv-sidecar-seq-api = { path = "../sidecar-seq-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 h753 = ["build-i2c/h753"]
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/sp-ctrl-api/Cargo.toml
+++ b/drv/sp-ctrl-api/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "drv-sp-ctrl-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -16,4 +17,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-spi-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 derive-idol-err = {path = "../../lib/derive-idol-err" }

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -16,4 +17,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -6,21 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crc = "3.0.0"
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-drv-update-api = {path = "../../drv/update-api"}
-if_chain = "1"
-memoffset = {version = "0.6.5", default-features = false}
-num-traits = { version = "0.2.12", default-features = false }
-ringbuf = {path = "../../lib/ringbuf"}
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+crc = { workspace = true }
+hubpack = { workspace = true }
+if_chain = { workspace = true }
+memoffset = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-update-api = { path = "../../drv/update-api" }
+ringbuf = { path = "../../lib/ringbuf" }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
-ssmarshal = {version = "1", default-features = false}
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
-
+idol = { workspace = true }

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -3,8 +3,6 @@ name = "drv-sprot-api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 crc = { workspace = true }
 hubpack = { workspace = true }

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "drv-stm32fx-rcc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32f3 = { version = "0.13.0", optional = true, default-features = false }
-stm32f4 = { version = "0.13.0", optional = true, default-features = false }
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
+num-traits = { workspace = true }
+stm32f3 = { workspace = true }
+stm32f4 = { workspace = true }
+zerocopy = { workspace = true }
+
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 f3 = ["stm32f3/stm32f303"]

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 num-traits = { workspace = true }
-stm32f3 = { workspace = true }
-stm32f4 = { workspace = true }
+stm32f3 = { workspace = true, optional = true }
+stm32f4 = { workspace = true, optional = true }
 zerocopy = { workspace = true }
 
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/drv/stm32fx-usart/Cargo.toml
+++ b/drv/stm32fx-usart/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 num-traits = { workspace = true }
-stm32f3 = { workspace = true }
-stm32f4 = { workspace = true }
+stm32f3 = { workspace = true, optional = true, features = ["stm32f303"] }
+stm32f4 = { workspace = true, optional = true, features = ["stm32f407"] }
 zerocopy = { workspace = true }
 
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/drv/stm32fx-usart/Cargo.toml
+++ b/drv/stm32fx-usart/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "drv-stm32fx-usart"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32f3 = { version = "0.13.2", features = ["stm32f303"], optional = true }
-stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
+num-traits = { workspace = true }
+stm32f3 = { workspace = true }
+stm32f4 = { workspace = true }
+zerocopy = { workspace = true }
+
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32g0-usart/Cargo.toml
+++ b/drv/stm32g0-usart/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "drv-stm32g0-usart"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-semihosting = { version = "0.5.0" }
+cortex-m = { workspace = true }
+cortex-m-semihosting = { workspace = true }
+num-traits = { workspace = true }
+stm32g0 = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 g031 = ["stm32g0/stm32g031", "drv-stm32xx-sys-api/g031"]

--- a/drv/stm32g0-usart/Cargo.toml
+++ b/drv/stm32g0-usart/Cargo.toml
@@ -10,7 +10,7 @@ num-traits = { workspace = true }
 stm32g0 = { workspace = true }
 zerocopy = { workspace = true }
 
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib" }
 
 [features]

--- a/drv/stm32h7-eth/Cargo.toml
+++ b/drv/stm32h7-eth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-stm32h7-eth"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -12,10 +12,11 @@ ipv6 = []
 vlan = []
 
 [dependencies]
-cfg-if = "1"
-cortex-m = "0.7"
-userlib = {path = "../../sys/userlib"}
-stm32h7 = {version = "0.14", default-features = false}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+stm32h7 = { workspace = true }
+
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -11,9 +11,9 @@ num-traits = { workspace = true }
 stm32h7 = { workspace = true }
 zerocopy = { workspace = true }
 
-drv-hash-api = { path = "../hash-api", default-features = false }
-drv-stm32h7-hash = { path = "../stm32h7-hash", default-features = false, optional = true }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-hash-api = { path = "../hash-api" }
+drv-stm32h7-hash = { path = "../stm32h7-hash", optional = true }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "drv-stm32h7-hash-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32h7 = { version = "0.14", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-stm32h7-hash = {path = "../stm32h7-hash", default-features = false, optional = true}
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-hash-api = {path = "../hash-api", default-features = false}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-hash-api = { path = "../hash-api", default-features = false }
+drv-stm32h7-hash = { path = "../stm32h7-hash", default-features = false, optional = true }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-hash/h753"]

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -3,8 +3,6 @@ name = "drv-stm32h7-hash-server"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 cfg-if = { workspace = true }
 cortex-m = { workspace = true }

--- a/drv/stm32h7-hash/Cargo.toml
+++ b/drv/stm32h7-hash/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "drv-stm32h7-hash"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stm32h7 = { version = "0.14", default-features = false }
-vcell = "0.1.2"
-drv-hash-api = {path = "../hash-api"}
-zerocopy = "0.6.1"
-userlib = {path = "../../sys/userlib"}
+stm32h7 = { workspace = true }
+vcell = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-hash-api = { path = "../hash-api" }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 h753 = ["stm32h7/stm32h753"]

--- a/drv/stm32h7-hash/Cargo.toml
+++ b/drv/stm32h7-hash/Cargo.toml
@@ -3,8 +3,6 @@ name = "drv-stm32h7-hash"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 stm32h7 = { workspace = true }
 vcell = { workspace = true }

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drv-stm32h7-qspi"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 stm32h7 = { workspace = true }

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-drv-qspi-api = {path = "../qspi-api"}
-stm32h7 = { version = "0.14", default-features = false }
-vcell = "0.1.2"
-zerocopy = "0.6.1"
-userlib = {path = "../../sys/userlib"}
+stm32h7 = { workspace = true }
+vcell = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-qspi-api = { path = "../qspi-api" }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 h743 = ["stm32h7/stm32h743"]

--- a/drv/stm32h7-rng/Cargo.toml
+++ b/drv/stm32h7-rng/Cargo.toml
@@ -4,16 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
+
 drv-rng-api = { path = "../rng-api" }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
-num-traits = { version = "0.2.14", default-features = false }
-stm32h7 = { version = "0.14", default-features = false }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
-zerocopy = { version = "0.6" }
 
 [build-dependencies]
-idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
+idol = { workspace = true }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -1,30 +1,32 @@
 [package]
 name = "drv-stm32h7-spi-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32h7-spi = {path = "../stm32h7-spi", default-features = false}
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-spi-api = {path = "../spi-api", default-features = false}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-stm32h7 = { version = "0.14", default-features = false }
-cfg-if = "1"
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-spi-api = { path = "../spi-api", default-features = false }
+drv-stm32h7-spi = { path = "../stm32h7-spi", default-features = false }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-serde = "1"
-quote = "1"
-call_rustfmt = {path = "../../build/call_rustfmt"}
-syn = {version = "1", features = ["parsing"]}
-proc-macro2 = "1"
-indexmap = "1.7"
+idol = { workspace = true }
+indexmap = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+
+build-util = { path = "../../build/util" }
+call_rustfmt = { path = "../../build/call_rustfmt" }
 
 [features]
 spi1 = []

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -11,9 +11,9 @@ num-traits = { workspace = true }
 stm32h7 = { workspace = true }
 zerocopy = { workspace = true }
 
-drv-spi-api = { path = "../spi-api", default-features = false }
-drv-stm32h7-spi = { path = "../stm32h7-spi", default-features = false }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-spi-api = { path = "../spi-api" }
+drv-stm32h7-spi = { path = "../stm32h7-spi" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "drv-stm32h7-spi"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-vcell = "0.1.2"
-stm32h7 = { version = "0.14", default-features = false }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+vcell = { workspace = true }
+zerocopy = { workspace = true }
+
+ringbuf = { path = "../../lib/ringbuf" }
 
 [features]
 h743 = ["stm32h7/stm32h743"]

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -4,23 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-update-api = {path = "../../drv/update-api"}
-drv-sprot-api = {path = "../../drv/sprot-api"}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"]}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-cfg-if = "1"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
-ssmarshal = {version = "1", default-features = false}
+cfg-if = { workspace = true }
+hubpack = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-spi-api = { path = "../../drv/spi-api" }
+drv-sprot-api = { path = "../../drv/sprot-api" }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
+drv-update-api = { path = "../../drv/update-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 sink_test = []

--- a/drv/stm32h7-startup/Cargo.toml
+++ b/drv/stm32h7-startup/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "drv-stm32h7-startup"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+stm32h7 = { workspace = true }
 
 [features]
 h743 = ["stm32h7/stm32h743"]

--- a/drv/stm32h7-update-server/Cargo.toml
+++ b/drv/stm32h7-update-server/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "stm32h7-update-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-stm32h7 = { version = "0.14", default-features = false, features = ["stm32h753"] }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true, features = ["stm32h753"] }
+zerocopy = { workspace = true }
+
 drv-update-api = { path = "../update-api/" }
-ringbuf = {path = "../../lib/ringbuf"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-build-util = {path = "../../build/util"}
+idol = { workspace = true }
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = { path = "../../sys/userlib" }
+stm32h7 = { workspace = true }
 
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false}
-stm32h7 = { version = "0.14", default-features = false }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 stm32h7 = { workspace = true }
 
-drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib" }
 
 [features]

--- a/drv/stm32xx-gpio-common/Cargo.toml
+++ b/drv/stm32xx-gpio-common/Cargo.toml
@@ -3,8 +3,6 @@ name = "drv-stm32xx-gpio-common"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 cfg-if = { workspace = true }
 num-traits = { workspace = true }

--- a/drv/stm32xx-gpio-common/Cargo.toml
+++ b/drv/stm32xx-gpio-common/Cargo.toml
@@ -6,17 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, optional = true }
-userlib = {path = "../../sys/userlib"}
-num-traits = {version = "0.2", default-features = false}
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+stm32g0 = { workspace = true, optional = true }
+stm32h7 = { workspace = true, optional = true }
+zerocopy = { workspace = true }
 
-[dependencies.stm32g0]
-optional = true
-git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
-branch = "stm32g0b1-initial-support"
-default-features = false
+userlib = { path = "../../sys/userlib" }
 
 [features]
 # When enabled, the `server` submodule is included, providing code for modeling

--- a/drv/stm32xx-i2c-server/Cargo.toml
+++ b/drv/stm32xx-i2c-server/Cargo.toml
@@ -11,8 +11,8 @@ stm32g0 = { workspace = true }
 stm32h7 = { workspace = true }
 
 drv-i2c-api = { path = "../i2c-api" }
-drv-stm32xx-i2c = { path = "../stm32xx-i2c", default-features = false  }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-stm32xx-i2c = { path = "../stm32xx-i2c"  }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 fixedmap = { path = "../../lib/fixedmap" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/drv/stm32xx-i2c-server/Cargo.toml
+++ b/drv/stm32xx-i2c-server/Cargo.toml
@@ -1,26 +1,28 @@
 [package]
 name = "drv-stm32xx-i2c-server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-fixedmap = {path = "../../lib/fixedmap"}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-stm32xx-i2c = {path = "../stm32xx-i2c", default-features = false }
-drv-i2c-api = {path = "../i2c-api"}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false, optional = true }
-stm32h7 = { version = "0.14", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+num-traits = { workspace = true }
+stm32g0 = { workspace = true }
+stm32h7 = { workspace = true }
+
+drv-i2c-api = { path = "../i2c-api" }
+drv-stm32xx-i2c = { path = "../stm32xx-i2c", default-features = false  }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+fixedmap = { path = "../../lib/fixedmap" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-i2c/h743", "drv-stm32xx-sys-api/h743", "build-i2c/h743"]
@@ -35,4 +37,3 @@ itm = []
 name = "drv-stm32xx-i2c-server"
 test = false
 bench = false
-

--- a/drv/stm32xx-i2c/Cargo.toml
+++ b/drv/stm32xx-i2c/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "drv-stm32xx-i2c"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-ringbuf = {path = "../../lib/ringbuf"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-drv-i2c-api = {path = "../i2c-api"}
-cfg-if = "1"
-bitfield = "0.13"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false, optional = true }
-stm32h7 = { version = "0.14", default-features = false }
+bitfield = { workspace = true }
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+stm32g0 = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-i2c-api = { path = "../i2c-api" }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]

--- a/drv/stm32xx-i2c/Cargo.toml
+++ b/drv/stm32xx-i2c/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 bitfield = { workspace = true }
 cfg-if = { workspace = true }
 num-traits = { workspace = true }
-stm32g0 = { workspace = true }
-stm32h7 = { workspace = true }
+stm32g0 = { workspace = true, optional = true }
+stm32h7 = { workspace = true, optional = true }
 zerocopy = { workspace = true }
 
 drv-i2c-api = { path = "../i2c-api" }

--- a/drv/stm32xx-i2c/Cargo.toml
+++ b/drv/stm32xx-i2c/Cargo.toml
@@ -12,7 +12,7 @@ stm32h7 = { workspace = true, optional = true }
 zerocopy = { workspace = true }
 
 drv-i2c-api = { path = "../i2c-api" }
-drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", default-features = false }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib" }
 

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -4,16 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-byteorder = {version = "1.3", default-features = false}
-num-traits = {version = "0.2", default-features = false}
-drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common"}
-cfg-if = "1"
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-stm32xx-gpio-common = { path = "../stm32xx-gpio-common" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [features]
 family-stm32h7 = ["drv-stm32xx-gpio-common/family-stm32h7"]

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -4,20 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitflags = "1.2.1"
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false, optional = true }
-stm32h7 = {version = "0.14", default-features = false, optional = true}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}
-drv-stm32xx-gpio-common = {path = "../stm32xx-gpio-common", features = ["server-support"]}
-task-jefe-api = {path="../../task/jefe-api"}
-cfg-if = "1"
+drv-stm32xx-gpio-common = { path = "../stm32xx-gpio-common", features = ["server-support"] }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
+task-jefe-api = { path="../../task/jefe-api" }
+userlib = { path = "../../sys/userlib" }
+
+bitflags = { workspace = true }
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32g0 = { workspace = true, optional = true }
+stm32h7 = { workspace = true, optional = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [features]
 family-stm32h7 = ["stm32h7"]

--- a/drv/stm32xx-uid/Cargo.toml
+++ b/drv/stm32xx-uid/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 
 [features]
 family-stm32g0 = []

--- a/drv/transceivers-api/Cargo.toml
+++ b/drv/transceivers-api/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "drv-transceivers-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-userlib = {path = "../../sys/userlib"}
-drv-fpga-api = {path = "../fpga-api"}
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+zerocopy = { workspace = true }
 
-num-traits = {version = "0.2.12", default-features = false}
-zerocopy = "0.6.1"
-serde = { version = "1", features = ["derive"], default-features = false}
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-fpga-api = { path = "../fpga-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/transceivers-server/Cargo.toml
+++ b/drv/transceivers-server/Cargo.toml
@@ -9,7 +9,7 @@ drv-i2c-api = { path = "../i2c-api" }
 drv-i2c-devices = { path = "../i2c-devices" }
 drv-sidecar-front-io = { path = "../sidecar-front-io", features = ["transceivers", "leds"] }
 drv-sidecar-seq-api = { path = "../sidecar-seq-api" }
-drv-transceivers-api = { path = "../transceivers-api", default-features = false }
+drv-transceivers-api = { path = "../transceivers-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 

--- a/drv/transceivers-server/Cargo.toml
+++ b/drv/transceivers-server/Cargo.toml
@@ -5,24 +5,25 @@ authors = ["Aaron Hartwig <aaron@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-drv-i2c-api = {path = "../i2c-api"}
-drv-i2c-devices = {path = "../i2c-devices"}
-drv-sidecar-front-io = {path = "../sidecar-front-io", features = ["transceivers", "leds"]}
-drv-sidecar-seq-api = {path = "../sidecar-seq-api"}
-drv-transceivers-api = {path = "../transceivers-api", default-features = false}
-cfg-if = "1"
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-i2c-api = { path = "../i2c-api" }
+drv-i2c-devices = { path = "../i2c-devices" }
+drv-sidecar-front-io = { path = "../sidecar-front-io", features = ["transceivers", "leds"] }
+drv-sidecar-seq-api = { path = "../sidecar-seq-api" }
+drv-transceivers-api = { path = "../transceivers-api", default-features = false }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
-num-traits = {version = "0.2.12", default-features = false}
-stm32h7 = {version = "0.14", default-features = false}
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
+
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/update-api/Cargo.toml
+++ b/drv/update-api/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "drv-update-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
-serde = {version = "1.0.145", default-features = false, features = ["derive"]}
-serde_repr = "0.1"
+hubpack = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+serde_repr = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
 
 [features]
 default = ["standalone"]
@@ -23,5 +24,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-
+idol = { workspace = true }

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "drv-user-leds-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-derive-idol-err = {path = "../../lib/derive-idol-err" }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -16,4 +17,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -8,8 +8,8 @@ cfg-if = { workspace = true }
 idol-runtime = { workspace = true }
 lpc55-pac = { workspace = true, optional = true }
 num-traits = { workspace = true }
-stm32f3 = { workspace = true, optional = true }
-stm32f4 = { workspace = true, optional = true }
+stm32f3 = { workspace = true, optional = true, features = ["stm32f303"] }
+stm32f4 = { workspace = true, optional = true, features = ["stm32f407"] }
 zerocopy = { workspace = true }
 
 drv-lpc55-gpio-api = { path = "../lpc55-gpio-api", optional = true }

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "drv-user-leds"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-drv-user-leds-api = {path = "../user-leds-api"}
-stm32f3 = { version = "0.13.0", features = ["stm32f303"], optional = true }
-stm32f4 = { version = "0.13.0", features = ["stm32f407"], optional = true }
-lpc55-pac = { version = "0.4", optional = true }
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", optional = true}
-drv-lpc55-gpio-api = {path = "../lpc55-gpio-api", optional = true}
-cfg-if = "1"
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+cfg-if = { workspace = true }
+idol-runtime = { workspace = true }
+lpc55-pac = { workspace = true, optional = true }
+num-traits = { workspace = true }
+stm32f3 = { workspace = true, optional = true }
+stm32f4 = { workspace = true, optional = true }
+zerocopy = { workspace = true }
+
+drv-lpc55-gpio-api = { path = "../lpc55-gpio-api", optional = true }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", optional = true }
+drv-user-leds-api = { path = "../user-leds-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 stm32g0 = ["drv-stm32xx-sys-api/family-stm32g0"]

--- a/drv/vsc-err/Cargo.toml
+++ b/drv/vsc-err/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-drv-spi-api = {path = "../spi-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-spi-api = { path = "../spi-api" }
+idol-runtime = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/vsc7448/Cargo.toml
+++ b/drv/vsc7448/Cargo.toml
@@ -4,19 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-serde = { version = "1", features = ["derive"], default-features = false}
+cfg-if = { workspace = true }
+serde = { workspace = true }
+vsc7448-pac = { workspace = true }
 
-drv-spi-api = {path = "../../drv/spi-api"}
-ringbuf = {path = "../../lib/ringbuf" }
-userlib = {path = "../../sys/userlib" }
+drv-spi-api = { path = "../../drv/spi-api" }
+ringbuf = { path = "../../lib/ringbuf"  }
+userlib = { path = "../../sys/userlib"  }
 vsc-err = { path = "../vsc-err" }
 vsc85xx = { path = "../vsc85xx" }
 
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
-
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/vsc85xx/Cargo.toml
+++ b/drv/vsc85xx/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-userlib = {path = "../../sys/userlib" }
-ringbuf = {path = "../../lib/ringbuf" }
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
+vsc7448-pac = { workspace = true }
+zerocopy = { workspace = true }
+
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
 vsc-err = { path = "../vsc-err" }
-zerocopy = "0.6.1"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/vsc85xx/Cargo.toml
+++ b/drv/vsc85xx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vsc85xx"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 vsc7448-pac = { workspace = true }

--- a/lib/armv6m-atomic-hack/Cargo.toml
+++ b/lib/armv6m-atomic-hack/Cargo.toml
@@ -3,9 +3,5 @@ name = "armv6m-atomic-hack"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }

--- a/lib/derive-idol-err/Cargo.toml
+++ b/lib/derive-idol-err/Cargo.toml
@@ -3,11 +3,9 @@ name = "derive-idol-err"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-syn = { version = "1", features = ["full"] }
-quote = "1"
+syn = { workspace = true }
+quote = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -21,4 +21,4 @@ lib-lpc55-usart = { path = "../lpc55-usart/" }
 unwrap-lite = { path = "../unwrap-lite" }
 
 [dev-dependencies]
-chrono = "0.4"
+chrono = { workspace = true }

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -4,26 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hkdf = { version = "0.12", default-features = false }
-hubpack = "0.1"
+dice-mfg-msgs = { workspace = true }
+hkdf = { workspace = true }
+hubpack = { workspace = true }
+lpc55-pac = { workspace = true }
+nb = { workspace = true }
+salty = { workspace = true }
+serde = { workspace = true }
+serde-big-array = { workspace = true }
+sha3 = { workspace = true }
+static_assertions = { workspace = true }
+zerocopy = { workspace = true }
+zeroize = { workspace = true }
+
 lib-lpc55-usart = { path = "../lpc55-usart/" }
-lpc55-pac = "0.4"
-nb = "1"
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde-big-array = "0.4"
-sha3 = { version = "0.10", default-features = false }
-static_assertions = "1"
 unwrap-lite = { path = "../unwrap-lite" }
-zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
-zerocopy = "0.6"
-
-[dependencies.dice-mfg-msgs]
-git = "https://github.com/oxidecomputer/dice-util"
-rev = "5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
-
-[dependencies.salty]
-git = "https://github.com/oxidecomputer/salty"
-rev = "eb3c31858f631a7fb9934246c8efdef080d05726"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/lib/fixedmap/Cargo.toml
+++ b/lib/fixedmap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fixedmap"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 test = false

--- a/lib/gnarle/Cargo.toml
+++ b/lib/gnarle/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "gnarle"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [features]
 std = []
-
-[dependencies]

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -4,15 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitflags = "1.3"
-fletcher = "0.3"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde-big-array = "0.4"
-serde_repr = "0.1"
-static_assertions = "1.1"
-zerocopy = "0.6.1"
-
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
+bitflags = { workspace = true }
+fletcher = { workspace = true }
+gateway-messages = { workspace = true }
+hubpack = { workspace = true }
+serde = { workspace = true }
+serde-big-array = { workspace = true }
+serde_repr = { workspace = true }
+static_assertions = { workspace = true }
+zerocopy = { workspace = true }
 
 unwrap-lite = { path = "../unwrap-lite" }

--- a/lib/hypocalls/Cargo.toml
+++ b/lib/hypocalls/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "hypocalls"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-abi = {path = "../../sys/abi"}
-serde = { version = "1.0.114", default-features = false }
-ssmarshal = { version = "1.0.0", default-features = false }
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-num-derive = "0.3.0"
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+abi = { path = "../../sys/abi" }
 lpc55_flash = { path = "../../lib/lpc55-flash" }
 
 [lib]

--- a/lib/lpc55-flash/Cargo.toml
+++ b/lib/lpc55-flash/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "lpc55_flash"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-abi = {path = "../../sys/abi"}
-lpc55_romapi = { path = "../../lib/lpc55-romapi" }
+abi = { path = "../../sys/abi" }
 drv-update-api = { path = "../../drv/update-api" }
+lpc55_romapi = { path = "../../lib/lpc55-romapi" }
 
 [lib]
 test = false

--- a/lib/lpc55-romapi/Cargo.toml
+++ b/lib/lpc55-romapi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lpc55_romapi"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["panic-messages"]
@@ -10,10 +10,10 @@ log-itm = []
 log-semihosting = []
 
 [dependencies]
-lpc55-pac = "0.4"
-num-derive = "0.3.3"
-num-traits = { version = "0.2", default-features = false }
-cfg-if = "1"
+lpc55-pac = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+cfg-if = { workspace = true }
 
 [lib]
 test = false

--- a/lib/lpc55-usart/Cargo.toml
+++ b/lib/lpc55-usart/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2"
-lpc55-pac = "0.4"
-nb = "1"
+embedded-hal = { workspace = true }
+lpc55-pac = { workspace = true }
+nb = { workspace = true }
+
 unwrap-lite = { path = "../../lib/unwrap-lite" }

--- a/lib/multitimer/Cargo.toml
+++ b/lib/multitimer/Cargo.toml
@@ -3,10 +3,8 @@ name = "multitimer"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-enum-map = "2.4.1"
+enum-map = { workspace = true }
 
 [target.'cfg(target_os = "none")'.dependencies]
 userlib = {path = "../../sys/userlib"}

--- a/lib/mutable-statics/Cargo.toml
+++ b/lib/mutable-statics/Cargo.toml
@@ -2,7 +2,3 @@
 name = "mutable-statics"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/lib/phash/Cargo.toml
+++ b/lib/phash/Cargo.toml
@@ -2,7 +2,3 @@
 name = "phash"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/lib/ringbuf/Cargo.toml
+++ b/lib/ringbuf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ringbuf"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 # To disable a ring buffer (but leave it otherwise present), enable the
@@ -9,4 +9,4 @@ edition = "2018"
 disabled = []
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
+userlib = { path = "../../sys/userlib" }

--- a/lib/task-config/Cargo.toml
+++ b/lib/task-config/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-toml = { version = "0.5" }
-syn = { version = "1", features = ["full"] }
-quote = "1"
-proc-macro2 = "1"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+toml = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/lib/unwrap-lite/Cargo.toml
+++ b/lib/unwrap-lite/Cargo.toml
@@ -2,7 +2,3 @@
 name = "unwrap-lite"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/lib/update-buffer/Cargo.toml
+++ b/lib/update-buffer/Cargo.toml
@@ -3,7 +3,5 @@ name = "update-buffer"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-spin = {version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
+spin = { workspace = true }

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "stage0"
 version = "0.1.0"
@@ -24,11 +22,13 @@ nb = { workspace = true }
 p256 = { workspace = true }
 panic-halt = { workspace = true }
 panic-semihosting = { workspace = true }
-salty = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 sha3 = { workspace = true, optional = true }
 static_assertions = { workspace = true, optional = true }
 zerocopy = { workspace = true }
+
+# Special-case for the Oxide fork of Salty
+salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726", optional = true}
 
 abi = { path = "../sys/abi" }
 lib-lpc55-usart = { path = "../lib/lpc55-usart", optional = true }

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "stage0"
 version = "0.1.0"
@@ -5,31 +7,33 @@ edition = "2018"
 
 [features]
 dice-mfg = ["dice_crate", "digest", "hubpack", "salty", "serde", "sha3",
-    "static_assertions", "unwrap-lite", "lib-lpc55-usart"]
+            "static_assertions", "unwrap-lite", "lib-lpc55-usart"]
 dice-self = ["dice_crate", "digest", "salty", "sha3", "unwrap-lite",]
 tz_support = []
 
 [dependencies]
-cfg-if = "1"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-digest = { version = "0.10", optional = true }
-hubpack = { version = "0.1", optional = true }
-panic-semihosting = "0.5.3"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+digest = { workspace = true, optional = true }
+ecdsa = { workspace = true }
+hmac = { workspace = true }
+hubpack = { workspace = true, optional = true }
+lpc55-pac = { workspace = true, features = ["rt"] }
+nb = { workspace = true }
+p256 = { workspace = true }
+panic-halt = { workspace = true }
+panic-semihosting = { workspace = true }
+salty = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+sha3 = { workspace = true, optional = true }
+static_assertions = { workspace = true, optional = true }
+zerocopy = { workspace = true }
+
+abi = { path = "../sys/abi" }
 lib-lpc55-usart = { path = "../lib/lpc55-usart", optional = true }
 lpc55_romapi = { path = "../lib/lpc55-romapi" }
-panic-halt = "0.2.0"
-lpc55-pac = {version = "0.4", features = ["rt"]}
-ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
-p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
-hmac = { version = "0.10.1", default-features = false }
-sha3 = { version = "0.10", default-features = false, optional = true }
-serde = { version = "1", default-features = false, features = ["derive"], optional = true }
-static_assertions = { version = "1", optional = true }
-zerocopy = "0.6.1"
-abi = { path = "../sys/abi" }
 unwrap-lite = { path = "../lib/unwrap-lite", optional = true }
-nb = "1"
 
 # features & deps can't have the same name, using this method from:
 # https://github.com/RustCrypto/RSA/pull/41/files
@@ -41,11 +45,6 @@ optional = true
 
 [build-dependencies]
 build-util = { path = "../build/util" }
-
-[dependencies.salty]
-git = "https://github.com/oxidecomputer/salty"
-rev = "eb3c31858f631a7fb9934246c8efdef080d05726"
-optional = true
 
 [[bin]]
 name = "stage0"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stage0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 dice-mfg = ["dice_crate", "digest", "hubpack", "salty", "serde", "sha3",
@@ -22,13 +22,11 @@ nb = { workspace = true }
 p256 = { workspace = true }
 panic-halt = { workspace = true }
 panic-semihosting = { workspace = true }
+salty = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 sha3 = { workspace = true, optional = true }
 static_assertions = { workspace = true, optional = true }
 zerocopy = { workspace = true }
-
-# Special-case for the Oxide fork of Salty
-salty = { git = "https://github.com/oxidecomputer/salty", rev = "eb3c31858f631a7fb9934246c8efdef080d05726", optional = true}
 
 abi = { path = "../sys/abi" }
 lib-lpc55-usart = { path = "../lib/lpc55-usart", optional = true }

--- a/stage0/src/image_header.rs
+++ b/stage0/src/image_header.rs
@@ -73,8 +73,6 @@ impl Image {
 
     #[cfg(any(feature = "dice-mfg", feature = "dice-self"))]
     fn get_img_size(&self) -> Option<usize> {
-        use core::convert::TryFrom;
-
         usize::try_from((unsafe { &*self.get_header() }).total_image_len).ok()
     }
 

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "abi"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
 zerocopy = { workspace = true }

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "abi"
 version = "0.1.0"

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "abi"
 version = "0.1.0"
@@ -6,10 +8,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.6.1"
-bitflags = "1.2.1"
-byteorder = { version = "1.3.4", default-features = false }
-serde = { version = "1.0.114", default-features = false, features = ["derive"] }
+zerocopy = { workspace = true }
+bitflags = { workspace = true }
+byteorder = { workspace = true }
+serde = { workspace = true }
 phash = { path = "../../lib/phash" }
 
 [lib]

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -4,30 +4,32 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-abi = {path = "../abi"}
-zerocopy = "0.6.1"
-byteorder = { version = "1.3.4", default-features = false }
-bitflags = "1.2.1"
-cfg-if = "1"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-serde = { version = "1.0.114", default-features = false }
-ssmarshal = { version = "1.0.0", default-features = false }
-unwrap-lite = { path = "../../lib/unwrap-lite" }
+bitflags = { workspace = true }
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+abi = { path = "../abi" }
 phash = { path = "../../lib/phash" }
+unwrap-lite = { path = "../../lib/unwrap-lite" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-serde = "1"
-ron = "0.7"
-abi = {path = "../abi"}
-phash-gen = {path = "../../build/phash-gen"}
-anyhow = "1.0.66"
-proc-macro2 = "1.0.32"
-syn = { version = "1.0.94", features = ["parsing"] }
-quote = "1.0.10"
-call_rustfmt = {path = "../../build/call_rustfmt"}
-build-kconfig = {path = "../../build/kconfig"}
-indexmap = "1.9.1"
+anyhow = { workspace = true }
+indexmap = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+ron = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+
+abi = { path = "../abi" }
+build-kconfig = { path = "../../build/kconfig" }
+build-util = { path = "../../build/util" }
+call_rustfmt = { path = "../../build/call_rustfmt" }
+phash-gen = { path = "../../build/phash-gen" }
 
 [lib]
 test = false

--- a/sys/num-tasks/Cargo.toml
+++ b/sys/num-tasks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hubris-num-tasks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "userlib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 panic-messages = []
@@ -10,46 +10,40 @@ log-semihosting = []
 log-null = []
 
 [dependencies]
-abi = {path = "../abi"}
 bstringify = { workspace = true }
+cfg-if = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
 ssmarshal = { workspace = true }
 zerocopy = { workspace = true }
-num-traits = { workspace = true }
-unwrap-lite = { path = "../../lib/unwrap-lite" }
-cfg-if = { workspace = true }
-armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 
-#
-# In order to use macros as discriminants in enums that make use of derive
-# macros (e.g., AsBytes, FromPrimitive), we need the syn crate to have "full"
-# enabled. The easiest way to do this is to use num-derive's "full-syntax",
-# which passes "full" through to syn.
-#
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
+abi = {path = "../abi"}
+armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
+unwrap-lite = { path = "../../lib/unwrap-lite" }
 
 [target.thumbv7em-none-eabihf.dependencies]
 # Note: we don't use cortex-m directly, this is here to ensure that the
 # feature is consistently specified in all tasks, to reduce overbuilding
 # of the PACs.
-cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m = { workspace = true }
 
 # We're repeating this a bazillion times because Cargo only gives us two
 # options: (1) define on the entire target triple, or (2) define on
 # target_arch, which Cargo rounds down to "arm". i.e. we can't detect
 # Cortex-Ms specifically. Thanks, Cargo.
 [target.thumbv7m-none-eabi.dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m = { workspace = true }
 [target.thumbv7em-none-eabi.dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m = { workspace = true }
 [target.thumbv6m-none-eabi.dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m = { workspace = true }
 [target."thumbv8m.main-none-eabihf".dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
+cortex-m = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [lib]
 test = false

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "userlib"
 version = "0.1.0"

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "userlib"
 version = "0.1.0"
@@ -11,14 +13,14 @@ log-null = []
 
 [dependencies]
 abi = {path = "../abi"}
-bstringify = "0.1.2"
-paste = "1"
-serde = { version = "1.0.114", default-features = false }
-ssmarshal = { version = "1.0.0", default-features = false }
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
+bstringify = { workspace = true }
+paste = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+num-traits = { workspace = true }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
-cfg-if = "1"
+cfg-if = { workspace = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 
 #

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -4,36 +4,35 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-heapless = "0.7.16"
-num-traits = {version = "0.2", default-features = false}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-static_assertions = "1.1"
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+gateway-messages = { workspace = true }
+heapless = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+static_assertions = { workspace = true }
+zerocopy = { workspace = true }
 
-drv-auxflash-api = {path = "../../drv/auxflash-api", optional = true}
-drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
-drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
-drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", features = ["h753"], optional = true}
-drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
-drv-update-api = {path = "../../drv/update-api"}
-host-sp-messages = {path = "../../lib/host-sp-messages"}
-mutable-statics = {path = "../../lib/mutable-statics"}
-ringbuf = {path = "../../lib/ringbuf"}
-task-control-plane-agent-api = {path = "../control-plane-agent-api"}
-task-jefe-api = {path = "../jefe-api"}
-task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
-task-validate-api = {path = "../validate-api"}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-update-buffer = {path = "../../lib/update-buffer"}
-
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", rev = "d7791e4d02571b8414b4c2976b0439234aa4d8c7"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-auxflash-api = { path = "../../drv/auxflash-api", optional = true }
+drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
+drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
+drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", features = ["h753"], optional = true }
+drv-stm32xx-uid = { path = "../../drv/stm32xx-uid", features = ["family-stm32h7"] }
+drv-update-api = { path = "../../drv/update-api" }
+host-sp-messages = { path = "../../lib/host-sp-messages" }
+mutable-statics = { path = "../../lib/mutable-statics" }
+ringbuf = { path = "../../lib/ringbuf" }
+task-control-plane-agent-api = { path = "../control-plane-agent-api" }
+task-jefe-api = { path = "../jefe-api" }
+task-net-api = { path = "../net-api", features = ["use-smoltcp"] }
+task-validate-api = { path = "../validate-api" }
+update-buffer = { path = "../../lib/update-buffer" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 [features]
 gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -12,9 +12,9 @@ drv-lpc55-gpio-api = { path = "../../drv/lpc55-gpio-api", optional = true }
 drv-rng-api = { path = "../../drv/rng-api", optional = true }
 drv-sp-ctrl-api = { path = "../../drv/sp-ctrl-api", optional = true }
 drv-spi-api = { path = "../../drv/spi-api" }
-drv-sprot-api = { path = "../../drv/sprot-api", default-features = false, optional = true }
-drv-stm32xx-i2c = { path = "../../drv/stm32xx-i2c", default-features = false, optional = true  }
-drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false, optional = true }
+drv-sprot-api = { path = "../../drv/sprot-api", optional = true }
+drv-stm32xx-i2c = { path = "../../drv/stm32xx-i2c", optional = true  }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", optional = true }
 drv-update-api = {path = "../../drv/update-api", optional = true}
 hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
 ringbuf = { path = "../../lib/ringbuf"  }

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -1,37 +1,38 @@
 [package]
 name = "task-hiffy"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
-ringbuf = {path = "../../lib/ringbuf" }
-drv-sp-ctrl-api = {path = "../../drv/sp-ctrl-api", optional = true}
-drv-i2c-api = {path = "../../drv/i2c-api"}
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-stm32xx-i2c = {path = "../../drv/stm32xx-i2c", default-features = false, optional = true }
-drv-lpc55-gpio-api = {path = "../../drv/lpc55-gpio-api", optional = true}
-drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api", optional = true}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false, optional = true}
-drv-hash-api = {path = "../../drv/hash-api", optional = true}
-drv-sprot-api = {path = "../../drv/sprot-api", default-features = false, optional = true}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "1"
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-serde = { version = "1.0.114", default-features = false }
-byteorder = { version = "1.3.4", default-features = false }
-armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
+armv6m-atomic-hack = { path = "../../lib/armv6m-atomic-hack" }
+drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
+drv-hash-api = { path = "../../drv/hash-api", optional = true }
+drv-i2c-api = { path = "../../drv/i2c-api" }
+drv-lpc55-gpio-api = { path = "../../drv/lpc55-gpio-api", optional = true }
 drv-rng-api = { path = "../../drv/rng-api", optional = true }
+drv-sp-ctrl-api = { path = "../../drv/sp-ctrl-api", optional = true }
+drv-spi-api = { path = "../../drv/spi-api" }
+drv-sprot-api = { path = "../../drv/sprot-api", default-features = false, optional = true }
+drv-stm32xx-i2c = { path = "../../drv/stm32xx-i2c", default-features = false, optional = true  }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false, optional = true }
 drv-update-api = {path = "../../drv/update-api", optional = true}
+hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
+ringbuf = { path = "../../lib/ringbuf"  }
+userlib = { path = "../../sys/userlib" }
+
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+hif = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/host-sp-comms-api/Cargo.toml
+++ b/task/host-sp-comms-api/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-num-traits = { version = "0.2.12", default-features = false }
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
 
-host-sp-messages = {path = "../../lib/host-sp-messages"}
-userlib = {path = "../../sys/userlib"}
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+host-sp-messages = { path = "../../lib/host-sp-messages" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -19,4 +19,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -16,7 +16,7 @@ zerocopy = { workspace = true }
 drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api" }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api" }
 drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", optional = true }
-drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api" }
 host-sp-messages = { path = "../../lib/host-sp-messages" }
 multitimer = { path = "../../lib/multitimer" }
 mutable-statics = { path = "../../lib/mutable-statics" }

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -1,34 +1,33 @@
 [package]
 name = "task-host-sp-comms"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-corncobs = "0.1.3"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-enum-map = "2.4.1"
-heapless = "0.7.16"
-num-traits = { version = "0.2.12", default-features = false }
-zerocopy = "0.6.1"
+cfg-if = { workspace = true }
+corncobs = { workspace = true }
+cortex-m = { workspace = true }
+enum-map = { workspace = true }
+heapless = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
-drv-gimlet-hf-api = {path = "../../drv/gimlet-hf-api"}
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api"}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false}
-drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", optional = true}
-host-sp-messages = {path = "../../lib/host-sp-messages"}
-multitimer = {path = "../../lib/multitimer"}
-mutable-statics = {path = "../../lib/mutable-statics"}
-ringbuf = {path = "../../lib/ringbuf"}
-task-control-plane-agent-api = {path = "../control-plane-agent-api"}
-task-host-sp-comms-api = {path = "../host-sp-comms-api"}
-userlib = {path = "../../sys/userlib"}
-
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api" }
+drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api" }
+drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", optional = true }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+host-sp-messages = { path = "../../lib/host-sp-messages" }
+multitimer = { path = "../../lib/multitimer" }
+mutable-statics = { path = "../../lib/mutable-statics" }
+ringbuf = { path = "../../lib/ringbuf" }
+task-control-plane-agent-api = { path = "../control-plane-agent-api" }
+task-host-sp-comms-api = { path = "../host-sp-comms-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 [features]
 stm32h743 = ["drv-stm32h7-usart/h743", "drv-stm32xx-sys-api/h743"]

--- a/task/idle/Cargo.toml
+++ b/task/idle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "task-idle"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -10,8 +10,8 @@ insomniac = []
 [dependencies]
 # The idle task cannot panic, so we deliberately don't request panic-messages
 # to keep the binary tiny.
-userlib = {path = "../../sys/userlib"}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
+userlib = { path = "../../sys/userlib" }
+cortex-m = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/jefe-api/Cargo.toml
+++ b/task/jefe-api/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-num-traits = {version = "0.2", default-features = false}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6"
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -1,28 +1,30 @@
 [package]
 name = "task-jefe"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-abi = {path = "../../sys/abi"}
-userlib = {path = "../../sys/userlib"}
-hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
-ringbuf = {path = "../../lib/ringbuf" }
-num-traits = { version = "0.2.12", default-features = false }
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6.1"
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-semihosting = { version = "0.5.0", optional = true }
-armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-task-jefe-api = {path = "../jefe-api"}
+cortex-m = { workspace = true }
+cortex-m-semihosting = { workspace = true, optional = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+abi = { path = "../../sys/abi" }
+armv6m-atomic-hack = { path = "../../lib/armv6m-atomic-hack" }
+hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
+ringbuf = { path = "../../lib/ringbuf"  }
+task-jefe-api = { path = "../jefe-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-serde = {version = "1", features = ["derive"]}
-anyhow = "1"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+anyhow = { workspace = true }
+idol = { workspace = true }
+serde = { workspace = true }
+
+build-util = { path = "../../build/util" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -4,26 +4,25 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-drv-sidecar-front-io = {path = "../../drv/sidecar-front-io", features = ["phy_smi"], optional = true}
-drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
-drv-spi-api = {path = "../../drv/spi-api"}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"]}
-drv-user-leds-api = {path = "../../drv/user-leds-api", optional = true }
-monorail-api = {path = "../../drv/monorail-api" }
-ringbuf = {path = "../../lib/ringbuf" }
+drv-sidecar-front-io = { path = "../../drv/sidecar-front-io", features = ["phy_smi"], optional = true }
+drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
+drv-spi-api = { path = "../../drv/spi-api" }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
+drv-user-leds-api = { path = "../../drv/user-leds-api", optional = true  }
+idol-runtime = { workspace = true }
+monorail-api = { path = "../../drv/monorail-api"  }
+ringbuf = { path = "../../lib/ringbuf"  }
 task-net-api = { path = "../net-api", optional = true }
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-vsc7448 = {path = "../../drv/vsc7448" }
-vsc85xx = {path = "../../drv/vsc85xx" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+vsc7448 = { path = "../../drv/vsc7448"  }
+vsc7448-pac = { workspace = true }
+vsc85xx = { path = "../../drv/vsc85xx"  }
 
-cfg-if = "1"
-num-traits = {version = "0.2", default-features = false}
-serde = { version = "1", features = ["derive"], default-features = false}
-ssmarshal = { version = "1", default-features = false }
-zerocopy = "0.6.1"
-
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448" }
+cfg-if = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
 
 [features]
 leds = ["drv-user-leds-api"]

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -10,26 +10,22 @@ mgmt = ["ksz8463"]
 ksz8463 = ["drv-spi-api", "dep:ksz8463"]
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-userlib = {path = "../../sys/userlib"}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-num-traits = {version = "0.2", default-features = false}
-zerocopy = "0.6"
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+smoltcp = { workspace = true, optional = true }
 
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-spi-api = { path = "../../drv/spi-api", optional = true }
 ksz8463 = { path = "../../drv/ksz8463", optional = true }
-drv-spi-api = {path = "../../drv/spi-api", optional = true}
-
-[dependencies.smoltcp]
-version = "0.8.0"
-optional = true
-default-features = false
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-net = {path = "../../build/net"}
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-net = { path = "../../build/net" }
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -5,45 +5,36 @@ authors = ["Cliff L. Biffle <cliff@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-num-traits = {version = "0.2.12", default-features = false}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-stm32h7 = {version = "0.14", default-features = false}
-zerocopy = "0.6"
-enum-map = "2.4.1"
+cortex-m = { workspace = true }
+enum-map = { workspace = true }
+heapless = { workspace = true }
+itertools = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+smoltcp = { workspace = true }
+ssmarshal = { workspace = true }
+stm32h7 = { workspace = true }
+vsc7448-pac = { workspace = true }
+zerocopy = { workspace = true }
 
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
-drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
-drv-local-vpd = {path = "../../drv/local-vpd", optional = true}
-drv-spi-api = {path = "../../drv/spi-api", optional = true}
-drv-stm32h7-eth = {path = "../../drv/stm32h7-eth", features = ["ipv6"]}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api"}
-drv-stm32xx-uid = {path = "../../drv/stm32xx-uid", features = ["family-stm32h7"]}
-drv-user-leds-api = {path = "../../drv/user-leds-api", optional = true}
-hubris-num-tasks = {path = "../../sys/num-tasks", features = ["task-enum"]}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-ksz8463 = { path = "../../drv/ksz8463", optional = true }
-multitimer = {path = "../../lib/multitimer"}
-mutable-statics = {path = "../../lib/mutable-statics"}
-ringbuf = {path = "../../lib/ringbuf"}
-task-jefe-api = {path = "../jefe-api"}
-task-net-api = {path = "../net-api", features = ["use-smoltcp"]}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448"}
+drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-local-vpd = { path = "../../drv/local-vpd", optional = true }
+drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
+drv-spi-api = { path = "../../drv/spi-api", optional = true }
+drv-stm32h7-eth = { path = "../../drv/stm32h7-eth", features = ["ipv6"] }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api" }
+drv-stm32xx-uid = { path = "../../drv/stm32xx-uid", features = ["family-stm32h7"] }
+drv-user-leds-api = { path = "../../drv/user-leds-api", optional = true }
+hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
+idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git" }
+ksz8463 = {path = "../../drv/ksz8463", optional = true }
+multitimer = { path = "../../lib/multitimer" }
+mutable-statics = { path = "../../lib/mutable-statics" }
+ringbuf = { path = "../../lib/ringbuf" }
+task-jefe-api = { path = "../jefe-api" }
+task-net-api = { path = "../net-api", features = ["use-smoltcp"] }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 vsc85xx = { path = "../../drv/vsc85xx"}
-itertools = { version = "0.10.5", default-features = false }
-heapless = { version = "0.7.16", default-features = false }
-
-[dependencies.smoltcp]
-version = "0.8.0"
-default-features = false
-features = [
-    "proto-ipv6",
-    "medium-ethernet",
-    "socket-udp",
-    "async",
-]
 
 [features]
 mgmt = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/mgmt"]

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -47,13 +47,14 @@ vlan = ["task-net-api/vlan", "build-net/vlan", "drv-stm32h7-eth/vlan"]
 gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/ksz8463"]
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-net = {path = "../../build/net"}
-serde = "1"
-quote = "1"
-syn = {version = "1", features = ["parsing"]}
-proc-macro2 = "1"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+
+build-net = { path = "../../build/net" }
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/ping/Cargo.toml
+++ b/task/ping/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "task-ping"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-drv-user-leds-api = {path = "../../drv/user-leds-api"}
+cortex-m = { workspace = true }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+drv-user-leds-api = { path = "../../drv/user-leds-api" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [features]
 uart = []

--- a/task/pong/Cargo.toml
+++ b/task/pong/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "task-pong"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 panic-messages = ["userlib/panic-messages"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-userlib = {path = "../../sys/userlib"}
-drv-user-leds-api = {path = "../../drv/user-leds-api"}
+cortex-m = { workspace = true }
+
+drv-user-leds-api = { path = "../../drv/user-leds-api" }
+userlib = { path = "../../sys/userlib" }
 
 [[bin]]
 name = "task-pong"

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -1,28 +1,30 @@
 [package]
 name = "task-power"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf" }
-drv-i2c-api = {path = "../../drv/i2c-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-cfg-if = "1"
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+paste = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"], optional = true}
-mutable-statics = {path = "../../lib/mutable-statics"}
-task-sensor-api = {path = "../sensor-api"}
-paste = "1.0.6"
+drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"], optional = true }
+mutable-statics = { path = "../../lib/mutable-statics" }
+ringbuf = { path = "../../lib/ringbuf"  }
+task-sensor-api = { path = "../sensor-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
 
 [features]
 gimlet = ["drv-gimlet-seq-api", "h753"]

--- a/task/secure/Cargo.toml
+++ b/task/secure/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "task-secure"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-hypocalls = {path = "../../lib/hypocalls"}
-lpc55_flash = {path = "../../lib/lpc55-flash"}
+cortex-m = { workspace = true }
+
+hypocalls = { path = "../../lib/hypocalls" }
+lpc55_flash = { path = "../../lib/lpc55-flash" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/sensor-api/Cargo.toml
+++ b/task/sensor-api/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "task-sensor-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-i2c-api = {path = "../../drv/i2c-api"}
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-i2c-api = { path = "../../drv/i2c-api" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -17,4 +18,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/task/sensor-polling/Cargo.toml
+++ b/task/sensor-polling/Cargo.toml
@@ -5,19 +5,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
+cortex-m = { workspace = true }
+zerocopy = { workspace = true }
 
-drv-i2c-api = {path = "../../drv/i2c-api"}
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-ringbuf = {path = "../../lib/ringbuf" }
-task-sensor-api = {path = "../sensor-api"}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+ringbuf = { path = "../../lib/ringbuf"  }
+task-sensor-api = { path = "../sensor-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
+anyhow = { workspace = true }
+
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
 
 [[bin]]
 name = "task-sensor-polling"

--- a/task/sensor/Cargo.toml
+++ b/task/sensor/Cargo.toml
@@ -1,29 +1,31 @@
 [package]
 name = "task-sensor"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf" }
-drv-i2c-api = {path = "../../drv/i2c-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-task-sensor-api = {path = "../sensor-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+ringbuf = { path = "../../lib/ringbuf"  }
+task-sensor-api = { path = "../sensor-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+idol = { workspace = true }
+
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/sp_measure/Cargo.toml
+++ b/task/sp_measure/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "task-sp-measure"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-drv-sp-ctrl-api = {path = "../../drv/sp-ctrl-api"}
-sha3 = {version = "0.10", default-features = false}
+sha3 = { workspace = true }
+
+drv-sp-ctrl-api = { path = "../../drv/sp-ctrl-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-anyhow = "1.0.31"
-serde = "1"
-quote = "1"
-sha3 = {version = "0.10", default-features = false}
+anyhow = { workspace = true }
+idol = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+sha3 = { workspace = true }
+
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -11,9 +11,9 @@ spd = { workspace = true }
 stm32h7 = { workspace = true }
 
 drv-gimlet-state = { path = "../../drv/gimlet-state" }
-drv-i2c-api = { path = "../../drv/i2c-api", default-features = false }
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-stm32xx-i2c = { path = "../../drv/stm32xx-i2c", features = ["amd_erratum_1394"] }
-drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 task-jefe-api = { path = "../jefe-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -1,27 +1,29 @@
 [package]
 name = "task-spd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf"}
-spd = { git = "https://github.com/oxidecomputer/spd" }
-num-traits = { version = "0.2.12", default-features = false }
-drv-stm32xx-sys-api = {path = "../../drv/stm32xx-sys-api", default-features = false}
-drv-stm32xx-i2c = {path = "../../drv/stm32xx-i2c", features = ["amd_erratum_1394"]}
-drv-gimlet-state = {path = "../../drv/gimlet-state"}
-task-jefe-api = {path = "../jefe-api"}
-drv-i2c-api = {path = "../../drv/i2c-api", default-features = false}
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+num-traits = { workspace = true }
+spd = { workspace = true }
+stm32h7 = { workspace = true }
+
+drv-gimlet-state = { path = "../../drv/gimlet-state" }
+drv-i2c-api = { path = "../../drv/i2c-api", default-features = false }
+drv-stm32xx-i2c = { path = "../../drv/stm32xx-i2c", features = ["amd_erratum_1394"] }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", default-features = false }
+ringbuf = { path = "../../lib/ringbuf" }
+task-jefe-api = { path = "../jefe-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
 
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-i2c/h743", "drv-stm32xx-sys-api/h743", "build-i2c/h743"]

--- a/task/template/Cargo.toml
+++ b/task/template/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "task-template"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/thermal-api/Cargo.toml
+++ b/task/thermal-api/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "task-thermal-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-num-traits = { version = "0.2.12", default-features = false }
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
 
-userlib = {path = "../../sys/userlib"}
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
+
+[build-dependencies]
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]
 test = false
 bench = false
-
-[build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
 name = "task-thermal"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-bitflags = "1.2.1"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-num-traits = { version = "0.2.12", default-features = false }
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6.1"
+bitflags = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
 
-drv-gimlet-seq-api = {path = "../../drv/gimlet-seq-api", optional = true}
-drv-i2c-api = {path = "../../drv/i2c-api"}
+drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-drv-onewire = {path = "../../drv/onewire"}
-drv-onewire-devices = {path = "../../drv/onewire-devices"}
-drv-sidecar-seq-api = {path = "../../drv/sidecar-seq-api", optional = true}
-ringbuf = {path = "../../lib/ringbuf" }
-task-sensor-api = {path = "../sensor-api"}
-task-thermal-api = {path = "../thermal-api"}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+drv-onewire = { path = "../../drv/onewire" }
+drv-onewire-devices = { path = "../../drv/onewire-devices" }
+drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
+ringbuf = { path = "../../lib/ringbuf"  }
+task-sensor-api = { path = "../sensor-api" }
+task-thermal-api = { path = "../thermal-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+anyhow = { workspace = true }
+idol = { workspace = true }
+
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
 
 [features]
 gimlet = ["drv-gimlet-seq-api", "h753"]

--- a/task/uartecho/Cargo.toml
+++ b/task/uartecho/Cargo.toml
@@ -1,21 +1,19 @@
 [package]
 name = "task-uartecho"
 version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
-cfg-if = "1"
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-heapless = "0.7.16"
-ringbuf = {path = "../../lib/ringbuf"}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+heapless = { workspace = true }
 
-drv-stm32h7-usart = {path = "../../drv/stm32h7-usart", optional = true}
+drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", optional = true }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [features]
 stm32h743 = ["drv-stm32h7-usart/h743"]

--- a/task/udpbroadcast/Cargo.toml
+++ b/task/udpbroadcast/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2021"
 vlan = ["task-net-api/vlan"]
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-num-traits = {version = "0.2", default-features = false}
-task-net-api = {path = "../net-api"}
-zerocopy = "0.6.1"
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+task-net-api = { path = "../net-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/udpecho/Cargo.toml
+++ b/task/udpecho/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-num-traits = {version = "0.2", default-features = false}
-task-net-api = {path = "../net-api"}
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+
+task-net-api = { path = "../net-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-task-net-api = {path = "../net-api"}
-zerocopy = "0.6.1"
+zerocopy = { workspace = true }
+
+task-net-api = { path = "../net-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 vlan = ["task-net-api/vlan"]

--- a/task/validate-api/Cargo.toml
+++ b/task/validate-api/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "task-validate-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-i2c-api = {path = "../../drv/i2c-api"}
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-i2c-api = { path = "../../drv/i2c-api" }
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -17,5 +18,5 @@ test = false
 bench = false
 
 [build-dependencies]
-build-i2c = {path = "../../build/i2c"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-i2c = { path = "../../build/i2c" }
+idol = { workspace = true }

--- a/task/validate/Cargo.toml
+++ b/task/validate/Cargo.toml
@@ -1,29 +1,31 @@
 [package]
 name = "task-validate"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf" }
-drv-i2c-api = {path = "../../drv/i2c-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-task-validate-api = {path = "../validate-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+ringbuf = { path = "../../lib/ringbuf"  }
+task-validate-api = { path = "../validate-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+idol = { workspace = true }
+
+build-i2c = { path = "../../build/i2c" }
+build-util = { path = "../../build/util" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/task/vpd-api/Cargo.toml
+++ b/task/vpd-api/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "task-vpd-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-drv-i2c-api = {path = "../../drv/i2c-api"}
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-i2c-api = { path = "../../drv/i2c-api" }
+userlib = { path = "../../sys/userlib" }
+
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/vpd/Cargo.toml
+++ b/task/vpd/Cargo.toml
@@ -1,29 +1,31 @@
 [package]
 name = "task-vpd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.build]
 target = "thumbv7em-none-eabihf"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-ringbuf = {path = "../../lib/ringbuf" }
-drv-i2c-api = {path = "../../drv/i2c-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-cfg-if = "1"
-num-traits = { version = "0.2.12", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
-task-vpd-api = {path = "../vpd-api"}
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+ringbuf = { path = "../../lib/ringbuf"  }
+task-vpd-api = { path = "../vpd-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c"}
-anyhow = "1.0.31"
-cfg-if = "1"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+idol = { workspace = true }
+
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/test/test-api/Cargo.toml
+++ b/test/test-api/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "test-api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-num-traits = { version = "0.2.12", default-features = false }
+userlib = { path = "../../sys/userlib" }
+num-traits = { workspace = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "test-assist"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-hubris-num-tasks = {path = "../../sys/num-tasks"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-test-api = {path = "../test-api"}
-cortex-m-semihosting = { version = "0.5.0", optional = true }
+cortex-m = { workspace = true }
+cortex-m-semihosting = { workspace = true, optional = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+hubris-num-tasks = { path = "../../sys/num-tasks" }
+test-api = { path = "../test-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/test/test-idol-api/Cargo.toml
+++ b/test/test-idol-api/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -17,4 +18,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/test/test-idol-server/Cargo.toml
+++ b/test/test-idol-server/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
-num-traits = { version = "0.2.12", default-features = false }
-serde = {version = "1", default-features = false, features = ["derive"]}
-ssmarshal = {version = "1", default-features = false}
-test-idol-api = {path = "../test-idol-api"}
-userlib = {path = "../../sys/userlib"}
-zerocopy = "0.6.1"
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+ssmarshal = { workspace = true }
+zerocopy = { workspace = true }
+
+test-idol-api = { path = "../test-idol-api" }
+userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "test-runner"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-hubris-num-tasks = {path = "../../sys/num-tasks"}
-test-api = {path = "../test-api"}
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-num-traits = { version = "0.2.12", default-features = false }
-cortex-m-semihosting = { version = "0.5.0", optional = true }
-armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
-cfg-if = "1"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-semihosting = { workspace = true, optional = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+armv6m-atomic-hack = { path = "../../lib/armv6m-atomic-hack" }
+hubris-num-tasks = { path = "../../sys/num-tasks" }
+test-api = { path = "../test-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -1,26 +1,27 @@
 [package]
 name = "test-suite"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-zerocopy = "0.6.1"
-userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
-hubris-num-tasks = {path = "../../sys/num-tasks"}
-num-traits = { version = "0.2.12", default-features = false }
-test-api = {path = "../test-api"}
-test-idol-api = {path = "../test-idol-api"}
-task-config = { path = "../../lib/task-config" }
-cfg-if = "1"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+hubris-num-tasks = { path = "../../sys/num-tasks" }
+task-config = {  path = "../../lib/task-config"  }
+test-api = { path = "../test-api" }
+test-idol-api = { path = "../test-idol-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # Some tests require talking to I2C devices on the target board
-drv-i2c-api = {path = "../../drv/i2c-api", optional = true}
-drv-i2c-devices = { path = "../../drv/i2c-devices", optional = true}
+drv-i2c-api = { path = "../../drv/i2c-api", optional = true }
+drv-i2c-devices = {  path = "../../drv/i2c-devices", optional = true }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
-build-i2c = {path = "../../build/i2c", optional = true}
+build-util = { path = "../../build/util" }
+build-i2c = { path = "../../build/i2c", optional = true }
 
 [features]
 itm = [ "userlib/log-itm" ]

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -4,7 +4,6 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -19,7 +19,7 @@ panic-halt = { workspace= true, optional = true }
 panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-rot-carrier"
 version = "0.1.0"
@@ -11,17 +11,15 @@ semihosting = ["panic-semihosting"]
 plls = []
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = "0.4"
-cfg-if = "1"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+lpc55-pac = { workspace = true }
+panic-halt = { workspace= true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -18,7 +18,7 @@ panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-gemini-bu"
 version = "0.1.0"
@@ -10,20 +10,18 @@ semihosting = ["panic-semihosting"]
 h753 = ["stm32h7/stm32h753"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace= true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-gimletlet"
 version = "0.1.0"
@@ -10,20 +10,18 @@ semihosting = ["panic-semihosting"]
 h753 = ["stm32h7/stm32h753"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "1"
-stm32h7 = { version = "0.14.0", default-features = false, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace= true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -18,7 +18,7 @@ panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -10,7 +10,7 @@ semihosting = ["panic-semihosting"]
 h753 = ["stm32h7/stm32h753"]
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 panic-halt = { workspace= true, optional = true }

--- a/test/tests-lpc55xpresso/Cargo.toml
+++ b/test/tests-lpc55xpresso/Cargo.toml
@@ -19,7 +19,7 @@ panic-halt = { workspace = true, optional = true }
 panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-lpc55xpresso/Cargo.toml
+++ b/test/tests-lpc55xpresso/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-lpc55xpresso"
 version = "0.1.0"
@@ -11,17 +11,15 @@ semihosting = ["panic-semihosting"]
 plls = []
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-lpc55-pac = "0.4"
-cfg-if = "1"
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+lpc55-pac = { workspace = true }
+panic-halt = { workspace = true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-psc/Cargo.toml
+++ b/test/tests-psc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "tests-psc"
 version = "0.1.0"
 

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -65,7 +65,7 @@ uses = ["rcc", "gpios1", "gpios2", "gpios3"]
 start = true
 
 [tasks.i2c_driver]
-name = "drv-stm32h7-i2c-server"
+name = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}

--- a/test/tests-stm32fx/Cargo.toml
+++ b/test/tests-stm32fx/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-stm32f4"
 version = "0.1.0"
@@ -9,25 +9,15 @@ itm = ["panic-itm"]
 semihosting = ["panic-semihosting"]
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["inline-asm"]}
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-itm = { workspace = true, optional = true }
+panic-halt = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32f3 = { workspace = true, optional = true, features = ["stm32f303", "rt"] }
+stm32f4 = { workspace = true, optional = true, features = ["stm32f407", "rt"] }
 
-[dependencies.stm32f3]
-features = ["stm32f303", "rt"]
-version = "0.13.0"
-optional = true
-
-[dependencies.stm32f4]
-features = ["stm32f407", "rt"]
-version = "0.13.0"
-optional = true
-
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/test/tests-stm32fx/Cargo.toml
+++ b/test/tests-stm32fx/Cargo.toml
@@ -17,7 +17,7 @@ panic-semihosting = { workspace = true, optional = true }
 stm32f3 = { workspace = true, optional = true, features = ["stm32f303", "rt"] }
 stm32f4 = { workspace = true, optional = true, features = ["stm32f407", "rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/test/tests-stm32g0/Cargo.toml
+++ b/test/tests-stm32g0/Cargo.toml
@@ -18,7 +18,7 @@ panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 stm32g0 = { workspace = true }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/test/tests-stm32g0/Cargo.toml
+++ b/test/tests-stm32g0/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-stm32g0"
 version = "0.1.0"
@@ -10,20 +10,18 @@ semihosting = ["panic-semihosting"]
 g070 = ["stm32g0/stm32g070"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace = true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32g0 = { workspace = true }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "tests-stm32h7"
 version = "0.1.0"
@@ -11,20 +11,18 @@ h743 = ["stm32h7/stm32h743"]
 h753 = ["stm32h7/stm32h753"]
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["inline-asm"] }
-cortex-m-rt = "0.6.12"
-panic-itm = { version = "0.4.1", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-panic-semihosting = { version = "0.5.3", optional = true }
-cfg-if = "1"
-stm32h7 = { version = "0.14", default-features = false, features = ["rt"] }
+cfg-if = { workspace = true }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+panic-halt = { workspace= true, optional = true }
+panic-itm = { workspace = true, optional = true }
+panic-semihosting = { workspace = true, optional = true }
+stm32h7 = { workspace = true, features = ["rt"] }
 
-[dependencies.kern]
-path = "../../sys/kern"
-default-features = false
+kern = { path = "../../sys/kern", default-features = false }
 
 [build-dependencies]
-build-util = {path = "../../build/util"}
+build-util = { path = "../../build/util" }
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -19,7 +19,7 @@ panic-itm = { workspace = true, optional = true }
 panic-semihosting = { workspace = true, optional = true }
 stm32h7 = { workspace = true, features = ["rt"] }
 
-kern = { path = "../../sys/kern", default-features = false }
+kern = { path = "../../sys/kern" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }


### PR DESCRIPTION
This PR switches to [workspace dependency inheritance](https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace), which is a way to define dependency versions _once_ at the root of a workspace.

After this PR, every (remote) crate is declared as `{ workspace = true }`, without any version or additional features*.  Local crates are still declared as `{ path = "../, ... }` for now, because I find it useful to distinguish between remote and local crates at a glance; I could be persuaded otherwise.

Doing this minimizes build churn, because all Hubris crates use the same versions + features of dependencies.  In addition, it makes it easier to bump dependencies in a single place!

*the hardware PAC crates are an exception to the "no features in crate-level `Cargo.toml` rule, because their features aren't additive.

In addition, this PR
- Switches every Hubris crate to `edition = "2021"`, fixing minor breakages
- Enables `default-features = false` for all (remote) dependencies, then selectively adds features that are needed
    - Goblin is the one exception, because it requires all features to unlock `goblin::Object`
- Removes `default-features = false` for all path (within-Hubris) dependencies that don't _have_ any default features
- Removed explicit versions for stuff that's already tracked in `Cargo.lock`

This is the rare PR where reviewing the `Cargo.lock` changes is useful, since that's ground truth for actual changes.