### PR TITLE
Integrate ignition and control-plane-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=ignition-integration#2c1d79a9eeb62f020893a2a2c3a7023017365eaf"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#9efd6c4e96aea0c0e15c1dd942163d4cf1ae19ba"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,7 @@ dependencies = [
  "drv-auxflash-api",
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",
+ "drv-ignition-api",
  "drv-monorail-api",
  "drv-sidecar-seq-api",
  "drv-sprot-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#4c145c03563860bad90f5ae025e03c13926ee6c4"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=ignition-integration#2c1d79a9eeb62f020893a2a2c3a7023017365eaf"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "ignition-integration" } # FIXME
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "ignition-integration" } # FIXME
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -238,7 +238,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2560
+stacksize = 4096
 start = true
 uses = [
     "usart1",

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -238,7 +238,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2560
+stacksize = 4096
 start = true
 uses = [
     "usart1",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -192,7 +192,7 @@ features = ["vlan"]
 name = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 65536, ram = 16384}
-stacksize = 2560
+stacksize = 4096
 start = true
 uses = [
     "usart1",

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -127,8 +127,8 @@ task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 4
-max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2560
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -125,8 +125,8 @@ task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 4
-max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2560
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -165,6 +165,7 @@ task-slots = [
     "monorail",
     "sensor",
     "sprot",
+    "ignition",
 ]
 features = ["sidecar", "vlan", "auxflash"]
 

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -148,8 +148,8 @@ task-slots = ["sys", "i2c_driver",
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2560
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -165,6 +165,7 @@ task-slots = [
     "monorail",
     "sensor",
     "sprot",
+    "ignition",
 ]
 features = ["sidecar", "vlan", "auxflash"]
 

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -148,8 +148,8 @@ task-slots = ["sys", "i2c_driver",
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-max-sizes = {flash = 65536, ram = 8192}
-stacksize = 2560
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
 start = true
 uses = [
     "system_flash", # TODO also used by `net`, both to read the stm32 uid

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -17,6 +17,7 @@ zerocopy = { workspace = true }
 drv-auxflash-api = { path = "../../drv/auxflash-api", optional = true }
 drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
+drv-ignition-api = { path = "../../drv/ignition-api", optional = true }
 drv-monorail-api = { path = "../../drv/monorail-api", optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-sprot-api = { path = "../../drv/sprot-api" }
@@ -39,7 +40,7 @@ idol = { workspace = true }
 
 [features]
 gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]
-sidecar = ["drv-sidecar-seq-api", "drv-monorail-api"]
+sidecar = ["drv-sidecar-seq-api", "drv-monorail-api", "drv-ignition-api"]
 psc = []
 
 vlan = ["task-net-api/vlan"]

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -64,7 +64,16 @@ enum MgsMessage {
     IgnitionState {
         target: u8,
     },
-    BulkIgnitionState,
+    BulkIgnitionState {
+        offset: u32,
+    },
+    IgnitionLinkEvents {
+        target: u8,
+    },
+    BulkIgnitionLinkEvents {
+        offset: u32,
+    },
+    ClearIgnitionLinkEvents,
     IgnitionCommand {
         target: u8,
         command: IgnitionCommand,

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -302,7 +302,7 @@ impl MgsHandler {
 
 impl SpHandler for MgsHandler {
     type BulkIgnitionStateIter = core::iter::Empty<IgnitionState>;
-    type BulkIgnitionLinkEventsIter = core::iter::Empty<LinkEvents>;
+    type BulkIgnitionLinkEventsIter = core::iter::Empty<ignition::LinkEvents>;
 
     fn discover(
         &mut self,
@@ -366,8 +366,8 @@ impl SpHandler for MgsHandler {
         &mut self,
         _sender: SocketAddrV6,
         _port: SpPort,
-        target: Option<u8>,
-        transceiver_select: Option<ignition::TransceiverSelect>,
+        _target: Option<u8>,
+        _transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
         Err(SpError::RequestUnsupportedForSp)

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -33,10 +33,6 @@ use userlib::{sys_get_timer, sys_irq_control, UnwrapLite};
 #[path = "mgs_gimlet/host_phase2.rs"]
 mod host_phase2;
 
-// TODO DELETE ME
-#[path = "mgs_sidecar/ignition.rs"]
-mod fake_ignition;
-
 use host_phase2::HostPhase2Requester;
 
 // How big does our shared update buffer need to be? Has to be able to handle SP
@@ -305,10 +301,8 @@ impl MgsHandler {
 }
 
 impl SpHandler for MgsHandler {
-    //type BulkIgnitionStateIter = core::iter::Empty<IgnitionState>;
-    //type BulkIgnitionLinkEventsIter = core::iter::Empty<IgnitionState>;
-    type BulkIgnitionStateIter = fake_ignition::BulkIgnitionStateIter;
-    type BulkIgnitionLinkEventsIter = fake_ignition::BulkIgnitionLinkEventsIter;
+    type BulkIgnitionStateIter = core::iter::Empty<IgnitionState>;
+    type BulkIgnitionLinkEventsIter = core::iter::Empty<LinkEvents>;
 
     fn discover(
         &mut self,
@@ -319,8 +313,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_ignition_ports(&mut self) -> Result<u32, SpError> {
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController.num_ignition_ports()
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn ignition_state(
@@ -330,8 +323,7 @@ impl SpHandler for MgsHandler {
         target: u8,
     ) -> Result<IgnitionState, SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController.ignition_state(target)
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn bulk_ignition_state(
@@ -343,8 +335,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
             offset
         }));
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController.bulk_ignition_state(offset)
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn ignition_link_events(
@@ -356,8 +347,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
             target
         }));
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController.ignition_link_events(target)
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn bulk_ignition_link_events(
@@ -369,8 +359,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
             offset
         }));
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController.bulk_ignition_link_events(offset)
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn clear_ignition_link_events(
@@ -381,9 +370,7 @@ impl SpHandler for MgsHandler {
         transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
-        //Err(SpError::RequestUnsupportedForSp)
-        fake_ignition::IgnitionController
-            .clear_ignition_link_events(target, transceiver_select)
+        Err(SpError::RequestUnsupportedForSp)
     }
 
     fn ignition_command(

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -170,7 +170,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_ignition_ports(&mut self) -> Result<u32, SpError> {
-        self.ignition.num_ports()
+        Ok(self.ignition.num_ports()?)
     }
 
     fn ignition_state(
@@ -180,7 +180,7 @@ impl SpHandler for MgsHandler {
         target: u8,
     ) -> Result<IgnitionState, SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
-        self.ignition.target_state(target)
+        Ok(self.ignition.target_state(target)?)
     }
 
     fn bulk_ignition_state(
@@ -192,7 +192,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
             offset
         }));
-        self.ignition.bulk_state(offset)
+        Ok(self.ignition.bulk_state(offset)?)
     }
 
     fn ignition_link_events(
@@ -204,7 +204,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
             target
         }));
-        self.ignition.target_link_events(target)
+        Ok(self.ignition.target_link_events(target)?)
     }
 
     fn bulk_ignition_link_events(
@@ -216,7 +216,7 @@ impl SpHandler for MgsHandler {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
             offset
         }));
-        self.ignition.bulk_link_events(offset)
+        Ok(self.ignition.bulk_link_events(offset)?)
     }
 
     fn clear_ignition_link_events(
@@ -227,7 +227,8 @@ impl SpHandler for MgsHandler {
         transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
-        self.ignition.clear_link_events(target, transceiver_select)
+        self.ignition.clear_link_events(target, transceiver_select)?;
+        Ok(())
     }
 
     fn ignition_command(
@@ -241,7 +242,8 @@ impl SpHandler for MgsHandler {
             target,
             command
         }));
-        self.ignition.command(target, command)
+        self.ignition.command(target, command)?;
+        Ok(())
     }
 
     fn sp_state(

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -10,10 +10,9 @@ use gateway_messages::sp_impl::{
     BoundsChecked, DeviceDescription, SocketAddrV6, SpHandler,
 };
 use gateway_messages::{
-    BulkIgnitionState, ComponentDetails, ComponentUpdatePrepare,
-    DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
-    SpComponent, SpError, SpPort, SpState, SpUpdatePrepare, UpdateChunk,
-    UpdateId, UpdateStatus,
+    ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
+    IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
+    SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -24,8 +23,12 @@ use userlib::sys_get_timer;
 
 // We're included under a special `path` cfg from main.rs, which confuses rustc
 // about where our submodules live. Pass explicit paths to correct it.
+#[path = "mgs_sidecar/ignition.rs"]
+mod ignition_handler;
 #[path = "mgs_sidecar/monorail_port_status.rs"]
 mod monorail_port_status;
+
+use ignition_handler::IgnitionController;
 
 userlib::task_slot!(SIDECAR_SEQ, sequencer);
 userlib::task_slot!(MONORAIL, monorail);
@@ -52,6 +55,7 @@ pub(crate) struct MgsHandler {
     sequencer: Sequencer,
     monorail: Monorail,
     sp_update: SpUpdate,
+    ignition: IgnitionController,
 }
 
 impl MgsHandler {
@@ -63,6 +67,7 @@ impl MgsHandler {
             sequencer: Sequencer::from(SIDECAR_SEQ.get_task_id()),
             monorail: Monorail::from(MONORAIL.get_task_id()),
             sp_update: SpUpdate::new(),
+            ignition: IgnitionController::new(),
         }
     }
 
@@ -152,12 +157,20 @@ impl MgsHandler {
 }
 
 impl SpHandler for MgsHandler {
+    type BulkIgnitionStateIter = ignition_handler::BulkIgnitionStateIter;
+    type BulkIgnitionLinkEventsIter =
+        ignition_handler::BulkIgnitionLinkEventsIter;
+
     fn discover(
         &mut self,
         _sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<DiscoverResponse, SpError> {
         self.common.discover(port)
+    }
+
+    fn num_ignition_ports(&mut self) -> Result<u32, SpError> {
+        self.ignition.num_ports()
     }
 
     fn ignition_state(
@@ -167,16 +180,54 @@ impl SpHandler for MgsHandler {
         target: u8,
     ) -> Result<IgnitionState, SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
-        Err(SpError::RequestUnsupportedForSp)
+        self.ignition.target_state(target)
     }
 
     fn bulk_ignition_state(
         &mut self,
         _sender: SocketAddrV6,
         _port: SpPort,
-    ) -> Result<BulkIgnitionState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState));
-        Err(SpError::RequestUnsupportedForSp)
+        offset: u32,
+    ) -> Result<Self::BulkIgnitionStateIter, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
+            offset
+        }));
+        self.ignition.bulk_state(offset)
+    }
+
+    fn ignition_link_events(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: u8,
+    ) -> Result<ignition::LinkEvents, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
+            target
+        }));
+        self.ignition.target_link_events(target)
+    }
+
+    fn bulk_ignition_link_events(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        offset: u32,
+    ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
+            offset
+        }));
+        self.ignition.bulk_link_events(offset)
+    }
+
+    fn clear_ignition_link_events(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        target: Option<u8>,
+        transceiver_select: Option<ignition::TransceiverSelect>,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
+        self.ignition.clear_link_events(target, transceiver_select)
     }
 
     fn ignition_command(
@@ -190,7 +241,7 @@ impl SpHandler for MgsHandler {
             target,
             command
         }));
