### PR TITLE
fix transceiver udp write size comparison

### DIFF
--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -262,8 +262,7 @@ impl ServerImpl {
             }
             HostRequest::Write(mem) => {
                 ringbuf_entry!(Trace::Write(modules, mem));
-                let data_size = mem.len() as u32 * modules.ports.0.count_ones();
-                if data_size as usize != data.len() {
+                if mem.len() as usize != data.len() {
                     return Err(Error::WrongDataSize);
                 }
                 self.write(mem, modules, data)?;


### PR DESCRIPTION
So I found this while investigating https://github.com/oxidecomputer/transceiver-control/pull/26 . There is no need to multiple this size by the number of ports here since write data gets broadcast into each port by the FPGA, not over SPI. This is unlike reads, which will return the read size **per port**.