### PR TITLE
Fix off-by-one-ish error in MPU RLAR programming.

### DIFF
--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -471,7 +471,7 @@ pub fn apply_memory_protection(task: &task::Task) {
         };
 
         // RLAR = our upper bound
-        let rlar = (region.base + region.size)
+        let rlar = (region.base + region.size - 32)
                 | (i as u32) << 1 // AttrIndx
                 | (1 << 0); // enable
 


### PR DESCRIPTION
The error stems from the RLAR value being inclusive which typically produces an off by one error. In this case the region is 32 byte aligned and so it's an off by one 32 byte chunk error instead.

This resolves #1016