### PR TITLE
Add `Power.pmbus_read` idol operation

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, sidecar-b-lab, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-b-stage0-lab, gimlet-rot-c, gimlet-rot-c-stage0, gimlet-rot-c-stage0-lab, donglet-g031]
+        build: [stm32f3, stm32f4, lpc55, lpc55-stage0, stm32h743, stm32h753, gemini, rot-carrier, rot-carrier-stage0, gimletlet, gimlet-b, gimlet-b-lab, gimlet-c, gimlet-c-lab, sidecar-a, sidecar-b, sidecar-b-lab, psc-a, psc-b, stm32g0, gimlet-rot-b, gimlet-rot-b-stage0, gimlet-rot-b-stage0-lab, gimlet-rot-c, gimlet-rot-c-stage0, gimlet-rot-c-stage0-lab, donglet-g031]
         include:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
@@ -73,6 +73,11 @@ jobs:
             app_toml: app/rot-carrier/stage0.toml
             target: thumbv8m.main-none-eabihf
             image: stage0
+          - build: gimletlet
+            app_name: gimletlet
+            app_toml: app/gimletlet/app.toml
+            target: thumbv7em-none-eabihf
+            image: default
           - build: gimlet-b
             app_name: gimlet-b
             app_toml: app/gimlet/rev-b.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "pmbus",
  "ringbuf",
  "smbus-pec",
+ "task-power-api",
  "userlib",
  "zerocopy",
 ]
