### PR TITLE
[sprot] Try to make error handling more idiomatic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "drv-update-api",
  "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",
+ "idol-runtime",
  "if_chain",
  "memoffset",
  "num-traits",

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -131,7 +131,7 @@ impl Handler {
                 // We want to ensure the number of bytes received matches the header's
                 // expected payload size.
                 let expected_payload = rx_bytes - MIN_MSG_SIZE;
-                if header.payload_len as usize != rx_bytes - MIN_MSG_SIZE {
+                if header.payload_len as usize != expected_payload {
                     ringbuf_entry!(Trace::HeaderSizeMismatch(
                         header.msgtype,
                         header.payload_len,
@@ -163,8 +163,6 @@ impl Handler {
         // consistent with the CRC and the length is known to be good.
         status.rx_received = status.rx_received.wrapping_add(1);
 
-        // The above cases either enqueued a message and returned size
-        // or generated 1-byte error code.
         match self.run(rx_buf, rxmsg, tx_buf, status) {
             Ok((msgtype, payload_size)) => {
                 tx_buf.from_existing(msgtype, payload_size).ok()

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -28,15 +28,21 @@ enum Trace {
     HandlerReturnSize(usize),
     Overrun(usize),
     Pio(bool),
+    PioOuterLoop,
+    PioInnerLoop,
     RotIrqAssert,
     RotIrqDeassert,
     Transmit(usize, usize),
     Underrun(usize),
+    SpuriousSpiInterrupt,
 }
 ringbuf!(Trace, 32, Trace::None);
 
 task_slot!(SYSCON, syscon_driver);
 task_slot!(GPIO, gpio_driver);
+
+// Notification mask for Flexcomm8 hs_spi IRQ; must match config in app.toml
+const SPI_IRQ: u32 = 1;
 
 // See drv/sprot-api/README.md
 // Messages are received from the Service Processor (SP) over a SPI interface.
@@ -76,9 +82,9 @@ struct IO {
     spi: crate::spi_core::Spi,
     gpio: drv_lpc55_gpio_api::Pins,
     // Transmit Buffer
-    tx_buf: [u8; BUF_SIZE],
+    tx_buf: TxMsg,
     // Receive Buffer
-    rx_buf: [u8; BUF_SIZE],
+    rx_buf: RxMsg,
     // Number of bytes copied into the receive buffer
     rxcount: usize,
     // Number of bytes copied from the transmit buffer into the FIFO
@@ -145,8 +151,8 @@ fn main() -> ! {
     let gpio = drv_lpc55_gpio_api::Pins::from(gpio_driver);
 
     let mut io = IO {
-        tx_buf: [0u8; BUF_SIZE],
-        rx_buf: [0u8; BUF_SIZE],
+        tx_buf: TxMsg::new(),
+        rx_buf: RxMsg::new(),
         gpio,
         spi,
         rxcount: 0,
@@ -154,6 +160,7 @@ fn main() -> ! {
         overrun: false,
         underrun: false,
     };
+
     let mut status = Status {
         supported: 1_u32 << (Protocol::V1 as u8),
         bootrom_crc32: CRC32.checksum(&bootrom().data[..]),
@@ -181,11 +188,13 @@ fn main() -> ! {
 
     // Process a null message as if it had been just received.
     // Expect that the Tx buffer is cleared.
+    let bytes_read = 0;
     server.handler.handle(
         transmit,
         crate::IoStatus::Flush,
-        &server.io.rx_buf[0..0],
-        &mut server.io.tx_buf[..],
+        &server.io.rx_buf,
+        bytes_read,
+        &mut server.io.tx_buf,
         server.status,
     );
 
@@ -205,12 +214,13 @@ fn main() -> ! {
         transmit = match server.handler.handle(
             transmit, // true if previous loop transmitted.
             iostat,
-            &server.io.rx_buf[0..server.io.rxcount],
-            &mut server.io.tx_buf[..],
+            &server.io.rx_buf,
+            server.io.rxcount,
+            &mut server.io.tx_buf,
             server.status,
         ) {
-            Some(_txlen) => {
-                ringbuf_entry!(Trace::HandlerReturnSize(_txlen));
+            Some(txlen) => {
+                ringbuf_entry!(Trace::HandlerReturnSize(txlen.0));
                 true
             }
             None => {
@@ -226,7 +236,7 @@ impl IO {
     /// Returns false on spurious interrupt.
     fn pio(&mut self, transmit: bool) {
         ringbuf_entry!(Trace::Pio(transmit));
-        let tx_end = self.tx_buf.len(); // Available bytes and trailing zeros
+        let tx_end = self.tx_buf.as_slice().len(); // Available bytes and trailing zeros
         let rx_end = self.rx_buf.len(); // All of the available bytes
         self.txcount = 0;
         self.rxcount = 0;
@@ -235,7 +245,7 @@ impl IO {
 
         if !transmit {
             // Ensure that unused Tx buffer is zero-filled.
-            self.tx_buf.fill(0);
+            self.tx_buf.as_mut().fill(0);
         }
 
         // Prime FIFOWR in order to be ready for start of frame.
@@ -249,7 +259,7 @@ impl IO {
             if self.txcount >= tx_end || !self.spi.can_tx() {
                 break;
             }
-            let b = self.tx_buf[self.txcount];
+            let b = self.tx_buf.as_slice()[self.txcount];
             self.spi.send_u8(b);
             self.txcount += 1;
         }
@@ -272,10 +282,12 @@ impl IO {
         // Track the state of chip select (CSn)
         let mut inframe = false;
         'outer: loop {
+            ringbuf_entry!(Trace::PioOuterLoop);
             // restart here on the one expected spurious interrupt.
-            sys_irq_control(1, true);
-            sys_recv_closed(&mut [], 1, TaskId::KERNEL).unwrap_lite();
+            sys_irq_control(SPI_IRQ, true);
+            sys_recv_closed(&mut [], SPI_IRQ, TaskId::KERNEL).unwrap_lite();
             loop {
+                ringbuf_entry!(Trace::PioInnerLoop);
                 // Get frame start/end interrupt from intstat (SSA/SSD).
                 let intstat = self.spi.intstat();
                 let fifostat = self.spi.fifostat();
@@ -294,6 +306,7 @@ impl IO {
                     // These are only happening just after queuing a
                     // response.
                     // TODO: It would be nice to eliminate the spurious interrupt.
+                    ringbuf_entry!(Trace::SpuriousSpiInterrupt);
                     continue 'outer;
                 }
 
@@ -337,7 +350,7 @@ impl IO {
                     if self.spi.can_tx() {
                         let (b, incr) = if self.txcount < tx_end {
                             io = true;
-                            (self.tx_buf[self.txcount], 1)
+                            (self.tx_buf.as_slice()[self.txcount], 1)
                         } else {
                             (0, 0)
                         };
@@ -348,7 +361,7 @@ impl IO {
                         let b = self.spi.read_u8();
                         let incr = if self.rxcount < rx_end {
                             io = true;
-                            self.rx_buf[self.rxcount] = b;
+                            self.rx_buf.as_mut()[self.rxcount] = b;
                             1
                         } else {
                             0

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 crc = { workspace = true }
 hubpack = { workspace = true }
+idol-runtime = { workspace = true }
 if_chain = { workspace = true }
 memoffset = { workspace = true }
 num-traits = { workspace = true }

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -3,6 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Client API for SP to RoT messages over SPI.
+//!
+//! An SP/RoT SPI message is:
+//!   1. A hubpack encoded `MsgHeader` containing the protocol, payload length,
+//!      and message type.
+//!   2. Payload according to MessageType, typically hubpack encoded
+//!      structure(s) and/or bulk data.
+//!   3. A CRC16 parameters that covers all of the bytes from the protocol ID to
+//!      the end of the payload.
+//!
 
 #![no_std]
 extern crate memoffset;
@@ -11,30 +20,20 @@ use crc::{Crc, CRC_16_XMODEM};
 use derive_idol_err::IdolError;
 use drv_update_api::{ImageVersion, UpdateError, UpdateTarget};
 use hubpack::SerializedSize;
-use if_chain::if_chain; // Chained if let statements are almost here.
+use idol_runtime::{Leased, R};
 use serde::{Deserialize, Serialize};
 // use derive_idol_err::IdolError;
 use userlib::{sys_send, FromPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
-/*
- * An SP/RoT SPI  message is:
- *   1. A u8 protocol ID (0x01) or a 0x00 indicating that no message is present.
- *   2. A hubpack encoded tuple (u16, MessageType) giving the payload length
- *      and message type.
- *   3. Payload according to MessageType, typically hubpack encoded
- *      structure(s) and/or bulk data.
- *   4. A CRC16 parameters that covers all of the bytes from the protocol ID to
- *      the end of the payload.
- */
-
+/// The canonical SpRot protocol error returned by this API
+//
 // TODO: Audit that each MsgError is used and has some reasonable action.
 // While a diverse set of error codes may be useful for debugging it
 // clutters code that just has to deal with the error.
 // then consider adding a function that translates an error code
 // into the desired action, e.g. InvalidCrc and FlowError should both
 // result in a retry on the SP side and an ErrorRsp on the RoT side.
-
 #[derive(
     Copy,
     Clone,
@@ -48,13 +47,13 @@ use zerocopy::{AsBytes, FromBytes};
     SerializedSize,
 )]
 #[repr(C)]
-pub enum MsgError {
+pub enum SprotError {
     /// There is no message
     NoMessage = 1,
     /// Transfer size is outside of maximum and minimum lenghts for message type.
     BadTransferSize = 2,
-    /// Server restarted
-    // ServerRestarted = 3,
+    /// A task crashed during an operation, commonly a lease read or write
+    TaskRestart = 3,
     /// CRC check failed.
     InvalidCrc = 4,
     /// FIFO overflow/underflow
@@ -83,49 +82,138 @@ pub enum MsgError {
     NonRotError = 18,
     /// A message with version = 0 was received unexpectedly.
     EmptyMessage = 19,
-    /// Update operation failed
-    UpdateError = 20,
 
     /// Insufficient bytes received
-    Incomplete = 21,
+    Incomplete = 20,
     /// Hubpack error
-    Serialization = 22,
+    Serialization = 21,
     /// Sequence number mismatch in Sink test
-    Sequence = 23,
+    Sequence = 22,
+
+    //
+    // Update Related Errors
+    //
+    UpdateBadLength = 23,
+    UpdateInProgress = 24,
+    UpdateOutOfBounds = 25,
+    UpdateTimeout = 26,
+    UpdateEccDoubleErr = 27,
+    UpdateEccSingleErr = 28,
+    UpdateSecureErr = 29,
+    UpdateReadProtErr = 30,
+    UpdateWriteEraseErr = 31,
+    UpdateInconsistencyErr = 32,
+    UpdateStrobeErr = 33,
+    UpdateProgSeqErr = 34,
+    UpdateWriteProtErr = 35,
+    UpdateBadImageType = 36,
+    UpdateAlreadyFinished = 37,
+    UpdateNotStarted = 38,
+    UpdateRunningImage = 39,
+    UpdateFlashError = 40,
+    UpdateSpRotError = 41,
+    UpdateUnknown = 42,
+
     /// Unknown Errors are mapped to 0xff
     Unknown = 0xff,
 }
 
-impl From<u8> for MsgError {
-    fn from(byte: u8) -> MsgError {
-        match byte {
-            1 => MsgError::NoMessage,
-            2 => MsgError::BadTransferSize,
-            4 => MsgError::InvalidCrc,
-            5 => MsgError::FlowError,
-            6 => MsgError::UnsupportedProtocol,
-            7 => MsgError::BadMessageType,
-            8 => MsgError::BadMessageLength,
-            9 => MsgError::SpiServerError,
-            10 => MsgError::Oversize,
-            11 => MsgError::TxNotIdle,
-            12 => MsgError::CannotAssertCSn,
-            13 => MsgError::RotNotReady,
-            14 => MsgError::RspTimeout,
-            15 => MsgError::BadResponse,
-            16 => MsgError::RotBusy,
-            17 => MsgError::NotImplemented,
-            18 => MsgError::NonRotError,
-            19 => MsgError::EmptyMessage,
-            20 => MsgError::UpdateError,
-            21 => MsgError::Incomplete,
-            22 => MsgError::Serialization,
-            23 => MsgError::Sequence,
-            _ => MsgError::Unknown,
+impl From<UpdateError> for SprotError {
+    fn from(value: UpdateError) -> Self {
+        match value {
+            UpdateError::BadLength => SprotError::UpdateBadLength,
+            UpdateError::UpdateInProgress => SprotError::UpdateInProgress,
+            UpdateError::OutOfBounds => SprotError::UpdateOutOfBounds,
+            UpdateError::Timeout => SprotError::UpdateTimeout,
+            UpdateError::EccDoubleErr => SprotError::UpdateEccDoubleErr,
+            UpdateError::EccSingleErr => SprotError::UpdateEccSingleErr,
+            UpdateError::SecureErr => SprotError::UpdateSecureErr,
+            UpdateError::ReadProtErr => SprotError::UpdateReadProtErr,
+            UpdateError::WriteEraseErr => SprotError::UpdateWriteEraseErr,
+            UpdateError::InconsistencyErr => SprotError::UpdateInconsistencyErr,
+            UpdateError::StrobeErr => SprotError::UpdateStrobeErr,
+            UpdateError::ProgSeqErr => SprotError::UpdateProgSeqErr,
+            UpdateError::WriteProtErr => SprotError::UpdateWriteProtErr,
+            UpdateError::BadImageType => SprotError::UpdateBadImageType,
+            UpdateError::UpdateAlreadyFinished => {
+                SprotError::UpdateAlreadyFinished
+            }
+            UpdateError::UpdateNotStarted => SprotError::UpdateNotStarted,
+            UpdateError::RunningImage => SprotError::UpdateRunningImage,
+            UpdateError::FlashError => SprotError::UpdateFlashError,
+            UpdateError::SpRotError => SprotError::UpdateSpRotError,
+            UpdateError::Unknown => SprotError::UpdateUnknown,
         }
     }
 }
 
+impl From<u8> for SprotError {
+    fn from(byte: u8) -> SprotError {
+        match byte {
+            1 => SprotError::NoMessage,
+            2 => SprotError::BadTransferSize,
+            4 => SprotError::InvalidCrc,
+            5 => SprotError::FlowError,
+            6 => SprotError::UnsupportedProtocol,
+            7 => SprotError::BadMessageType,
+            8 => SprotError::BadMessageLength,
+            9 => SprotError::SpiServerError,
+            10 => SprotError::Oversize,
+            11 => SprotError::TxNotIdle,
+            12 => SprotError::CannotAssertCSn,
+            13 => SprotError::RotNotReady,
+            14 => SprotError::RspTimeout,
+            15 => SprotError::BadResponse,
+            16 => SprotError::RotBusy,
+            17 => SprotError::NotImplemented,
+            18 => SprotError::NonRotError,
+            19 => SprotError::EmptyMessage,
+            20 => SprotError::Incomplete,
+            21 => SprotError::Serialization,
+            22 => SprotError::Sequence,
+            23 => SprotError::UpdateBadLength,
+            24 => SprotError::UpdateInProgress,
+            25 => SprotError::UpdateOutOfBounds,
+            26 => SprotError::UpdateTimeout,
+            27 => SprotError::UpdateEccDoubleErr,
+            28 => SprotError::UpdateEccSingleErr,
+            29 => SprotError::UpdateSecureErr,
+            30 => SprotError::UpdateReadProtErr,
+            31 => SprotError::UpdateWriteEraseErr,
+            32 => SprotError::UpdateInconsistencyErr,
+            33 => SprotError::UpdateStrobeErr,
+            34 => SprotError::UpdateProgSeqErr,
+            35 => SprotError::UpdateWriteProtErr,
+            36 => SprotError::UpdateBadImageType,
+            37 => SprotError::UpdateAlreadyFinished,
+            38 => SprotError::UpdateNotStarted,
+            39 => SprotError::UpdateRunningImage,
+            40 => SprotError::UpdateFlashError,
+            41 => SprotError::UpdateSpRotError,
+            42 => SprotError::UpdateUnknown,
+            _ => SprotError::Unknown,
+        }
+    }
+}
+
+impl From<hubpack::Error> for SprotError {
+    fn from(_: hubpack::Error) -> Self {
+        SprotError::Serialization
+    }
+}
+
+// Return true if the error is recoverable, otherwise return false
+pub fn is_recoverable_error(err: SprotError) -> bool {
+    match err {
+        SprotError::InvalidCrc
+        | SprotError::EmptyMessage
+        | SprotError::RotNotReady
+        | SprotError::RotBusy => true,
+        _ => false,
+    }
+}
+
+/// The successful result of pulsing the active low chip-select line
 #[derive(
     Copy, Clone, FromBytes, AsBytes, Serialize, Deserialize, SerializedSize,
 )]
@@ -135,6 +223,7 @@ pub struct PulseStatus {
     pub rot_irq_end: u8,
 }
 
+/// The result of a bulk sink transfer test
 #[derive(
     Copy, Clone, FromBytes, AsBytes, Serialize, Deserialize, SerializedSize,
 )]
@@ -333,90 +422,228 @@ impl From<u8> for MsgType {
     }
 }
 
+/// A builder/serializer for messages that wraps the transmit buffer
+///
+/// Each public method returns the serialized buffer that can be sent on the
+/// wire.
+pub struct TxMsg {
+    buf: [u8; BUF_SIZE],
+}
+
+impl TxMsg {
+    pub fn new() -> TxMsg {
+        TxMsg { buf: [0; BUF_SIZE] }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..]
+    }
+
+    pub fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[..]
+    }
+
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[HEADER_SIZE..BUF_SIZE - CRC_SIZE]
+    }
+
+    /// Serialize an ErrorRsp with a one byte payload, which is a serialized
+    /// `SprotError`
+    pub fn error_rsp(&mut self, err: SprotError) -> VerifiedTxMsg {
+        let payload_size = 1;
+        self.buf[HEADER_SIZE] = err as u8;
+        self.from_existing(MsgType::ErrorRsp, payload_size)
+            .unwrap_lite()
+    }
+
+    /// Serialize a request with no payload
+    pub fn no_payload(&mut self, msgtype: MsgType) -> VerifiedTxMsg {
+        let payload_size = 0;
+        self.write_header(msgtype, payload_size);
+        self.write_crc(payload_size)
+    }
+
+    /// Serialize a request from a MsgType and Lease
+    pub fn from_lease(
+        &mut self,
+        msgtype: MsgType,
+        source: Leased<R, [u8]>,
+    ) -> Result<VerifiedTxMsg, SprotError> {
+        if source.len() > PAYLOAD_SIZE_MAX {
+            return Err(SprotError::Oversize);
+        }
+
+        let dest = &mut self.buf[HEADER_SIZE..][..source.len()];
+        source
+            .read_range(0..source.len(), dest)
+            .map_err(|_| SprotError::TaskRestart)?;
+
+        self.write_header(msgtype, source.len());
+        Ok(self.write_crc(source.len()))
+    }
+
+    /// Serialize a request from a buffer with an already written payload
+    pub fn from_existing(
+        &mut self,
+        msgtype: MsgType,
+        payload_size: usize,
+    ) -> Result<VerifiedTxMsg, SprotError> {
+        if payload_size > PAYLOAD_SIZE_MAX {
+            return Err(SprotError::Oversize);
+        }
+        self.write_header(msgtype, payload_size);
+        Ok(self.write_crc(payload_size))
+    }
+
+    fn write_header(&mut self, msgtype: MsgType, payload_size: usize) {
+        let _ = MsgHeader::new_v1(msgtype, payload_size)
+            .unwrap_lite()
+            .serialize(&mut self.buf[..])
+            .unwrap_lite();
+    }
+
+    fn write_crc(&mut self, payload_size: usize) -> VerifiedTxMsg {
+        let crc_begin = HEADER_SIZE + payload_size;
+        let msg_bytes = &self.buf[0..crc_begin];
+        let crc = CRC16.checksum(msg_bytes);
+        let end = crc_begin + CRC_SIZE;
+        let crc_buf = &mut self.buf[crc_begin..end];
+        let _ = hubpack::serialize(crc_buf, &crc).unwrap_lite();
+        VerifiedTxMsg(end)
+    }
+}
+
+/// A type indicating that a complete message has been successfully serialized and therefore
+/// fits in the allocated buffer.
+#[derive(Clone, Copy)]
+pub struct VerifiedTxMsg(pub usize);
+
+/// A parser/deserializer for messages received over SPI
+pub struct RxMsg {
+    buf: [u8; BUF_SIZE],
+}
+
+impl RxMsg {
+    pub fn new() -> RxMsg {
+        RxMsg { buf: [0; BUF_SIZE] }
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..]
+    }
+
+    pub fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[..]
+    }
+
+    pub fn payload(&self, rxmsg: &VerifiedRxMsg) -> &[u8] {
+        &self.buf[HEADER_SIZE..][..rxmsg.0.payload_len as usize]
+    }
+
+    pub fn parse_header(
+        &self,
+        valid_bytes: usize,
+    ) -> Result<MsgHeader, SprotError> {
+        // We want to be able to return `RotBusy` before `Incomplete`.
+        self.parse_protocol()?;
+        if valid_bytes < HEADER_SIZE {
+            return Err(SprotError::Incomplete);
+        }
+        let (header, _) = hubpack::deserialize::<MsgHeader>(&self.buf[..])?;
+        if header.payload_len as usize > PAYLOAD_SIZE_MAX {
+            return Err(SprotError::BadMessageLength);
+        }
+        Ok(header)
+    }
+
+    pub fn validate_crc(&self, header: &MsgHeader) -> Result<(), SprotError> {
+        // The only way to get a `MsgHeader` is to call parse_header, which
+        // already validated the payload size.
+        let crc_start = HEADER_SIZE + (header.payload_len as usize);
+        let crc_buf = &self.buf[crc_start..][..CRC_SIZE];
+        let (expected, _) = hubpack::deserialize::<u16>(crc_buf)?;
+        let actual = CRC16.checksum(&self.buf[..crc_start]);
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(SprotError::InvalidCrc)
+        }
+    }
+
+    /// Deserialize a hubpack encoded message, `M`, from the wrapped buffer
+    pub fn deserialize_hubpack_payload<M>(
+        &self,
+        rxmsg: &VerifiedRxMsg,
+    ) -> Result<M, SprotError>
+    where
+        M: for<'de> Deserialize<'de>,
+    {
+        let (msg, _) = hubpack::deserialize::<M>(self.payload(rxmsg))?;
+        Ok(msg)
+    }
+
+    /// Parse the first byte of the protocol, returning an appropriate error
+    /// if necessary.
+    fn parse_protocol(&self) -> Result<(), SprotError> {
+        match Protocol::from(self.buf[0]) {
+            Protocol::Ignore => Err(SprotError::NoMessage),
+            Protocol::Busy => Err(SprotError::RotBusy),
+            Protocol::V1 => Ok(()),
+            _ => Err(SprotError::UnsupportedProtocol),
+        }
+    }
+}
+
+/// A type indicating that the message header has been parsed and the CRC has
+/// been successfully verified
+pub struct VerifiedRxMsg(pub MsgHeader);
+
+// The SpRot Header prepended to each message traversing the SPI bus
+// between the RoT and SP.
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
-#[repr(C, packed)]
-struct MsgHeader {
-    protocol: Protocol,
-    msgtype: MsgType,
-    len: u16,
+pub struct MsgHeader {
+    pub protocol: Protocol,
+    pub msgtype: MsgType,
+    // Length of the payload (does not include Header or CRC)
+    pub payload_len: u16,
 }
 
-#[derive(
-    Copy, Clone, Eq, PartialEq, Serialize, Deserialize, SerializedSize,
-)]
-#[repr(C)]
-pub enum UpdateRspKind {
-    Ok = 1,
-    Value = 2,
-    Error = 3,
-    Unknown = 0xff,
-}
-
-impl From<u8> for UpdateRspKind {
-    fn from(kind: u8) -> Self {
-        match kind {
-            kind if kind == (UpdateRspKind::Ok as u8) => UpdateRspKind::Ok,
-            kind if kind == (UpdateRspKind::Value as u8) => {
-                UpdateRspKind::Value
-            }
-            kind if kind == (UpdateRspKind::Error as u8) => {
-                UpdateRspKind::Error
-            }
-            _ => UpdateRspKind::Unknown,
+impl MsgHeader {
+    /// Create a new `MsgHeader` with protocol version `V1`.
+    ///
+    /// Return an error if the message payload does not fit within a u16 or
+    /// it is greater than `PAYLOAD_SIZE_MAX`.
+    pub fn new_v1(
+        msgtype: MsgType,
+        payload_size: usize,
+    ) -> Result<MsgHeader, SprotError> {
+        if payload_size > PAYLOAD_SIZE_MAX {
+            return Err(SprotError::BadMessageLength);
         }
+        let len = u16::try_from(payload_size)
+            .map_err(|_| SprotError::BadMessageLength)?;
+        Ok(MsgHeader {
+            protocol: Protocol::V1,
+            msgtype,
+            payload_len: len,
+        })
+    }
+
+    /// Serialize a `MsgHeader` into `buf`, returning the number of bytes written
+    /// or an error if serialization fails.
+    pub fn serialize(&self, buf: &mut [u8]) -> Result<usize, SprotError> {
+        let size = hubpack::serialize(&mut buf[..HEADER_SIZE], self)?;
+        Ok(size)
     }
 }
 
-impl From<UpdateRspKind> for u8 {
-    fn from(kind: UpdateRspKind) -> Self {
-        match kind {
-            UpdateRspKind::Ok => UpdateRspKind::Ok as u8,
-            UpdateRspKind::Value => UpdateRspKind::Value as u8,
-            UpdateRspKind::Error => UpdateRspKind::Error as u8,
-            _ => UpdateRspKind::Unknown as u8,
-        }
-    }
-}
-
-#[derive(
-    Copy, Clone, Serialize, Deserialize, SerializedSize, Eq, PartialEq,
-)]
-#[repr(C, packed)]
-pub struct UpdateRspHeader {
-    pub kind: UpdateRspKind,
-    pub value: u32, // unused, value, or error code depending on kind.
-}
-
-// Hubpack doesn't serialize Option or Result but that's
-// what we want.
-// Map the various Update api results to a signle struct
-// that hubpack can handle.
-// match Result<(), UpdateError> {
-//  Ok(()) => { new(None, None) },
-//  Err(err) => { new(None, err.into()) },
-// match Result<u32, UpdateError> {
-//  Ok(block_size) => { new(Some(block_size), None) },
-//  Err(err) => { new(None, err.into()) },
-impl UpdateRspHeader {
-    pub fn new(arg: Option<u32>, err: Option<u32>) -> Self {
-        match err {
-            None => match arg {
-                None => Self {
-                    kind: UpdateRspKind::Ok,
-                    value: 0,
-                },
-                Some(value) => Self {
-                    kind: UpdateRspKind::Value,
-                    value,
-                },
-            },
-            Some(error) => Self {
-                kind: UpdateRspKind::Error,
-                value: error,
-            },
-        }
-    }
-}
+/// Headers for update responses, that are embedded as part of the payload of
+/// an update response.
+pub type UpdateRspHeader = Result<Option<u32>, u32>;
 
 const CRC16: Crc<u16> = Crc::<u16>::new(&CRC_16_XMODEM);
 pub const HEADER_SIZE: usize = <MsgHeader as SerializedSize>::MAX_SIZE;
@@ -428,137 +655,5 @@ pub const BUF_SIZE: usize = HEADER_SIZE + PAYLOAD_SIZE_MAX + CRC_SIZE;
 pub const MIN_MSG_SIZE: usize = HEADER_SIZE + CRC_SIZE;
 // XXX ROT FIFO size should be discovered.
 pub const ROT_FIFO_SIZE: usize = 8;
-
-// RX parse
-//   given a buffer
-//   - check protocol
-//   - get length
-//   - check length against buffer limits including CRC
-//   - calculate CRC
-//   - check CRC against stored CRC
-//   - Result<(MsgType, &[u8]), MsgError>
-pub fn parse(buffer: &[u8]) -> Result<(MsgType, &[u8]), MsgError> {
-    if buffer.is_empty() {
-        return Err(MsgError::NoMessage);
-    }
-    match Protocol::from(buffer[0]) {
-        Protocol::Ignore => return Err(MsgError::NoMessage),
-        Protocol::Busy => return Err(MsgError::RotBusy),
-        Protocol::V1 => {}
-        Protocol::Unsupported => return Err(MsgError::UnsupportedProtocol),
-    }
-    if buffer.len() < HEADER_SIZE + CRC_SIZE {
-        return Err(MsgError::BadMessageLength);
-    }
-    if let Ok((header, payload_start)) =
-        hubpack::deserialize::<MsgHeader>(buffer)
-    {
-        let len = header.len as usize;
-        if_chain! {
-            if let Some(crc_buf) = payload_start.get(len..len + CRC_SIZE);
-            if let Ok((crc, _)) = hubpack::deserialize::<u16>(crc_buf);
-            if let Some(msg_bytes) = buffer.get(0..HEADER_SIZE+len);
-            if crc == CRC16.checksum(msg_bytes);
-            then {
-                Ok((header.msgtype, &payload_start[..len]))
-            } else {
-                Err(MsgError::InvalidCrc)
-            }
-        }
-    } else {
-        // Content didn't matter for hubpack::deserialize.
-        // So, there weren't enough bytes to decode a header.
-        Err(MsgError::BadMessageLength)
-    }
-}
-
-/// Parse the header from an incomplete received message
-pub fn rx_payload_remaining_mut(
-    valid_bytes: usize,
-    buffer: &mut [u8],
-) -> Result<&mut [u8], MsgError> {
-    if valid_bytes.min(buffer.len()) < HEADER_SIZE {
-        return Err(MsgError::Incomplete);
-    }
-    match Protocol::from(buffer[0]) {
-        Protocol::Ignore => return Err(MsgError::NoMessage),
-        Protocol::Busy => return Err(MsgError::RotBusy),
-        Protocol::V1 => (),
-        _ => return Err(MsgError::UnsupportedProtocol),
-    }
-    if let Ok((header, _payload_start)) =
-        hubpack::deserialize::<MsgHeader>(buffer)
-    {
-        let end = MIN_MSG_SIZE + (header.len as usize);
-        if end > buffer.len() {
-            Err(MsgError::BadMessageLength)
-        } else if valid_bytes < end {
-            Ok(&mut buffer[valid_bytes..end])
-        } else {
-            Ok(&mut buffer[end..end])
-        }
-    } else {
-        Err(MsgError::Serialization)
-    }
-}
-
-/// Read access to the first portion or all of the transmit buffer.
-pub fn payload_buf(size: Option<usize>, buffer: &[u8]) -> &[u8] {
-    let start = HEADER_SIZE;
-    let end = match size {
-        Some(size) => HEADER_SIZE + size,
-        None => buffer.len() - CRC_SIZE,
-    };
-    match buffer.get(start..end) {
-        Some(buf) => buf,
-        None => panic!(), // Don't come to me with your miniscule buffers.
-    }
-}
-
-/// Read/write access to the first portion or all of the transmit buffer.
-pub fn payload_buf_mut(size: Option<usize>, buffer: &mut [u8]) -> &mut [u8] {
-    let start = HEADER_SIZE;
-    let end = match size {
-        Some(size) => HEADER_SIZE + size,
-        None => buffer.len() - CRC_SIZE,
-    };
-    match buffer.get_mut(start..end) {
-        Some(buf) => buf,
-        None => panic!(), // Don't come to me with your miniscule buffers.
-    }
-}
-
-/// Finish the message header, compute message CRC and return the
-/// number of bytes to transmit from the underlying buffer.
-/// The payload has to have been placed in the bytes designated by payload_range()
-/// and the payload parameter must be the actual bytes that were used for the payload.
-pub fn compose(
-    msgtype: MsgType,
-    payload_size: usize,
-    buffer: &mut [u8],
-) -> Result<usize, MsgError> {
-    let header = MsgHeader {
-        protocol: Protocol::V1,
-        msgtype,
-        len: u16::try_from(payload_size)
-            .map_err(|_| MsgError::BadMessageLength)?,
-    };
-    let _size = hubpack::serialize(&mut buffer[..HEADER_SIZE], &header)
-        .map_err(|_e| MsgError::Serialization)?;
-    if let Some(msg_bytes) = buffer.get(0..HEADER_SIZE + payload_size) {
-        let crc = CRC16.checksum(msg_bytes);
-        let crc_begin = HEADER_SIZE + payload_size;
-        let end = crc_begin + CRC_SIZE;
-        if let Some(crc_buf) = buffer.get_mut(crc_begin..end) {
-            if let Ok(_n) = hubpack::serialize(crc_buf, &crc) {
-                return Ok(end);
-            } else {
-                return Err(MsgError::Serialization);
-            }
-        }
-    }
-    // Bounds are the only error here.
-    Err(MsgError::BadMessageLength)
-}
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+use core::convert::Into;
 use drv_spi_api::{CsState, Spi};
 use drv_sprot_api::*;
 use drv_stm32xx_sys_api as sys_api;
@@ -28,18 +29,18 @@ enum Trace {
     CSnAssert,
     CSnDeassert,
     Debug(bool),
-    Error(MsgError),
-    FailedRetries { retries: u16, errcode: MsgError },
-    MsgError(MsgError),
-    ParseErr(u8, u8, u8, u8),
+    Error(SprotError),
+    FailedRetries { retries: u16, errcode: SprotError },
+    SprotError(SprotError),
     PulseFailed,
     RotNotReady,
     RotReadyTimeout,
+    RxParseError(u8, u8, u8, u8),
+    RxSpiError,
     RxPart1(usize),
     RxPart2(usize),
-    RxPayloadRemainingMutErr(u8, u8, u8, u8),
     SendRecv(usize),
-    SinkFail(MsgError, u16),
+    SinkFail(SprotError, u16),
     SinkLoop(u16),
     TxPart1(usize),
     TxPart2(usize),
@@ -47,6 +48,9 @@ enum Trace {
     UnexpectedRotIrq,
     UpdResponse(UpdateRspHeader),
     WrongMsgType(MsgType),
+    UpdatePrep,
+    UpdateWriteOneBlock,
+    UpdateFinish,
 }
 ringbuf!(Trace, 64, Trace::None);
 
@@ -66,7 +70,7 @@ const TIMEOUT_WRITE_ONE_BLOCK: u32 = 2_000;
 const PART1_DELAY: u64 = 0;
 const PART2_DELAY: u64 = 2; // Observed to be at least 2ms on gimletlet
 
-const MAX_UPD_ATTEMPTS: u16 = 3;
+const MAX_UPDATE_ATTEMPTS: u16 = 3;
 cfg_if::cfg_if! {
     if #[cfg(feature = "sink_test")] {
         const MAX_SINKREQ_ATTEMPTS: u16 = 2; // TODO parameterize
@@ -124,12 +128,24 @@ cfg_if::cfg_if! {
     }
 }
 
+/// Return an error if the expected MsgType doesn't match the actual MsgType
+macro_rules! expect_msg {
+    ($expected:expr, $actual:expr) => {
+        if $expected != $actual {
+            ringbuf_entry!(Trace::WrongMsgType($actual));
+            Err(SprotError::BadMessageType)
+        } else {
+            Ok(())
+        }
+    };
+}
+
 pub struct ServerImpl {
     sys: sys_api::Sys,
     spi: drv_spi_api::SpiDevice,
     // Use separate buffers so that retries can be generic.
-    pub tx_buf: [u8; BUF_SIZE],
-    pub rx_buf: [u8; BUF_SIZE],
+    pub tx_buf: TxMsg,
+    pub rx_buf: RxMsg,
 }
 
 #[export_name = "main"]
@@ -145,8 +161,8 @@ fn main() -> ! {
     let mut server = ServerImpl {
         sys,
         spi,
-        tx_buf: [0u8; BUF_SIZE],
-        rx_buf: [0u8; BUF_SIZE],
+        tx_buf: TxMsg::new(),
+        rx_buf: RxMsg::new(),
     };
 
     loop {
@@ -158,9 +174,10 @@ impl ServerImpl {
     /// Handle the mechanics of sending a message and waiting for a response.
     fn do_send_recv(
         &mut self,
-        size: usize,
+        txmsg: VerifiedTxMsg,
         timeout: u32,
-    ) -> Result<(MsgType, usize), MsgError> {
+    ) -> Result<VerifiedRxMsg, SprotError> {
+        let size = txmsg.0;
         ringbuf_entry!(Trace::SendRecv(size));
         // Polling and timeout configuration
         // TODO: Use EXTI interrupt and just a timeout, no polling.
@@ -194,16 +211,11 @@ impl ServerImpl {
                     ringbuf_entry!(Trace::PulseFailed);
                     // Did not clear ROT_IRQ
                     debug_set(&self.sys, false); // XXX
-                    return Err(MsgError::RotNotReady);
+                    return Err(SprotError::RotNotReady);
                 }
             }
         }
-        let buf = match self.tx_buf.get(0..size) {
-            Some(buf) => buf,
-            None => {
-                return Err(MsgError::BadMessageLength);
-            }
-        };
+        let buf = &self.tx_buf.as_slice()[..size];
 
         // In order to improve reliability, start by sending only the
         // first ROT_FIFO_SIZE bytes and then delaying a short time.
@@ -215,7 +227,7 @@ impl ServerImpl {
         let part1 = if let Some(part1) = buf.get(0..ROT_FIFO_SIZE.min(size)) {
             part1
         } else {
-            return Err(MsgError::BadMessageLength);
+            return Err(SprotError::BadMessageLength);
         };
         let part2 = buf.get(part1.len()..).unwrap_lite(); // empty or not
         ringbuf_entry!(Trace::TxPart1(part1.len()));
@@ -224,7 +236,7 @@ impl ServerImpl {
             ringbuf_entry!(Trace::CSnAssert);
             self.spi
                 .lock(CsState::Asserted)
-                .map_err(|_| MsgError::SpiServerError)?;
+                .map_err(|_| SprotError::SpiServerError)?;
             if PART1_DELAY != 0 {
                 hl::sleep_for(PART1_DELAY);
             }
@@ -234,20 +246,20 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::CSnDeassert);
                 _ = self.spi.release();
             }
-            return Err(MsgError::SpiServerError);
+            return Err(SprotError::SpiServerError);
         }
         if !part2.is_empty() {
             hl::sleep_for(PART2_DELAY); // TODO: configurable
             ringbuf_entry!(Trace::CSnDeassert);
             if self.spi.write(part2).is_err() {
                 _ = self.spi.release();
-                return Err(MsgError::SpiServerError);
+                return Err(SprotError::SpiServerError);
             }
         }
         if ((PART1_DELAY != 0) || !part2.is_empty())
             && self.spi.release().is_err()
         {
-            return Err(MsgError::SpiServerError);
+            return Err(SprotError::SpiServerError);
         }
 
         /*
@@ -275,7 +287,7 @@ impl ServerImpl {
         // take an interrupt on ROT_IRQ falling edge with timeout.
         if !self.wait_rot_irq(true, timeout) {
             ringbuf_entry!(Trace::RotNotReady);
-            return Err(MsgError::RotNotReady);
+            return Err(SprotError::RotNotReady);
         }
 
         // Read just the header.
@@ -283,90 +295,86 @@ impl ServerImpl {
         ringbuf_entry!(Trace::CSnAssert);
         self.spi
             .lock(CsState::Asserted)
-            .map_err(|_| MsgError::SpiServerError)?;
+            .map_err(|_| SprotError::SpiServerError)?;
         if PART1_DELAY != 0 {
             hl::sleep_for(PART1_DELAY);
         }
 
-        // We can fetch FIFO size number of bytes reliably.
-        // After that, a short delay and fetch the rest if there is
-        // a payload.
-        // Small messages will fit entirely in the RoT FIFO.
-        //
-        // We don't, but we could speculate that some RoT responses will
-        // be longer than ROT_FIFO_SIZE and get ROT_FIFO_SIZE
-        // instead of MIN_MSG_SIZE.
-        //
-        // TODO: Use DMA on RoT to avoid this dance.
+        // Fill in rx_buf with a complete message and validate its crc
+        let res = self.do_spi_read();
+
+        // We must release the SPI bus before we return
+        ringbuf_entry!(Trace::CSnDeassert);
+        self.spi.release().map_err(|_| SprotError::SpiServerError)?;
+
+        res
+    }
+
+    // Fetch as many bytes as we can and parse the header.
+    // Return the parsed header or an error.
+    //
+    // We can fetch FIFO size number of bytes reliably.
+    // After that, a short delay and fetch the rest if there is
+    // a payload.
+    // Small messages will fit entirely in the RoT FIFO.
+    //
+    // We don't, but we could speculate that some RoT responses will
+    // be longer than ROT_FIFO_SIZE and get ROT_FIFO_SIZE
+    // instead of MIN_MSG_SIZE.
+    //
+    // TODO: Use DMA on RoT to avoid this dance.
+    //
+    // We know statically that self.rx_buf is large enough to hold
+    // part1_len bytes.
+    fn do_spi_read(&mut self) -> Result<VerifiedRxMsg, SprotError> {
         let part1_len = MIN_MSG_SIZE.min(ROT_FIFO_SIZE);
         ringbuf_entry!(Trace::RxPart1(part1_len));
-        let buf = self.rx_buf.get_mut(..part1_len).unwrap_lite();
-        let result: Result<usize, MsgError> = if self.spi.read(buf).is_err() {
-            Err(MsgError::SpiServerError)
-        } else {
-            match rx_payload_remaining_mut(part1_len, &mut self.rx_buf) {
-                Ok(buf) => {
-                    ringbuf_entry!(Trace::RxPart2(buf.len()));
-                    // Allow RoT time to rouse itself.
-                    hl::sleep_for(PART2_DELAY);
-                    if self.spi.read(buf).is_err() {
-                        Err(MsgError::SpiServerError)
-                    } else {
-                        Ok(part1_len + buf.len())
-                    }
-                }
-                Err(err) => {
-                    ringbuf_entry!(Trace::RxPayloadRemainingMutErr(
-                        self.rx_buf[0],
-                        self.rx_buf[1],
-                        self.rx_buf[2],
-                        self.rx_buf[3]
-                    ));
-                    Err(err)
-                }
-            }
-        };
 
-        ringbuf_entry!(Trace::CSnDeassert);
-        if self.spi.release().is_err() {
-            Err(MsgError::SpiServerError)
-        } else {
-            match result {
-                Err(e) => {
-                    ringbuf_entry!(Trace::ParseErr(
-                        self.rx_buf[0],
-                        self.rx_buf[1],
-                        self.rx_buf[2],
-                        self.rx_buf[3]
-                    ));
-                    Err(e)
-                }
-                Ok(rlen) => match parse(&self.rx_buf[0..rlen]) {
-                    Err(e) => {
-                        ringbuf_entry!(Trace::ParseErr(
-                            self.rx_buf[0],
-                            self.rx_buf[1],
-                            self.rx_buf[2],
-                            self.rx_buf[3]
-                        ));
-                        Err(e)
-                    }
-                    Ok((msgtype, payload_buf)) => {
-                        Ok((msgtype, payload_buf.len()))
-                    }
-                },
-            }
-        }
+        // We fill in all of buf or we fail
+        let buf = &mut self.rx_buf.as_mut()[..part1_len];
+        self.spi.read(buf).map_err(|_| {
+            ringbuf_entry!(Trace::RxSpiError);
+            SprotError::SpiServerError
+        })?;
+
+        let header = self.rx_buf.parse_header(part1_len).map_err(|e| {
+            self.log_parse_error();
+            e
+        })?;
+
+        let part2_len =
+            MIN_MSG_SIZE + (header.payload_len as usize) - part1_len;
+        ringbuf_entry!(Trace::RxPart2(part2_len));
+
+        // Allow RoT time to rouse itself.
+        hl::sleep_for(PART2_DELAY);
+
+        // Read part two
+        let buf = &mut self.rx_buf.as_mut()[part1_len..][..part2_len];
+        self.spi.read(buf).map_err(|_| SprotError::SpiServerError)?;
+
+        self.rx_buf.validate_crc(&header)?;
+
+        Ok(VerifiedRxMsg(header))
+    }
+
+    fn log_parse_error(&self) {
+        ringbuf_entry!(Trace::RxParseError(
+            self.rx_buf.as_slice()[0],
+            self.rx_buf.as_slice()[1],
+            self.rx_buf.as_slice()[2],
+            self.rx_buf.as_slice()[3]
+        ));
     }
 
     fn do_send_recv_retries(
         &mut self,
-        size: usize,
+        txmsg: VerifiedTxMsg,
         timeout: u32,
         retries: u16,
-    ) -> Result<(MsgType, usize), MsgError> {
+    ) -> Result<VerifiedRxMsg, SprotError> {
         let mut attempts_left = retries;
-        let mut errcode = MsgError::Unknown;
+        let mut errcode = SprotError::Unknown;
         loop {
             if attempts_left == 0 {
                 ringbuf_entry!(Trace::FailedRetries { retries, errcode });
@@ -374,47 +382,33 @@ impl ServerImpl {
             }
             attempts_left -= 1;
 
-            match self.do_send_recv(size, timeout) {
+            match self.do_send_recv(txmsg, timeout) {
                 // Recoverable errors dealing with our ability to receive
                 // the message from the RoT.
-                Err(err) if err == MsgError::InvalidCrc => {
-                    errcode = err;
-                    continue;
-                }
-                Err(err)
-                    if matches!(
-                        err,
-                        MsgError::EmptyMessage
-                            | MsgError::RotNotReady
-                            | MsgError::RotBusy
-                    ) =>
-                {
-                    errcode = err;
-                    continue;
-                }
-                // The remaining errors are not recoverable.
                 Err(err) => {
-                    ringbuf_entry!(Trace::MsgError(err));
-                    errcode = err;
-                    break;
+                    ringbuf_entry!(Trace::SprotError(err));
+                    if is_recoverable_error(err) {
+                        errcode = err;
+                        continue;
+                    } else {
+                        return Err(err);
+                    }
                 }
+
                 // Intact messages from the RoT may indicate an error on
                 // its side.
-                Ok((msgtype, payload_len)) => {
-                    match msgtype {
-                        MsgType::ErrorRsp if payload_len > 0 => {
-                            let payload = payload_buf(
-                                Some(payload_len),
-                                &self.rx_buf[..],
-                            );
-                            errcode =
-                                MsgError::from_u8(payload[0]).unwrap_lite();
-                            ringbuf_entry!(Trace::MsgError(errcode));
+                Ok(rxmsg @ VerifiedRxMsg(header)) => {
+                    match header.msgtype {
+                        MsgType::ErrorRsp => {
+                            assert_eq!(header.payload_len, 1);
+                            let payload = &self.rx_buf.payload(&rxmsg);
+                            errcode = SprotError::from(payload[0]);
+                            ringbuf_entry!(Trace::SprotError(errcode));
                             if matches!(
                                 errcode,
-                                MsgError::FlowError
-                                    | MsgError::InvalidCrc
-                                    | MsgError::UnsupportedProtocol
+                                SprotError::FlowError
+                                    | SprotError::InvalidCrc
+                                    | SprotError::UnsupportedProtocol
                             ) {
                                 // TODO: There are rare cases where
                                 // the RoT dose not receive
@@ -422,17 +416,12 @@ impl ServerImpl {
                                 // See issue XXX.
                                 continue;
                             }
-                            // Other codes from RoT are not recoverable
-                            // with a retry.
-                            break;
-                        }
-                        MsgType::ErrorRsp => {
-                            // No optional error code present.
-                            errcode = MsgError::Unknown;
-                            break;
+                            // Other errors from RoT are not recoverable with
+                            // a retry.
+                            return Err(errcode);
                         }
                         // All of the non-error message types are ok here.
-                        _ => return Ok((msgtype, payload_len)),
+                        _ => return Ok(rxmsg),
                     }
                 }
             }
@@ -441,32 +430,11 @@ impl ServerImpl {
     }
 
     /// Retrieve low-level RoT status
-    fn do_status(&mut self) -> Result<Status, MsgError> {
-        match compose(
-            MsgType::StatusReq,
-            0,
-            self.tx_buf.get_mut(..).unwrap_lite(),
-        ) {
-            Ok(size) => match self.do_send_recv(size, TIMEOUT_QUICK) {
-                Err(err) => Err(err),
-                Ok((msgtype, payload_size)) => match msgtype {
-                    MsgType::StatusRsp => {
-                        match hubpack::deserialize::<Status>(payload_buf(
-                            Some(payload_size),
-                            &self.rx_buf[..],
-                        )) {
-                            Ok((status, _n)) => Ok(status),
-                            Err(_) => Err(MsgError::Serialization),
-                        }
-                    }
-                    _ => {
-                        ringbuf_entry!(Trace::BadResponse(msgtype));
-                        Err(MsgError::BadResponse)
-                    }
-                },
-            },
-            Err(_err) => Err(MsgError::Serialization),
-        }
+    fn do_status(&mut self) -> Result<Status, SprotError> {
+        let txmsg = self.tx_buf.no_payload(MsgType::StatusReq);
+        let rxmsg = self.do_send_recv(txmsg, TIMEOUT_QUICK)?;
+        expect_msg!(MsgType::StatusRsp, rxmsg.0.msgtype)?;
+        self.rx_buf.deserialize_hubpack_payload::<Status>(&rxmsg)
     }
 
     /// Clear the ROT_IRQ and the RoT's Tx buffer by toggling the CSn signal.
@@ -475,12 +443,12 @@ impl ServerImpl {
         &mut self,
         delay: u64,
         delay_after: u64,
-    ) -> Result<PulseStatus, MsgError> {
+    ) -> Result<PulseStatus, SprotError> {
         let rot_irq_begin = self.is_rot_irq_asserted();
         ringbuf_entry!(Trace::CSnAssert);
         self.spi
             .lock(CsState::Asserted)
-            .map_err(|_| MsgError::CannotAssertCSn)?;
+            .map_err(|_| SprotError::CannotAssertCSn)?;
         if delay != 0 {
             hl::sleep_for(delay);
         }
@@ -522,59 +490,28 @@ impl ServerImpl {
         rsp: MsgType,
         timeout: u32,
         attempts: u16,
-    ) -> Result<Option<u32>, RequestError<UpdateError>> {
-        let size =
-            compose(req, payload_len, &mut self.tx_buf[..]).map_err(|_| {
-                idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-            })?;
-        ringbuf_entry!(Trace::TxSize(size));
-        let (msgtype, payload_len) = self
-            .do_send_recv_retries(size, timeout, attempts)
-            .map_err(|_| {
-                idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-            })?;
-        if msgtype == rsp {
-            let buf = payload_buf(Some(payload_len), &self.rx_buf[..]);
-            let (rsp, _) = hubpack::deserialize::<UpdateRspHeader>(buf)
-                .map_err(|_| {
-                    idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-                })?;
+    ) -> Result<Option<u32>, SprotError> {
+        let txmsg = self.tx_buf.from_existing(req, payload_len)?;
+        ringbuf_entry!(Trace::TxSize(txmsg.0));
+        let rxmsg @ VerifiedRxMsg(header) =
+            self.do_send_recv_retries(txmsg, timeout, attempts)?;
+
+        if header.msgtype == rsp {
+            let rsp = self
+                .rx_buf
+                .deserialize_hubpack_payload::<UpdateRspHeader>(&rxmsg)?;
             ringbuf_entry!(Trace::UpdResponse(rsp));
-            match rsp.kind {
-                UpdateRspKind::Ok => Ok(None),
-                UpdateRspKind::Error => {
-                    let u_err = if let Ok(u_err) =
-                        drv_update_api::UpdateError::try_from(rsp.value as u8)
-                    {
-                        u_err
-                    } else {
-                        drv_update_api::UpdateError::Unknown
-                    };
-                    Err(RequestError::Runtime(u_err))
-                }
-                UpdateRspKind::Value => Ok(Some(rsp.value)),
-                _ => Err(RequestError::Runtime(UpdateError::SpRotError)),
-            }
+            rsp.map_err(|e: u32| {
+                UpdateError::try_from(e)
+                    .unwrap_or(UpdateError::Unknown)
+                    .into()
+            })
         } else {
-            match msgtype {
-                MsgType::ErrorRsp if (payload_len > 0) => {
-                    ringbuf_entry!(Trace::Error(MsgError::from(
-                        payload_buf(None, &self.rx_buf[..])[0]
-                    )));
-                    Err(idol_runtime::RequestError::Runtime(
-                        UpdateError::SpRotError,
-                    ))
-                }
-                MsgType::ErrorRsp => Err(idol_runtime::RequestError::Runtime(
-                    UpdateError::SpRotError,
-                )),
-                _ => {
-                    ringbuf_entry!(Trace::WrongMsgType(msgtype));
-                    Err(idol_runtime::RequestError::Runtime(
-                        UpdateError::SpRotError,
-                    ))
-                }
-            }
+            expect_msg!(MsgType::ErrorRsp, header.msgtype)?;
+            let payload = self.rx_buf.payload(&rxmsg);
+            let err = SprotError::from(payload[0]);
+            ringbuf_entry!(Trace::Error(err));
+            Err(err)
         }
     }
 }
@@ -587,7 +524,7 @@ impl idl::InOrderSpRotImpl for ServerImpl {
         msgtype: drv_sprot_api::MsgType,
         source: Leased<R, [u8]>,
         sink: Leased<W, [u8]>,
-    ) -> Result<Received, RequestError<MsgError>> {
+    ) -> Result<Received, RequestError<SprotError>> {
         self.send_recv_retries(recv_msg, msgtype, 1, source, sink)
     }
 
@@ -599,47 +536,22 @@ impl idl::InOrderSpRotImpl for ServerImpl {
         attempts: u16,
         source: Leased<R, [u8]>,
         sink: Leased<W, [u8]>,
-    ) -> Result<Received, RequestError<MsgError>> {
-        // get available payload buffer
-        if let Some(buf) =
-            payload_buf_mut(None, &mut self.tx_buf[..]).get_mut(..source.len())
-        {
-            // self.tx.init(msgtype);
-            // Read the message into our local buffer offset by the header size
-            match source.read_range(0..source.len(), buf) {
-                Ok(()) => {}
-                Err(()) => {
-                    return Err(idol_runtime::RequestError::Fail(
-                        ClientError::WentAway,
-                    ));
-                }
-            }
-        } else {
-            return Err(idol_runtime::RequestError::Runtime(
-                MsgError::Oversize,
-            ));
-        }
-        let size = match compose(msgtype, source.len(), &mut self.tx_buf[..]) {
-            Ok(size) => size,
-            Err(_err) => {
-                return Err(idol_runtime::RequestError::Runtime(
-                    MsgError::Serialization,
-                ));
-            }
-        };
+    ) -> Result<Received, RequestError<SprotError>> {
+        let txmsg = self.tx_buf.from_lease(msgtype, source)?;
+
         // Send message, then receive response using the same local buffer.
-        match self.do_send_recv_retries(size, TIMEOUT_MAX, attempts) {
-            Ok((msgtype, payload_size)) => {
-                let payload = payload_buf(Some(payload_size), &self.rx_buf[..]);
+        match self.do_send_recv_retries(txmsg, TIMEOUT_MAX, attempts) {
+            Ok(rxmsg) => {
+                let payload = self.rx_buf.payload(&rxmsg);
                 if !payload.is_empty() {
-                    sink.write_range(0..payload_size, payload).map_err(
+                    sink.write_range(0..payload.len(), payload).map_err(
                         |_| RequestError::Fail(ClientError::WentAway),
                     )?;
                 }
                 Ok(Received {
-                    length: payload_size as u16,
+                    length: u16::try_from(payload.len()).unwrap_lite(),
                     msgtype: msgtype as u8,
-                }) // XXX 'as' truncates
+                })
             }
             Err(err) => Err(idol_runtime::RequestError::Runtime(err)),
         }
@@ -651,7 +563,7 @@ impl idl::InOrderSpRotImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
         delay: u16,
-    ) -> Result<PulseStatus, RequestError<MsgError>> {
+    ) -> Result<PulseStatus, RequestError<SprotError>> {
         // If ROT_IRQ is asserted (a response is pending)
         // ROT_IRQ should be deasserted in response to CSn pulse.
         self.do_pulse_cs(delay.into(), delay.into())
@@ -666,7 +578,7 @@ impl idl::InOrderSpRotImpl for ServerImpl {
             // The RoT will read all of the bytes of a MsgType::SinkReq and
             // include the received sequence number in its SinkRsp message.
             //
-            // The RoT reports a errors in an ErrorRsp message.
+            // The RoT reports errors in an ErrorRsp message.
             //
             // For the sake of working with a logic analyzer,
             // a known pattern is put into the SinkReq messages so that
@@ -678,7 +590,7 @@ impl idl::InOrderSpRotImpl for ServerImpl {
                 _: &RecvMessage,
                 count: u16,
                 size: u16,
-            ) -> Result<SinkStatus, RequestError<MsgError>> {
+            ) -> Result<SinkStatus, RequestError<SprotError>> {
                 let size = size as usize;
                 debug_set(&self.sys, false);
 
@@ -686,7 +598,7 @@ impl idl::InOrderSpRotImpl for ServerImpl {
                     // The payload is big enough to contain the sequence number
                     // and additional bytes.
                     let mut n: u8 = HEADER_SIZE as u8;
-                    let buf = payload_buf_mut(Some(size), &mut self.tx_buf[..]);
+                    let buf = &mut self.tx_buf.payload_mut()[..size];
                     buf.fill_with(|| {
                         let seq = n;
                         n = n.wrapping_add(1);
@@ -704,44 +616,38 @@ impl idl::InOrderSpRotImpl for ServerImpl {
                     // The first two payload bytes are a message
                     // sequence number if there is space for it.
                     if core::mem::size_of::<u16>() <= size {
-                        let seq_buf = payload_buf_mut(Some(core::mem::size_of::<u16>()), &mut self.tx_buf[..]);
+                        let seq_buf = &mut self.tx_buf.payload_mut()[..core::mem::size_of::<u16>()];
                         LittleEndian::write_u16(seq_buf, sent);
                     }
-                    match compose(MsgType::SinkReq, size, &mut self.tx_buf[..]) {
-                        Err(_err) => break Err(MsgError::Serialization),
-                        Ok(size) => {
-                            match self.do_send_recv_retries(size, TIMEOUT_QUICK, MAX_SINKREQ_ATTEMPTS) {
+
+                    match self.tx_buf.from_existing(MsgType::SinkReq, size) {
+                        Err(_err) => break Err(SprotError::Serialization),
+                        Ok(txmsg) => {
+                            match self.do_send_recv_retries(txmsg, TIMEOUT_QUICK, MAX_SINKREQ_ATTEMPTS) {
                                 Err(err) => {
                                     ringbuf_entry!(Trace::SinkFail(err, sent));
                                     break Err(err)
                                 },
-                                Ok((msgtype, payload_len)) => {
-                                    match msgtype {
+                                Ok(rxmsg @ VerifiedRxMsg(header)) => {
+                                    match header.msgtype {
                                         MsgType::SinkRsp => {
                                             // TODO: Check sequence number in response.
-                                            if payload_len >= core::mem::size_of::<u16>() {
-                                                let seq_buf = payload_buf(Some(core::mem::size_of::<u16>()), &self.rx_buf[..]);
+                                            if header.payload_len as usize >= core::mem::size_of::<u16>() {
+                                                let seq_buf = &self.rx_buf.payload(&rxmsg)[..core::mem::size_of::<u16>()];
                                                 let r_seqno = LittleEndian::read_u16(seq_buf);
                                                 if sent != r_seqno {
-                                                    break Err(MsgError::Sequence);
+                                                    break Err(SprotError::Sequence);
                                                 }
                                             }
                                         },
-                                        MsgType::ErrorRsp if (payload_len > 0) => {
-                                            let bytes = payload_buf(Some(payload_len), &self.rx_buf[..]);
-                                            if let Some(code) = MsgError::from_u8(bytes[0]) {
-                                                break Err(code);
-                                            } else {
-                                                break Err(MsgError::Unknown);
-                                            }
-                                        },
                                         MsgType::ErrorRsp => {
-                                            break Err(MsgError::Unknown);
+                                            let payload = self.rx_buf.payload(&rxmsg);
+                                            break Err(SprotError::from(payload[0]));
                                         },
                                         _ => {
                                             // Other non-SinkRsp messages from the RoT
                                             // are not recoverable with a retry.
-                                            break Err(MsgError::BadMessageType);
+                                            break Err(SprotError::BadMessageType);
                                         },
                                     }
                                 },
@@ -766,8 +672,8 @@ impl idl::InOrderSpRotImpl for ServerImpl {
                 _: &RecvMessage,
                 _count: u16,
                 _size: u16,
-            ) -> Result<SinkStatus, RequestError<MsgError>> {
-                Err(RequestError::Runtime(MsgError::NotImplemented))
+            ) -> Result<SinkStatus, RequestError<SprotError>> {
+                Err(RequestError::Runtime(SprotError::NotImplemented))
             }
         }
     }
@@ -781,31 +687,29 @@ impl idl::InOrderSpRotImpl for ServerImpl {
     fn status(
         &mut self,
         _: &RecvMessage,
-    ) -> Result<Status, RequestError<MsgError>> {
+    ) -> Result<Status, RequestError<SprotError>> {
         self.do_status().map_err(|e| e.into())
     }
 
     fn block_size(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<usize, RequestError<UpdateError>> {
+    ) -> Result<usize, RequestError<SprotError>> {
         match self.upd(
             MsgType::UpdBlockSizeReq,
             0,
             MsgType::UpdBlockSizeRsp,
             TIMEOUT_QUICK,
             1,
-        ) {
-            Ok(Some(block_size)) => {
+        )? {
+            Some(block_size) => {
                 let bs = block_size as usize;
                 ringbuf_entry!(Trace::BlockSize(bs));
-                // Ok(block_size as usize)
                 Ok(bs)
             }
-            Ok(None) => Err(idol_runtime::RequestError::Runtime(
-                UpdateError::SpRotError,
+            None => Err(idol_runtime::RequestError::Runtime(
+                SprotError::UpdateSpRotError,
             )),
-            Err(e) => Err(e),
         }
     }
 
@@ -813,22 +717,19 @@ impl idl::InOrderSpRotImpl for ServerImpl {
         &mut self,
         _msg: &userlib::RecvMessage,
         image_type: UpdateTarget,
-    ) -> Result<(), idol_runtime::RequestError<UpdateError>> {
-        let payload = payload_buf_mut(None, &mut self.tx_buf[..]);
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        ringbuf_entry!(Trace::UpdatePrep);
+        let payload = self.tx_buf.payload_mut();
         let payload_len = hubpack::serialize(&mut payload[0..], &image_type)
-            .map_err(|_| {
-                idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-            })?;
-        match self.upd(
+            .map_err(|e| Into::<SprotError>::into(e))?;
+        let _ = self.upd(
             MsgType::UpdPrepImageUpdateReq,
             payload_len,
             MsgType::UpdPrepImageUpdateRsp,
             TIMEOUT_QUICK,
             1,
-        ) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(())
     }
 
     fn write_one_block(
@@ -841,92 +742,79 @@ impl idl::InOrderSpRotImpl for ServerImpl {
             idol_runtime::Leased<idol_runtime::R, [u8]>,
             1024,
         >,
-    ) -> Result<(), idol_runtime::RequestError<UpdateError>> {
-        let payload = payload_buf_mut(None, &mut self.tx_buf[..]);
-        let n = hubpack::serialize(&mut payload[0..], &block_num).map_err(
-            |_| idol_runtime::RequestError::Runtime(UpdateError::SpRotError),
-        )?;
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        ringbuf_entry!(Trace::UpdateWriteOneBlock);
+
+        let payload = self.tx_buf.payload_mut();
+        let n = hubpack::serialize(payload, &block_num)
+            .map_err(|e| idol_runtime::RequestError::Runtime(e.into()))?;
         block
             .read_range(0..block.len(), &mut payload[n..n + block.len()])
             .map_err(|_| {
-                idol_runtime::RequestError::Runtime(UpdateError::BadLength)
+                idol_runtime::RequestError::Runtime(
+                    SprotError::BadMessageLength,
+                )
             })?;
         let payload_len = n + block.len();
-        match self.upd(
+        let _ = self.upd(
             MsgType::UpdWriteOneBlockReq,
             payload_len,
             MsgType::UpdWriteOneBlockRsp,
             TIMEOUT_WRITE_ONE_BLOCK,
-            MAX_UPD_ATTEMPTS,
-        ) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+            MAX_UPDATE_ATTEMPTS,
+        )?;
+        Ok(())
     }
 
     fn finish_image_update(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<(), idol_runtime::RequestError<UpdateError>> {
-        match self.upd(
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        let _ = self.upd(
             MsgType::UpdFinishImageUpdateReq,
             0,
             MsgType::UpdFinishImageUpdateRsp,
             TIMEOUT_QUICK,
             1,
-        ) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(())
     }
 
     fn current_version(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<ImageVersion, idol_runtime::RequestError<UpdateError>> {
-        let size =
-            compose(MsgType::UpdCurrentVersionReq, 0, &mut self.tx_buf[..])
-                .map_err(|_| {
-                    idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-                })?;
-        let (msgtype, payload_len) = self
-            .do_send_recv_retries(size, TIMEOUT_QUICK, 2)
-            .map_err(|_| {
-                idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-            })?;
-        if msgtype == MsgType::UpdCurrentVersionRsp {
-            let buf = payload_buf(Some(payload_len), &self.rx_buf[..]);
-            let (rsp, _) =
-                hubpack::deserialize::<ImageVersion>(buf).map_err(|_| {
-                    idol_runtime::RequestError::Runtime(UpdateError::SpRotError)
-                })?;
-            Ok(rsp)
-        } else {
-            Err(idol_runtime::RequestError::Runtime(UpdateError::SpRotError))
-        }
+    ) -> Result<ImageVersion, idol_runtime::RequestError<SprotError>> {
+        let txmsg = self.tx_buf.no_payload(MsgType::UpdCurrentVersionReq);
+        let rxmsg @ VerifiedRxMsg(header) = self
+            .do_send_recv_retries(txmsg, TIMEOUT_QUICK, 2)
+            .map_err(|e| idol_runtime::RequestError::Runtime(e))?;
+
+        expect_msg!(MsgType::UpdCurrentVersionRsp, header.msgtype)?;
+        let rsp = self
+            .rx_buf
+            .deserialize_hubpack_payload::<ImageVersion>(&rxmsg)?;
+        Ok(rsp)
     }
 
     fn abort_update(
         &mut self,
         _msg: &userlib::RecvMessage,
-    ) -> Result<(), idol_runtime::RequestError<UpdateError>> {
-        match self.upd(
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        let _ = self.upd(
             MsgType::UpdAbortUpdateReq,
             0,
             MsgType::UpdAbortUpdateRsp,
             TIMEOUT_QUICK,
             1,
-        ) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(())
     }
 }
 
 mod idl {
     use super::{
-        ImageVersion, MsgError, MsgType, PulseStatus, Received, SinkStatus,
-        Status, UpdateError, UpdateTarget,
+        ImageVersion, MsgType, PulseStatus, Received, SinkStatus, SprotError,
+        Status, UpdateTarget,
     };
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -302,7 +302,7 @@ impl ServerImpl {
         }
 
         // Fill in rx_buf with a complete message and validate its crc
-        let res = self.do_spi_read();
+        let res = self.do_read_response();
 
         // We must release the SPI bus before we return
         ringbuf_entry!(Trace::CSnDeassert);
@@ -327,7 +327,7 @@ impl ServerImpl {
     //
     // We know statically that self.rx_buf is large enough to hold
     // part1_len bytes.
-    fn do_spi_read(&mut self) -> Result<VerifiedRxMsg, SprotError> {
+    fn do_read_response(&mut self) -> Result<VerifiedRxMsg, SprotError> {
         let part1_len = MIN_MSG_SIZE.min(ROT_FIFO_SIZE);
         ringbuf_entry!(Trace::RxPart1(part1_len));
 

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -420,7 +420,7 @@ impl ServerImpl {
                                 // TODO: There are rare cases where
                                 // the RoT dose not receive
                                 // a 0x01 as the first byte in a message.
-                                // See issue XXX.
+                                // See issue #929.
                                 continue;
                             }
                             // Other errors from RoT are not recoverable with

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -74,7 +74,7 @@ const PART2_DELAY: u64 = 2; // Observed to be at least 2ms on gimletlet
 const MAX_UPDATE_ATTEMPTS: u16 = 3;
 cfg_if::cfg_if! {
     if #[cfg(feature = "sink_test")] {
-        const MAX_SINKREQ_ATTEMPTS: u16 = 2; // TODO parameterize
+        const MAX_SINKREQ_ATTEMPTS: u16 = 3; // TODO parameterize
     }
 }
 

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 
-use core::convert::TryFrom;
 use derive_idol_err::IdolError;
 use hubpack::SerializedSize;
 use serde::{/*de::DeserializeOwned,*/ Deserialize, Serialize};
@@ -79,35 +78,6 @@ pub enum UpdateError {
     // Specific to RoT (LPC55)
     SpRotError = 19,
     Unknown = 0xff,
-}
-
-impl TryFrom<u8> for UpdateError {
-    type Error = ();
-
-    fn try_from(byte: u8) -> Result<Self, Self::Error> {
-        match byte {
-            1 => Ok(UpdateError::BadLength),
-            2 => Ok(UpdateError::UpdateInProgress),
-            3 => Ok(UpdateError::OutOfBounds),
-            4 => Ok(UpdateError::Timeout),
-            5 => Ok(UpdateError::EccDoubleErr),
-            6 => Ok(UpdateError::EccSingleErr),
-            7 => Ok(UpdateError::SecureErr),
-            8 => Ok(UpdateError::ReadProtErr),
-            9 => Ok(UpdateError::WriteEraseErr),
-            10 => Ok(UpdateError::InconsistencyErr),
-            11 => Ok(UpdateError::StrobeErr),
-            12 => Ok(UpdateError::ProgSeqErr),
-            13 => Ok(UpdateError::WriteProtErr),
-            14 => Ok(UpdateError::BadImageType),
-            15 => Ok(UpdateError::UpdateAlreadyFinished),
-            16 => Ok(UpdateError::UpdateNotStarted),
-            17 => Ok(UpdateError::RunningImage),
-            18 => Ok(UpdateError::FlashError),
-            19 => Ok(UpdateError::SpRotError),
-            _ => Err(()),
-        }
-    }
 }
 
 impl hubpack::SerializedSize for UpdateError {

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -17,7 +17,7 @@ Interface(
             },
             reply: Result(
                 ok: "Received",
-                err: CLike("MsgError"),
+                err: CLike("SprotError"),
             ),
         ),
         "send_recv_retries": (
@@ -37,14 +37,14 @@ Interface(
             },
             reply: Result(
                 ok: "Received",
-                err: CLike("MsgError"),
+                err: CLike("SprotError"),
             ),
         ),
     "status": (
         doc: "Return untrusted status from RoT",
         reply: Result(
             ok: "Status",
-            err: CLike("MsgError"),
+            err: CLike("SprotError"),
         ),
         encoding: Ssmarshal,
     ),
@@ -55,7 +55,7 @@ Interface(
             },
             reply: Result(
                 ok: "PulseStatus",
-                err: CLike("MsgError"),
+                err: CLike("SprotError"),
             ),
         ),
         "rot_sink": (
@@ -66,7 +66,7 @@ Interface(
             },
             reply: Result(
                 ok: "SinkStatus",
-                err: CLike("MsgError"),
+                err: CLike("SprotError"),
             ),
         ),
 
@@ -76,7 +76,7 @@ Interface(
             args: { },
             reply: Result(
                 ok: "usize",
-                err: CLike("UpdateError"),
+                err: CLike("SprotError"),
             ),
         ),
         "prep_image_update": (
@@ -89,7 +89,7 @@ Interface(
             },
             reply : Result(
                 ok: "()",
-                err: CLike("UpdateError"),    // MsgError and UpdateError
+                err: CLike("SprotError"),    // SprotError and SprotError
             ),
         ),
         "write_one_block": (
@@ -102,7 +102,7 @@ Interface(
             },
             reply: Result (
                 ok: "()",
-                err: CLike("UpdateError"),    // MsgError and UpdateError
+                err: CLike("SprotError"),    // SprotError and SprotError
             ),
         ),
         "abort_update": (
@@ -110,7 +110,7 @@ Interface(
             args : { },
             reply : Result(
                 ok: "()",
-                err: CLike("UpdateError"),    // MsgError and UpdateError
+                err: CLike("SprotError"),    // SprotError and SprotError
             ),
         ),
         "finish_image_update": (
@@ -118,7 +118,7 @@ Interface(
             args : { },
             reply : Result(
                 ok: "()",
-                err: CLike("UpdateError"),    // MsgError and UpdateError
+                err: CLike("SprotError"),    // SprotError and SprotError
             ),
         ),
         "current_version": (
@@ -126,7 +126,7 @@ Interface(
           args : { },
           reply : Result(
             ok: "ImageVersion",
-            err: CLike("UpdateError"),
+            err: CLike("SprotError"),
           ),
         ),
     }

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -89,7 +89,7 @@ Interface(
             },
             reply : Result(
                 ok: "()",
-                err: CLike("SprotError"),    // SprotError and SprotError
+                err: CLike("SprotError"),
             ),
         ),
         "write_one_block": (
@@ -102,7 +102,7 @@ Interface(
             },
             reply: Result (
                 ok: "()",
-                err: CLike("SprotError"),    // SprotError and SprotError
+                err: CLike("SprotError"),
             ),
         ),
         "abort_update": (
@@ -110,7 +110,7 @@ Interface(
             args : { },
             reply : Result(
                 ok: "()",
-                err: CLike("SprotError"),    // SprotError and SprotError
+                err: CLike("SprotError"),
             ),
         ),
         "finish_image_update": (
@@ -118,7 +118,7 @@ Interface(
             args : { },
             reply : Result(
                 ok: "()",
-                err: CLike("SprotError"),    // SprotError and SprotError
+                err: CLike("SprotError"),
             ),
         ),
         "current_version": (

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -88,7 +88,7 @@ impl MgsCommon {
 }
 
 fn rot_state(sprot: &SpRot) -> Result<RotState, RotError> {
-    let status = sprot.status().map_err(MsgErrorConvert)?;
+    let status = sprot.status().map_err(SprotErrorConvert)?;
     Ok(RotState {
         version: ImageVersion {
             version: status.version,
@@ -102,10 +102,10 @@ fn rot_state(sprot: &SpRot) -> Result<RotState, RotError> {
     })
 }
 
-pub(crate) struct MsgErrorConvert(pub drv_sprot_api::MsgError);
+pub(crate) struct SprotErrorConvert(pub drv_sprot_api::SprotError);
 
-impl From<MsgErrorConvert> for RotError {
-    fn from(err: MsgErrorConvert) -> Self {
+impl From<SprotErrorConvert> for RotError {
+    fn from(err: SprotErrorConvert) -> Self {
         RotError::MessageError { code: err.0 as u32 }
     }
 }


### PR DESCRIPTION
Overall, the behavior of the protocol should not have changed!

The overriding goal of this commit is to simplify error handling while
making it more idiomatic. The primary methodology used was "parse, don't
validate", meaning encoding knowledge about what was already discovered
in the type system, so that we don't have to redo checks about length,
or reparse the `MsgHeader`. The mechanisms to implement this methodology
are the two types: `RxMsg` and `TxMsg`, and the corresponding types
`VerifiedRxMsg` and `VerifiedTxMsg`, which ensure that a complete
message with a valid `MsgHeader` has been read into `rx_buf` or a valid
message  has been serialized into `tx_buf`, respectively.

The above changes rippled through the rest of the code, and allowed
removing some extra checks around message/buffer sizes. There were a
handful of other changes including:

 * Some function signatures changed to use the new types
 * `MsgError` was renamed to `SprotError`
 * `UpdateError` variants are now mapped 1:1 into `SprotError` variants.
While this adds a bunch of extra variants, it gives us more information
about what went wrong for debugging, and also allows us to expose a
single error type from Sprot.
 * Some extra ringbuf trace messages for debugging were added.
 * Some standalone functions related to buffer access were superceded
   by their `TxMsg`/`RxMsg` methods.
 * `ErrorRsp` messages now always include an underlying 1-byte code