### PR TITLE
add Gimlet rev B/C lab images, and donglet images, to CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-c, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-c, gimlet-rot-c-stage0]
+        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-c, gimlet-rot-c-stage0]
         include:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
@@ -78,9 +78,19 @@ jobs:
             app_toml: app/gimlet/rev-b.toml
             target: thumbv7em-none-eabihf
             image: default
+          - build: gimlet-b-lab
+            app_name: gimlet-b-lab
+            app_toml: app/gimlet/rev-b-lab.toml
+            target: thumbv7em-none-eabihf
+            image: default
           - build: gimlet-c
             app_name: gimlet-c
             app_toml: app/gimlet/rev-c.toml
+            target: thumbv7em-none-eabihf
+            image: default
+          - build: gimlet-c-lab
+            app_name: gimlet-c-lab
+            app_toml: app/gimlet/rev-c-lab.toml
             target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-a

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-c, gimlet-rot-c-stage0]
+        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-c, gimlet-rot-c-stage0, donglet-g031]
         include:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
@@ -133,6 +133,11 @@ jobs:
             app_toml: app/gimlet-rot/stage0-c.toml
             target: thumbv8m.main-none-eabihf
             image: stage0
+          - build: donglet-g031
+            app_name: donglet-g031
+            app_toml: app/donglet/app-g031.toml
+            target: thumbv6m-none-eabi
+            image: default
           - os: ubuntu-latest
             deps: sudo apt-get update && sudo apt-get install binutils-arm-none-eabi libudev-dev
           - os: windows-latest


### PR DESCRIPTION
I would like to be able to pull these images directly from CI jobs for the manufacturing stuff, so I have whacked them into the workflow file.  Hopefully correctly!