@@ -2853,7 +2854,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/pmbus#9f5d86bfd04cbb6d7a7fcb38e00071c8b643f6f3"
 dependencies = [
  "anyhow",
  "convert_case 0.3.2",
@@ -3938,11 +3938,13 @@ dependencies = [
 name = "task-power-api"
 version = "0.1.0"
 dependencies = [
- "derive-idol-err",
+ "drv-i2c-api",
  "hubpack",
  "idol",
  "num-traits",
+ "pmbus",
  "serde",
+ "static_assertions",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3920,10 +3920,29 @@ dependencies = [
  "drv-i2c-devices",
  "drv-sidecar-seq-api",
  "drv-stm32xx-sys-api",
+ "hubpack",
+ "idol",
+ "idol-runtime",
  "mutable-statics",
+ "num-traits",
  "paste",
  "ringbuf",
+ "serde",
+ "task-power-api",
  "task-sensor-api",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "task-power-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "hubpack",
+ "idol",
+ "num-traits",
+ "serde",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,6 +2854,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/pmbus?branch=extra-mwocp68#0de3821e295e457b608a8ffa33f4e075ff46a59b"
 dependencies = [
  "anyhow",
  "convert_case 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,6 +2854,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/pmbus#781cf33414b267277e168ed7f8699c3959090f76"
 dependencies = [
  "anyhow",
  "convert_case 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,7 +2854,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/pmbus?branch=extra-mwocp68#0de3821e295e457b608a8ffa33f4e075ff46a59b"
 dependencies = [
  "anyhow",
  "convert_case 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false, branch = "extra-mwocp68" }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false, branch = "extra-mwocp68" } # FIXME after merging pmbus#9
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,8 @@ idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
+#pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
+pmbus = { path = "../pmbus" }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false, branch = "extra-mwocp68" } # FIXME after merging pmbus#9
+pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,8 +124,7 @@ idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
-#pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
-pmbus = { path = "../pmbus" }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false, branch = "extra-mwocp68" }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }
 spd = { git = "https://github.com/oxidecomputer/spd", default-features = false }
 sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }

--- a/app/gimletlet/src/main.rs
+++ b/app/gimletlet/src/main.rs
@@ -5,17 +5,6 @@
 #![no_std]
 #![no_main]
 
-#[cfg(not(any(feature = "panic-itm", feature = "panic-semihosting")))]
-compile_error!(
-    "Must have either feature panic-itm or panic-semihosting enabled"
-);
-
-// Panic behavior controlled by Cargo features:
-#[cfg(feature = "panic-itm")]
-extern crate panic_itm; // breakpoint on `rust_begin_unwind` to catch panics
-#[cfg(feature = "panic-semihosting")]
-extern crate panic_semihosting; // requires a debugger
-
 // We have to do this if we don't otherwise use it to ensure its vector table
 // gets linked in.
 extern crate stm32h7;

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -180,7 +180,7 @@ task-slots = ["i2c_driver"]
 [tasks.power]
 name = "task-power"
 priority = 4
-max-sizes = {flash = 16384, ram = 4096}
+max-sizes = {flash = 32768, ram = 4096}
 stacksize = 1000
 start = true
 task-slots = ["i2c_driver", "sensor", "sys"]

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -178,7 +178,7 @@ task-slots = ["i2c_driver"]
 [tasks.power]
 name = "task-power"
 priority = 4
-max-sizes = {flash = 16384, ram = 4096}
+max-sizes = {flash = 32768, ram = 4096}
 stacksize = 1000
 start = true
 task-slots = ["i2c_driver", "sensor", "sys"]

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -300,7 +300,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 name = "task-power"
 features = ["itm", "sidecar"]
 priority = 6
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 32768, ram = 4096 }
 stacksize = 2048
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -299,7 +299,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 name = "task-power"
 features = ["itm", "sidecar"]
 priority = 6
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 32768, ram = 4096 }
 stacksize = 2048
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -89,6 +89,8 @@ pub enum ResponseCode {
     BadDeviceState = 23,
     /// Bad return value for selected mux/segment
     BadSelectedMux = 24,
+    /// Requested operation is not supported
+    OperationNotSupported = 25,
 }
 
 ///

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -15,6 +15,7 @@ derive-idol-err = { path = "../../lib/derive-idol-err" }
 drv-i2c-api = { path = "../i2c-api" }
 drv-onewire = { path = "../onewire" }
 ringbuf = { path = "../../lib/ringbuf" }
+task-power-api = { path = "../../task/power-api" }
 userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -270,9 +270,12 @@ impl Mwocp68 {
             Operation::ReadPin => {
                 PmbusValue::from(pmbus_read!(self.device, READ_PIN)?.get()?)
             }
-            Operation::PmbusRevision => PmbusValue::Raw8(
-                pmbus_read!(self.device, PMBUS_REVISION)?.get()?,
-            ),
+            Operation::PmbusRevision => {
+                let (val, width) =
+                    pmbus_read!(self.device, PMBUS_REVISION)?.raw();
+                assert_eq!(width.0, 8);
+                PmbusValue::Raw8(val as u8)
+            }
             Operation::MfrId => self.read_block::<9>(CommandCode::MFR_ID)?,
             Operation::MfrModel => {
                 self.read_block::<17>(CommandCode::MFR_MODEL)?

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -156,14 +156,17 @@ impl Mwocp68 {
         self.set_rail()?;
 
         let val = match op {
-            Operation::FanConfig1_2 => PmbusValue::Raw8(
-                pmbus_read!(self.device, FAN_CONFIG_1_2)?.get()?,
+            Operation::FanConfig1_2 => {
+                let (val, width) =
+                    pmbus_read!(self.device, FAN_CONFIG_1_2)?.raw();
+                assert_eq!(width.0, 8);
+                PmbusValue::Raw8(val as u8)
+            }
+            Operation::FanCommand1 => PmbusValue::from(
+                pmbus_read!(self.device, FAN_COMMAND_1)?.get()?,
             ),
-            Operation::FanCommand1 => PmbusValue::Unitless(
-                pmbus_read!(self.device, FAN_COMMAND_1)?.get()?.0,
-            ),
-            Operation::FanCommand2 => PmbusValue::Unitless(
-                pmbus_read!(self.device, FAN_COMMAND_1)?.get()?.0,
+            Operation::FanCommand2 => PmbusValue::from(
+                pmbus_read!(self.device, FAN_COMMAND_1)?.get()?,
             ),
             Operation::IoutOcFaultLimit => PmbusValue::from(
                 pmbus_read!(self.device, IOUT_OC_FAULT_LIMIT)?.get()?,
@@ -220,12 +223,18 @@ impl Mwocp68 {
                 assert_eq!(width.0, 8);
                 PmbusValue::Raw8(val as u8)
             }
-            Operation::StatusMfrSpecific => PmbusValue::Raw8(
-                pmbus_read!(self.device, STATUS_MFR_SPECIFIC)?.get()?,
-            ),
-            Operation::StatusFans1_2 => PmbusValue::Raw8(
-                pmbus_read!(self.device, STATUS_FANS_1_2)?.get()?,
-            ),
+            Operation::StatusMfrSpecific => {
+                let (val, width) =
+                    pmbus_read!(self.device, STATUS_MFR_SPECIFIC)?.raw();
+                assert_eq!(width.0, 8);
+                PmbusValue::Raw8(val as u8)
+            }
+            Operation::StatusFans1_2 => {
+                let (val, width) =
+                    pmbus_read!(self.device, STATUS_FANS_1_2)?.raw();
+                assert_eq!(width.0, 8);
+                PmbusValue::Raw8(val as u8)
+            }
             Operation::ReadEin => {
                 self.read_block::<6>(CommandCode::READ_EIN)?
             }

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -7,18 +7,14 @@ Interface(
             doc: "performs a pmbus read operation",
             encoding: Hubpack,
             args: {
-                "dev": (
-                    type: "Device",
-                    recv: FromPrimitive("u8"),
-                ),
-                "op": (
-                    type: "Operation",
-                    recv: FromPrimitive("u8"),
-                ),
+                "dev": "Device",
+                "rail": "u8",
+                "index": "u32",
+                "op": "Operation",
             },
             reply: Result(
-                ok: "Value",
-                err: CLike("PowerError"),
+                ok: "PmbusValue",
+                err: CLike("ResponseCode"),
             ),
         ),
     },

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -1,0 +1,25 @@
+// Power API
+
+Interface(
+    name: "Power",
+    ops: {
+        "pmbus_read": (
+            doc: "performs a pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "dev": (
+                    type: "Device",
+                    recv: FromPrimitive("u8"),
+                ),
+                "op": (
+                    type: "Operation",
+                    recv: FromPrimitive("u8"),
+                ),
+            },
+            reply: Result(
+                ok: "Value",
+                err: CLike("PowerError"),
+            ),
+        ),
+    },
+)

--- a/task/power-api/Cargo.toml
+++ b/task/power-api/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 [dependencies]
 hubpack.workspace = true
 num-traits.workspace = true
+pmbus.workspace = true
 serde.workspace = true
+static_assertions.workspace = true
 zerocopy.workspace = true
 
-derive-idol-err = { path = "../../lib/derive-idol-err"  }
+drv-i2c-api = { path = "../../drv/i2c-api" }
 userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]

--- a/task/power-api/Cargo.toml
+++ b/task/power-api/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "task-power-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hubpack.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+zerocopy.workspace = true
+
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
+userlib = { path = "../../sys/userlib" }
+
+[build-dependencies]
+idol.workspace = true

--- a/task/power-api/build.rs
+++ b/task/power-api/build.rs
@@ -3,9 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    idol::client::build_client_stub(
-        "../../idl/power.idol",
-        "client_stub.rs",
-    )?;
+    idol::client::build_client_stub("../../idl/power.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/task/power-api/build.rs
+++ b/task/power-api/build.rs
@@ -3,15 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_target_board();
-
-    idol::server::build_server_support(
+    idol::client::build_client_stub(
         "../../idl/power.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
+        "client_stub.rs",
     )?;
-
-    build_i2c::codegen(build_i2c::Disposition::Sensors)?;
-
     Ok(())
 }

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -6,37 +6,122 @@
 
 #![no_std]
 
-use derive_idol_err::IdolError;
+pub use drv_i2c_api::ResponseCode;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
-use userlib::{sys_send, FromPrimitive};
+use userlib::sys_send;
 
-#[derive(
-    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
-)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]
 pub enum Device {
-    Mwocp68,
+    PowerShelf,
 }
 
-#[derive(
-    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
-)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]
 pub enum Operation {
-    Todo1,
-    Todo2,
+    FanConfig1_2,
+    FanCommand1,
+    FanCommand2,
+    IoutOcFaultLimit,
+    IoutOcWarnLimit,
+    OtWarnLimit,
+    IinOcWarnLimit,
+    PoutOpWarnLimit,
+    PinOpWarnLimit,
+    StatusByte,
+    StatusWord,
+    StatusVout,
+    StatusIout,
+    StatusInput,
+    StatusTemperature,
+    StatusCml,
+    StatusMfrSpecific,
+    StatusFans1_2,
+    ReadEin,
+    ReadEout,
+    ReadVin,
+    ReadIin,
+    ReadVcap,
+    ReadVout,
+    ReadIout,
+    ReadTemperature1,
+    ReadTemperature2,
+    ReadTemperature3,
+    ReadFanSpeed1,
+    ReadFanSpeed2,
+    ReadPout,
+    ReadPin,
+    PmbusRevision,
+    MfrId,
+    MfrModel,
+    MfrRevision,
+    MfrLocation,
+    MfrDate,
+    MfrSerial,
+    MfrVinMin,
+    MfrVinMax,
+    MfrIinMax,
+    MfrPinMax,
+    MfrVoutMin,
+    MfrVoutMax,
+    MfrIoutMax,
+    MfrPoutMax,
+    MfrTambientMax,
+    MfrTambientMin,
+    MfrEfficiencyHl,
+    MfrMaxTemp1,
+    MfrMaxTemp2,
+    MfrMaxTemp3,
 }
 
-#[derive(
-    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
-)]
-pub enum Value {
-    Todo1,
-    Todo2,
+pub const MAX_BLOCK_LEN: usize = 17;
+
+// We use a `u8` for the actual block length; ensure `MAX_BLOCK_LEN` fits.
+static_assertions::const_assert!(MAX_BLOCK_LEN <= u8::MAX as usize);
+
+#[derive(Debug, Clone, Deserialize, Serialize, SerializedSize)]
+pub enum PmbusValue {
+    Celsius(f32),
+    Amperes(f32),
+    Watts(f32),
+    Volts(f32),
+    Rpm(f32),
+    Raw8(u8),
+    Raw16(u16),
+    Unitless(f32),
+    Block {
+        data: [u8; MAX_BLOCK_LEN],
+        len: u8,
+    },
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
-pub enum PowerError {
-    Todo = 1,
+impl From<pmbus::units::Celsius> for PmbusValue {
+    fn from(value: pmbus::units::Celsius) -> Self {
+        Self::Celsius(value.0)
+    }
+}
+
+impl From<pmbus::units::Amperes> for PmbusValue {
+    fn from(value: pmbus::units::Amperes) -> Self {
+        Self::Amperes(value.0)
+    }
+}
+
+impl From<pmbus::units::Watts> for PmbusValue {
+    fn from(value: pmbus::units::Watts) -> Self {
+        Self::Watts(value.0)
+    }
+}
+
+impl From<pmbus::units::Volts> for PmbusValue {
+    fn from(value: pmbus::units::Volts) -> Self {
+        Self::Volts(value.0)
+    }
+}
+
+impl From<pmbus::units::Rpm> for PmbusValue {
+    fn from(value: pmbus::units::Rpm) -> Self {
+        Self::Rpm(value.0)
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -88,10 +88,7 @@ pub enum PmbusValue {
     Raw8(u8),
     Raw16(u16),
     Unitless(f32),
-    Block {
-        data: [u8; MAX_BLOCK_LEN],
-        len: u8,
-    },
+    Block { data: [u8; MAX_BLOCK_LEN], len: u8 },
 }
 
 impl From<pmbus::units::Celsius> for PmbusValue {

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API crate for the Gimlet Host Flash server.
+
+#![no_std]
+
+use derive_idol_err::IdolError;
+use hubpack::SerializedSize;
+use serde::{Deserialize, Serialize};
+use userlib::{sys_send, FromPrimitive};
+
+#[derive(
+    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
+)]
+pub enum Device {
+    Mwocp68,
+}
+
+#[derive(
+    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
+)]
+pub enum Operation {
+    Todo1,
+    Todo2,
+}
+
+#[derive(
+    Debug, Clone, Copy, FromPrimitive, Deserialize, Serialize, SerializedSize,
+)]
+pub enum Value {
+    Todo1,
+    Todo2,
+}
+
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
+pub enum PowerError {
+    Todo = 1,
+}
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -87,7 +87,7 @@ pub enum PmbusValue {
     Rpm(f32),
     Raw8(u8),
     Raw16(u16),
-    Unitless(f32),
+    Percent(f32),
     Block { data: [u8; MAX_BLOCK_LEN], len: u8 },
 }
 
