### PR TITLE
Add monorail link flap bools and resetting counters to control-plane-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#9efd6c4e96aea0c0e15c1dd942163d4cf1ae19ba"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=vsc7448-counters-update#7004c7f800146d5670731415469ae4d29aadbea6"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=vsc7448-counters-update#7004c7f800146d5670731415469ae4d29aadbea6"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=vsc7448-counters-update#d299e2f5ac3ee2768cead01b48609856f2fed154"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=vsc7448-counters-update#d299e2f5ac3ee2768cead01b48609856f2fed154"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#ce829adddaff79867ebdd88f3b4550e3658e17f6"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "vsc7448-counters-update" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "vsc7448-counters-update" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -281,11 +281,11 @@ const OUR_DEVICES: &[DeviceDescription<'static>] = &[
         capabilities: DeviceCapabilities::UPDATEABLE,
         presence: DevicePresence::Present, // TODO: ok to assume always present?
     },
-    // If we're building for sidecar, we always claim to have a VSC7448.
+    // If we're building for sidecar, we always claim to have a monorail.
     #[cfg(feature = "sidecar")]
     DeviceDescription {
-        component: SpComponent::VSC7448,
-        device: SpComponent::VSC7448.const_as_str(),
+        component: SpComponent::MONORAIL,
+        device: SpComponent::MONORAIL.const_as_str(),
         description: "Management network switch",
         capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS,
         // Fine to assume this is always present; if it isn't, we can't respond

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -119,6 +119,9 @@ enum MgsMessage {
     ComponentDetails {
         component: SpComponent,
     },
+    ComponentClearStatus {
+        component: SpComponent,
+    },
 }
 
 ringbuf!(Log, 16, Log::Empty);

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -686,6 +686,18 @@ impl SpHandler for MgsHandler {
         self.common.inventory().component_details(&component, index)
     }
 
+    fn component_clear_status(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
+            component
+        }));
+        Err(SpError::RequestUnsupportedForComponent)
+    }
+
     fn mgs_response_error(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -404,6 +404,18 @@ impl SpHandler for MgsHandler {
         self.common.inventory().component_details(&component, index)
     }
 
+    fn component_clear_status(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
+            component
+        }));
+        Err(SpError::RequestUnsupportedForComponent)
+    }
+
     fn get_startup_options(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -453,7 +453,7 @@ impl SpHandler for MgsHandler {
         }));
 
         match component {
-            SpComponent::VSC7448 => Ok(drv_monorail_api::PORT_COUNT as u32),
+            SpComponent::MONORAIL => Ok(drv_monorail_api::PORT_COUNT as u32),
             _ => self.common.inventory().num_component_details(&component),
         }
     }
@@ -467,7 +467,7 @@ impl SpHandler for MgsHandler {
         index: BoundsChecked,
     ) -> ComponentDetails {
         match component {
-            SpComponent::VSC7448 => ComponentDetails::PortStatus(
+            SpComponent::MONORAIL => ComponentDetails::PortStatus(
                 monorail_port_status::port_status(&self.monorail, index),
             ),
             _ => self.common.inventory().component_details(&component, index),
@@ -491,7 +491,7 @@ impl SpHandler for MgsHandler {
         );
 
         match component {
-            SpComponent::VSC7448 => {
+            SpComponent::MONORAIL => {
                 // Reset counters on every port.
                 for port in 0..drv_monorail_api::PORT_COUNT as u8 {
                     match self.monorail.reset_port_counters(port) {

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -5,7 +5,7 @@
 use crate::{mgs_common::MgsCommon, update::sp::SpUpdate, Log, MgsMessage};
 use core::convert::Infallible;
 use drv_ignition_api::IgnitionError;
-use drv_monorail_api::Monorail;
+use drv_monorail_api::{Monorail, MonorailError};
 use drv_sidecar_seq_api::Sequencer;
 use gateway_messages::sp_impl::{
     BoundsChecked, DeviceDescription, SocketAddrV6, SpHandler,
@@ -471,6 +471,43 @@ impl SpHandler for MgsHandler {
                 monorail_port_status::port_status(&self.monorail, index),
             ),
             _ => self.common.inventory().component_details(&component, index),
+        }
+    }
+
+    fn component_clear_status(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
+            component
+        }));
+
+        // Below we assume we can cast the port count to a u8; const assert that
+        // that cast is valid.
+        static_assertions::const_assert!(
+            drv_monorail_api::PORT_COUNT <= u8::MAX as usize
+        );
+
+        match component {
+            SpComponent::VSC7448 => {
+                // Reset counters on every port.
+                for port in 0..drv_monorail_api::PORT_COUNT as u8 {
+                    match self.monorail.reset_port_counters(port) {
+                        // If `port` is unconfigured, it has no counters to
+                        // reset; this isn't a meaningful failure.
+                        Ok(()) | Err(MonorailError::UnconfiguredPort) => (),
+                        Err(other) => {
+                            return Err(SpError::ComponentOperationFailed(
+                                other as u32,
+                            ));
+                        }
+                    }
+                }
+                Ok(())
+            }
+            _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
@@ -4,7 +4,7 @@
 
 use drv_monorail_api::{Monorail, MonorailError};
 use gateway_messages::sp_impl::BoundsChecked;
-use gateway_messages::vsc7448_port_status::{
+use gateway_messages::monorail_port_status::{
     LinkStatus, PacketCount, PhyStatus, PhyType, PortConfig, PortCounters,
     PortDev, PortMode, PortSerdes, PortStatus, PortStatusError,
     PortStatusErrorCode, Speed,

--- a/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
@@ -3,12 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use drv_monorail_api::{Monorail, MonorailError};
-use gateway_messages::sp_impl::BoundsChecked;
 use gateway_messages::monorail_port_status::{
     LinkStatus, PacketCount, PhyStatus, PhyType, PortConfig, PortCounters,
     PortDev, PortMode, PortSerdes, PortStatus, PortStatusError,
     PortStatusErrorCode, Speed,
 };
+use gateway_messages::sp_impl::BoundsChecked;
 
 pub(super) fn port_status(
     monorail: &Monorail,

--- a/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
+++ b/task/control-plane-agent/src/mgs_sidecar/monorail_port_status.rs
@@ -155,6 +155,8 @@ impl From<PortCountersConvert> for PortCounters {
         Self {
             tx: PacketCountConvert(s.tx).into(),
             rx: PacketCountConvert(s.rx).into(),
+            link_down_sticky: s.link_down_sticky,
+            phy_link_down_sticky: s.phy_link_down_sticky,
         }
     }
 }


### PR DESCRIPTION
This tracks updates made in https://github.com/oxidecomputer/management-gateway-service/pull/24:

* Renames `SpComponent::VSC7448` -> `SpComponent::MONORAIL`
* Adds two link flap bools to `PortCounters`
* Adds a "clear component status" MGS message, which for `SpComponent::MONORAIL` resets counters on all ports. No other component is valid for this message (for now).