### PR TITLE
Add input current and voltage sensors on MWOCP68

### DIFF
--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -298,8 +298,8 @@ name = "psu0mcu"
 address = 0b1011_000
 device = "mwocp68"
 description = "PSU 0 MCU"
-power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -314,8 +314,8 @@ name = "psu1mcu"
 address = 0b1011_001
 device = "mwocp68"
 description = "PSU 1 MCU"
-power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -330,8 +330,8 @@ name = "psu2mcu"
 address = 0b1011_010
 device = "mwocp68"
 description = "PSU 2 MCU"
-power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -346,8 +346,8 @@ name = "psu3mcu"
 address = 0b1011_011
 device = "mwocp68"
 description = "PSU 3 MCU"
-power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -362,8 +362,8 @@ name = "psu4mcu"
 address = 0b1011_100
 device = "mwocp68"
 description = "PSU 4 MCU"
-power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -378,8 +378,8 @@ name = "psu5mcu"
 address = 0b1011_101
 device = "mwocp68"
 description = "PSU 5 MCU"
-power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "status"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -298,8 +298,8 @@ name = "psu0mcu"
 address = 0b1011_000
 device = "mwocp68"
 description = "PSU 0 MCU"
-power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -314,8 +314,8 @@ name = "psu1mcu"
 address = 0b1011_001
 device = "mwocp68"
 description = "PSU 1 MCU"
-power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -330,8 +330,8 @@ name = "psu2mcu"
 address = 0b1011_010
 device = "mwocp68"
 description = "PSU 2 MCU"
-power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -346,8 +346,8 @@ name = "psu3mcu"
 address = 0b1011_011
 device = "mwocp68"
 description = "PSU 3 MCU"
-power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -362,8 +362,8 @@ name = "psu4mcu"
 address = 0b1011_100
 device = "mwocp68"
 description = "PSU 4 MCU"
-power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -378,8 +378,8 @@ name = "psu5mcu"
 address = 0b1011_101
 device = "mwocp68"
 description = "PSU 5 MCU"
-power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "status"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -275,8 +275,8 @@ name = "psu0mcu"
 address = 0b1011_000
 device = "mwocp68"
 description = "PSU 0 MCU"
-power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -291,8 +291,8 @@ name = "psu1mcu"
 address = 0b1011_001
 device = "mwocp68"
 description = "PSU 1 MCU"
-power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -307,8 +307,8 @@ name = "psu2mcu"
 address = 0b1011_010
 device = "mwocp68"
 description = "PSU 2 MCU"
-power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -323,8 +323,8 @@ name = "psu3mcu"
 address = 0b1011_011
 device = "mwocp68"
 description = "PSU 3 MCU"
-power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -339,8 +339,8 @@ name = "psu4mcu"
 address = 0b1011_100
 device = "mwocp68"
 description = "PSU 4 MCU"
-power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -355,8 +355,8 @@ name = "psu5mcu"
 address = 0b1011_101
 device = "mwocp68"
 description = "PSU 5 MCU"
-power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
-sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [config.spi.spi2]
 controller = 2

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -275,8 +275,8 @@ name = "psu0mcu"
 address = 0b1011_000
 device = "mwocp68"
 description = "PSU 0 MCU"
-power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -291,8 +291,8 @@ name = "psu1mcu"
 address = 0b1011_001
 device = "mwocp68"
 description = "PSU 1 MCU"
-power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -307,8 +307,8 @@ name = "psu2mcu"
 address = 0b1011_010
 device = "mwocp68"
 description = "PSU 2 MCU"
-power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -323,8 +323,8 @@ name = "psu3mcu"
 address = 0b1011_011
 device = "mwocp68"
 description = "PSU 3 MCU"
-power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -339,8 +339,8 @@ name = "psu4mcu"
 address = 0b1011_100
 device = "mwocp68"
 description = "PSU 4 MCU"
-power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -355,8 +355,8 @@ name = "psu5mcu"
 address = 0b1011_101
 device = "mwocp68"
 description = "PSU 5 MCU"
