### PR TITLE
jefe: introduce "tasks-to-hold" config

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -28,6 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+tasks-to-hold = ["thermal"]
+
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -28,6 +28,9 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
+[tasks.jefe.config]
+tasks-to-hold = ["thermal"]
+
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -122,6 +122,11 @@ fn main() -> ! {
 
     let mut disposition: [Disposition; hubris_num_tasks::NUM_TASKS] =
         [Disposition::Restart; hubris_num_tasks::NUM_TASKS];
+
+    for held_task in generated::HELD_TASKS {
+        disposition[held_task as usize] = Disposition::Hold;
+    }
+
     let mut logged: [bool; hubris_num_tasks::NUM_TASKS] =
         [false; hubris_num_tasks::NUM_TASKS];
     let deadline = sys_get_timer().now + TIMER_INTERVAL;


### PR DESCRIPTION
Listing task names in this configuration key will cause Jefe to, by default, leave them in a faulted state instead of automatically restarting them.

This is, obviously(?), not a thing you want to do in production, but it should be useful for catching intermittent failures on a bench.