### PR TITLE
Allow MGS to query for VSC7448 port status 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-monorail-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
+ "serde",
+ "ssmarshal",
+ "userlib",
+ "vsc7448",
+ "vsc85xx",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-onewire"
 version = "0.1.0"
 dependencies = [
@@ -2499,18 +2514,6 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
-]
-
-[[package]]
-name = "monorail-api"
-version = "0.1.0"
-dependencies = [
- "derive-idol-err",
- "num-traits",
- "serde",
- "userlib",
- "vsc7448",
- "zerocopy",
 ]
 
 [[package]]
@@ -3849,6 +3852,7 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if",
+ "drv-monorail-api",
  "drv-sidecar-front-io",
  "drv-sidecar-seq-api",
  "drv-spi-api",
@@ -3856,7 +3860,6 @@ dependencies = [
  "drv-user-leds-api",
  "idol",
  "idol-runtime",
- "monorail-api",
  "num-traits",
  "ringbuf",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#d7791e4d02571b8414b4c2976b0439234aa4d8c7"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#6d13d40d1b6c612fea72be4aa9c900c72cda261c"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
@@ -3694,6 +3694,7 @@ dependencies = [
  "drv-auxflash-api",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",
+ "drv-monorail-api",
  "drv-sidecar-seq-api",
  "drv-stm32h7-usart",
  "drv-stm32xx-uid",

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -128,7 +128,7 @@ task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }]
 name = "task-control-plane-agent"
 priority = 4
 max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -126,7 +126,7 @@ task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }]
 name = "task-control-plane-agent"
 priority = 4
 max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -147,9 +147,9 @@ task-slots = ["sys", "i2c_driver",
 
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
-priority = 6
+priority = 7
 max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
@@ -162,6 +162,7 @@ task-slots = [
     "sequencer",
     "auxflash",
     "validate",
+    "monorail",
 ]
 features = ["sidecar", "vlan", "auxflash"]
 
@@ -329,7 +330,7 @@ task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 7
+priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -147,9 +147,9 @@ task-slots = ["sys", "i2c_driver",
 
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
-priority = 6
+priority = 7
 max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2048
+stacksize = 2560
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid
@@ -162,6 +162,7 @@ task-slots = [
     "sequencer",
     "auxflash",
     "validate",
+    "monorail",
 ]
 features = ["sidecar", "vlan", "auxflash"]
 
@@ -328,7 +329,7 @@ task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 7
+priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "monorail-api"
+name = "drv-monorail-api"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-derive-idol-err = { path = "../../lib/derive-idol-err"  }
+derive-idol-err = { path = "../../lib/derive-idol-err" }
 userlib = { path = "../../sys/userlib" }
 vsc7448 = { path = "../vsc7448" }
+vsc85xx = { path = "../vsc85xx" }
 
 num-traits = { workspace = true }
 serde = { workspace = true }
+ssmarshal = { workspace = true }
 zerocopy = { workspace = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
@@ -17,3 +19,6 @@ zerocopy = { workspace = true }
 [lib]
 test = false
 bench = false
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -21,4 +21,4 @@ test = false
 bench = false
 
 [build-dependencies]
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = { workspace = true }

--- a/drv/monorail-api/build.rs
+++ b/drv/monorail-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/monorail.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -6,10 +6,15 @@
 
 use derive_idol_err::IdolError;
 use serde::{Deserialize, Serialize};
-use userlib::{FromPrimitive, ToPrimitive};
+use userlib::*;
+
+pub use vsc85xx::{
+    tesla::{TeslaSerdes6gObConfig, TeslaSerdes6gPatch},
+    vsc8562::{Sd6gObCfg, Sd6gObCfg1},
+};
 
 pub use vsc7448::{
-    config::{PortConfig, PortDev, PortMode},
+    config::{PortConfig, PortDev, PortMode, PortSerdes, Speed},
     VscError,
 };
 
@@ -207,3 +212,5 @@ pub struct MacTableEntry {
     pub mac: [u8; 6],
     pub port: u16,
 }
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/vsc85xx/src/tesla.rs
+++ b/drv/vsc85xx/src/tesla.rs
@@ -6,7 +6,7 @@ use crate::util::detype;
 use crate::Trace;
 use crate::{Phy, PhyRw};
 
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
@@ -268,14 +268,14 @@ impl<'a, 'b, P: PhyRw> TeslaPhy<'a, 'b, P> {
     }
 }
 
-#[derive(Copy, Clone, AsBytes)]
+#[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct TeslaSerdes6gPatch {
     cfg: [u8; 38],
     // There's also a status buf, but we'll skip that for now
 }
 
-#[derive(Copy, Clone, AsBytes)]
+#[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct TeslaSerdes6gObConfig {
     pub ob_post0: u8,

--- a/drv/vsc85xx/src/vsc8562.rs
+++ b/drv/vsc85xx/src/vsc8562.rs
@@ -4,7 +4,7 @@
 
 use core::convert::TryInto;
 
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 use crate::{Phy, PhyRw, Trace};
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
@@ -984,7 +984,7 @@ impl<'a, 'b, P: PhyRw> Vsc8562Phy<'a, 'b, P> {
     }
 }
 
