### PR TITLE
no longer need to hold thermal

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -17,9 +17,6 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-tasks-to-hold = ["thermal"]
-
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -17,9 +17,6 @@ start = true
 features = ["itm"]
 stacksize = 1536
 
-[tasks.jefe.config]
-tasks-to-hold = ["thermal"]
-
 [tasks.jefe.config.on-state-change]
 net = {bit-number = 3}
 host_sp_comms = {bit-number = 1}


### PR DESCRIPTION
We were holding the `thermal` task to debug a failure that we had (non-reproducibly) seen, but we now believe that that was in fact fixed in #1035; we no longer need to hold the `thermal` task on fault. 