### PR TITLE
Use larger HIFFY_DATA for Sidecar A/B and Gimlet C

### DIFF
--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -236,7 +236,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "spi", "stm32h7", "itm", "i2c", "gpio"]
 priority = 5
-max-sizes = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "i2c_driver"]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -236,7 +236,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["h753", "spi", "stm32h7", "itm", "i2c", "gpio", "sprot"]
 priority = 5
-max-sizes = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1024
 start = true
 task-slots = ["sys", "i2c_driver", "sprot"]

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -56,6 +56,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         target_board = "gimlet-a",
         target_board = "gimlet-b",
+        target_board = "gimlet-c",
+        target_board = "sidecar-a",
+        target_board = "sidecar-b",
         target_board = "gimletlet-2",
         target_board = "nucleo-h743zi2",
         target_board = "nucleo-h753zi"


### PR DESCRIPTION
This will speed up auxflash on Sidecar (pending https://github.com/oxidecomputer/humility/pull/265) and QSPI on Gimlet rev C.