### PR TITLE
Add support for a `status` message to update-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
  "chrono",
  "dice-mfg-msgs",
  "hkdf",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "lib-lpc55-usart",
  "lpc55-pac",
  "nb 1.0.0",
@@ -735,7 +735,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/dice-util#5bc735ff11c6b4dcf8af598f8f3911d66db7b6ad"
 dependencies = [
  "corncobs",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "serde",
  "serde-big-array",
  "zerocopy",
@@ -1143,7 +1143,7 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "drv-sprot-api",
  "drv-update-api",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "idol-runtime",
  "if_chain",
  "lpc55-pac",
@@ -1431,7 +1431,7 @@ dependencies = [
  "crc",
  "derive-idol-err",
  "drv-update-api",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "idol",
  "idol-runtime",
  "if_chain",
@@ -1590,7 +1590,7 @@ dependencies = [
  "drv-sprot-api",
  "drv-stm32xx-sys-api",
  "drv-update-api",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "idol",
  "idol-runtime",
  "num-traits",
@@ -1733,7 +1733,7 @@ dependencies = [
  "drv-sidecar-front-io",
  "drv-sidecar-seq-api",
  "drv-transceivers-api",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "idol",
  "idol-runtime",
  "mutable-statics",
@@ -1751,7 +1751,7 @@ name = "drv-update-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "idol",
  "num-traits",
  "serde",
@@ -1943,7 +1943,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service#ce829adddaff79867ebdd88f3b4550e3658e17f6"
 dependencies = [
  "bitflags",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack 0.1.0",
  "serde",
  "serde-big-array",
  "serde_repr",
@@ -2167,7 +2167,7 @@ dependencies = [
  "bitflags",
  "fletcher",
  "gateway-messages",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "serde",
  "serde-big-array",
  "serde_repr",
@@ -2179,27 +2179,26 @@ dependencies = [
 [[package]]
 name = "hubpack"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e0e5e2a94d97b34fa215ea1311937ab0880f86ee575ca4acd2ff66fa22b88c"
+source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
- "hubpack_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack_derive 0.1.0",
  "serde",
 ]
 
 [[package]]
 name = "hubpack"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8f3c0e51b49dd73e277f8d157f7248e91b3597e3487884181b259682b715d3"
 dependencies = [
- "hubpack_derive 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack_derive 0.1.1",
  "serde",
 ]
 
 [[package]]
 name = "hubpack_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd74819b334bf50982a40ec2a44cdf4e197ebbc74c02624897ecb66dbf828c"
+source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2208,8 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "hubpack_derive"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f928320aff16ee8818ef7309180f8b5897057fd79d9dcb8de3ed1ba6dcc125a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,8 +2244,8 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idol"
-version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f01add54e8406192cf9348265c2863d69aa98f48"
+version = "0.2.1"
+source = "git+https://github.com/oxidecomputer/idolatry.git#b2f4c9e48fdba85ce3306e4d9dca7a18f4660759"
 dependencies = [
  "indexmap",
  "quote",
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f01add54e8406192cf9348265c2863d69aa98f48"
+source = "git+https://github.com/oxidecomputer/idolatry.git#b2f4c9e48fdba85ce3306e4d9dca7a18f4660759"
 dependencies = [
  "userlib",
  "zerocopy",
@@ -2415,11 +2415,13 @@ dependencies = [
  "build-util",
  "cfg-if",
  "drv-update-api",
+ "hubpack 0.1.1",
  "hypocalls",
  "idol",
  "idol-runtime",
  "num-traits",
  "ringbuf",
+ "serde",
  "userlib",
  "zerocopy",
 ]
@@ -3514,7 +3516,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/sprockets.git#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "derive_more",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack 0.1.0",
  "salty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-big-array",
@@ -3527,7 +3529,7 @@ source = "git+https://github.com/oxidecomputer/sprockets.git#77df31efa5619d0767f
 dependencies = [
  "corncobs",
  "derive_more",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack 0.1.0",
  "salty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sprockets-common",
@@ -3569,7 +3571,7 @@ dependencies = [
  "digest 0.10.3",
  "ecdsa",
  "hmac 0.10.1",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "lib-lpc55-usart",
  "lpc55-pac",
  "lpc55_romapi",
@@ -3645,10 +3647,12 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "drv-update-api",
+ "hubpack 0.1.1",
  "idol",
  "idol-runtime",
  "num-traits",
  "ringbuf",
+ "serde",
  "stm32h7",
  "userlib",
  "zerocopy",
@@ -4530,7 +4534,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/transceiver-control#2c40fc5d4797f5e8307b2d63c75ecb46e3a7c937"
 dependencies = [
  "bitflags",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack 0.1.1",
  "serde",
 ]
 

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -6,7 +6,7 @@ memory = "256k.toml"
 stacksize = 1024
 image-names = ["a", "b"]
 epoch = 0
-version = 0
+version = 1
 
 [kernel]
 name = "rot-carrier"

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -246,8 +246,11 @@ impl Handler {
             }
             MsgType::UpdCurrentVersionReq => {
                 let version = self.update.current_version();
-                let rsp: Result<ImageVersion, u32> = Ok(version);
-                hubpack::serialize(tx_payload, &rsp)?
+                hubpack::serialize(tx_payload, &version)?
+            }
+            MsgType::UpdStatusReq => {
+                let status = self.update.status();
+                hubpack::serialize(tx_payload, &status)?
             }
             MsgType::SinkReq => {
                 // The first two bytes of a SinkReq payload are the U16
@@ -268,6 +271,7 @@ impl Handler {
             | MsgType::UpdAbortUpdateRsp
             | MsgType::UpdFinishImageUpdateRsp
             | MsgType::UpdCurrentVersionRsp
+            | MsgType::UpdStatusRsp
             | MsgType::Unknown => {
                 status.rx_invalid = status.rx_invalid.wrapping_add(1);
                 return Err(SprotError::BadMessageType);
@@ -290,6 +294,7 @@ fn req_msgtype_to_rsp_msgtype(msgtype: MsgType) -> MsgType {
         MsgType::UpdAbortUpdateReq => MsgType::UpdAbortUpdateRsp,
         MsgType::UpdFinishImageUpdateReq => MsgType::UpdFinishImageUpdateRsp,
         MsgType::UpdCurrentVersionReq => MsgType::UpdCurrentVersionRsp,
+        MsgType::UpdStatusReq => MsgType::UpdStatusRsp,
         MsgType::SinkReq => MsgType::SinkRsp,
 
         // All of the unexpected messages
@@ -305,6 +310,7 @@ fn req_msgtype_to_rsp_msgtype(msgtype: MsgType) -> MsgType {
         | MsgType::UpdAbortUpdateRsp
         | MsgType::UpdFinishImageUpdateRsp
         | MsgType::UpdCurrentVersionRsp
+        | MsgType::UpdStatusRsp
         | MsgType::Unknown => {
             panic!("MsgType is not a request: {}", msgtype as u8)
         }

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -10,8 +10,10 @@ ringbuf = { path = "../../lib/ringbuf" }
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 
 cfg-if = { workspace = true }
+hubpack = { workspace = true }
 idol-runtime = { workspace = true }
 num-traits = { workspace = true }
+serde = { workspace = true }
 zerocopy = { workspace = true }
 
 [build-dependencies]

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -189,9 +189,7 @@ impl idl::InOrderUpdateImpl for ServerImpl {
             tz_table!().active_slot()
         };
         ringbuf_entry!(Trace::ActiveImage(active_slot));
-        Ok(UpdateStatus {
-            active_slot: active_slot as u8,
-        })
+        Ok(UpdateStatus { active_slot })
     }
 }
 

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -18,7 +18,7 @@ extern crate memoffset;
 
 use crc::{Crc, CRC_16_XMODEM};
 use derive_idol_err::IdolError;
-use drv_update_api::{ImageVersion, UpdateError, UpdateTarget};
+use drv_update_api::{ImageVersion, UpdateError, UpdateStatus, UpdateTarget};
 use hubpack::SerializedSize;
 use idol_runtime::{Leased, R};
 use serde::{Deserialize, Serialize};
@@ -344,6 +344,8 @@ pub enum MsgType {
     UpdFinishImageUpdateRsp = 19,
     UpdCurrentVersionReq = 20,
     UpdCurrentVersionRsp = 21,
+    UpdStatusReq = 22,
+    UpdStatusRsp = 23,
 
     /// Reserved value.
     Unknown = 0xff,
@@ -374,6 +376,8 @@ impl From<u8> for MsgType {
             19 => MsgType::UpdFinishImageUpdateRsp,
             20 => MsgType::UpdCurrentVersionReq,
             21 => MsgType::UpdCurrentVersionRsp,
+            22 => MsgType::UpdStatusReq,
+            23 => MsgType::UpdStatusRsp,
             _ => MsgType::Unknown,
         }
     }

--- a/drv/stm32h7-update-server/Cargo.toml
+++ b/drv/stm32h7-update-server/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hubpack = { workspace = true }
 idol-runtime = { workspace = true }
 num-traits = { workspace = true }
+serde = { workspace = true }
 stm32h7 = { workspace = true, features = ["stm32h753"] }
 zerocopy = { workspace = true }
 

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -11,7 +11,7 @@
 
 use core::convert::Infallible;
 use drv_update_api::stm32h7::{BLOCK_SIZE_BYTES, FLASH_WORD_BYTES};
-use drv_update_api::{ImageVersion, UpdateError, UpdateTarget};
+use drv_update_api::{ImageVersion, UpdateError, UpdateStatus, UpdateTarget};
 use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
 use ringbuf::*;
 use stm32h7::stm32h753 as device;
@@ -389,6 +389,20 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
             version: HUBRIS_BUILD_VERSION,
         })
     }
+
+    fn status(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<
+        UpdateStatus,
+        idol_runtime::RequestError<core::convert::Infallible>,
+    > {
+        // TODO: Return which actual bank is in use - Maybe don't use
+        // UpdateTarget for this either, if we can't tell what bank it is.
+        Ok(UpdateStatus {
+            active_slot: UpdateTarget::DevNull as u8,
+        })
+    }
 }
 
 #[export_name = "main"]
@@ -408,7 +422,7 @@ fn main() -> ! {
 
 include!(concat!(env!("OUT_DIR"), "/consts.rs"));
 mod idl {
-    use super::{ImageVersion, UpdateError, UpdateTarget};
+    use super::{ImageVersion, UpdateError, UpdateStatus, UpdateTarget};
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -400,7 +400,7 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
         // TODO: Return which actual bank is in use - Maybe don't use
         // UpdateTarget for this either, if we can't tell what bank it is.
         Ok(UpdateStatus {
-            active_slot: UpdateTarget::DevNull as u8,
+            active_slot: UpdateTarget::DevNull,
         })
     }
 }

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -10,7 +10,6 @@ use serde::{/*de::DeserializeOwned,*/ Deserialize, Serialize};
 use userlib::{sys_send, FromPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
-#[repr(u8)]
 #[derive(
     FromPrimitive,
     AsBytes,
@@ -22,6 +21,7 @@ use zerocopy::{AsBytes, FromBytes};
     Deserialize,
     SerializedSize,
 )]
+#[repr(u8)]
 pub enum UpdateTarget {
     // Represents targets where we only ever write to a single
     // alternate flash location. This is typically used in
@@ -39,6 +39,7 @@ pub enum UpdateTarget {
 #[derive(
     Copy,
     Clone,
+    Debug,
     FromBytes,
     AsBytes,
     PartialEq,
@@ -51,6 +52,22 @@ pub enum UpdateTarget {
 pub struct ImageVersion {
     pub epoch: u32,
     pub version: u32,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    FromBytes,
+    AsBytes,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    SerializedSize,
+)]
+#[repr(C)]
+pub struct UpdateStatus {
+    pub active_slot: u8,
 }
 
 #[derive(Clone, Copy, FromPrimitive, IdolError, Serialize, Deserialize)]

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -55,17 +55,8 @@ pub struct ImageVersion {
 }
 
 #[derive(
-    Copy,
-    Clone,
-    FromBytes,
-    AsBytes,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    SerializedSize,
+    Copy, Clone, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
 )]
-#[repr(C)]
 pub struct UpdateStatus {
     pub active_slot: u8,
 }

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -58,7 +58,7 @@ pub struct ImageVersion {
     Copy, Clone, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
 )]
 pub struct UpdateStatus {
-    pub active_slot: u8,
+    pub active_slot: UpdateTarget,
 }
 
 #[derive(Clone, Copy, FromPrimitive, IdolError, Serialize, Deserialize)]

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -136,6 +136,7 @@ Interface(
               ok: "UpdateStatus",
               err: CLike("SprotError"),
             ),
+            encoding: Hubpack
 		)
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -129,5 +129,13 @@ Interface(
             err: CLike("SprotError"),
           ),
         ),
+        "update_status": (
+            doc: "Get info about installed images",
+            args: { },
+            reply : Result(
+              ok: "UpdateStatus",
+              err: CLike("SprotError"),
+            ),
+		)
     }
 )

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -64,6 +64,7 @@ Interface(
 			args: { },
 			reply : Simple("UpdateStatus"),
 			idempotent: true,
+			encoding: Hubpack
 		)
 	}
 

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -59,6 +59,12 @@ Interface(
 			reply : Simple("ImageVersion"),
 			idempotent: true,
 		),
+		"status": (
+			doc: "Get info about installed images",
+			args: { },
+			reply : Simple("UpdateStatus"),
+			idempotent: true,
+		)
 	}
 
 )

--- a/lib/hypocalls/src/lib.rs
+++ b/lib/hypocalls/src/lib.rs
@@ -8,7 +8,7 @@
 //! Hypovisor calls
 
 pub use lpc55_flash::{
-    HypoStatus, UpdateTarget, __write_block, FLASH_PAGE_SIZE,
+    HypoStatus, UpdateTarget, __active_slot, __write_block, FLASH_PAGE_SIZE,
 };
 
 pub const TABLE_MAGIC: u32 = 0xabcd_abcd;
@@ -22,6 +22,7 @@ macro_rules! declare_tz_table {
         static TZ_TABLE: SecureTable = SecureTable {
             magic: 0,
             write_to_flash: None,
+            active_slot: None,
         };
     };
 }