-#[derive(Copy, Clone, AsBytes)]
+#[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct Sd6gObCfg {
     pub ob_ena1v_mode: u8,
@@ -1013,7 +1013,7 @@ impl Sd6gObCfg {
     }
 }
 
-#[derive(Copy, Clone, AsBytes)]
+#[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct Sd6gObCfg1 {
     pub ob_ena_cas: u8,

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -17,6 +17,7 @@ zerocopy = { workspace = true }
 drv-auxflash-api = { path = "../../drv/auxflash-api", optional = true }
 drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-monorail-api = { path = "../../drv/monorail-api", optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", features = ["h753"], optional = true }
 drv-stm32xx-uid = { path = "../../drv/stm32xx-uid", features = ["family-stm32h7"] }
@@ -36,7 +37,7 @@ idol = { workspace = true }
 
 [features]
 gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]
-sidecar = ["drv-sidecar-seq-api"]
+sidecar = ["drv-sidecar-seq-api", "drv-monorail-api"]
 psc = []
 
 vlan = ["task-net-api/vlan"]

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -168,6 +168,15 @@ const OUR_DEVICES: &[DeviceDescription<'static>] = &[
         capabilities: DeviceCapabilities::UPDATEABLE,
         presence: DevicePresence::Present, // TODO: ok to assume always present?
     },
+    // If we're building for sidecar, we always claim to have a VSC7448.
+    #[cfg(feature = "sidecar")]
+    DeviceDescription {
+        component: SpComponent::VSC7448,
+        device: SpComponent::VSC7448.const_as_str(),
+        description: "Management network switch",
+        capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS,
+        presence: DevicePresence::Present, // TODO: ok to assume always present?
+    },
 ];
 
 // We use a generic component ID of `{prefix}{index}` for all of

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -175,7 +175,9 @@ const OUR_DEVICES: &[DeviceDescription<'static>] = &[
         device: SpComponent::VSC7448.const_as_str(),
         description: "Management network switch",
         capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS,
-        presence: DevicePresence::Present, // TODO: ok to assume always present?
+        // Fine to assume this is always present; if it isn't, we can't respond
+        // to MGS messages anyway!
+        presence: DevicePresence::Present,
     },
 ];
 

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -107,6 +107,9 @@ enum MgsMessage {
     },
     GetStartupOptions,
     SetStartupOptions(gateway_messages::StartupOptions),
+    ComponentDetails {
+        component: SpComponent,
+    },
 }
 
 ringbuf!(Log, 16, Log::Empty);

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -6,7 +6,7 @@ use crate::{inventory::Inventory, Log, MgsMessage};
 use core::convert::Infallible;
 use gateway_messages::sp_impl::DeviceDescription;
 use gateway_messages::{DiscoverResponse, SpError, SpPort, SpState};
-use ringbuf::ringbuf_entry_root;
+use ringbuf::ringbuf_entry_root as ringbuf_entry;
 
 // TODO How are we versioning SP images? This is a placeholder.
 const VERSION: u32 = 1;
@@ -29,12 +29,12 @@ impl MgsCommon {
         &mut self,
         port: SpPort,
     ) -> Result<DiscoverResponse, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Discovery));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::Discovery));
         Ok(DiscoverResponse { sp_port: port })
     }
 
     pub(crate) fn sp_state(&mut self) -> Result<SpState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SpState));
 
         // TODO Replace with the real serial number once it's available; for now
         // use the stm32 96-bit uid
