### PR TITLE
Allowing getting and setting the host boot flash device via control-plane-agent/MGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-mock-gimlet-hf-server"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "drv-gimlet-hf-api",
+ "drv-hash-api",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-mock-gimlet-seq-server"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#ce829adddaff79867ebdd88f3b4550e3658e17f6"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#3e06733ead9547d5ce76b9fa2d794e672f398715"
 dependencies = [
  "bitflags",
  "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -146,7 +146,11 @@ start = true
 task-slots = ["hash_driver", "hf", "i2c_driver", "rng_driver", "sprot", "sys", "update_server", "user_leds"]
 
 [tasks.hf]
+# If you do not have a gimletlet qspi-let adapter but want to test the hf API
+# (e.g., from control-plane-agent / MGS), switch to `drv-mock-gimlet-hf-server`.
 name = "drv-gimlet-hf-server"
+#name = "drv-mock-gimlet-hf-server"
+
 features = ["h753", "hash"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096}

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -149,7 +149,6 @@ task-slots = ["hash_driver", "hf", "i2c_driver", "rng_driver", "sprot", "sys", "
 # If you do not have a gimletlet qspi-let adapter but want to test the hf API
 # (e.g., from control-plane-agent / MGS), switch to `drv-mock-gimlet-hf-server`.
 name = "drv-gimlet-hf-server"
-#name = "drv-mock-gimlet-hf-server"
 
 features = ["h753", "hash"]
 priority = 6

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -149,7 +149,6 @@ task-slots = ["hash_driver", "hf", "i2c_driver", "rng_driver", "sprot", "sys", "
 # If you do not have a gimletlet qspi-let adapter but want to test the hf API
 # (e.g., from control-plane-agent / MGS), switch to `drv-mock-gimlet-hf-server`.
 name = "drv-gimlet-hf-server"
-
 features = ["h753", "hash"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096}

--- a/drv/mock-gimlet-hf-server/Cargo.toml
+++ b/drv/mock-gimlet-hf-server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "drv-mock-gimlet-hf-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
+drv-hash-api = { path = "../hash-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+idol = { workspace = true }
+
+# None of these features do anything in the mock server; they exist only to
+# match the feature list in the real hf server (allowing a quick substitution
+# for real -> mock in app.toml without having to muck with features).
+[features]
+host_access = []
+hash = []
+h743 = []
+h753 = []

--- a/drv/mock-gimlet-hf-server/build.rs
+++ b/drv/mock-gimlet-hf-server/build.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::server::build_server_support(
+        "../../idl/gimlet-hf.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/mock-gimlet-hf-server/src/main.rs
+++ b/drv/mock-gimlet-hf-server/src/main.rs
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Gimlet host flash server.
+//!
+//! This server is responsible for managing access to the host flash; it embeds
+//! the QSPI flash driver.
+
+#![no_std]
+#![no_main]
+
+use drv_gimlet_hf_api::{HfDevSelect, HfError, HfMuxState, PAGE_SIZE_BYTES};
+use drv_hash_api::SHA256_SZ;
+use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R, W};
+use userlib::RecvMessage;
+
+#[export_name = "main"]
+fn main() -> ! {
+    let mut buffer = [0; idl::INCOMING_SIZE];
+    let mut server = ServerImpl {
+        capacity: 16 << 20, // Claim to have 16 MiB
+        mux_state: HfMuxState::SP,
+        dev_state: HfDevSelect::Flash0,
+    };
+
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
+    }
+}
+
+struct ServerImpl {
+    capacity: usize,
+
+    /// Selects between the SP and SP3 talking to the QSPI flash
+    mux_state: HfMuxState,
+
+    /// Selects between QSPI flash chips 1 and 2 (if present)
+    dev_state: HfDevSelect,
+}
+
+impl idl::InOrderHostFlashImpl for ServerImpl {
+    fn read_id(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<[u8; 20], RequestError<HfError>> {
+        Ok(*b"mockmockmockmockmock")
+    }
+
+    fn capacity(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<usize, RequestError<HfError>> {
+        Ok(self.capacity)
+    }
+
+    fn read_status(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u8, RequestError<HfError>> {
+        Ok(0)
+    }
+
+    fn bulk_erase(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<HfError>> {
+        Ok(())
+    }
+
+    fn page_program(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        let zero = [0; PAGE_SIZE_BYTES];
+
+        dest.write_range(0..dest.len(), &zero[..dest.len()])
+            .map_err(|_| RequestError::Fail(ClientError::WentAway))?;
+
+        Ok(())
+    }
+
+    fn sector_erase(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+    ) -> Result<(), RequestError<HfError>> {
+        Ok(())
+    }
+
+    fn get_mux(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<HfMuxState, RequestError<HfError>> {
+        Ok(self.mux_state)
+    }
+
+    fn set_mux(
+        &mut self,
+        _: &RecvMessage,
+        state: HfMuxState,
+    ) -> Result<(), RequestError<HfError>> {
+        self.mux_state = state;
+        Ok(())
+    }
+
+    fn get_dev(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<HfDevSelect, RequestError<HfError>> {
+        Ok(self.dev_state)
+    }
+
+    fn set_dev(
+        &mut self,
+        _: &RecvMessage,
+        state: HfDevSelect,
+    ) -> Result<(), RequestError<HfError>> {
+        self.dev_state = state;
+        Ok(())
+    }
+
+    #[cfg(feature = "hash")]
+    fn hash(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _len: u32,
+    ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
+        Ok(*b"mockmockmockmockmockmockmockmock")
+    }
+
+    #[cfg(not(feature = "hash"))]
+    fn hash(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _len: u32,
+    ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
+        Err(HfError::HashNotConfigured.into())
+    }
+}
+
+mod idl {
+    use super::{HfDevSelect, HfError, HfMuxState};
+
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -125,6 +125,13 @@ enum MgsMessage {
     ComponentClearStatus {
         component: SpComponent,
     },
+    ComponentGetActiveSlot {
+        component: SpComponent,
+    },
+    ComponentSetActiveSlot {
+        component: SpComponent,
+        slot: u16,
+    },
 }
 
 ringbuf!(Log, 16, Log::Empty);

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -686,6 +686,43 @@ impl SpHandler for MgsHandler {
         self.common.inventory().component_details(&component, index)
     }
 
+    fn component_get_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<u16, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
+            component
+        }));
+
+        match component {
+            SpComponent::HOST_CPU_BOOT_FLASH => {
+                self.host_flash_update.active_slot()
+            }
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_set_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: u16,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
+            component,
+            slot,
+        }));
+        match component {
+            SpComponent::HOST_CPU_BOOT_FLASH => {
+                self.host_flash_update.set_active_slot(slot)
+            }
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
     fn component_clear_status(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -404,6 +404,40 @@ impl SpHandler for MgsHandler {
         self.common.inventory().component_details(&component, index)
     }
 
+    fn component_get_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<u16, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
+            component
+        }));
+
+        // For now, we don't have any components with active slots.
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_set_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: u16,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
+            component,
+            slot,
+        }));
+
+        // For now, we don't have any components with active slots.
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
     fn component_clear_status(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -474,6 +474,40 @@ impl SpHandler for MgsHandler {
         }
     }
 
+    fn component_get_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<u16, SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
+            component
+        }));
+
+        // For now, we don't have any components with active slots.
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_set_active_slot(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: u16,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
+            component,
+            slot,
+        }));
+
+        // For now, we don't have any components with active slots.
+        match component {
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
     fn component_clear_status(
         &mut self,
         _sender: SocketAddrV6,


### PR DESCRIPTION
Also adds a mock `gimlet-hf` server for use on gimletlets that don't have a qspi for the real `gimlet-hf` to use.