@@ -35,6 +36,7 @@ macro_rules! declare_not_tz_table {
         static TZ_TABLE: SecureTable = SecureTable {
             magic: TABLE_MAGIC,
             write_to_flash: Some(__write_block),
+            active_slot: Some(__active_slot),
         };
     };
 }
@@ -54,6 +56,9 @@ pub struct SecureTable {
     // function
     pub write_to_flash:
         Option<unsafe extern "C" fn(UpdateTarget, u32, *mut u8) -> HypoStatus>,
+    // This is modeled as an option to avoid the need for a useless stub
+    // function
+    pub active_slot: Option<unsafe extern "C" fn() -> UpdateTarget>,
 }
 
 impl SecureTable {
@@ -81,6 +86,29 @@ impl SecureTable {
         }
         if let Some(func) = core::ptr::read_volatile(&self.write_to_flash) {
             return func(img, block_num, buf);
+        }
+        unreachable!()
+    }
+
+    pub unsafe fn active_slot(&self) -> UpdateTarget {
+        // SAFETY
+        // This entire function gets marked as unsafe because it takes a
+        // raw pointer (necessary for TrustZone ABI reasons)
+        //
+        // The table of applicable secure function calls is updated
+        // at build time. The compiler doesn't know this and wants to
+        // optimize this function based on the initial state which isn't
+        // what we want.
+        //
+        // We're doing a volatile read of the magic and comparing it to
+        // what we expect. If it is what we expect, we can assume the
+        // function table is what we generated at build time.
+        let magic = core::ptr::read_volatile(&self.magic);
+        if magic != TABLE_MAGIC {
+            panic!();
+        }
+        if let Some(func) = core::ptr::read_volatile(&self.active_slot) {
+            return func();
         }
         unreachable!()
     }