@@ -118,6 +118,12 @@ impl From<pmbus::units::Volts> for PmbusValue {
 impl From<pmbus::units::Rpm> for PmbusValue {
     fn from(value: pmbus::units::Rpm) -> Self {
         Self::Rpm(value.0)
+    }
+}
+
+impl From<pmbus::units::Percent> for PmbusValue {
+    fn from(value: pmbus::units::Percent) -> Self {
+        Self::Percent(value.0)
     }
 }
 

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -4,10 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = { workspace = true }
-cortex-m = { workspace = true }
-paste = { workspace = true }
-zerocopy = { workspace = true }
+cfg-if.workspace = true
+cortex-m.workspace = true
+hubpack.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+paste.workspace = true
+serde.workspace = true
+zerocopy.workspace = true
 
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
 drv-i2c-api = { path = "../../drv/i2c-api" }
@@ -16,12 +20,14 @@ drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"], optional = true }
 mutable-statics = { path = "../../lib/mutable-statics" }
 ringbuf = { path = "../../lib/ringbuf"  }
+task-power-api = { path = "../power-api" }
 task-sensor-api = { path = "../sensor-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
-anyhow = { workspace = true }
-cfg-if = { workspace = true }
+anyhow.workspace = true
+cfg-if.workspace = true
+idol.workspace = true
 
 build-i2c = { path = "../../build/i2c" }
 build-util = { path = "../../build/util" }

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -157,7 +157,9 @@ impl Device {
             | Device::Isl68224(_)
             | Device::Tps546B24A(_)
             | Device::Adm1272(_)
-            | Device::Max5970(_) => return Err(ResponseCode::NoDevice),
+            | Device::Max5970(_) => {
+                return Err(ResponseCode::OperationNotSupported)
+            }
         };
         Ok(v)
     }


### PR DESCRIPTION
The bulk of this PR adds the `Power.pmbus_read()` operation for remote use via `humility rpc` during compliance, and the 50+ variant enum describing all the ACAN-114 pmbus commands we want to read. This command (for now?) only supports the MWOCP68.

There are a handful of other changes included as a part of this work:

1. Adds gimletlet to CI and fixes its build
2. Removes the `NReplyMismatch` error from `udprpc`: for idol calls with `encoding: Hubpack` or `encoding: Ssmarshal`, the reply size is expected to be _at most_ the reply size requested by `humility rpc`, but is not guaranteed to be exactly that value. Removing this error allows smaller replies to come through okay.
3. The `power` task is now an idol server, so its previous main loop (sleep 1 second, then read data and post it to the `sensors` task) lives inside the idol server notification system.