### PR TITLE
Fix test code, minor efficiency change, minor refactor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ version = "0.1.0"
 dependencies = [
  "crc",
  "derive-idol-err",
+ "drv-spi-api",
  "drv-update-api",
  "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idol",

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -252,8 +252,12 @@ impl Handler {
             MsgType::SinkReq => {
                 // The first two bytes of a SinkReq payload are the U16
                 // mod 2^16 sequence number.
-                tx_payload[0..2].copy_from_slice(&rx_payload[0..2]);
-                2
+                if rx_payload.len() >= core::mem::size_of::<u16>() {
+                    tx_payload[0..2].copy_from_slice(&rx_payload[0..core::mem::size_of::<u16>()]);
+                    core::mem::size_of::<u16>()
+                } else {
+                    0
+                }
             }
             // All of the unexpected messages
             MsgType::Invalid

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -16,6 +16,7 @@ zerocopy = { workspace = true }
 
 derive-idol-err = { path = "../../lib/derive-idol-err" }
 drv-update-api = { path = "../../drv/update-api" }
+drv-spi-api = { path = "../../drv/spi-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
 userlib = { path = "../../sys/userlib" }

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -18,6 +18,7 @@ extern crate memoffset;
 
 use crc::{Crc, CRC_16_XMODEM};
 use derive_idol_err::IdolError;
+use drv_spi_api::SpiError;
 use drv_update_api::{ImageVersion, UpdateError, UpdateTarget};
 use hubpack::SerializedSize;
 use idol_runtime::{Leased, R};
@@ -116,6 +117,12 @@ pub enum SprotError {
 
     /// Unknown Errors are mapped to 0xff
     Unknown = 0xff,
+}
+
+impl From<SpiError> for SprotError {
+    fn from(_value: SpiError) -> Self {
+        SprotError::SpiServerError
+    }
 }
 
 impl From<UpdateError> for SprotError {


### PR DESCRIPTION
RoT: Fix array out of bounds in test code (SpRot.rot_sink).

SP: Follow @ajs's lead and factor out do_send_request() similar to do_read_response() to simplify chip select signal management.

SP: In do_read_response(), always read one full RoT FIFO of data to start which may exceed the minimum message size by 2-bytes but saves a second read for any respose read from the RoT that has only a one or two byte payload.

SP: To support possibly reading extra bytes, make the calculation of the size of the second read more careful.

SP and RoT: Replace multiple `core::mem::size_of::<u16>()` with a local const U16_SIZE.