### PR TITLE
control-plane-agent: Report PowerState from `sp_state`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#6d13d40d1b6c612fea72be4aa9c900c72cda261c"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=include-power-state-in-sp-state#b1c1ed8b18fa338980e3e59874ebc3a582ca7fc7"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=include-power-state-in-sp-state#b1c1ed8b18fa338980e3e59874ebc3a582ca7fc7"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#559e27ab7837129e61c47afb1d7ba37c4231c792"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", branch = "include-power-state-in-sp-state", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", branch = "include-power-state-in-sp-state", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -5,7 +5,9 @@
 use crate::{inventory::Inventory, Log, MgsMessage};
 use core::convert::Infallible;
 use gateway_messages::sp_impl::DeviceDescription;
-use gateway_messages::{DiscoverResponse, SpError, SpPort, SpState};
+use gateway_messages::{
+    DiscoverResponse, PowerState, SpError, SpPort, SpState,
+};
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
 
 // TODO How are we versioning SP images? This is a placeholder.
@@ -33,7 +35,10 @@ impl MgsCommon {
         Ok(DiscoverResponse { sp_port: port })
     }
 
-    pub(crate) fn sp_state(&mut self) -> Result<SpState, SpError> {
+    pub(crate) fn sp_state(
+        &mut self,
+        power_state: PowerState,
+    ) -> Result<SpState, SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::SpState));
 
         // TODO Replace with the real serial number once it's available; for now
@@ -50,6 +55,7 @@ impl MgsCommon {
         Ok(SpState {
             serial_number,
             version: VERSION,
+            power_state,
         })
     }
 

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -115,6 +115,11 @@ impl MgsHandler {
         // calling this method.
         Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
+
+    fn power_state_impl(&self) -> Result<PowerState, SpError> {
+        // We have no states other than A2.
+        Ok(PowerState::A2)
+    }
 }
 
 impl SpHandler for MgsHandler {
@@ -164,7 +169,8 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<SpState, SpError> {
-        self.common.sp_state()
+        let power_state = self.power_state_impl()?;
+        self.common.sp_state(power_state)
     }
 
     fn sp_update_prepare(
@@ -255,9 +261,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
-
-        // We have no states other than A2.
-        Ok(PowerState::A2)
+        self.power_state_impl()
     }
 
     fn set_power_state(


### PR DESCRIPTION
Calls to return the SpState of a given SP now return the PowerState as well. This is to minimize calls from MGS when interacting with wicketd.

Individual `SpHandler::power_state` methods had the logic put into `power_state_impl` methods directly on the MgsHandler to prevent logging an extra `RingBuf` entry and the need to pass unused parameters.

This change depends upon
https://github.com/oxidecomputer/management-gateway-service/pull/15 and must be merged after that, once the cargo changes in here are also fixed.