@@ -56,7 +56,7 @@ impl MgsCommon {
     pub(crate) fn reset_prepare(&mut self) -> Result<(), SpError> {
         // TODO: Add some kind of auth check before performing a reset.
         // https://github.com/oxidecomputer/hubris/issues/723
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ResetPrepare));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ResetPrepare));
         self.reset_requested = true;
         Ok(())
     }

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -13,10 +13,10 @@ use drv_gimlet_seq_api::Sequencer;
 use drv_stm32h7_usart::Usart;
 use gateway_messages::sp_impl::{DeviceDescription, SocketAddrV6, SpHandler};
 use gateway_messages::{
-    BulkIgnitionState, ComponentUpdatePrepare, DiscoverResponse, Header,
-    IgnitionCommand, IgnitionState, Message, MessageKind, MgsError, PowerState,
-    SpComponent, SpError, SpPort, SpRequest, SpState, SpUpdatePrepare,
-    UpdateChunk, UpdateId, UpdateStatus,
+    BulkIgnitionState, ComponentDetails, ComponentUpdatePrepare,
+    DiscoverResponse, Header, IgnitionCommand, IgnitionState, Message,
+    MessageKind, MgsError, PowerState, SpComponent, SpError, SpPort, SpRequest,
+    SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
 use heapless::Deque;
 use host_sp_messages::HostStartupOptions;
@@ -618,6 +618,32 @@ impl SpHandler for MgsHandler {
         self.startup_options = options.into();
 
         Ok(())
+    }
+
+    fn num_component_details(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<u32, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
+            component
+        }));
+
+        // TODO: Wire up any component info we can (sensor measurements, etc)
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_details(
+        &mut self,
+        _component: SpComponent,
+        _index: u32,
+    ) -> ComponentDetails {
+        // We never return successfully from `num_component_details()`, so this
+        // function should never be called.
+        panic!()
     }
 
     fn mgs_response_error(

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -21,7 +21,7 @@ use gateway_messages::{
 use heapless::Deque;
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root;
+use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::{Address, UdpMetadata};
 use userlib::{sys_get_timer, sys_irq_control, UnwrapLite};
@@ -197,7 +197,7 @@ impl MgsHandler {
         };
 
         // We have data we want to flush and an attached MGS; build our packet.
-        ringbuf_entry_root!(Log::SerialConsoleSend {
+        ringbuf_entry!(Log::SerialConsoleSend {
             buffered: self.usart.from_rx.len(),
         });
 
@@ -288,9 +288,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
-            target
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -299,7 +297,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<BulkIgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -310,7 +308,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -331,7 +329,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -347,7 +345,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -369,7 +367,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -391,9 +389,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
 
         let status = match component {
             // Unlike `update_chunk()`, we only need to match on `SP_ITSELF`
@@ -418,9 +414,7 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
 
         match component {
             // Unlike `update_chunk()`, we only need to match on `SP_ITSELF`
@@ -444,7 +438,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
         use drv_gimlet_seq_api::PowerState as DrvPowerState;
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
 
         // TODO Do we want to expose the sub-states to the control plane? For
         // now, squish them down.
@@ -475,9 +469,7 @@ impl SpHandler for MgsHandler {
         power_state: PowerState,
     ) -> Result<(), SpError> {
         use drv_gimlet_seq_api::PowerState as DrvPowerState;
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
-            power_state
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
 
         let power_state = match power_state {
             PowerState::A0 => DrvPowerState::A0,
@@ -496,7 +488,7 @@ impl SpHandler for MgsHandler {
         port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
 
         // Including a component in the serial console messages is half-baked at
         // the moment; we can at least check that it's the one component we
@@ -524,7 +516,7 @@ impl SpHandler for MgsHandler {
         mut offset: u64,
         mut data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -565,7 +557,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         self.attached_serial_console_mgs = None;
         Ok(())
     }
@@ -587,7 +579,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory_num_devices() as u32
     }
 
@@ -600,7 +592,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
 
         Ok(self.startup_options.into())
     }
@@ -611,9 +603,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
-            options
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
 
         self.startup_options = options.into();
 
@@ -626,7 +616,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -653,7 +643,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -668,7 +658,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),
@@ -772,7 +762,7 @@ impl UsartHandler {
 
         // Clean up / ringbuf debug log after transmitting.
         if n_transmitted > 0 {
-            ringbuf_entry_root!(Log::UsartTx {
+            ringbuf_entry!(Log::UsartTx {
                 num_bytes: n_transmitted
             });
             self.to_tx.drain_front(n_transmitted);
@@ -780,14 +770,14 @@ impl UsartHandler {
         if self.to_tx.is_empty() {
             self.usart.disable_tx_fifo_empty_interrupt();
         } else {
-            ringbuf_entry_root!(Log::UsartTxFull {
+            ringbuf_entry!(Log::UsartTxFull {
                 remaining: self.to_tx.len()
             });
         }
 
         // Clear any errors.
         if self.usart.check_and_clear_rx_overrun() {
-            ringbuf_entry_root!(Log::UsartRxOverrun);
+            ringbuf_entry!(Log::UsartRxOverrun);
             // TODO-correctness Should we notify MGS of dropped data here? We
             // could increment `self.from_rx_offset`, but (a) we don't know how
             // much data we lost, and (b) it would indicate lost data in the
@@ -820,13 +810,13 @@ impl UsartHandler {
         // and log that fact locally via ringbuf.
         self.from_rx_offset += discarded_data;
         if discarded_data > 0 {
-            ringbuf_entry_root!(Log::UsartRxBufferDataDropped {
+            ringbuf_entry!(Log::UsartRxBufferDataDropped {
                 num_bytes: discarded_data
             });
         }
 
         if n_received > 0 {
-            ringbuf_entry_root!(Log::UsartRx {
+            ringbuf_entry!(Log::UsartRx {
                 num_bytes: n_received
             });
             if self.from_rx_flush_deadline.is_none() {

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -7,9 +7,10 @@ use core::convert::Infallible;
 use crate::{mgs_common::MgsCommon, update::sp::SpUpdate, Log, MgsMessage};
 use gateway_messages::sp_impl::{DeviceDescription, SocketAddrV6, SpHandler};
 use gateway_messages::{
-    BulkIgnitionState, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
-    SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    BulkIgnitionState, ComponentDetails, ComponentUpdatePrepare,
+    DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
+    SpComponent, SpError, SpPort, SpState, SpUpdatePrepare, UpdateChunk,
+    UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -337,6 +337,32 @@ impl SpHandler for MgsHandler {
         self.common.inventory_device_description(index as usize)
     }
 
+    fn num_component_details(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<u32, SpError> {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
+            component
+        }));
+
+        // TODO: Wire up any component info we can (sensor measurements, etc)
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_details(
+        &mut self,
+        _component: SpComponent,
+        _index: u32,
+    ) -> ComponentDetails {
+        // We never return successfully from `num_component_details()`, so this
+        // function should never be called.
+        panic!()
+    }
+
     fn get_startup_options(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -14,7 +14,7 @@ use gateway_messages::{
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root;
+use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::UdpMetadata;
 use userlib::sys_get_timer;
@@ -132,9 +132,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
-            target
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -143,7 +141,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<BulkIgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -154,7 +152,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -175,7 +173,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -191,7 +189,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -208,9 +206,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
 
         match component {
             SpComponent::SP_ITSELF => Ok(self.sp_update.status()),
@@ -225,7 +221,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -245,9 +241,7 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
 
         match component {
             SpComponent::SP_ITSELF => self.sp_update.abort(&id),
@@ -260,7 +254,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
 
         // We have no states other than A2.
         Ok(PowerState::A2)
@@ -272,9 +266,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         power_state: PowerState,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
-            power_state
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
 
         // We have no states other than A2; always fail.
         Err(SpError::RequestUnsupportedForSp)
@@ -286,7 +278,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -297,7 +289,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -309,7 +301,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -330,7 +322,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory_num_devices() as u32
     }
 
@@ -344,7 +336,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -369,7 +361,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -379,9 +371,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
-            options
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -392,7 +382,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -407,7 +397,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -15,7 +15,7 @@ use gateway_messages::{
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root;
+use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use task_control_plane_agent_api::ControlPlaneAgentError;
 use task_net_api::UdpMetadata;
 use userlib::sys_get_timer;
@@ -148,9 +148,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
-            target
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -159,7 +157,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<BulkIgnitionState, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -170,7 +168,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -191,7 +189,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -207,7 +205,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -224,9 +222,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
 
         match component {
             SpComponent::SP_ITSELF => Ok(self.sp_update.status()),
@@ -241,7 +237,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -261,9 +257,7 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
-            component
-        }));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
 
         match component {
             SpComponent::SP_ITSELF => self.sp_update.abort(&id),
@@ -277,7 +271,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
         use drv_sidecar_seq_api::TofinoSeqState;
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
 
         // TODO Is this mapping of the sub-states correct? Do we want to expose
         // them to the control plane somehow (probably not)?
@@ -302,9 +296,7 @@ impl SpHandler for MgsHandler {
         power_state: PowerState,
     ) -> Result<(), SpError> {
         use drv_sidecar_seq_api::TofinoSequencerPolicy;
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
-            power_state
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
 
         let policy = match power_state {
             PowerState::A0 => TofinoSequencerPolicy::LatchOffOnFault,
@@ -323,7 +315,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -334,7 +326,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -346,7 +338,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -367,7 +359,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory_num_devices() as u32
     }
 
@@ -381,7 +373,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -413,7 +405,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -423,9 +415,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
-            options
-        )));
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -436,7 +426,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -451,7 +441,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),

--- a/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use drv_monorail_api::{Monorail, MonorailError};
+use gateway_messages::vsc7448_port_status::{
+    LinkStatus, PacketCount, PhyStatus, PhyType, PortConfig, PortCounters,
+    PortDev, PortMode, PortSerdes, PortStatus, PortStatusError,
+    PortStatusErrorCode, Speed,
+};
+
+pub(super) fn port_status(
+    monorail: &Monorail,
+    port: u32,
+) -> Result<PortStatus, PortStatusError> {
+    let (port_status, counters, phy_status) = monorail
+        .get_port_status(port as u8)
+        .and_then(|port_status| {
+            monorail
+                .get_port_counters(port as u8)
+                .map(|counters| (port_status, counters))
+        })
+        .and_then(|(port_status, counters)| {
+            match monorail.get_phy_status(port as u8) {
+                Ok(phy_status) => Ok((port_status, counters, Some(phy_status))),
+                Err(MonorailError::NoPhy) => Ok((port_status, counters, None)),
+                Err(err) => Err(err),
+            }
+        })
+        .map_err(|err| {
+            let code = match err {
+                MonorailError::UnconfiguredPort => {
+                    PortStatusErrorCode::Unconfigured
+                }
+                _ => PortStatusErrorCode::Other(err as u32),
+            };
+            PortStatusError { port, code }
+        })?;
+    Ok(PortStatus {
+        port,
+        cfg: PortConfigConvert(port_status.cfg).into(),
+        link_status: LinkStatusConvert(port_status.link_up).into(),
+        phy_status: phy_status.map(|s| PhyStatusConvert(s).into()),
+        counters: PortCountersConvert(counters).into(),
+    })
+}
+
+struct PortConfigConvert(drv_monorail_api::PortConfig);
+
+impl From<PortConfigConvert> for PortConfig {
+    fn from(PortConfigConvert(s): PortConfigConvert) -> Self {
+        Self {
+            mode: PortModeConvert(s.mode).into(),
+            dev: (PortDevConvert(s.dev.0).into(), s.dev.1),
+            serdes: (PortSerdesConvert(s.serdes.0).into(), s.serdes.1),
+        }
+    }
+}
+
+struct PortDevConvert(drv_monorail_api::PortDev);
+
+impl From<PortDevConvert> for PortDev {
+    fn from(PortDevConvert(m): PortDevConvert) -> Self {
+        match m {
+            drv_monorail_api::PortDev::Dev1g => Self::Dev1g,
+            drv_monorail_api::PortDev::Dev2g5 => Self::Dev2g5,
+            drv_monorail_api::PortDev::Dev10g => Self::Dev10g,
+        }
+    }
+}
+
+struct PortSerdesConvert(drv_monorail_api::PortSerdes);
+
+impl From<PortSerdesConvert> for PortSerdes {
+    fn from(PortSerdesConvert(m): PortSerdesConvert) -> Self {
+        match m {
+            drv_monorail_api::PortSerdes::Serdes1g => Self::Serdes1g,
+            drv_monorail_api::PortSerdes::Serdes6g => Self::Serdes6g,
+            drv_monorail_api::PortSerdes::Serdes10g => Self::Serdes10g,
+        }
+    }
+}
+
+struct PortModeConvert(drv_monorail_api::PortMode);
+
+impl From<PortModeConvert> for PortMode {
+    fn from(PortModeConvert(m): PortModeConvert) -> Self {
+        match m {
+            drv_monorail_api::PortMode::Sfi => Self::Sfi,
+            drv_monorail_api::PortMode::BaseKr => Self::BaseKr,
+            drv_monorail_api::PortMode::Sgmii(s) => {
+                Self::Sgmii(SpeedConvert(s).into())
+            }
+            drv_monorail_api::PortMode::Qsgmii(s) => {
+                Self::Qsgmii(SpeedConvert(s).into())
+            }
+        }
+    }
+}
+
+struct SpeedConvert(drv_monorail_api::Speed);
+
+impl From<SpeedConvert> for Speed {
+    fn from(SpeedConvert(s): SpeedConvert) -> Self {
+        match s {
+            drv_monorail_api::Speed::Speed100M => Self::Speed100M,
+            drv_monorail_api::Speed::Speed1G => Self::Speed1G,
+            drv_monorail_api::Speed::Speed10G => Self::Speed10G,
+        }
+    }
+}
+
+struct LinkStatusConvert(drv_monorail_api::LinkStatus);
+
+impl From<LinkStatusConvert> for LinkStatus {
+    fn from(LinkStatusConvert(s): LinkStatusConvert) -> Self {
+        match s {
+            drv_monorail_api::LinkStatus::Error => Self::Error,
+            drv_monorail_api::LinkStatus::Down => Self::Down,
+            drv_monorail_api::LinkStatus::Up => Self::Up,
+        }
+    }
+}
+
+struct PhyStatusConvert(drv_monorail_api::PhyStatus);
+
+impl From<PhyStatusConvert> for PhyStatus {
+    fn from(PhyStatusConvert(s): PhyStatusConvert) -> Self {
+        Self {
+            ty: PhyTypeConvert(s.ty).into(),
+            mac_link_up: LinkStatusConvert(s.mac_link_up).into(),
+            media_link_up: LinkStatusConvert(s.media_link_up).into(),
+        }
+    }
+}
+
+struct PhyTypeConvert(drv_monorail_api::PhyType);
+
+impl From<PhyTypeConvert> for PhyType {
+    fn from(PhyTypeConvert(t): PhyTypeConvert) -> Self {
+        match t {
+            drv_monorail_api::PhyType::Vsc8504 => Self::Vsc8504,
+            drv_monorail_api::PhyType::Vsc8522 => Self::Vsc8522,
+            drv_monorail_api::PhyType::Vsc8552 => Self::Vsc8552,
+            drv_monorail_api::PhyType::Vsc8562 => Self::Vsc8562,
+        }
+    }
+}
+
+struct PortCountersConvert(drv_monorail_api::PortCounters);
+
+impl From<PortCountersConvert> for PortCounters {
+    fn from(PortCountersConvert(s): PortCountersConvert) -> Self {
+        Self {
+            tx: PacketCountConvert(s.tx).into(),
+            rx: PacketCountConvert(s.rx).into(),
+        }
+    }
+}
+
+struct PacketCountConvert(drv_monorail_api::PacketCount);
+
+impl From<PacketCountConvert> for PacketCount {
+    fn from(PacketCountConvert(c): PacketCountConvert) -> Self {
+        Self {
+            multicast: c.multicast,
+            unicast: c.unicast,
+            broadcast: c.broadcast,
+        }
+    }
+}

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+drv-monorail-api = { path = "../../drv/monorail-api"  }
 drv-sidecar-front-io = { path = "../../drv/sidecar-front-io", features = ["phy_smi"], optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-spi-api = { path = "../../drv/spi-api" }
 drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
 drv-user-leds-api = { path = "../../drv/user-leds-api", optional = true  }
 idol-runtime = { workspace = true }
-monorail-api = { path = "../../drv/monorail-api"  }
 ringbuf = { path = "../../lib/ringbuf"  }
 task-net-api = { path = "../net-api", optional = true }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -3,11 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::bsp::{self, Bsp};
-use idol_runtime::{NotificationHandler, RequestError};
-use monorail_api::{
+use drv_monorail_api::{
     LinkStatus, MacTableEntry, MonorailError, PacketCount, PhyStatus, PhyType,
     PortCounters, PortDev, PortStatus, VscError,
 };
+use idol_runtime::{NotificationHandler, RequestError};
 use userlib::{sys_get_timer, sys_set_timer};
 use vsc7448::{
     config::{PortMap, PortMode},


### PR DESCRIPTION
Adds handlers for a new "component details" message type from MGS. Currently the only meaningful component that can return details is the vsc7448 on a sidecar, but in the future we can slot in other components that have status (or sensor measurements, etc.) in this same handler.

This PR is smaller than it appears: the bulk of it is converting between the (nearly identical) monorail types and the corresponding `gateway-messages` types. It also includes some minor shuffling around of `monorail-api` (including adding generation of an idol client).