### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,26 +2408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lpc55-reset-reason"
-version = "0.1.0"
-dependencies = [
- "lpc55-pac",
- "num-derive",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "lpc55-rtc-counters"
-version = "0.1.0"
-dependencies = [
- "lpc55-pac",
- "num-derive",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
 name = "lpc55-update-server"
 version = "0.1.0"
 dependencies = [


### PR DESCRIPTION
`master` picked up some crates that aren't part of the repo (yet?); this peels them back out of Cargo.lock.