### PR TITLE
Report real host identity via local VPD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,6 +3715,7 @@ dependencies = [
  "drv-gimlet-hf-api",
  "drv-gimlet-seq-api",
  "drv-ignition-api",
+ "drv-local-vpd",
  "drv-monorail-api",
  "drv-sidecar-seq-api",
  "drv-sprot-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3753,6 +3753,7 @@ dependencies = [
  "num-traits",
  "serde",
  "ssmarshal",
+ "static_assertions",
  "userlib",
  "zerocopy",
 ]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -254,8 +254,16 @@ task-slots = [
     "validate",
     "sensor",
     "sprot",
+    "i2c_driver",
 ]
-features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
+features = [
+    "gimlet",
+    "usart1",
+    "vlan",
+    "baud_rate_3M",
+    "hardware_flow_control",
+    "vpd-identity",
+]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -254,8 +254,16 @@ task-slots = [
     "validate",
     "sensor",
     "sprot",
+    "i2c_driver",
 ]
-features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
+features = [
+    "gimlet",
+    "usart1",
+    "vlan",
+    "baud_rate_3M",
+    "hardware_flow_control",
+    "vpd-identity",
+]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]

--- a/idl/control-plane-agent.idol
+++ b/idl/control-plane-agent.idol
@@ -58,5 +58,10 @@ Interface(
                 err: CLike("ControlPlaneAgentError"),
             ),
         ),
+        "identity": (
+            doc: "Get the identity of the current sled.",
+            reply: Simple("Identity"),
+            idempotent: true,
+        ),
     },
 )

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![cfg_attr(not(test), no_std)]
 
-use core::{mem, str};
 use hubpack::SerializedSize;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_big_array::BigArray;
@@ -131,38 +130,9 @@ pub enum SpToHost {
     Phase2Data,
 }
 
