### PR TITLE
Add separate monitoring for PHY link flapping

### DIFF
--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -18,6 +18,9 @@ pub use vsc7448::{
     VscError,
 };
 
+/// Maximum number of ports
+pub const PORT_COUNT: usize = vsc7448::PORT_COUNT;
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct PortStatus {

--- a/drv/monorail-api/src/lib.rs
+++ b/drv/monorail-api/src/lib.rs
@@ -48,6 +48,13 @@ pub struct PortCounters {
     /// - For the 10G port, this is `LOCK_CHANGED_STICKY`, i.e. it will _also_
     ///   be true if the link went from down -> up
     pub link_down_sticky: bool,
+
+    /// `true` if this port has a PHY attached and the PHY's link down bit is
+    /// set.  This is typically bit 13 in the interrupt status (0x1A) register.
+    ///
+    /// Note that the link down bit must be enabled in the interrupt mask
+    /// register!
+    pub phy_link_down_sticky: bool,
 }
 
 /// Error-code-only version of [VscError], for use in RPC calls

--- a/drv/vsc7448/src/config.rs
+++ b/drv/vsc7448/src/config.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! High-level configuration abstraction for the VSC7448
+use crate::PORT_COUNT;
 use serde::{Deserialize, Serialize};
 
 /// Port speed
@@ -54,10 +55,10 @@ pub struct PortConfig {
 /// The VSC7448 has 52 physical ports.  The port mode uniquely determines the
 /// port device type (1G, 2G5, etc) and device number.
 #[derive(Copy, Clone, Debug)]
-pub struct PortMap([Option<PortMode>; 53]);
+pub struct PortMap([Option<PortMode>; PORT_COUNT]);
 
 impl PortMap {
-    pub const fn new(p: [Option<PortMode>; 53]) -> Self {
+    pub const fn new(p: [Option<PortMode>; PORT_COUNT]) -> Self {
         Self(p)
     }
 

--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -25,6 +25,9 @@ pub use vsc_err::VscError;
 
 use crate::dev::Dev10g;
 
+/// Maximum port count
+pub const PORT_COUNT: usize = 53;
+
 /// This trait abstracts over various ways of talking to a VSC7448.
 pub trait Vsc7448Rw {
     /// Writes to a VSC7448 register.  Depending on the underlying transit

--- a/drv/vsc85xx/src/vsc8504.rs
+++ b/drv/vsc85xx/src/vsc8504.rs
@@ -238,6 +238,12 @@ impl<'a, P: PhyRw> Vsc8504Phy<'a, P> {
         // There are no significant startup scripts for TESLA
         // (vtss_phy_100BaseT_long_linkup_workaround doesn't seem relevant,
         // called at line 8499)
+
+        // We're now done with configuration from the SDK!
+
+        // Enable the link state change mask, to detect PHY link flapping
+        self.phy
+            .modify(phy::STANDARD::INTERRUPT_MASK(), |r| r.set_link_mask(1))?;
         Ok(())
     }
 }

--- a/drv/vsc85xx/src/vsc8522.rs
+++ b/drv/vsc85xx/src/vsc8522.rs
@@ -69,6 +69,10 @@ impl<'a, P: PhyRw> Vsc8522Phy<'a, P> {
         // Configure the PHY in QSGMII + 12 port mode
         self.phy.cmd(0x80A0)?;
 
+        // Enable the link state change mask, to detect PHY link flapping
+        self.phy
+            .modify(phy::STANDARD::INTERRUPT_MASK(), |r| r.set_link_mask(1))?;
+
         Ok(())
     }
 }

--- a/drv/vsc85xx/src/vsc8552.rs
+++ b/drv/vsc85xx/src/vsc8552.rs
@@ -63,7 +63,12 @@ impl<'a, 'b, P: PhyRw> Vsc8552Phy<'a, 'b, P> {
                 *r = phy::standard::LED_BEHAVIOR::from(
                     x | disable_led1_combine | split_rx_tx_activity,
                 );
-            })
+            })?;
+
+            // Enable the link state change mask, to detect PHY link flapping
+            v.modify(phy::STANDARD::INTERRUPT_MASK(), |r| r.set_link_mask(1))?;
+
+            Ok(())
         })?;
 
         // Now, we reset the PHY to put those settings into effect.  For some

--- a/drv/vsc85xx/src/vsc8562.rs
+++ b/drv/vsc85xx/src/vsc8562.rs
@@ -71,6 +71,11 @@ impl<'a, 'b, P: PhyRw> Vsc8562Phy<'a, 'b, P> {
         self.fix_bz21484()?;
 
         // In the SDK, there's more configuration for 100BT, which we don't use
+        // We're now done with the SDK stuff!
+
+        // Enable the link state change mask, to detect PHY link flapping
+        self.phy
+            .modify(phy::STANDARD::INTERRUPT_MASK(), |r| r.set_link_mask(1))?;
 
         Ok(())
     }
@@ -206,8 +211,13 @@ impl<'a, 'b, P: PhyRw> Vsc8562Phy<'a, 'b, P> {
 
         // ...and we're done with phy_reset_private!
 
+        // Enable the link state change mask, to detect PHY link flapping
+        self.phy
+            .modify(phy::STANDARD::INTERRUPT_MASK(), |r| r.set_link_mask(1))?;
+
         // Note that the Sidecar BSP performs additional SERDES tuning
         // in `vsc7448_postconfig`, based on empirical testing.
+
         Ok(())
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -30,9 +30,6 @@ mod monorail_port_status;
 userlib::task_slot!(SIDECAR_SEQ, sequencer);
 userlib::task_slot!(MONORAIL, monorail);
 
-// TODO Should this live in monorail-api instead?
-const NUM_VSC7448_PORTS: u32 = 53;
-
 // How big does our shared update buffer need to be? Has to be able to handle SP
 // update blocks for now, no other updateable components.
 const UPDATE_BUFFER_SIZE: usize = SpUpdate::BLOCK_SIZE;
@@ -390,7 +387,7 @@ impl SpHandler for MgsHandler {
         }));
 
         match component {
-            SpComponent::VSC7448 => Ok(NUM_VSC7448_PORTS),
+            SpComponent::VSC7448 => Ok(drv_monorail_api::PORT_COUNT as u32),
             _ => self.common.inventory().num_component_details(&component),
         }
     }


### PR DESCRIPTION
In some cases, the VSC7448 link is going to a PHY, so link status is less meaningful.  This is mostly relevant for Sidecar ports 40-43, which use a VSC8504 as a QSGMII → 4x SGMII converter before going off-board; the link between the VSC7448 and VSC8504 should _always be up_, because they're on the same board.

This PR adds a separate `phy_link_down_sticky: bool` to the `struct PortCounters`, which returns the **PHY's** opinion on whether the link has gone done.  We want this to be stateless (i.e. explicitly cleared by `reset_port_counters`), but the PHY registers are self-clearing; to work around this, we add a separate cache in the Monorail `ServerImpl`.

(this cache will be lost if the `monorail` task restarts, but it would reconfigure the PHYs anyways in that case, so that seems fine)