### PR TITLE
Fix errors starting at 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ stm32f3 = { version = "0.13.0", default-features = false }
 stm32f4 = { version = "0.13.0", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }
 strsim = { version = "0.10.0", default-features = false }
-syn = { version = "1", default-features = false, features = ["parsing"] }
+syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
 toml = { version = "0.5.6", default-features = false }
 vcell = { version = "0.1.2", default-features = false }
 walkdir = { version = "2.0.0", default-features = false }

--- a/drv/ignition-api/src/lib.rs
+++ b/drv/ignition-api/src/lib.rs
@@ -32,7 +32,7 @@ pub const PORT_MAX: usize = 40;
     IdolError,
 )]
 pub enum IgnitionError {
-    ServerDied,
+    ServerDied = 1,
     FpgaError,
     InvalidPort,
     InvalidValue,

--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -41,7 +41,7 @@ pub struct PortCounters {
 )]
 #[repr(C)]
 pub enum MonorailError {
-    SpiError,
+    SpiError = 1,
     ServerDied,
     ProxyError,
     BadChipId,

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -6,7 +6,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
-/// Adds three `impl` blocks for the given error type:
+/// Adds three `impl` blocks for the given error `enum` type:
 /// - `From<E> for u16` (Idol encoding)
 /// - `From<E> for u32` (Hiffy encoding)
 /// - `TryFrom<u32> for E` (Idol decoding)
@@ -14,6 +14,9 @@ use syn::{parse_macro_input, DeriveInput};
 /// The given type must also derive `FromPrimitive`, which is used in the
 /// `TryFrom<u32>` implementation.  Sadly, this cannot be automatically added
 /// to the type by this macro.
+///
+/// The `enum` must not include 0, because 0 is decoded as "okay" by IPC
+/// infrastructure.
 #[proc_macro_derive(IdolError)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, .. } = parse_macro_input!(input);

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -54,7 +54,7 @@ pub enum PhyError {
 #[repr(u32)]
 pub enum KszError {
     /// This functionality is not available on the given board
-    NotAvailable,
+    NotAvailable = 1,
     /// The MAC table index is too large
     BadMacIndex,
     /// The given address is not a valid register
@@ -153,7 +153,7 @@ pub struct ManagementCounters {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
 #[repr(u32)]
 pub enum MgmtError {
-    NotAvailable,
+    NotAvailable = 1,
     VscError,
     KszError,
 }


### PR DESCRIPTION
Error values of 0 are mistaken for "no error" by Hiffy IPC.