### PR TITLE
Switch smoltcp to using our patched fork, for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,8 +3472,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2308a1657c8db1f5b4993bab4e620bdbe5623bd81f254cf60326767bb243237"
+source = "git+https://github.com/oxidecomputer/smoltcp?branch=v0.8.0#d9cfed9bb5e263b1c8d2730c8009eea50c8f25d5"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ path = "sys/userlib"
 [patch."https://github.com/oxidecomputer/hubris".abi]
 path = "sys/abi"
 
+[patch.crates-io]
+smoltcp = { git = "https://github.com/oxidecomputer/smoltcp", branch = "v0.8.0" }
+
 [workspace.dependencies]
 anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
 atty = { version = "0.2", default-features = false }


### PR DESCRIPTION
This needs testing, but should _hopefully_ fix #995 

The change has to be done via a Cargo `patch` (instead of changing the `smoltcp = { ... }` dependency): [`gateway-messages`](https://github.com/oxidecomputer/management-gateway-service/blob/main/gateway-messages/Cargo.toml#L18) _also_ uses `smoltcp`, and we use its types in API calls, so the versions must be identical.

