### PR TITLE
task/sensor: move sensor data off stack into static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ dependencies = [
  "drv-i2c-devices",
  "idol",
  "idol-runtime",
+ "mutable-statics",
  "num-traits",
  "ringbuf",
  "task-sensor-api",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -196,7 +196,7 @@ name = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 3800        # Sensor data is stored on the stack
+stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -196,7 +196,7 @@ name = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 3800        # Sensor data is stored on the stack
+stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -218,8 +218,8 @@ interrupts = {"usart1.irq" = 0b10}
 name = "task-sensor"
 features = ["itm"]
 priority = 5
-max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 3800        # Sensor data is stored on the stack
+max-sizes = {flash = 8192, ram = 2048 }
+stacksize = 1024
 start = true
 
 [tasks.sprot]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -200,8 +200,8 @@ features = ["psc"]
 [tasks.sensor]
 name = "task-sensor"
 priority = 3
-max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 1504    # Sensor data is stored on the stack
+max-sizes = {flash = 8192, ram = 2048 }
+stacksize = 1024
 start = true
 
 [tasks.sensor_polling]

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -198,8 +198,8 @@ features = ["psc"]
 [tasks.sensor]
 name = "task-sensor"
 priority = 3
-max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 1504    # Sensor data is stored on the stack
+max-sizes = {flash = 8192, ram = 2048 }
+stacksize = 1024
 start = true
 
 [tasks.sensor_polling]

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -249,7 +249,7 @@ name = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
-stacksize = 1920        # Sensor data is stored on the stack
+stacksize = 1024
 start = true
 
 [tasks.ecp5_mainboard]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -249,7 +249,7 @@ name = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
-stacksize = 1920        # Sensor data is stored on the stack
+stacksize = 1024
 start = true
 
 [tasks.ecp5_mainboard]

--- a/task/sensor/Cargo.toml
+++ b/task/sensor/Cargo.toml
@@ -18,6 +18,7 @@ drv-i2c-devices = { path = "../../drv/i2c-devices" }
 ringbuf = { path = "../../lib/ringbuf"  }
 task-sensor-api = { path = "../sensor-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+mutable-statics = { path = "../../lib/mutable-statics" }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/task/sensor/src/main.rs
+++ b/task/sensor/src/main.rs
@@ -14,7 +14,7 @@ use userlib::*;
 use task_sensor_api::config::NUM_SENSORS;
 
 struct ServerImpl {
-    data: [Reading; NUM_SENSORS],
+    data: &'static mut [Reading; NUM_SENSORS],
     deadline: u64,
 }
 
@@ -96,10 +96,11 @@ fn main() -> ! {
     //
     sys_set_timer(Some(deadline), TIMER_MASK);
 
-    let mut server = ServerImpl {
-        data: [Reading::Absent; NUM_SENSORS],
-        deadline,
+    let data = mutable_statics::mutable_statics! {
+        static mut SENSOR_DATA: [Reading; NUM_SENSORS] = [|| Reading::Absent; _];
     };
+
+    let mut server = ServerImpl { data, deadline };
 
     let mut buffer = [0; idl::INCOMING_SIZE];
 


### PR DESCRIPTION
This makes the task's memory usage much more visible, and means you'll get a compile error -- not a runtime stack overflow -- if you add too many sensors without increasing the RAM allocation.