### PR TITLE
Power up automatically

### DIFF
--- a/app/gimlet/rev-b-lab.toml
+++ b/app/gimlet/rev-b-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "gimlet-b-lab"
+features.gimlet_seq = ["stay-in-a2"]

--- a/app/gimlet/rev-c-lab.toml
+++ b/app/gimlet/rev-c-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-c.toml"
+
+[patches]
+name = "gimlet-c-lab"
+features.gimlet_seq = ["stay-in-a2"]

--- a/app/sidecar/rev-a-lab.toml
+++ b/app/sidecar/rev-a-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-a.toml"
+
+[patches]
+name = "sidecar-a-lab"
+features.sequencer = ["stay-in-a2"]

--- a/app/sidecar/rev-b-lab.toml
+++ b/app/sidecar/rev-b-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "sidecar-b-lab"
+features.sequencer = ["stay-in-a2"]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -21,10 +21,11 @@ use lpc55_areas::{
 /// files.  Specifically, it allows you to **add features** to specific tasks;
 /// nothing else.
 ///
+/// Here's an example:
 /// ```toml
 /// name = "sidecar-a-lab"
 /// inherit = "rev-a.toml"
-/// patches.sequencer = ["stay-in-a2"]
+/// features.sequencer = ["stay-in-a2"]
 /// ```
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -24,6 +24,8 @@ use lpc55_areas::{
 /// Here's an example:
 /// ```toml
 /// name = "sidecar-a-lab"
+///
+/// [patches]
 /// inherit = "rev-a.toml"
 /// features.sequencer = ["stay-in-a2"]
 /// ```

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -17,9 +17,9 @@ use lpc55_areas::{
     ROTKeyStatus, SecureBootCfg,
 };
 
-/// An `PatchedConfig` allows a minimal form of inheritance between TOML
-/// files.  Specifically, it allows you to **add features** to specific tasks;
-/// nothing else.
+/// A `PatchedConfig` allows a minimal form of inheritance between TOML files
+/// Specifically, it allows you to **add features** to specific tasks; nothing
+/// else.
 ///
 /// Here's an example:
 /// ```toml

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -37,3 +37,4 @@ sha2 = { workspace = true }
 
 [features]
 h753 = ["drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]
+stay-in-a2 = []

--- a/drv/sidecar-seq-server/Cargo.toml
+++ b/drv/sidecar-seq-server/Cargo.toml
@@ -22,6 +22,7 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [features]
 h753 = ["build-i2c/h753"]
+stay-in-a2 = []
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -597,6 +597,11 @@ fn main() -> ! {
         .write_reg(drv_i2c_devices::tmp451::Register::RemoteTempThermBLimit, 90)
         .unwrap();
 
+    // Power on, unless suppressed by the `stay-in-a2` feature
+    if !cfg!(feature = "stay-in-a2") {
+        server.tofino.policy = TofinoSequencerPolicy::LatchOffOnFault;
+    }
+
     //
     // This will put our timer in the past, and should immediately kick us.
     //


### PR DESCRIPTION
This PR enables automatic power-on in the stock Gimlet and Sidecar images.

Gimlet comes up to `A0`; Sidecar to `LatchOffOnFault`.

In addition, I add `gimlet-{b,c}-lab.toml` and `sidecar-{a,b}-lab.toml` app files, which preserve the previous behavior of staying in A2.

To minimize TOML copypasta, I implemented _very minimal_ TOML inheritance, where you can specify a base file then enable task features.  For the `*-lab.toml` images, I enabled `stay-in-a2`, which is a new feature on the Gimlet and Sidecar sequencer tasks.

This somewhat complicates the build archive.  I ship the **base** `app.toml` file, then a separate `patches.toml` that describes patches applied during inheritance.  This maintains backwards-compatibility with Humility, which expects `app.toml` to include everything that it needs.

Closes https://github.com/oxidecomputer/hubris/issues/908