### PR TITLE
Add 'link down' sticky bit to `PortCounters`

### DIFF
--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -38,6 +38,16 @@ pub struct PacketCount {
 pub struct PortCounters {
     pub rx: PacketCount,
     pub tx: PacketCount,
+
+    /// `true` if the link has gone down since the last call to
+    /// `port_reset_counters`
+    ///
+    /// Due to hardware differences between 1G and 10G ports, this has slightly
+    /// different semantics depending on port speed:
+    /// - On the 1G ports, this is `LINK_DOWN_STICKY` | `OUT_OF_SYNC_STICKY`
+    /// - For the 10G port, this is `LOCK_CHANGED_STICKY`, i.e. it will _also_
+    ///   be true if the link went from down -> up
+    pub link_down_sticky: bool,
 }
 
 /// Error-code-only version of [VscError], for use in RPC calls

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -170,7 +170,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
             None => return Err(MonorailError::UnconfiguredPort.into()),
             Some(cfg) => cfg,
         };
-        let (tx, rx) = match cfg.dev.0 {
+        let (tx, rx, link_down_sticky) = match cfg.dev.0 {
             PortDev::Dev1g | PortDev::Dev2g5 => {
                 let stats = ASM().DEV_STATISTICS(port);
                 let rx_uc = self
@@ -197,6 +197,19 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     .vsc7448
                     .read(stats.TX_MC_CNT())
                     .map_err(MonorailError::from)?;
+
+                let dev = match cfg.dev.0 {
+                    PortDev::Dev1g => DevGeneric::new_1g(cfg.dev.1),
+                    PortDev::Dev2g5 => DevGeneric::new_2g5(cfg.dev.1),
+                    _ => unreachable!(),
+                }
+                .map_err(MonorailError::from)?;
+
+                let link_down = self
+                    .vsc7448
+                    .read(dev.regs().PCS1G_CFG_STATUS().PCS1G_STICKY())
+                    .map_err(MonorailError::from)?;
+
                 let tx = PacketCount {
                     unicast: tx_uc.into(),
                     multicast: tx_mc.into(),
@@ -207,7 +220,9 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     multicast: rx_mc.into(),
                     broadcast: rx_bc.into(),
                 };
-                (tx, rx)
+                let link_down_sticky = link_down.link_down_sticky() != 0
+                    || link_down.out_of_sync_sticky() != 0;
+                (tx, rx, link_down_sticky)
             }
             PortDev::Dev10g => {
                 let stats = DEV10G(cfg.dev.1).DEV_STATISTICS_32BIT();
@@ -245,10 +260,23 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     multicast: rx_mc.into(),
                     broadcast: rx_bc.into(),
                 };
-                (tx, rx)
+
+                let intr = self
+                    .vsc7448
+                    .read(
+                        PCS10G_BR(cfg.dev.1).PCS_10GBR_STATUS().PCS_INTR_STAT(),
+                    )
+                    .map_err(MonorailError::from)?;
+                let link_down_sticky = intr.lock_changed_sticky() != 0;
+
+                (tx, rx, link_down_sticky)
             }
         };
-        Ok(PortCounters { tx, rx })
+        Ok(PortCounters {
+            tx,
+            rx,
+            link_down_sticky,
+        })
     }
 
     fn reset_port_counters(
@@ -284,6 +312,24 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                 self.vsc7448
                     .write(stats.TX_MC_CNT(), 0.into())
                     .map_err(MonorailError::from)?;
+
+                let dev = match cfg.dev.0 {
+                    PortDev::Dev1g => DevGeneric::new_1g(cfg.dev.1),
+                    PortDev::Dev2g5 => DevGeneric::new_2g5(cfg.dev.1),
+                    _ => unreachable!(),
+                }
+                .map_err(MonorailError::from)?;
+
+                // Clear the two bits that we use to detect link drops
+                self.vsc7448
+                    .write_with(
+                        dev.regs().PCS1G_CFG_STATUS().PCS1G_STICKY(),
+                        |r| {
+                            r.set_link_down_sticky(1);
+                            r.set_out_of_sync_sticky(1);
+                        },
+                    )
+                    .map_err(MonorailError::from)?;
             }
             PortDev::Dev10g => {
                 let stats = DEV10G(cfg.dev.1).DEV_STATISTICS_32BIT();
@@ -304,6 +350,13 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     .map_err(MonorailError::from)?;
                 self.vsc7448
                     .write(stats.TX_MC_CNT(), 0.into())
+                    .map_err(MonorailError::from)?;
+
+                self.vsc7448
+                    .write_with(
+                        PCS10G_BR(cfg.dev.1).PCS_10GBR_STATUS().PCS_INTR_STAT(),
+                        |r| r.set_lock_changed_sticky(1),
+                    )
                     .map_err(MonorailError::from)?;
             }
         }

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -198,6 +198,8 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                     .read(stats.TX_MC_CNT())
                     .map_err(MonorailError::from)?;
 
+                // TODO: if this port uses a PHY, then should we be checking
+                // the PHY's status instead of ours?
                 let dev = match cfg.dev.0 {
                     PortDev::Dev1g => DevGeneric::new_1g(cfg.dev.1),
                     PortDev::Dev2g5 => DevGeneric::new_2g5(cfg.dev.1),


### PR DESCRIPTION
The 1G and 10G ports are quite different; this is best "lowest common denominator" I can figure out

(and even now, it's got some semantic subtleties that differ between 1G and 10G ports)