--- a/lib/lpc55-flash/src/lib.rs
+++ b/lib/lpc55-flash/src/lib.rs
@@ -156,3 +156,15 @@ pub unsafe extern "C" fn __write_block(
 
     HypoStatus::Success
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn __active_slot() -> UpdateTarget {
+    let current = this_image!();
+    if image_a_base!() == current {
+        UpdateTarget::ImageA
+    } else if image_b_base!() == current {
+        UpdateTarget::ImageB
+    } else {
+        UpdateTarget::Bootloader
+    }
+}

--- a/lib/lpc55-flash/src/lib.rs
+++ b/lib/lpc55-flash/src/lib.rs
@@ -164,7 +164,9 @@ pub unsafe extern "C" fn __active_slot() -> UpdateTarget {
         UpdateTarget::ImageA
     } else if image_b_base!() == current {
         UpdateTarget::ImageB
-    } else {
+    } else if image_stage0_base!() == current {
         UpdateTarget::Bootloader
+    } else {
+        unreachable!()
     }
 }

--- a/task/secure/src/main.rs
+++ b/task/secure/src/main.rs
@@ -15,6 +15,7 @@ use userlib::*;
 static TZ_TABLE: SecureTable = SecureTable {
     magic: TABLE_MAGIC,
     write_to_flash: Some(write_to_flash),
+    active_slot: Some(active_slot),
 };
 
 #[export_name = "main"]
@@ -44,6 +45,29 @@ pub unsafe extern "C" fn write_to_flash(
         sg
         push {{lr}}
         bl __write_block
+        pop {{lr}}
+        bxns lr
+        ",
+        options(noreturn)
+    );
+}
+
+#[naked]
+#[no_mangle]
+#[link_section = ".nsc"]
+pub unsafe extern "C" fn active_slot() -> UpdateTarget {
+    // ARM really wants another function to branch to based on
+    // their secure docs. We also don't have full compiler support yet
+    // so for now just keep it simple and have a single function with
+    // the sg instruction
+    //
+    // The sg is a nop when not using TrustZone. This will need to be
+    // a bxns when we get full TrustZone support
+    core::arch::asm!(
+        "
+        sg
+        push {{lr}}
+        bl __active_slot
         pop {{lr}}
         bxns lr
         ",


### PR DESCRIPTION
Currently the status only reports on the currently active slot. The value is correct for the lpc55, but there is a placeholder for the stm32h7. Future commits will provide more detail in the `UpdateStatus` value returned such as which version is in which slot, the image ids, and image hashes. We expect to remove the `current_version` API, such that it is subsumed as part of `status`.

The API has been plumbed through the update servers and sprot servers on both RoT and SP.