### PR TITLE
Enable DICE on Gimlet rot & create lab images

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-c, gimlet-rot-c-stage0, donglet-g031]
+        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-b-stage0-lab, gimlet-rot-c, gimlet-rot-c-stage0, gimlet-rot-c-stage0-lab, donglet-g031]
         include:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
@@ -123,6 +123,11 @@ jobs:
             app_toml: app/gimlet-rot/stage0-b.toml
             target: thumbv8m.main-none-eabihf
             image: stage0
+          - build: gimlet-rot-b-stage0-lab
+            app_name: gimlet-rot-b-lab
+            app_toml: app/gimlet-rot/stage0-b-lab.toml
+            target: thumbv8m.main-none-eabihf
+            image: stage0
           - build: gimlet-rot-c
             app_name: gimlet-rot-c
             app_toml: app/gimlet-rot/app-c.toml
@@ -131,6 +136,11 @@ jobs:
           - build: gimlet-rot-c-stage0
             app_name: gimlet-rot-c
             app_toml: app/gimlet-rot/stage0-c.toml
+            target: thumbv8m.main-none-eabihf
+            image: stage0
+          - build: gimlet-rot-c-stage0-lab
+            app_name: gimlet-rot-c-lab
+            app_toml: app/gimlet-rot/stage0-c-lab.toml
             target: thumbv8m.main-none-eabihf
             image: stage0
           - build: donglet-g031

--- a/app/gimlet-rot/stage0-b-lab.toml
+++ b/app/gimlet-rot/stage0-b-lab.toml
@@ -1,0 +1,32 @@
+name = "gimlet-rot-b-lab"
+target = "thumbv8m.main-none-eabihf"
+board = "gimlet-rot-b"
+chip = "../../chips/lpc55"
+memory = "256k.toml"
+stacksize = 1024
+image-names = ["stage0"]
+external-images = ["a", "b"]
+
+[kernel]
+name = "stage0"
+requires = {flash = 0x9000, ram = 16000}
+features = ["dice-self"]
+stacksize = 13000
+
+[tasks.idle]
+name = "task-idle"
+priority = 0
+max-sizes = {flash = 256, ram = 256}
+stacksize = 256
+start = true
+
+[signing]
+enable-secure-boot = true
+enable-dice = true
+dice-inc-nxp-cfg = false
+dice-cust-cfg = false
+dice-inc-sec-epoch = false
+
+[[signing.certs]]
+cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
+priv-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-b.toml
+++ b/app/gimlet-rot/stage0-b.toml
@@ -9,8 +9,9 @@ external-images = ["a", "b"]
 
 [kernel]
 name = "stage0"
-requires = {flash = 0x4000, ram = 4096}
-features = []
+requires = {flash = 0x9000, ram = 16000}
+features = ["dice-mfg"]
+stacksize = 13000
 
 [tasks.idle]
 name = "task-idle"
@@ -21,7 +22,7 @@ start = true
 
 [signing]
 enable-secure-boot = true
-enable-dice = false
+enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false

--- a/app/gimlet-rot/stage0-c-lab.toml
+++ b/app/gimlet-rot/stage0-c-lab.toml
@@ -1,0 +1,31 @@
+name = "gimlet-rot-c-lab"
+target = "thumbv8m.main-none-eabihf"
+board = "gimlet-rot-c"
+chip = "../../chips/lpc55"
+secure-separation = true
+image-names = ["stage0"]
+external-images = ["a", "b"]
+
+[kernel]
+name = "stage0"
+requires = {flash = 0x9000, ram = 16000}
+features = ["tz_support", "dice-self"]
+stacksize = 13000
+
+[tasks.idle]
+name = "task-idle"
+priority = 0
+max-sizes = {flash = 256, ram = 256}
+stacksize = 256
+start = true
+
+[signing]
+enable-secure-boot = true
+enable-dice = true
+dice-inc-nxp-cfg = false
+dice-cust-cfg = false
+dice-inc-sec-epoch = false
+
+[[signing.certs]]
+cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
+priv-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-c.toml
+++ b/app/gimlet-rot/stage0-c.toml
@@ -8,8 +8,8 @@ external-images = ["a", "b"]
 
 [kernel]
 name = "stage0"
-requires = {flash = 0x8000, ram = 16000}
-features = ["tz_support", "dice-self"]
+requires = {flash = 0x9000, ram = 16000}
+features = ["tz_support", "dice-mfg"]
 stacksize = 13000
 
 [tasks.idle]
@@ -21,7 +21,7 @@ start = true
 
 [signing]
 enable-secure-boot = true
-enable-dice = false
+enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false


### PR DESCRIPTION
Enables DICE our gimlet b & c builds. The new lab images configure DICE to create self-signed identity certs. Non-lab images configure DICE for the manufacturing process.