### PR TITLE
Enable VLANs on the management network, with one exception

### DIFF
--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -704,9 +704,9 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
     /// - The uplink port (49) sends and receives packets with one VLAN tag, and
     ///   uses that packet to select which VLAN (i.e. which downstream port)
     ///   should receive that packet.  The VLAN tag is stripped on egress.
-    fn configure_vlan_with_mask<F: Fn(u8) -> u64>(
+    fn configure_vlan_with_mask(
         &self,
-        f: F,
+        f: fn(u8) -> u64,
     ) -> Result<(), VscError> {
         const UPLINK: u8 = 49; // DEV10G_0, uplink to the Tofino 2
 

--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -691,8 +691,23 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
         Ok(())
     }
 
-    /// Implements the VLAN scheme described in RFD 250.
-    pub fn configure_vlan_strict(&self) -> Result<(), VscError> {
+    /// Configures VLANs for a production-style system.
+    ///
+    /// For details, see RFD 250, but in brief:
+    ///
+    /// - VLANs in the form 0x1YY are configured for each downstream port.
+    ///   Ports active on a given VLAN are selected by the given function `f`;
+    ///   typically, each VLAN will contain a downstream port and the uplink
+    ///   port.
+    /// - Downstream ports send and receive untagged frames, and apply their
+    ///   VLAN tag on packet ingress.
+    /// - The uplink port (49) sends and receives packets with one VLAN tag, and
+    ///   uses that packet to select which VLAN (i.e. which downstream port)
+    ///   should receive that packet.  The VLAN tag is stripped on egress.
+    fn configure_vlan_with_mask<F: Fn(u8) -> u64>(
+        &self,
+        f: F,
+    ) -> Result<(), VscError> {
         const UPLINK: u8 = 49; // DEV10G_0, uplink to the Tofino 2
 
         // Enable the VLAN
@@ -709,10 +724,11 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
         for p in (0..=52).filter(|p| *p != UPLINK) {
             let port = ANA_CL().PORT(p);
 
-            // Configure the 0x1YY VLAN for this port
+            // Configure the 0x1YY VLAN for this port, using our closure to
+            // decide what mask to apply
             self.write_port_mask(
                 ANA_L3().VLAN(0x100 + p as u16).VLAN_MASK_CFG(),
-                (1 << p) | (1 << UPLINK),
+                f(p),
             )?;
 
             // The downstream ports expect untagged frames, and classify
@@ -766,31 +782,21 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
         Ok(())
     }
 
+    /// Implements the VLAN scheme described in RFD 250.
+    pub fn configure_vlan_strict(&self) -> Result<(), VscError> {
+        const UPLINK: u8 = 49; // DEV10G_0, uplink to the Tofino 2
+        self.configure_vlan_with_mask(|p| (1 << p) | (1 << UPLINK))
+    }
+
     /// Implements the VLAN scheme described in RFD 250, with one exception:
     /// the technician ports are on **every VLAN**, so they can talk to any SP
     /// without having to go through the CPU port to the Tofino.
     pub fn configure_vlan_semistrict(&self) -> Result<(), VscError> {
         const UPLINK: u8 = 49; // DEV10G_0, uplink to the Tofino 2
-
         const TECHNICIAN_1: u8 = 44;
         const TECHNICIAN_2: u8 = 45;
-
-        // Enable the VLAN
-        self.write_with(ANA_L3().COMMON().VLAN_CTRL(), |r| r.set_vlan_ena(1))?;
-
-        // By default, there are three VLANs configured in ANA_L3:
-        // 0, 1, and 4095.  We disable all of them, since we only want to
-        // allow very specific VIDs.
-        for vid in [0, 1, 4095] {
-            self.write_port_mask(ANA_L3().VLAN(vid).VLAN_MASK_CFG(), 0)?;
-        }
-
-        // Configure the downstream ports, which each have their own VLANs
-        for p in (0..=52).filter(|&p| p != UPLINK) {
-            let port = ANA_CL().PORT(p);
-
-            // Pick a mask of what ports are conntected to this port
-            let mask = if p == TECHNICIAN_1 || p == TECHNICIAN_2 {
+        self.configure_vlan_with_mask(|p| {
+            if p == TECHNICIAN_1 || p == TECHNICIAN_2 {
                 // Technician ports are connected to every port!
                 (1 << 53) - 1
             } else {
@@ -799,63 +805,8 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
                     | (1 << UPLINK)
                     | (1 << TECHNICIAN_1)
                     | (1 << TECHNICIAN_2)
-            };
-
-            // Configure the 0x1YY VLAN for this port
-            self.write_port_mask(
-                ANA_L3().VLAN(0x100 + p as u16).VLAN_MASK_CFG(),
-                mask,
-            )?;
-
-            // The downstream ports expect untagged frames, and classify
-            // them based on a per-port VID assigned here.
-            self.modify(port.VLAN_CTRL(), |r| {
-                r.set_port_vid(0x100 + p as u32);
-                r.set_vlan_aware_ena(1);
-            })?;
-            // Accept no TPIDs, and only route untagged frames.
-            self.modify(port.VLAN_TPID_CTRL(), |r| {
-                r.set_basic_tpid_aware_dis(0b1111);
-                r.set_rt_tag_ctrl(0b0001);
-            })?;
-        }
-
-        // The uplink port requires one VLAN tag, and pops it on ingress
-        //
-        // It has a default VID of 0x1, but we removed all ports from
-        // that VLAN, so it will only accept our desired set of VIDs.
-        let port = ANA_CL().PORT(UPLINK);
-        self.modify(port.VLAN_CTRL(), |r| {
-            r.set_vlan_pop_cnt(1);
-            r.set_vlan_aware_ena(1);
-        })?;
-        // Only accept 0x8100 as a valid TPID, to keep things simple,
-        // and only route frames with one accepted tag
-        self.modify(port.VLAN_TPID_CTRL(), |r| {
-            r.set_basic_tpid_aware_dis(0b1110);
-            r.set_rt_tag_ctrl(0b0010);
-        })?;
-        // Discard frames with < 1 tag
-        self.modify(port.VLAN_FILTER_CTRL(0), |r| {
-            r.set_tag_required_ena(1);
-        })?;
-        let rew = REW().PORT(UPLINK);
-        // Use the rewriter to tag all frames on egress from the upstream port
-        // (using the VID assigned on ingress into a downstream port)
-        self.modify(rew.TAG_CTRL(), |r| {
-            r.set_tag_cfg(1);
-        })?;
-
-        // Configure VLAN ingress filtering, so packets that arrive and
-        // aren't part of an appropriate VLAN are dropped.  This occurs
-        // after VLAN classification, so the downstream ports that have
-        // frames classified on ingress should work.
-        self.write_port_mask(
-            ANA_L3().COMMON().VLAN_FILTER_CTRL(),
-            (1 << 53) - 1,
-        )?;
-
-        Ok(())
+            }
+        })
     }
 
     /// Checks the 10GBASE-KR autonegotiation state machine for the given dev.

--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -753,10 +753,14 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
             r.set_vlan_pop_cnt(1);
             r.set_vlan_aware_ena(1);
         })?;
-        // Only accept 0x8100 as a valid TPID, to keep things simple,
-        // and only route frames with one accepted tag
         self.modify(port.VLAN_TPID_CTRL(), |r| {
+            // Only accept 0x8100 as a valid TPID, to keep things simple. This
+            // is the designated EtherType for "Customer VLAN tag" in IEEE
+            // 802.1Q; the register's polarity requires us to **clear** bit 0 to
+            // accept this TPID.
             r.set_basic_tpid_aware_dis(0b1110);
+
+            // Only route frames with one accepted tag
             r.set_rt_tag_ctrl(0b0010);
         })?;
         // Discard frames with < 1 tag

--- a/task/monorail-server/src/bsp/sidecar_a.rs
+++ b/task/monorail-server/src/bsp/sidecar_a.rs
@@ -194,6 +194,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         self.phy_vsc8504_init()?;
         self.phy_vsc8562_init()?;
         self.vsc7448.configure_ports_from_map(&PORT_MAP)?;
+        self.vsc7448.configure_vlan_semistrict()?;
         self.vsc7448_postconfig()?;
 
         Ok(())

--- a/task/monorail-server/src/bsp/sidecar_b.rs
+++ b/task/monorail-server/src/bsp/sidecar_b.rs
@@ -174,6 +174,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         self.phy_vsc8504_init()?;
         self.phy_vsc8562_init()?;
         self.vsc7448.configure_ports_from_map(&PORT_MAP)?;
+        self.vsc7448.configure_vlan_semistrict()?;
         self.vsc7448_postconfig()?;
 
         Ok(())


### PR DESCRIPTION
The difference between `configure_vlan_strict` and `configure_vlan_semistrict` is the handling of technician ports: in this PR, the technician ports remain able to talk to every SP.  This makes development easier, until MGS is ready to go (and booting autonomously).

I tested this on the `niles` rev B Sidecar, and confirmed that the SPs are now isolated:
```
matt@niles ~ (sidecar-b) $ h monorail mac
humility: attached to 0483:3754:002600184D4B500E20373831 via ST-Link V3
Reading 4 MAC addresses...
 PORT |        MAC
------|-------------------
   13 | 0e:1d:80:ba:b8:c6
   15 | 0e:1d:80:ba:b8:c7
   44 | 00:0e:c6:46:43:d9
   48 | 0e:1d:dc:cf:27:34
matt@niles ~ (sidecar-b) $ h net mac
humility: attached to 0483:3754:002600184D4B500E20373831 via ST-Link V3
humility: Reading 3 MAC addresses...
 PORT |        MAC
------|-------------------
    1 | 00:0e:c6:46:43:d9
    3 | 0e:1d:dc:cf:27:34
      | 0e:1d:dc:cf:27:35
```

The first command shows that the VSC7448 switch is receiving packets from 3 SPs (ports 13, 15, and 48; MAC addresses beginning with `0e:1d`).  The second command shows that the SP's local switch is only seeing packets from the SP itself (on PORT 3) and the host (on PORT 1); this indicates that SP-to-SP communication is no longer possible.
