### PR TITLE
host-sp-comms: Improve ringbuf usability and remember host boot fail/panic messages

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -202,7 +202,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 7
-max-sizes = {flash = 32768, ram = 16384}
+max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -202,7 +202,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 7
-max-sizes = {flash = 32768, ram = 16384}
+max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -131,7 +131,7 @@ features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
 priority = 8
-max-sizes = {flash = 32768, ram = 16384}
+max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -653,8 +653,7 @@ impl ServerImpl {
                 Some(response)
             }
             HostToSp::HostBootFailure { .. } => {
-                // TODO what do we do in reaction to this? reboot? forward to
-                // MGS?
+                // TODO forward to MGS
                 //
                 // For now, copy it into a static var we can pull out via
                 // `humility readvar LAST_HOST_BOOT_FAIL`.


### PR DESCRIPTION
This PR removes the low-level uart ringbuf tracing (we have sufficient mileage that this has outlived its usefulness) in favor of tracing full messages. It also stashes the messages sent as part of a host boot fail or panic into static vars that we can pull out (if someone painfully) via humility.

Ringbuf from a gimlet boot that (intentionally) ended in failure:

```
john@igor ~ $ pfexec humility -t sn6 -a ./build-gimlet-b.zip ringbuf host_sp_comms
humility: WARNING: archive on command-line overriding archive in environment file
humility: attached to 0483:3754:0020000F4741500920383733 via ST-Link V3
humility: ring buffer task_host_sp_comms::__RINGBUF in host_sp_comms:
 NDX LINE      GEN    COUNT PAYLOAD
   0  314        1        2 JefeNotification { now: 0x6f0, state: A0 }
   1  585        1        1 Request { now: 0x3406d, sequence: 0x1, message: GetStatus }
   2  192        1        1 Response { now: 0x3406d, sequence: 0x8000000000000001, message: Status { status: Status { bits: 0x1 }, startup: HostStartupOptions { bits: 0x18 } } }
   3  585        1        1 Request { now: 0x34079, sequence: 0x2, message: AckSpStart }
   4  192        1        1 Response { now: 0x34079, sequence: 0x8000000000000002, message: Ack }
   5  585        1        1 Request { now: 0x34084, sequence: 0x3, message: GetBootStorageUnit }
   6  192        1        1 Response { now: 0x34084, sequence: 0x8000000000000003, message: BootStorageUnit(A) }
   7  585        1        1 Request { now: 0x3408f, sequence: 0x4, message: GetIdentity }
   8  192        1        1 Response { now: 0x340a5, sequence: 0x8000000000000004, message: Identity(Identity { model: [ 0x39, 0x31, 0x33, 0x2d, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31, 0x39, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ], revision: 0x2, serial: [ 0x42, 0x52, 0x4d, 0x39, 0x39, 0x39, 0x39, 0x30, 0x30, 0x30, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ] }) }
   9  314        1        1 JefeNotification { now: 0x3e9a0, state: A0PlusHP }
  10  585        1        1 Request { now: 0x3fc39, sequence: 0x5, message: HostBootFailure { reason: 0x2 } }
  11  192        1        1 Response { now: 0x3fc39, sequence: 0x8000000000000005, message: Ack }
```

The ringbuf includes the boot failure reason code (`0x2` is `IPCC_BOOTFAIL_NOPHASE2`), at which point we can dump the buffer containing the last boot fail message via `humility readvar LAST_HOST_BOOT_FAIL`:

```
john@igor ~ $ pfexec humility -t sn6 -a ./build-gimlet-b.zip readvar LAST_HOST_BOOT_FAIL | head -n 50
humility: WARNING: archive on command-line overriding archive in environment file
humility: attached to 0483:3754:0020000F4741500920383733 via ST-Link V3
LAST_HOST_BOOT_FAIL (0x2401c10d) = MaybeUninit<[u8; 4096]> {
    value: [
        0x43,
        0x6f,
        0x75,
        0x6c,
        0x64,
        0x20,
        0x6e,
        0x6f,
        0x74,
        0x20,
        0x66,
        0x69,
        0x6e,
        0x64,
        0x20,
        0x61,
        0x20,
        0x76,
        0x61,
        0x6c,
        0x69,
        0x64,
        0x20,
        0x70,
        0x68,
        0x61,
        0x73,
        0x65,
        0x32,
        0x20,
        0x69,
        0x6d,
        0x61,
        0x67,
        0x65,
        0x20,
        0x6f,
        0x6e,
        0x20,
        0x64,
        0x69,
        0x73,
        0x6b,
        0x3a,
        0x31,
        0x37,
        0x0,
        0x0,
```

That buffer is 4 KiB long and humility prints it as seen above, which is not suuuper helpful, but if we decode it we see

```
Could not find a valid phase2 image on disk:17
```

which is more reasonable.

If the host panicked and sent a message along with it, it would be similarly retrievable via `humility readvar LAST_HOST_PANIC`.

(cc @citrus-it @rmustacc @jclulow)