### PR TITLE
lib/derive-idol-error: improve compile errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
 name = "derive-idol-err"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -33,15 +33,13 @@ pub enum Op {
     WriteReadBlock = 2,
 }
 
-/// The response code returned from the I2C controller (or from the kernel in
-/// the case of [`ResponseCode::Dead`]).  These response codes pretty specific,
-/// not because the caller is expected to necessarily handle them differently,
-/// but to give upstack software some modicum of context surrounding the error.
+/// The response code returned from the I2C server.  These response codes pretty
+/// specific, not because the caller is expected to necessarily handle them
+/// differently, but to give upstack software some modicum of context
+/// surrounding the error.
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 #[repr(u32)]
 pub enum ResponseCode {
-    /// Server has died
-    Dead = core::u32::MAX,
     /// Bad response from server
     BadResponse = 1,
     /// Bad argument sent to server

--- a/lib/derive-idol-err/Cargo.toml
+++ b/lib/derive-idol-err/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 syn = { workspace = true }
 quote = { workspace = true }
+proc-macro2 = {workspace = true}
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This now prints nice compile error messages highlighting any invalid discriminants, and also catches attempts to use non-C-style enums.