-/// Helper type describing the barcode byte string we expect to be present in
-/// the VPD (which we can parse into an `Identity`).
-///
-/// This struct includes the delimiters (expected to be colons) so it can derive
-/// `AsBytes` and `FromBytes` to be used as a deserialization type by
-/// `local-vpd`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, AsBytes, FromBytes)]
-#[repr(C, packed)]
-pub struct BarcodeVpd {
-    pub version: [u8; 4],
-    pub delim0: u8,
-    pub part_number: [u8; 10],
-    pub delim1: u8,
-    pub revision: [u8; 3],
-    pub delim2: u8,
-    pub serial: [u8; 11],
-}
-const_assert_eq!(mem::size_of::<BarcodeVpd>(), 31);
-
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Deserialize,
-    Serialize,
-    SerializedSize,
-    FromBytes,
-    AsBytes,
+    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
-#[repr(C, packed)]
 pub struct Identity {
     #[serde(with = "BigArray")]
     pub model: [u8; Identity::MODEL_LEN],
@@ -182,45 +152,8 @@ impl Default for Identity {
 }
 
 impl Identity {
-    const MODEL_LEN: usize = 51;
-    const SERIAL_LEN: usize = 51;
-}
-
-impl TryFrom<BarcodeVpd> for Identity {
-    type Error = ();
-
-    fn try_from(vpd: BarcodeVpd) -> Result<Self, Self::Error> {
-        // Check expected values of fields, since `vpd` was presumably created
-        // via zerocopy (i.e., memcopying a byte array).
-        if vpd.delim0 != b':' || vpd.delim1 != b':' || vpd.delim2 != b':' {
-            return Err(());
-        }
-
-        // Allow `0` or `O` for the version
-        if vpd.version != *b"0XV1" && vpd.version != *b"OXV1" {
-            return Err(());
-        }
-
-        let mut identity = Self::default();
-
-        // Parse revision into a u32;
-        identity.revision = str::from_utf8(&vpd.revision)
-            .map_err(|_| ())?
-            .parse()
-            .map_err(|_| ())?;
-
-        // Insert a hyphen 3 characters into the part number (which we know is
-        // longer than 3 characters from the checks above).
-        identity.model[..3].copy_from_slice(&vpd.part_number[..3]);
-        identity.model[3] = b'-';
-        identity.model[4..][..vpd.part_number.len() - 3]
-            .copy_from_slice(&vpd.part_number[3..]);
-
-        // Copy the serial as-is.
-        identity.serial[..vpd.serial.len()].copy_from_slice(&vpd.serial);
-
-        Ok(identity)
-    }
+    pub const MODEL_LEN: usize = 51;
+    pub const SERIAL_LEN: usize = 51;
 }
 
 // See RFD 316 for values.
@@ -678,34 +611,5 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
         assert_eq!(expected_without_cksum, &buf[..n - CHECKSUM_SIZE]);
-    }
-
-    #[test]
-    fn parse_identity_from_vpd() {
-        fn make_id(model: &[u8], revision: u32, serial: &[u8]) -> Identity {
-            let mut id = Identity {
-                model: [0; Identity::MODEL_LEN],
-                revision,
-                serial: [0; Identity::SERIAL_LEN],
-            };
-            id.model[..model.len()].copy_from_slice(model);
-            id.serial[..serial.len()].copy_from_slice(serial);
-            id
-        }
-
-        for (s, expected) in [
-            (
-                b"0XV1:9130000019:006:BRM42220023" as &[u8],
-                make_id(b"913-0000019", 6, b"BRM42220023"),
-            ),
-            (
-                b"OXV1:9130000019:002:OXE99990006",
-                make_id(b"913-0000019", 2, b"OXE99990006"),
-            ),
-        ] {
-            let vpd = BarcodeVpd::read_from(s).unwrap();
-            let identity = Identity::try_from(vpd).unwrap();
-            assert_eq!(identity, expected, "failure parsing vpd {s:?}");
-        }
     }
 }

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -135,8 +135,9 @@ pub enum SpToHost {
 /// the VPD (which we can parse into an `Identity`).
 ///
 /// This struct includes the delimiters (expected to be colons) so it can derive
-/// `FromBytes` and be used as a deserialization type by `local-vpd`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromBytes)]
+/// `AsBytes` and `FromBytes` to be used as a deserialization type by
+/// `local-vpd`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AsBytes, FromBytes)]
 #[repr(C, packed)]
 pub struct BarcodeVpd {
     pub version: [u8; 4],
@@ -150,8 +151,18 @@ pub struct BarcodeVpd {
 const_assert_eq!(mem::size_of::<BarcodeVpd>(), 31);
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    SerializedSize,
+    FromBytes,
+    AsBytes,
 )]
+#[repr(C, packed)]
 pub struct Identity {
     #[serde(with = "BigArray")]
     pub model: [u8; Identity::MODEL_LEN],

--- a/task/control-plane-agent-api/Cargo.toml
+++ b/task/control-plane-agent-api/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-num-traits = { version = "0.2.12", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-ssmarshal = {version = "1", default-features = false}
-zerocopy = "0.6.1"
+num-traits.workspace = true
+serde.workspace = true
+ssmarshal.workspace = true
+static_assertions.workspace = true
+zerocopy.workspace = true
 
 derive-idol-err = {path = "../../lib/derive-idol-err" }
 host-sp-messages = {path = "../../lib/host-sp-messages"}

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -7,13 +7,47 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
-pub use host_sp_messages::{HostStartupOptions, Identity};
+pub use host_sp_messages::HostStartupOptions;
+use static_assertions::const_assert;
 use userlib::*;
+use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ControlPlaneAgentError {
     DataUnavailable = 1,
     InvalidStartupOptions,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, FromBytes, AsBytes)]
+#[repr(C, packed)]
+pub struct Identity {
+    pub part_number: [u8; Self::PART_NUMBER_LEN],
+    pub revision: u32,
+    pub serial: [u8; Self::SERIAL_LEN],
+}
+
+impl Identity {
+    pub const PART_NUMBER_LEN: usize = 11;
+    pub const SERIAL_LEN: usize = 11;
+}
+
+impl From<Identity> for host_sp_messages::Identity {
+    fn from(id: Identity) -> Self {
+        // The Host/SP protocol has larger fields for model/serial than we
+        // use currently; statically assert that we haven't outgrown them.
+        const_assert!(
+            Identity::PART_NUMBER_LEN <= host_sp_messages::Identity::MODEL_LEN
+        );
+        const_assert!(
+            Identity::SERIAL_LEN <= host_sp_messages::Identity::SERIAL_LEN
+        );
+
+        let mut new_id = Self::default();
+        new_id.model[..id.part_number.len()].copy_from_slice(&id.part_number);
+        new_id.revision = id.revision;
+        new_id.serial[..id.serial.len()].copy_from_slice(&id.serial);
+        new_id
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
-pub use host_sp_messages::HostStartupOptions;
+pub use host_sp_messages::{HostStartupOptions, Identity};
 use userlib::*;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -18,6 +18,7 @@ drv-auxflash-api = { path = "../../drv/auxflash-api", optional = true }
 drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
 drv-ignition-api = { path = "../../drv/ignition-api", optional = true }
+drv-local-vpd = { path = "../../drv/local-vpd", optional = true }
 drv-monorail-api = { path = "../../drv/monorail-api", optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-sprot-api = { path = "../../drv/sprot-api" }
@@ -49,3 +50,4 @@ usart1 = []
 baud_rate_3M = []
 hardware_flow_control = []
 auxflash = ["drv-auxflash-api"]
+vpd-identity = ["drv-local-vpd"]

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -5,20 +5,23 @@
 #![no_std]
 #![no_main]
 
+use core::{mem, str};
 use gateway_messages::{
     sp_impl, IgnitionCommand, MgsError, PowerState, SpComponent, SpPort,
     UpdateId,
 };
-use host_sp_messages::{HostStartupOptions, Identity};
+use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, NotificationHandler, RequestError};
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
-use task_control_plane_agent_api::ControlPlaneAgentError;
+use static_assertions::const_assert_eq;
+use task_control_plane_agent_api::{ControlPlaneAgentError, Identity};
 use task_net_api::{
     Address, LargePayloadBehavior, Net, RecvError, SendError, SocketName,
     UdpMetadata,
 };
 use userlib::{sys_set_timer, task_slot};
+use zerocopy::{AsBytes, FromBytes};
 
 mod inventory;
 mod mgs_common;
@@ -168,10 +171,59 @@ impl ServerImpl {
 
     #[cfg(feature = "vpd-identity")]
     fn identity_from_vpd(&self) -> Option<Identity> {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, AsBytes, FromBytes)]
+        #[repr(C, packed)]
+        pub struct BarcodeVpd {
+            pub version: [u8; 4],
+            pub delim0: u8,
+            // VPD omits the hyphen 3 bytes into the part number, which we add
+            // back into `Identity` below, hence the "minus 1".
+            pub part_number: [u8; Identity::PART_NUMBER_LEN - 1],
+            pub delim1: u8,
+            pub revision: [u8; 3],
+            pub delim2: u8,
+            pub serial: [u8; Identity::SERIAL_LEN],
+        }
+        const_assert_eq!(mem::size_of::<BarcodeVpd>(), 31);
+
         let i2c_task = I2C.get_task_id();
-        let barcode: host_sp_messages::BarcodeVpd =
+        let barcode: BarcodeVpd =
             drv_local_vpd::read_config(i2c_task, *b"BARC").ok()?;
-        barcode.try_into().ok()
+
+        // Check expected values of fields, since `barcode` was created
+        // via zerocopy (i.e., memcopying a byte array).
+        if barcode.delim0 != b':'
+            || barcode.delim1 != b':'
+            || barcode.delim2 != b':'
+        {
+            return None;
+        }
+
+        // Allow `0` or `O` for the first byte of the version (which isn't
+        // part of the identity we return, but tells us the format of the
+        // barcode string itself).
+        if barcode.version != *b"0XV1" && barcode.version != *b"OXV1" {
+            return None;
+        }
+
+        let mut identity = Identity::default();
+
+        // Parse revision into a u32
+        identity.revision =
+            str::from_utf8(&barcode.revision).ok()?.parse().ok()?;
+
+        // Insert a hyphen 3 characters into the part number (which we know we
+        // have room for based on the size of the `part_number` fields)
+        identity.part_number[..3].copy_from_slice(&barcode.part_number[..3]);
+        identity.part_number[3] = b'-';
+        identity.part_number[4..][..barcode.part_number.len() - 3]
+            .copy_from_slice(&barcode.part_number[3..]);
+
+        // Copy the serial as-is.
+        identity.serial[..barcode.serial.len()]
+            .copy_from_slice(&barcode.serial);
+
+        Some(identity)
     }
 }
 

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -15,8 +15,8 @@ use drv_usart::Usart;
 use enum_map::Enum;
 use heapless::Vec;
 use host_sp_messages::{
-    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError, SpToHost, Status,
-    MAX_MESSAGE_SIZE,
+    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError, Identity,
+    SpToHost, Status, MAX_MESSAGE_SIZE,
 };
 use idol_runtime::{NotificationHandler, RequestError};
 use multitimer::{Multitimer, Repeat};
@@ -606,11 +606,11 @@ impl ServerImpl {
                 let mut serial = [0; 51];
                 model[..fake_model.len()].copy_from_slice(&fake_model[..]);
                 serial[..fake_serial.len()].copy_from_slice(&fake_serial[..]);
-                Some(SpToHost::Identity {
+                Some(SpToHost::Identity(Identity {
                     model,
                     revision: 2,
                     serial,
-                })
+                }))
             }
             HostToSp::GetMacAddresses => {
                 let block = self.net.get_spare_mac_addresses();

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -600,7 +600,7 @@ impl ServerImpl {
             }
             HostToSp::GetIdentity => {
                 let identity = self.cp_agent.identity();
-                Some(SpToHost::Identity(identity))
+                Some(SpToHost::Identity(identity.into()))
             }
             HostToSp::GetMacAddresses => {
                 let block = self.net.get_spare_mac_addresses();

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -15,8 +15,8 @@ use drv_usart::Usart;
 use enum_map::Enum;
 use heapless::Vec;
 use host_sp_messages::{
-    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError, Identity,
-    SpToHost, Status, MAX_MESSAGE_SIZE,
+    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError,
+    Identity, SpToHost, Status, MAX_MESSAGE_SIZE,
 };
 use idol_runtime::{NotificationHandler, RequestError};
 use multitimer::{Multitimer, Repeat};

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -15,8 +15,8 @@ use drv_usart::Usart;
 use enum_map::Enum;
 use heapless::Vec;
 use host_sp_messages::{
-    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError,
-    Identity, SpToHost, Status, MAX_MESSAGE_SIZE,
+    Bsu, DecodeFailureReason, Header, HostToSp, HubpackError, SpToHost, Status,
+    MAX_MESSAGE_SIZE,
 };
 use idol_runtime::{NotificationHandler, RequestError};
 use multitimer::{Multitimer, Repeat};
@@ -599,18 +599,8 @@ impl ServerImpl {
                 Some(SpToHost::BootStorageUnit(bsu))
             }
             HostToSp::GetIdentity => {
-                // TODO how do we get our real identity?
-                let fake_model = b"913-0000019";
-                let fake_serial = b"OXE99990000";
-                let mut model = [0; 51];
-                let mut serial = [0; 51];
-                model[..fake_model.len()].copy_from_slice(&fake_model[..]);
-                serial[..fake_serial.len()].copy_from_slice(&fake_serial[..]);
-                Some(SpToHost::Identity(Identity {
-                    model,
-                    revision: 2,
-                    serial,
-                }))
+                let identity = self.cp_agent.identity();
+                Some(SpToHost::Identity(identity))
             }
             HostToSp::GetMacAddresses => {
                 let block = self.net.get_spare_mac_addresses();


### PR DESCRIPTION
Adds an idol call in `control-plane-agent` that reports the sled's identity from reading it out of the FRUID EEPROM. `host-sp-comms` reports that identity to the host when it asks for it, instead of the placeholder identity it was using previously.

I put the VPD reading in `control-plane-agent` because we will also want to report this info up to MGS, although that is not done as a part of this PR (and may need tweaking to handle sidecar/psc, if those don't use the same barcode format?).