### PR TITLE
Add support for #[idol(server_death)] attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
 name = "derive-idol-err"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "proc-macro2",
  "quote",
  "syn",

--- a/lib/derive-idol-err/Cargo.toml
+++ b/lib/derive-idol-err/Cargo.toml
@@ -8,5 +8,7 @@ syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = {workspace = true}
 
+abi = { path = "../../sys/abi" }
+
 [lib]
 proc-macro = true

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -4,7 +4,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput};
 
 /// Adds three `impl` blocks for the given error `enum` type:
 /// - `From<E> for u16` (Idol encoding)
@@ -17,7 +17,12 @@ use syn::{parse_macro_input, DeriveInput};
 ///
 /// The `enum` must not include 0, because 0 is decoded as "okay" by IPC
 /// infrastructure.
-#[proc_macro_derive(IdolError)]
+///
+/// If one of the variants is annoted with `#[idol(server_death)]`, that variant
+/// will be returned when performing an RPC call against a task that has died /
+/// was restarted.  If no such annotation is present, such an RPC call will
+/// crash the caller (when `unwrap` is called on the return code).
+#[proc_macro_derive(IdolError, attributes(idol))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, data, .. } = parse_macro_input!(input);
 
@@ -34,6 +39,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     let mut variant_errors = vec![];
     let mut discriminant = None;
+    let mut dead_code = None;
     for v in &data.variants {
         if v.fields != syn::Fields::Unit {
             variant_errors.push(compile_error(
@@ -74,7 +80,78 @@ pub fn derive(input: TokenStream) -> TokenStream {
             // Bit of a hack to reuse the error reporting code:
             check_discriminant(&mut variant_errors, ident.span(), 0);
         }
+        for s in &v.attrs {
+            if s.path.segments[0].ident == "idol" {
+                if s.tokens.is_empty() {
+                    variant_errors.push(compile_error(
+                        s.span(),
+                        "expected parentheses, e.g. #[idol(..)]",
+                    ));
+                }
+                for t in s.tokens.clone() {
+                    let g = match &t {
+                        proc_macro2::TokenTree::Group(g) => g,
+                        _ => {
+                            variant_errors.push(compile_error(
+                                t.span(),
+                                &format!(
+                                    "Unexpected token {t:?}; \
+                                     expected #[idol(...)]"
+                                ),
+                            ));
+                            continue;
+                        }
+                    };
+                    if g.delimiter() != proc_macro2::Delimiter::Parenthesis {
+                        variant_errors.push(compile_error(
+                            t.span(),
+                            "Expected parenthesis, e.g. #[idol(...)]",
+                        ));
+                        continue;
+                    }
+                    let s: syn::Ident = match syn::parse2(g.stream()) {
+                        Ok(s) => s,
+                        _ => {
+                            variant_errors.push(compile_error(
+                                g.span(),
+                                &format!(
+                                "Could not parse {g} as a single identifier"
+                            ),
+                            ));
+                            continue;
+                        }
+                    };
+                    match s.to_string().as_str() {
+                        "server_death" => {
+                            if dead_code.is_some() {
+                                variant_errors.push(compile_error(
+                                    s.span(),
+                                    "Multiple variants annotated with \
+                                    #[idol(server_death)]",
+                                ));
+                            }
+                            dead_code = Some(v.ident.clone());
+                        }
+                        i => {
+                            variant_errors.push(compile_error(
+                                s.span(),
+                                &format!("Unknown attribute {i}"),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    let first_dead_code = abi::FIRST_DEAD_CODE;
+    let dead_code_handler = dead_code.map(|dead| {
+        quote! {
+            if v >= #first_dead_code {
+                return Ok(Self::#dead);
+            }
+        }
+    });
 
     let output = quote! {
         #( #variant_errors )*
@@ -92,6 +169,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
         impl core::convert::TryFrom<u32> for #ident {
             type Error = ();
             fn try_from(v: u32) -> Result<Self, Self::Error> {
+                #dead_code_handler
+
                 Self::from_u32(v).ok_or(())
             }
         }

--- a/lib/derive-idol-err/src/lib.rs
+++ b/lib/derive-idol-err/src/lib.rs
@@ -80,7 +80,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
             // Bit of a hack to reuse the error reporting code:
             check_discriminant(&mut variant_errors, ident.span(), 0);
         }
+
         for s in &v.attrs {
+            // We only look at attributes of the form #[idol...], and only
+            // *accept* one: #[idol(server_death)].
             if s.path.segments[0].ident == "idol" {
                 if s.tokens.is_empty() {
                     variant_errors.push(compile_error(

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -20,6 +20,9 @@ pub enum ThermalError {
     AlreadyInAutoMode = 6,
     InvalidWatchdogTime = 7,
     InvalidParameter = 8,
+
+    #[idol(server_death)]
+    ServerDeath,
 }
 
 #[derive(


### PR DESCRIPTION
This will help eliminate the Fault Amplifier, where callers to a server that restarted will try to unwrap a dead code and crash themselves.