### PR TITLE
Add an error indicating that the `net` server restarted

### DIFF
--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -127,10 +127,15 @@ impl ServerImpl {
                 // the host is responsible for retrying.
                 //
                 // Other errors are unexpected and panic.
+                //
+                // This includes ServerRestarted; the server should only
+                // restart due to the watchdog, and the watchdog should fire
+                // because we're literally replying to a packet here.
                 ringbuf_entry!(Trace::SendError(e));
                 match e {
                     SendError::QueueFull => (),
                     SendError::Other
+                    | SendError::ServerRestarted
                     | SendError::NotYours
                     | SendError::InvalidVLan => panic!(),
                 }

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -128,9 +128,10 @@ impl ServerImpl {
                 //
                 // Other errors are unexpected and panic.
                 //
-                // This includes ServerRestarted; the server should only
-                // restart due to the watchdog, and the watchdog should fire
-                // because we're literally replying to a packet here.
+                // This includes ServerRestarted, because the server should only
+                // restart if the watchdog times out, and the watchdog should
+                // not be timing out, because we're literally replying to a
+                // packet here.
                 ringbuf_entry!(Trace::SendError(e));
                 match e {
                     SendError::QueueFull => (),

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -24,6 +24,9 @@ pub enum SendError {
     QueueFull = 3,
 
     Other = 4,
+
+    #[idol(server_death)]
+    ServerRestarted = 5,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -41,9 +41,12 @@ fn main() -> ! {
                             sys_recv_closed(&mut [], 1, TaskId::KERNEL)
                                 .unwrap();
                         }
-                        Err(SendError::NotYours) => panic!(),
-                        Err(SendError::InvalidVLan) => panic!(),
-                        Err(SendError::Other) => panic!(),
+                        Err(
+                            SendError::ServerRestarted
+                            | SendError::NotYours
+                            | SendError::InvalidVLan
+                            | SendError::Other,
+                        ) => panic!(),
                     }
                 }
             }


### PR DESCRIPTION
This prevents **mandatory crashing** (in the generated Idol code) by clients when the watchdog fires.

A client could still crash if it wasn't expecting this particular error, but that's on them.