### PR TITLE
Fix salty dep by adding branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
  "lib-lpc55-usart",
  "lpc55-pac",
  "nb 1.0.0",
- "salty 0.2.0 (git+https://github.com/oxidecomputer/salty)",
+ "salty 0.2.0 (git+https://github.com/oxidecomputer/salty?branch=v0.2.0-zeroize)",
  "serde",
  "serde-big-array",
  "sha3",
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "salty"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/salty#eb3c31858f631a7fb9934246c8efdef080d05726"
+source = "git+https://github.com/oxidecomputer/salty?branch=v0.2.0-zeroize#eb3c31858f631a7fb9934246c8efdef080d05726"
 dependencies = [
  "ed25519",
  "subtle",
@@ -3555,7 +3555,7 @@ dependencies = [
  "p256",
  "panic-halt",
  "panic-semihosting",
- "salty 0.2.0 (git+https://github.com/oxidecomputer/salty)",
+ "salty 0.2.0 (git+https://github.com/oxidecomputer/salty?branch=v0.2.0-zeroize)",
  "serde",
  "sha3",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
-salty = { git = "https://github.com/oxidecomputer/salty", default-features = false }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }


### PR DESCRIPTION
Previously salty used an explicit git rev in the Cargo.toml. This isn't great practice since it prevents easy updating and allows you to reference a commit that isn't on a branch, and is thus subject to being arbitrarily GC'd by Github at any time, breaking the build.

The conversion to workspace dependencies dropped the rev with the rationale that it appeared in the Cargo.lock. This was true, but, the rev was also not on salty's default branch. Cargo only checks out the branch you request. So, on machines that hadn't previously built the explicit-rev version and still had a salty checkout cached, the build now fails because the locked commit is absent.

This switches the dependency to name the branch in our fork where our desired commits live. This ensures that we can cargo update to anything new we push on that branch, and that the commits actually get checked out by Cargo.

I've audited the other packages that were using rev= dependencies before the workspace change, and in all cases, their commits were on their default branches. So only salty needs to change here.