### PR TITLE
Set output enable for LED controller by default

### DIFF
--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -637,11 +637,7 @@ impl Transceivers {
                 Reg::LED_CTRL::RESET,
             )?;
 
-            fpga.write(
-                WriteOp::BitSet,
-                Addr::LED_CTRL,
-                Reg::LED_CTRL::OE,
-            )?;
+            fpga.write(WriteOp::BitSet, Addr::LED_CTRL, Reg::LED_CTRL::OE)?;
         }
 
         Ok(())

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -636,6 +636,12 @@ impl Transceivers {
                 Addr::LED_CTRL,
                 Reg::LED_CTRL::RESET,
             )?;
+
+            fpga.write(
+                WriteOp::BitSet,
+                Addr::LED_CTRL,
+                Reg::LED_CTRL::OE,
+            )?;
         }
 
         Ok(())


### PR DESCRIPTION
A [previous FPGA change](https://github.com/oxidecomputer/quartz/issues/44) adjusted the default state of the LED controllers reset and output enable pins. The output enable used to be enabled by default, but that is no longer the case. The SP needs to enable it now.