### PR TITLE
Fix subtraction order

### DIFF
--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -791,7 +791,7 @@ impl<'a> ThermalControl<'a> {
                 for (v, model) in Self::zip_temperatures(values, inputs) {
                     if let TemperatureReading::Valid { value, time_ms } = v {
                         let temperature = value.0
-                            + (time_ms - now_ms) as f32 / 1000.0
+                            + (now_ms - time_ms) as f32 / 1000.0
                                 * model.temperature_slew_deg_per_sec;
 
                         all_subcritical &= temperature


### PR DESCRIPTION
Previously, this subtraction would panic if we were in the `Overheating` state and missed a sample.  I don't think this is what we're seeing in the field, but it's definitely incorrect, so let's fix it.