### PR TITLE
Be consistent with specifying images in linker script

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -450,20 +450,6 @@ impl Config {
         Ok(memories)
     }
 
-    pub fn image_memories(
-        &self,
-        region: String,
-    ) -> Result<IndexMap<String, Range<u32>>> {
-        let mut memories: IndexMap<String, Range<u32>> = IndexMap::new();
-        for a in &self.external_images {
-            if let Some(r) = self.memories(a)?.get(&region) {
-                memories.insert(a.clone(), r.start..r.end);
-            }
-        }
-
-        Ok(memories)
-    }
-
     /// Calculates the output region which contains the given address
     pub fn output_region(&self, vaddr: u64) -> Option<&str> {
         let vaddr = u32::try_from(vaddr).ok()?;

--- a/stage0/src/image_header.rs
+++ b/stage0/src/image_header.rs
@@ -6,8 +6,8 @@ use abi::{ImageHeader, ImageVectors};
 use lpc55_romapi::FLASH_PAGE_SIZE;
 
 extern "C" {
-    static IMAGEA: abi::ImageVectors;
-    static IMAGEB: abi::ImageVectors;
+    static __IMAGE_A_BASE: abi::ImageVectors;
+    static __IMAGE_B_BASE: abi::ImageVectors;
     // __vector size is currently defined in the linker script as
     //
     // __vector_size = SIZEOF(.vector_table);
@@ -43,7 +43,7 @@ const PAGE_SIZE: u32 = FLASH_PAGE_SIZE as u32;
 // being furnished by our linker script, which we trust.
 
 pub fn get_image_b() -> Option<Image> {
-    let imageb = unsafe { &IMAGEB };
+    let imageb = unsafe { &__IMAGE_B_BASE };
 
     let img = Image(imageb);
 
@@ -55,7 +55,7 @@ pub fn get_image_b() -> Option<Image> {
 }
 
 pub fn get_image_a() -> Option<Image> {
-    let imagea = unsafe { &IMAGEA };
+    let imagea = unsafe { &__IMAGE_A_BASE };
 
     let img = Image(imagea);
 


### PR DESCRIPTION
It turns out we have two disjoint ways of specifying approximately the same thing w.r.t. other images. Switch to a single method.