-        Err(SpError::RequestUnsupportedForSp)
+        self.ignition.command(target, command)
     }
 
     fn sp_state(
@@ -372,7 +423,7 @@ impl SpHandler for MgsHandler {
     fn device_description(
         &mut self,
         index: BoundsChecked,
-    ) -> DeviceDescription<'_> {
+    ) -> DeviceDescription<'static> {
         self.common.inventory().device_description(index)
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -227,7 +227,8 @@ impl SpHandler for MgsHandler {
         transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
         ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
-        self.ignition.clear_link_events(target, transceiver_select)?;
+        self.ignition
+            .clear_link_events(target, transceiver_select)?;
         Ok(())
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar/ignition.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/ignition.rs
@@ -2,147 +2,297 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use drv_ignition_api::{
+    AllLinkEventsIter, AllPortsIter, Ignition, IgnitionError,
+};
 use gateway_messages::ignition::{
     IgnitionState, LinkEvents, ReceiverStatus, SystemFaults, SystemPowerState,
     SystemType, Target, TransceiverEvents, TransceiverSelect,
 };
-use gateway_messages::SpError;
+use gateway_messages::{IgnitionCommand, SpError};
+use heapless::Vec;
+use userlib::UnwrapLite;
 
-pub(super) struct IgnitionController;
+userlib::task_slot!(IGNITION, ignition);
 
-const FAKE_NUM_PORTS: u32 = 350;
+pub(super) struct IgnitionController {
+    task: Ignition,
+    // We cache the number of ignition ports the first time we successfully call
+    // it since it never changes (it's the total number of ports, which is baked
+    // into the FPGA image, not the number of present targets, which varies at
+    // runtime).
+    num_ports: Option<u32>,
+}
 
 impl IgnitionController {
-    pub(super) fn num_ignition_ports(&self) -> Result<u32, SpError> {
-        Ok(FAKE_NUM_PORTS)
+    pub(super) fn new() -> Self {
+        Self {
+            task: Ignition::new(IGNITION.get_task_id()),
+            num_ports: None,
+        }
     }
 
-    pub(super) fn ignition_state(
+    pub(super) fn num_ports(&mut self) -> Result<u32, SpError> {
+        if let Some(n) = self.num_ports {
+            return Ok(n);
+        }
+
+        let n = u32::from(self.task.port_count().map_err(map_ignition_error)?);
+        self.num_ports = Some(n);
+        Ok(n)
+    }
+
+    pub(super) fn target_state(
         &mut self,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        Ok(fake_ignition_state(target))
+        let port = self.task.port(target).map_err(map_ignition_error)?;
+        Ok(PortConvert(port).into())
     }
 
-    pub(super) fn bulk_ignition_state(
+    pub(super) fn bulk_state(
         &mut self,
         offset: u32,
     ) -> Result<BulkIgnitionStateIter, SpError> {
-        Ok(BulkIgnitionStateIter { offset })
+        let iter = self.task.all_ports().map_err(map_ignition_error)?;
+        Ok(BulkIgnitionStateIter {
+            iter: iter.skip(offset as usize),
+        })
     }
 
-    pub(super) fn ignition_link_events(
+    pub(super) fn target_link_events(
         &mut self,
         target: u8,
     ) -> Result<LinkEvents, SpError> {
-        Ok(fake_all_link_events(target))
+        let events =
+            self.task.link_events(target).map_err(map_ignition_error)?;
+        Ok(LinkEventsConvert(events).into())
     }
 
-    pub(super) fn bulk_ignition_link_events(
+    pub(super) fn bulk_link_events(
         &mut self,
         offset: u32,
     ) -> Result<BulkIgnitionLinkEventsIter, SpError> {
-        Ok(BulkIgnitionLinkEventsIter { offset })
+        let iter = self.task.all_link_events().map_err(map_ignition_error)?;
+        Ok(BulkIgnitionLinkEventsIter {
+            iter: iter.skip(offset as usize),
+        })
     }
 
-    pub(super) fn clear_ignition_link_events(
+    pub(super) fn clear_link_events(
         &mut self,
-        _target: Option<u8>,
-        _transceiver_select: Option<TransceiverSelect>,
+        target: Option<u8>,
+        transceiver_select: Option<TransceiverSelect>,
     ) -> Result<(), SpError> {
+        use drv_ignition_api::TransceiverSelect as IgnitionTxrSelect;
+
+        // Convert `target` to a range (either of length 1, if we got a target,
+        // or for all targets).
+        let targets = match target {
+            Some(t) => t..t + 1,
+            None => 0..self.num_ports()? as u8,
+        };
+
+        // Convert `transceiver_select` into a vec of at most 3 items (all
+        // transceivers if we didn't get one, or 1 if we did).
+        let mut txrs = Vec::<_, 3>::new();
+        match transceiver_select {
+            Some(TransceiverSelect::Controller) => {
+                txrs.push(IgnitionTxrSelect::Controller).unwrap_lite();
+            }
+            Some(TransceiverSelect::TargetLink0) => {
+                txrs.push(IgnitionTxrSelect::TargetLink0).unwrap_lite();
+            }
+            Some(TransceiverSelect::TargetLink1) => {
+                txrs.push(IgnitionTxrSelect::TargetLink1).unwrap_lite();
+            }
+            None => {
+                txrs.push(IgnitionTxrSelect::Controller).unwrap_lite();
+                txrs.push(IgnitionTxrSelect::TargetLink0).unwrap_lite();
+                txrs.push(IgnitionTxrSelect::TargetLink1).unwrap_lite();
+            }
+        }
+
+        // Clear all requested events (at least 1, at most num_ports * 3).
+        //
+        // We fail on the first error here; is that reasonable? Should we return
+        // as part of the error how far we got? If the caller cares at that
+        // level, is it sufficient for them to be able to call us separately for
+        // each target/transceiver they care about?
+        for target in targets {
+            for &txr in &txrs {
+                self.task
+                    .clear_transceiver_events(target, txr)
+                    .map_err(map_ignition_error)?;
+            }
+        }
+
         Ok(())
     }
-}
 
-fn fake_ignition_state(target: u8) -> IgnitionState {
-    IgnitionState {
-        receiver_status: fake_receiver_status(),
-        target: if target < 5 {
-            None
-        } else {
-            Some(fake_target())
-        },
-    }
-}
-
-fn fake_receiver_status() -> ReceiverStatus {
-    ReceiverStatus {
-        aligned: true,
-        locked: true,
-        polarity_inverted: false,
-    }
-}
-
-fn fake_target() -> Target {
-    Target {
-        system_type: SystemType::Gimlet,
-        power_state: SystemPowerState::On,
-        power_reset_in_progress: false,
-        faults: SystemFaults {
-            power_a3: false,
-            power_a2: false,
-            sp: false,
-            rot: false,
-        },
-        controller0_present: true,
-        controller1_present: true,
-        link0_receiver_status: fake_receiver_status(),
-        link1_receiver_status: fake_receiver_status(),
+    pub(super) fn command(
+        &mut self,
+        target: u8,
+        command: IgnitionCommand,
+    ) -> Result<(), SpError> {
+        self.task
+            .send_request(target, CommandConvert(command).into())
+            .map_err(map_ignition_error)
     }
 }
 
 pub struct BulkIgnitionStateIter {
-    offset: u32,
+    iter: core::iter::Skip<AllPortsIter>,
 }
 
 impl Iterator for BulkIgnitionStateIter {
     type Item = IgnitionState;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.offset < FAKE_NUM_PORTS {
-            let s = fake_ignition_state(self.offset as u8);
-            self.offset += 1;
-            Some(s)
-        } else {
-            None
-        }
-    }
-}
-
-fn fake_transceiver_events(encoding_error: bool) -> TransceiverEvents {
-    TransceiverEvents {
-        encoding_error,
-        decoding_error: false,
-        ordered_set_invalid: false,
-        message_version_invalid: false,
-        message_type_invalid: false,
-        message_checksum_invalid: false,
-    }
-}
-
-fn fake_all_link_events(target: u8) -> LinkEvents {
-    let encoding_error = target < 10;
-    LinkEvents {
-        controller: fake_transceiver_events(encoding_error),
-        target_link0: fake_transceiver_events(encoding_error),
-        target_link1: fake_transceiver_events(encoding_error),
+        self.iter.next().map(|state| PortConvert(state).into())
     }
 }
 
 pub struct BulkIgnitionLinkEventsIter {
-    offset: u32,
+    iter: core::iter::Skip<AllLinkEventsIter>,
 }
 
 impl Iterator for BulkIgnitionLinkEventsIter {
     type Item = LinkEvents;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.offset < FAKE_NUM_PORTS {
-            let s = fake_all_link_events(self.offset as u8);
-            self.offset += 1;
-            Some(s)
-        } else {
-            None
+        self.iter
+            .next()
+            .map(|events| LinkEventsConvert(events).into())
+    }
+}
+
+fn map_ignition_error(err: IgnitionError) -> SpError {
+    use gateway_messages::ignition::IgnitionError as E;
+    let err = match err {
+        IgnitionError::FpgaError => E::FpgaError,
+        IgnitionError::InvalidPort => E::InvalidPort,
+        IgnitionError::InvalidValue => E::InvalidValue,
+        IgnitionError::NoTargetPresent => E::NoTargetPresent,
+        IgnitionError::RequestInProgress => E::RequestInProgress,
+        IgnitionError::RequestDiscarded => E::RequestDiscarded,
+        _ => E::Other(err as u32),
+    };
+    SpError::Ignition(err)
+}
+
+struct CommandConvert(IgnitionCommand);
+
+impl From<CommandConvert> for drv_ignition_api::Request {
+    fn from(c: CommandConvert) -> Self {
+        match c.0 {
+            IgnitionCommand::PowerOn => Self::SystemPowerOn,
+            IgnitionCommand::PowerOff => Self::SystemPowerOff,
+            IgnitionCommand::PowerReset => Self::SystemPowerReset,
+        }
+    }
+}
+
+struct PortConvert(drv_ignition_api::Port);
+
+impl From<PortConvert> for IgnitionState {
+    fn from(port: PortConvert) -> Self {
+        let PortConvert(port) = port;
+        Self {
+            receiver_status: ReceiverStatusConvert(port.receiver_status).into(),
+            target: port.target.map(|t| TargetConvert(t).into()),
+        }
+    }
+}
+
+struct ReceiverStatusConvert(drv_ignition_api::ReceiverStatus);
+
+impl From<ReceiverStatusConvert> for ReceiverStatus {
+    fn from(s: ReceiverStatusConvert) -> Self {
+        Self {
+            aligned: s.0.aligned,
+            locked: s.0.locked,
+            polarity_inverted: s.0.polarity_inverted,
+        }
+    }
+}
+
+struct TargetConvert(drv_ignition_api::Target);
+
+impl From<TargetConvert> for Target {
+    fn from(t: TargetConvert) -> Self {
+        let TargetConvert(t) = t;
+        Self {
+            system_type: SystemType::from(u16::from(t.id.0)),
+            power_state: SystemPowerStateConvert(t.power_state).into(),
+            power_reset_in_progress: t.power_reset_in_progress,
+            faults: SystemFaultsConvert(t.faults).into(),
+            controller0_present: t.controller0_present,
+            controller1_present: t.controller1_present,
+            link0_receiver_status: ReceiverStatusConvert(
+                t.link0_receiver_status,
+            )
+            .into(),
+            link1_receiver_status: ReceiverStatusConvert(
+                t.link1_receiver_status,
+            )
+            .into(),
+        }
+    }
+}
+
+struct SystemPowerStateConvert(drv_ignition_api::SystemPowerState);
+
+impl From<SystemPowerStateConvert> for SystemPowerState {
+    fn from(s: SystemPowerStateConvert) -> Self {
+        use drv_ignition_api::SystemPowerState as Sps;
+        match s.0 {
+            Sps::Off => Self::Off,
+            Sps::On => Self::On,
+            Sps::Aborted => Self::Aborted,
+            Sps::PoweringOff => Self::PoweringOff,
+            Sps::PoweringOn => Self::PoweringOn,
+        }
+    }
+}
+
+struct SystemFaultsConvert(drv_ignition_api::SystemFaults);
+
+impl From<SystemFaultsConvert> for SystemFaults {
+    fn from(s: SystemFaultsConvert) -> Self {
+        Self {
+            power_a3: s.0.power_a3,
+            power_a2: s.0.power_a2,
+            sp: s.0.sp,
+            rot: s.0.rot,
+        }
+    }
+}
+
+struct LinkEventsConvert(drv_ignition_api::LinkEvents);
+
+impl From<LinkEventsConvert> for LinkEvents {
+    fn from(e: LinkEventsConvert) -> Self {
+        Self {
+            controller: TransceiverEventsConvert(e.0.controller).into(),
+            target_link0: TransceiverEventsConvert(e.0.target_link0).into(),
+            target_link1: TransceiverEventsConvert(e.0.target_link1).into(),
+        }
+    }
+}
+
+struct TransceiverEventsConvert(drv_ignition_api::TransceiverEvents);
+
+impl From<TransceiverEventsConvert> for TransceiverEvents {
+    fn from(e: TransceiverEventsConvert) -> Self {
+        let TransceiverEventsConvert(e) = e;
+        Self {
+            encoding_error: e.encoding_error,
+            decoding_error: e.decoding_error,
+            ordered_set_invalid: e.ordered_set_invalid,
+            message_version_invalid: e.message_version_invalid,
+            message_type_invalid: e.message_type_invalid,
+            message_checksum_invalid: e.message_checksum_invalid,
         }
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar/ignition.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/ignition.rs
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use gateway_messages::ignition::{
+    IgnitionState, LinkEvents, ReceiverStatus, SystemFaults, SystemPowerState,
+    SystemType, Target, TransceiverEvents, TransceiverSelect,
+};
+use gateway_messages::SpError;
+
+pub(super) struct IgnitionController;
+
+const FAKE_NUM_PORTS: u32 = 350;
+
+impl IgnitionController {
+    pub(super) fn num_ignition_ports(&self) -> Result<u32, SpError> {
+        Ok(FAKE_NUM_PORTS)
+    }
+
+    pub(super) fn ignition_state(
+        &mut self,
+        target: u8,
+    ) -> Result<IgnitionState, SpError> {
+        Ok(fake_ignition_state(target))
+    }
+
+    pub(super) fn bulk_ignition_state(
+        &mut self,
+        offset: u32,
+    ) -> Result<BulkIgnitionStateIter, SpError> {
+        Ok(BulkIgnitionStateIter { offset })
+    }
+
+    pub(super) fn ignition_link_events(
+        &mut self,
+        target: u8,
+    ) -> Result<LinkEvents, SpError> {
+        Ok(fake_all_link_events(target))
+    }
+
+    pub(super) fn bulk_ignition_link_events(
+        &mut self,
+        offset: u32,
+    ) -> Result<BulkIgnitionLinkEventsIter, SpError> {
+        Ok(BulkIgnitionLinkEventsIter { offset })
+    }
+
+    pub(super) fn clear_ignition_link_events(
+        &mut self,
+        _target: Option<u8>,
+        _transceiver_select: Option<TransceiverSelect>,
+    ) -> Result<(), SpError> {
+        Ok(())
+    }
+}
+
+fn fake_ignition_state(target: u8) -> IgnitionState {
+    IgnitionState {
+        receiver_status: fake_receiver_status(),
+        target: if target < 5 {
+            None
+        } else {
+            Some(fake_target())
+        },
+    }
+}
+
+fn fake_receiver_status() -> ReceiverStatus {
+    ReceiverStatus {
+        aligned: true,
+        locked: true,
+        polarity_inverted: false,
+    }
+}
+
+fn fake_target() -> Target {
+    Target {
+        system_type: SystemType::Gimlet,
+        power_state: SystemPowerState::On,
+        power_reset_in_progress: false,
+        faults: SystemFaults {
+            power_a3: false,
+            power_a2: false,
+            sp: false,
+            rot: false,
+        },
+        controller0_present: true,
+        controller1_present: true,
+        link0_receiver_status: fake_receiver_status(),
+        link1_receiver_status: fake_receiver_status(),
+    }
+}
+
+pub struct BulkIgnitionStateIter {
+    offset: u32,
+}
+
+impl Iterator for BulkIgnitionStateIter {
+    type Item = IgnitionState;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset < FAKE_NUM_PORTS {
+            let s = fake_ignition_state(self.offset as u8);
+            self.offset += 1;
+            Some(s)
+        } else {
+            None
+        }
+    }
+}
+
+fn fake_transceiver_events(encoding_error: bool) -> TransceiverEvents {
+    TransceiverEvents {
+        encoding_error,
+        decoding_error: false,
+        ordered_set_invalid: false,
+        message_version_invalid: false,
+        message_type_invalid: false,
+        message_checksum_invalid: false,
+    }
+}
+
+fn fake_all_link_events(target: u8) -> LinkEvents {
+    let encoding_error = target < 10;
+    LinkEvents {
+        controller: fake_transceiver_events(encoding_error),
+        target_link0: fake_transceiver_events(encoding_error),
+        target_link1: fake_transceiver_events(encoding_error),
+    }
+}
+
+pub struct BulkIgnitionLinkEventsIter {
+    offset: u32,
+}
+
+impl Iterator for BulkIgnitionLinkEventsIter {
+    type Item = LinkEvents;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset < FAKE_NUM_PORTS {
+            let s = fake_all_link_events(self.offset as u8);
+            self.offset += 1;
+            Some(s)
+        } else {
+            None
+        }
+    }
+}

--- a/task/control-plane-agent/src/mgs_sidecar/ignition.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/ignition.rs
@@ -6,7 +6,7 @@ use core::cell::Cell;
 use drv_ignition_api::{AllLinkEventsIter, AllPortsIter, Ignition};
 use gateway_messages::ignition::{
     IgnitionState, LinkEvents, ReceiverStatus, SystemFaults, SystemPowerState,
-    SystemType, Target, TransceiverEvents, TransceiverSelect,
+    SystemType, TargetState, TransceiverEvents, TransceiverSelect,
 };
 use gateway_messages::{IgnitionCommand, SpError};
 use heapless::Vec;
@@ -207,7 +207,7 @@ impl From<PortConvert> for IgnitionState {
     fn from(port: PortConvert) -> Self {
         let PortConvert(port) = port;
         Self {
-            receiver_status: ReceiverStatusConvert(port.receiver_status).into(),
+            receiver: ReceiverStatusConvert(port.receiver_status).into(),
             target: port.target.map(|t| TargetConvert(t).into()),
         }
     }
@@ -227,7 +227,7 @@ impl From<ReceiverStatusConvert> for ReceiverStatus {
 
 struct TargetConvert(drv_ignition_api::Target);
 
-impl From<TargetConvert> for Target {
+impl From<TargetConvert> for TargetState {
     fn from(t: TargetConvert) -> Self {
         let TargetConvert(t) = t;
         Self {


### PR DESCRIPTION
This PR fleshes out the existing control-plane-agent ignition placeholders (getting ignition state and sending ignition commands) and adds a few new methods (getting and clearing ignition link events). As of this PR and https://github.com/oxidecomputer/management-gateway-service/pull/22 on which it depends, we can interact with ignition over the management network. The most interesting of these is fetching the state of all targets:

```
john@jeeves ~ $ ./faux-mgs --interface axf0 ignition all
Nov 28 22:09:13.053 INFO binding to [::]:22222 on axf0, component: faux-mgs
target 0: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
...snip...
target 7: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
target 8: IgnitionState { receiver_status: ReceiverStatus { aligned: true, locked: true, polarity_inverted: false }, target: Some(Target { system_type: Gimlet, power_state: On, power_reset_in_progress: false, faults: SystemFaults { power_a3: false, power_a2: false, sp: false, rot: false }, controller0_present: true, controller1_present: false, link0_receiver_status: ReceiverStatus { aligned: true, locked: true, polarity_inverted: false }, link1_receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false } }) }
target 9: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
...snip...
target 19: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
target 20: IgnitionState { receiver_status: ReceiverStatus { aligned: true, locked: true, polarity_inverted: false }, target: Some(Target { system_type: Gimlet, power_state: On, power_reset_in_progress: false, faults: SystemFaults { power_a3: false, power_a2: false, sp: false, rot: false }, controller0_present: true, controller1_present: false, link0_receiver_status: ReceiverStatus { aligned: true, locked: true, polarity_inverted: false }, link1_receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false } }) }
target 21: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
...snip...
target 34: IgnitionState { receiver_status: ReceiverStatus { aligned: false, locked: false, polarity_inverted: false }, target: None }
```

but we can also:

* fetch state of an individual target
* get transceiver link events for an individual or all targets
* clear transceiver link events for an individual target+transceiver, an individual target+all transceivers, all targets+all tranceivers
* send power-on, power-off, or power-reset commands to an individual target