### PR TITLE
Use stm32g0 crate, which speeds up the build significantly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,8 @@ dependencies = [
 [[package]]
 name = "stm32g0"
 version = "0.15.1"
-source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-update#9bb993b07a5906ac4503d702e7ff507f229d1b44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2fda706a5ca8a4c4c7c965668ff908c10dfeb1c2da581b6a2007ee60ae4787"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ static_assertions = { version = "1", default-features = false }
 stm32f3 = { version = "0.13.0", default-features = false }
 stm32f4 = { version = "0.13.0", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }
+stm32g0 = { version = "0.15.1", default-features = false }
 strsim = { version = "0.10.0", default-features = false }
 syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
 toml = { version = "0.5.6", default-features = false }
@@ -128,7 +129,6 @@ salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroi
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false }


### PR DESCRIPTION
I don't remember why we switched to using a fork of the `stm32-rs-nightlies` repo, but this appears to build fine!

It's also a significant speedup – rebuilding `app/sidecar/rev-a.toml` with no changes goes from 15 -> 9 seconds.

This is counterintuitive: `sidecar` doesn't use `stm32g0` at all.  It turns out Cargo walks the entire checkout of all dependencies searching for manifests, and the checkout for `stm32-rs-nightlies` contains _thousands_ of subfolders.