-power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current"] }
-sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
+power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "voltage-in", "current-in"] }
+sensors = { voltage-in = 2, current-in = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
 
 [config.spi.spi2]
 controller = 2

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -195,10 +195,10 @@ struct I2cSensors {
     voltage: usize,
 
     #[serde(default)]
-    current_in: usize,
+    input_current: usize,
 
     #[serde(default)]
-    voltage_in: usize,
+    input_voltage: usize,
 
     #[serde(default)]
     speed: usize,
@@ -290,12 +290,12 @@ impl I2cSensorsDescription {
                     desc.add_sensor(Sensor::Voltage, d, i, d_index);
                 }
 
-                for i in 0..s.current_in {
-                    desc.add_sensor(Sensor::CurrentIn, d, i, d_index);
+                for i in 0..s.input_current {
+                    desc.add_sensor(Sensor::InputCurrent, d, i, d_index);
                 }
 
-                for i in 0..s.voltage_in {
-                    desc.add_sensor(Sensor::VoltageIn, d, i, d_index);
+                for i in 0..s.input_voltage {
+                    desc.add_sensor(Sensor::InputVoltage, d, i, d_index);
                 }
 
                 for i in 0..s.speed {
@@ -419,8 +419,8 @@ pub enum Sensor {
     Power,
     Current,
     Voltage,
-    CurrentIn,
-    VoltageIn,
+    InputCurrent,
+    InputVoltage,
     Speed,
 }
 
@@ -434,8 +434,8 @@ impl std::fmt::Display for Sensor {
                 Sensor::Power => "POWER",
                 Sensor::Current => "CURRENT",
                 Sensor::Voltage => "VOLTAGE",
-                Sensor::CurrentIn => "CURRENT_IN",
-                Sensor::VoltageIn => "VOLTAGE_IN",
+                Sensor::InputCurrent => "INPUT_CURRENT",
+                Sensor::InputVoltage => "INPUT_VOLTAGE",
                 Sensor::Speed => "SPEED",
             }
         )

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -195,6 +195,12 @@ struct I2cSensors {
     voltage: usize,
 
     #[serde(default)]
+    current_in: usize,
+
+    #[serde(default)]
+    voltage_in: usize,
+
+    #[serde(default)]
     speed: usize,
 
     names: Option<Vec<String>>,
@@ -282,6 +288,14 @@ impl I2cSensorsDescription {
 
                 for i in 0..s.voltage {
                     desc.add_sensor(Sensor::Voltage, d, i, d_index);
+                }
+
+                for i in 0..s.current_in {
+                    desc.add_sensor(Sensor::CurrentIn, d, i, d_index);
+                }
+
+                for i in 0..s.voltage_in {
+                    desc.add_sensor(Sensor::VoltageIn, d, i, d_index);
                 }
 
                 for i in 0..s.speed {
@@ -399,12 +413,14 @@ pub enum Disposition {
 }
 
 #[derive(Copy, Clone, Deserialize, Debug, PartialEq, Eq, Hash)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum Sensor {
     Temperature,
     Power,
     Current,
     Voltage,
+    CurrentIn,
+    VoltageIn,
     Speed,
 }
 
@@ -418,6 +434,8 @@ impl std::fmt::Display for Sensor {
                 Sensor::Power => "POWER",
                 Sensor::Current => "CURRENT",
                 Sensor::Voltage => "VOLTAGE",
+                Sensor::CurrentIn => "CURRENT_IN",
+                Sensor::VoltageIn => "VOLTAGE_IN",
                 Sensor::Speed => "SPEED",
             }
         )

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2169,7 +2169,7 @@ impl Archive {
 
         let archive = File::create(&tmp_path)?;
         let mut inner = zip::ZipWriter::new(archive);
-        inner.set_comment("hubris build archive v4");
+        inner.set_comment("hubris build archive v5");
         Ok(Self {
             final_path,
             tmp_path,

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -139,11 +139,13 @@ pub trait VoltageSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
     fn read_vout(&self) -> Result<userlib::units::Volts, T>;
 }
 
-pub trait CurrentInSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
+pub trait InputCurrentSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>>
+{
     fn read_iin(&self) -> Result<userlib::units::Amperes, T>;
 }
 
-pub trait VoltageInSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
+pub trait InputVoltageSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>>
+{
     fn read_vin(&self) -> Result<userlib::units::Volts, T>;
 }
 

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -139,6 +139,14 @@ pub trait VoltageSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
     fn read_vout(&self) -> Result<userlib::units::Volts, T>;
 }
 
+pub trait CurrentInSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
+    fn read_iin(&self) -> Result<userlib::units::Amperes, T>;
+}
+
+pub trait VoltageInSensor<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
+    fn read_vin(&self) -> Result<userlib::units::Volts, T>;
+}
+
 pub trait Validate<T: core::convert::Into<drv_i2c_api::ResponseCode>> {
     //
     // We have a default implementation that returns false to allow for

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -5,8 +5,8 @@
 //! MWOCP68-3600 Murata power shelf
 
 use crate::{
-    pmbus_validate, BadValidation, CurrentInSensor, CurrentSensor, Validate,
-    VoltageInSensor, VoltageSensor,
+    pmbus_validate, BadValidation, CurrentSensor, InputCurrentSensor,
+    InputVoltageSensor, Validate, VoltageSensor,
 };
 use core::cell::Cell;
 use drv_i2c_api::*;
@@ -139,7 +139,7 @@ impl CurrentSensor<Error> for Mwocp68 {
     }
 }
 
-impl VoltageInSensor<Error> for Mwocp68 {
+impl InputVoltageSensor<Error> for Mwocp68 {
     fn read_vin(&self) -> Result<Volts, Error> {
         self.set_rail()?;
         let vin = pmbus_read!(self.device, READ_VIN)?;
@@ -147,7 +147,7 @@ impl VoltageInSensor<Error> for Mwocp68 {
     }
 }
 
-impl CurrentInSensor<Error> for Mwocp68 {
+impl InputCurrentSensor<Error> for Mwocp68 {
     fn read_iin(&self) -> Result<Amperes, Error> {
         self.set_rail()?;
         let iin = pmbus_read!(self.device, READ_IIN)?;

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -5,7 +5,8 @@
 //! MWOCP68-3600 Murata power shelf
 
 use crate::{
-    pmbus_validate, BadValidation, CurrentSensor, Validate, VoltageSensor,
+    pmbus_validate, BadValidation, CurrentInSensor, CurrentSensor, Validate,
+    VoltageInSensor, VoltageSensor,
 };
 use core::cell::Cell;
 use drv_i2c_api::*;
@@ -135,5 +136,21 @@ impl CurrentSensor<Error> for Mwocp68 {
         self.set_rail()?;
         let iout = pmbus_read!(self.device, READ_IOUT)?;
         Ok(Amperes(iout.get()?.0))
+    }
+}
+
+impl VoltageInSensor<Error> for Mwocp68 {
+    fn read_vin(&self) -> Result<Volts, Error> {
+        self.set_rail()?;
+        let vin = pmbus_read!(self.device, READ_VIN)?;
+        Ok(Volts(vin.get()?.0))
+    }
+}
+
+impl CurrentInSensor<Error> for Mwocp68 {
+    fn read_iin(&self) -> Result<Amperes, Error> {
+        self.set_rail()?;
+        let iin = pmbus_read!(self.device, READ_IIN)?;
+        Ok(Amperes(iin.get()?.0))
     }
 }

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -400,8 +400,8 @@ impl From<MeasurementKindConvert> for MeasurementKind {
             Sensor::Power => Self::Power,
             Sensor::Current => Self::Current,
             Sensor::Voltage => Self::Voltage,
-            Sensor::CurrentIn => Self::CurrentIn,
-            Sensor::VoltageIn => Self::VoltageIn,
+            Sensor::InputCurrent => Self::InputCurrent,
+            Sensor::InputVoltage => Self::InputVoltage,
             Sensor::Speed => Self::Speed,
         }
     }

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -400,6 +400,8 @@ impl From<MeasurementKindConvert> for MeasurementKind {
             Sensor::Power => Self::Power,
             Sensor::Current => Self::Current,
             Sensor::Voltage => Self::Voltage,
+            Sensor::CurrentIn => Self::CurrentIn,
+            Sensor::VoltageIn => Self::VoltageIn,
             Sensor::Speed => Self::Speed,
         }
     }

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -22,7 +22,9 @@ use userlib::units::*;
 use userlib::*;
 
 use drv_i2c_api::ResponseCode;
-use drv_i2c_devices::{CurrentSensor, TempSensor, VoltageSensor};
+use drv_i2c_devices::{
+    CurrentInSensor, CurrentSensor, TempSensor, VoltageInSensor, VoltageSensor,
+};
 
 use sensor_api::{NoData, SensorId};
 
@@ -58,7 +60,9 @@ struct PowerControllerConfig {
     device: DeviceType,
     builder: fn(TaskId) -> (drv_i2c_api::I2cDevice, u8), // device, rail
     voltage: SensorId,
+    voltage_in: Option<SensorId>,
     current: SensorId,
+    current_in: Option<SensorId>,
     temperature: Option<SensorId>,
 }
 
@@ -115,6 +119,26 @@ impl Device {
         };
         Ok(r)
     }
+
+    fn read_vin(&self) -> Result<Volts, ResponseCode> {
+        let r = match &self {
+            Device::Mwocp68(dev) => dev.read_vin()?,
+            // Do any other devices have VIN? For now we only added support to
+            // MWOCP68
+            _ => return Err(ResponseCode::NoDevice),
+        };
+        Ok(r)
+    }
+
+    fn read_iin(&self) -> Result<Amperes, ResponseCode> {
+        let r = match &self {
+            Device::Mwocp68(dev) => dev.read_iin()?,
+            // Do any other devices have IIN? For now we only added support to
+            // MWOCP68
+            _ => return Err(ResponseCode::NoDevice),
+        };
+        Ok(r)
+    }
 }
 
 impl PowerControllerConfig {
@@ -149,7 +173,9 @@ macro_rules! rail_controller {
                 device: DeviceType::$which,
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
+                voltage_in: None,
                 current: sensors::[<$dev:upper _ $rail:upper _CURRENT_SENSOR>],
+                current_in: None,
                 temperature: Some(
                     sensors::[<$dev:upper _ $rail:upper _TEMPERATURE_SENSOR>]
                 ),
@@ -167,7 +193,9 @@ macro_rules! rail_controller_notemp {
                 device: DeviceType::$which,
                 builder:i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
+                voltage_in: None,
                 current: sensors::[<$dev:upper _ $rail:upper _CURRENT_SENSOR>],
+                current_in: None,
                 temperature: None,
             }
         }
@@ -183,7 +211,9 @@ macro_rules! adm1272_controller {
                 device: DeviceType::$which($rsense),
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<ADM1272_ $rail:upper _VOLTAGE_SENSOR>],
+                voltage_in: None,
                 current: sensors::[<ADM1272_ $rail:upper _CURRENT_SENSOR>],
+                current_in: None,
                 temperature: Some(
                     sensors::[<ADM1272_ $rail:upper _TEMPERATURE_SENSOR>]
                 ),
@@ -201,7 +231,9 @@ macro_rules! max5970_controller {
                 device: DeviceType::$which($rsense),
                 builder: i2c_config::power::$rail,
                 voltage: sensors::[<MAX5970_ $rail:upper _VOLTAGE_SENSOR>],
+                voltage_in: None,
                 current: sensors::[<MAX5970_ $rail:upper _CURRENT_SENSOR>],
+                current_in: None,
                 temperature: None,
             }
         }
@@ -217,7 +249,13 @@ macro_rules! mwocp68_controller {
                 device: DeviceType::$which,
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<MWOCP68_ $rail:upper _VOLTAGE_SENSOR>],
+                voltage_in: Some(
+                    sensors::[<MWOCP68_ $rail:upper _VOLTAGE_IN_SENSOR>]
+                ),
                 current: sensors::[<MWOCP68_ $rail:upper _CURRENT_SENSOR>],
+                current_in: Some(
+                    sensors::[<MWOCP68_ $rail:upper _CURRENT_IN_SENSOR>]
+                ),
                 temperature: None, // Temperature sensors are independent of
                                    // power rails and measured separately
             }
@@ -429,6 +467,28 @@ fn main() -> ! {
                 }
                 Err(_) => {
                     sensor.nodata(c.voltage, NoData::DeviceError).unwrap();
+                }
+            }
+
+            if let Some(id) = c.voltage_in {
+                match dev.read_vin() {
+                    Ok(reading) => {
+                        sensor.post(id, reading.0).unwrap();
+                    }
+                    Err(_) => {
+                        sensor.nodata(id, NoData::DeviceError).unwrap();
+                    }
+                }
+            }
+
+            if let Some(id) = c.current_in {
+                match dev.read_iin() {
+                    Ok(reading) => {
+                        sensor.post(id, reading.0).unwrap();
+                    }
+                    Err(_) => {
+                        sensor.nodata(id, NoData::DeviceError).unwrap();
+                    }
                 }
             }
         }

--- a/task/validate-api/src/lib.rs
+++ b/task/validate-api/src/lib.rs
@@ -53,6 +53,8 @@ pub enum Sensor {
     Power,
     Current,
     Voltage,
+    CurrentIn,
+    VoltageIn,
     Speed,
 }
 

--- a/task/validate-api/src/lib.rs
+++ b/task/validate-api/src/lib.rs
@@ -53,8 +53,8 @@ pub enum Sensor {
     Power,
     Current,
     Voltage,
-    CurrentIn,
-    VoltageIn,
+    InputCurrent,
+    InputVoltage,
     Speed,
 }
 


### PR DESCRIPTION
This adds new sensor types (`InputCurrent`, `InputVoltage`), implements them for the mwocp68, and requires a corresponding humility change (https://github.com/oxidecomputer/humility/pull/266).