### PR TITLE
Use sensors in thermal task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ dependencies = [
 name = "drv-transceivers-api"
 version = "0.1.0"
 dependencies = [
+ "build-i2c",
  "derive-idol-err",
  "drv-fpga-api",
  "idol",
@@ -1723,6 +1724,7 @@ dependencies = [
  "num-traits",
  "serde",
  "ssmarshal",
+ "task-sensor-api",
  "transceiver-messages",
  "userlib",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "ssmarshal",
  "stm32h7",
  "task-net-api",
+ "task-sensor-api",
  "task-thermal-api",
  "transceiver-messages",
  "userlib",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -111,7 +111,7 @@ name = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 4504
+stacksize = 6000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -111,7 +111,7 @@ name = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 4504
+stacksize = 6000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -267,9 +267,10 @@ max-sizes = {flash = 65536, ram = 16384}
 stacksize = 4096
 start = true
 task-slots = [
-    "sys",
     "i2c_driver",
     "net",
+    "sensor",
+    "sys",
     "thermal",
     {front_io = "ecp5_front_io"},
     {seq = "sequencer"}]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -270,6 +270,7 @@ start = true
 task-slots = [
     "i2c_driver",
     "net",
+    "sensor",
     "sys",
     "thermal",
     {front_io = "ecp5_front_io"},

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -946,7 +946,7 @@ impl ConfigGenerator {
         for (index, d) in self.devices.iter().enumerate() {
             by_device.insert(&d.device, d);
 
-            let (controller, port) = self.lookup_controller_port(&d);
+            let (controller, port) = self.lookup_controller_port(d);
 
             by_port.insert(port, index);
             by_controller.insert(controller, index);

--- a/drv/transceivers-api/Cargo.toml
+++ b/drv/transceivers-api/Cargo.toml
@@ -13,7 +13,9 @@ zerocopy = { workspace = true }
 
 derive-idol-err = { path = "../../lib/derive-idol-err" }
 drv-fpga-api = { path = "../fpga-api" }
+task-sensor-api = { path = "../../task/sensor-api" }
 userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol = { workspace = true }
+build-i2c = { path = "../../build/i2c" }

--- a/drv/transceivers-api/build.rs
+++ b/drv/transceivers-api/build.rs
@@ -7,5 +7,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../../idl/transceivers.idol",
         "client_stub.rs",
     )?;
+
+    let disposition = build_i2c::Disposition::Sensors;
+    if let Err(e) = build_i2c::codegen(disposition) {
+        println!("code generation failed: {}", e);
+        std::process::exit(1);
+    }
+
     Ok(())
 }

--- a/drv/transceivers-api/src/lib.rs
+++ b/drv/transceivers-api/src/lib.rs
@@ -9,6 +9,7 @@
 use derive_idol_err::IdolError;
 use drv_fpga_api::FpgaError;
 use serde::{Deserialize, Serialize};
+use task_sensor_api::{config::other_sensors, SensorId};
 use userlib::{sys_send, FromPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
@@ -98,6 +99,42 @@ pub const PAGE_SIZE_BYTES: usize = 128;
 /// ports.
 pub const NUM_PORTS: u8 = 32;
 
+////////////////////////////////////////////////////////////////////////////////
+
+pub const TRANSCEIVER_TEMPERATURE_SENSORS: [SensorId; NUM_PORTS as usize] = [
+    other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR2_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR3_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR4_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR5_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR6_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR7_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR8_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR9_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR10_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR11_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR12_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR13_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR14_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR15_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR16_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR17_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR18_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR19_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR20_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR21_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR22_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR23_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR24_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR25_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR26_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR27_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR28_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR29_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR30_TEMPERATURE_SENSOR,
+    other_sensors::QSFP_XCVR31_TEMPERATURE_SENSOR,
+];
 ////////////////////////////////////////////////////////////////////////////////
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/transceivers-server/Cargo.toml
+++ b/drv/transceivers-server/Cargo.toml
@@ -14,6 +14,7 @@ drv-transceivers-api = { path = "../transceivers-api" }
 mutable-statics = { path = "../../lib/mutable-statics" }
 ringbuf = { path = "../../lib/ringbuf" }
 task-net-api = { path = "../../task/net-api" }
+task-sensor-api = { path = "../../task/sensor-api" }
 task-thermal-api = { path = "../../task/thermal-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -87,7 +87,7 @@ struct ServerImpl {
     sensor_api: Sensor,
 
     /// Thermal models are populated by the host
-    thermal_models: [Option<ThermalModel>; NUM_PORTS],
+    thermal_models: [Option<ThermalModel>; NUM_PORTS as usize],
 }
 
 #[derive(Copy, Clone)]
@@ -343,7 +343,7 @@ impl ServerImpl {
 
 // This must be in the same order as the `DYNAMIC_INPUTS` array in
 // `thermal/src/bsp/sidecar_ab.rs`
-const SENSOR_IDS: [SensorId; NUM_PORTS] = [
+const SENSOR_IDS: [SensorId; NUM_PORTS as usize] = [
     other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
     other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,
     other_sensors::QSFP_XCVR2_TEMPERATURE_SENSOR,
@@ -607,7 +607,7 @@ fn main() -> ! {
             leds_initialized: false,
             thermal_api,
             sensor_api,
-            thermal_models: [None; NUM_PORTS],
+            thermal_models: [None; NUM_PORTS as usize],
         };
 
         ringbuf_entry!(Trace::LEDInit);

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -87,7 +87,7 @@ struct ServerImpl {
     sensor_api: task_sensor_api::Sensor,
 
     /// Thermal models are populated by the host
-    thermal_models: [Option<ThermalModel>; 32],
+    thermal_models: [Option<ThermalModel>; NUM_PORTS],
 }
 
 #[derive(Copy, Clone)]
@@ -343,7 +343,7 @@ impl ServerImpl {
 
 // This must be in the same order as the `DYNAMIC_INPUTS` array in
 // `thermal/src/bsp/sidecar_ab.rs`
-const SENSOR_IDS: [SensorId; 32] = [
+const SENSOR_IDS: [SensorId; NUM_PORTS] = [
     other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
     other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,
     other_sensors::QSFP_XCVR2_TEMPERATURE_SENSOR,
@@ -607,7 +607,7 @@ fn main() -> ! {
             leds_initialized: false,
             thermal_api,
             sensor_api,
-            thermal_models: [None; 32],
+            thermal_models: [None; NUM_PORTS],
         };
 
         ringbuf_entry!(Trace::LEDInit);

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -23,9 +23,7 @@ use idol_runtime::{
     ClientError, Leased, NotificationHandler, RequestError, R, W,
 };
 use ringbuf::*;
-use task_sensor_api::{
-    config::other_sensors, NoData, Sensor, SensorError, SensorId,
-};
+use task_sensor_api::{NoData, Sensor, SensorError};
 use task_thermal_api::{Thermal, ThermalError, ThermalProperties};
 use transceiver_messages::mgmt::ManagementInterface;
 use userlib::{units::Celsius, *};

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -16,7 +16,7 @@ use drv_sidecar_front_io::{
 use drv_sidecar_seq_api::{SeqError, Sequencer};
 use drv_transceivers_api::{
     ModulesStatus, PowerState, PowerStatesAll, TransceiversError, NUM_PORTS,
-    PAGE_SIZE_BYTES,
+    PAGE_SIZE_BYTES, TRANSCEIVER_TEMPERATURE_SENSORS,
 };
 use hubpack::SerializedSize;
 use idol_runtime::{
@@ -283,10 +283,10 @@ impl ServerImpl {
                 }
 
                 // Tell the `sensor` task that this device is no longer present
-                if let Err(e) = self
-                    .sensor_api
-                    .nodata_now(SENSOR_IDS[i], NoData::DeviceNotPresent)
-                {
+                if let Err(e) = self.sensor_api.nodata_now(
+                    TRANSCEIVER_TEMPERATURE_SENSORS[i],
+                    NoData::DeviceNotPresent,
+                ) {
                     ringbuf_entry!(Trace::SensorError(i, e));
                 }
 
@@ -321,9 +321,11 @@ impl ServerImpl {
             match temperature {
                 Ok(t) => {
                     // We got a temperature! Send it over to the thermal task
-                    if let Err(e) =
-                        self.sensor_api.post(SENSOR_IDS[i], t.0, now)
-                    {
+                    if let Err(e) = self.sensor_api.post(
+                        TRANSCEIVER_TEMPERATURE_SENSORS[i],
+                        t.0,
+                        now,
+                    ) {
                         ringbuf_entry!(Trace::SensorError(i, e));
                     }
                 }
@@ -340,43 +342,6 @@ impl ServerImpl {
         }
     }
 }
-
-// This must be in the same order as the `DYNAMIC_INPUTS` array in
-// `thermal/src/bsp/sidecar_ab.rs`
-const SENSOR_IDS: [SensorId; NUM_PORTS as usize] = [
-    other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR2_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR3_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR4_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR5_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR6_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR7_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR8_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR9_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR10_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR11_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR12_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR13_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR14_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR15_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR16_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR17_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR18_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR19_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR20_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR21_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR22_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR23_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR24_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR25_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR26_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR27_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR28_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR29_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR30_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR31_TEMPERATURE_SENSOR,
-];
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -244,8 +244,6 @@ impl ServerImpl {
     }
 
     fn update_thermal_loop(&mut self, status: ModulesStatus) {
-        let now = sys_get_timer().now;
-
         for i in 0..self.thermal_models.len() {
             let port = LogicalPort(i as u8);
             let mask = 1 << i;
@@ -319,11 +317,10 @@ impl ServerImpl {
             match temperature {
                 Ok(t) => {
                     // We got a temperature! Send it over to the thermal task
-                    if let Err(e) = self.sensor_api.post(
-                        TRANSCEIVER_TEMPERATURE_SENSORS[i],
-                        t.0,
-                        now,
-                    ) {
+                    if let Err(e) = self
+                        .sensor_api
+                        .post_now(TRANSCEIVER_TEMPERATURE_SENSORS[i], t.0)
+                    {
                         ringbuf_entry!(Trace::SensorError(i, e));
                     }
                 }

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -84,7 +84,7 @@ struct ServerImpl {
     thermal_api: Thermal,
 
     /// Handle to write temperatures to the `sensors` task
-    sensor_api: task_sensor_api::Sensor,
+    sensor_api: Sensor,
 
     /// Thermal models are populated by the host
     thermal_models: [Option<ThermalModel>; NUM_PORTS],

--- a/idl/sensor.idol
+++ b/idl/sensor.idol
@@ -41,6 +41,7 @@ Interface(
                 ok: "()",
                 err: CLike("SensorError"),
             ),
+            idempotent: true,
         ),
         "nodata": (
             args: {
@@ -58,6 +59,7 @@ Interface(
                 ok: "()",
                 err: CLike("SensorError"),
             ),
+            idempotent: true,
         ),
         "get_nerrors": (
             args: {

--- a/idl/sensor.idol
+++ b/idl/sensor.idol
@@ -14,6 +14,7 @@ Interface(
                 ok: "f32",
                 err: CLike("SensorError"),
             ),
+            idempotent: true,
         ),
         "get_reading": (
             args: {
@@ -27,6 +28,7 @@ Interface(
                 err: CLike("SensorError"),
             ),
             encoding: Hubpack,
+            idempotent: true,
         ),
         "post": (
             args: {

--- a/idl/thermal.idol
+++ b/idl/thermal.idol
@@ -88,12 +88,10 @@ Interface(
             ),
         ),
         "update_dynamic_input": (
-            doc: "Provides a reading and thermal model for a dynamic sensor",
+            doc: "Provides a thermal model for a dynamic sensor",
             args: {
                 "index": "usize",
-                "time": "u64",
                 "model": "ThermalProperties",
-                "temperature": "Celsius",
             },
             reply: Result(
                 ok: "()",

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -419,6 +419,8 @@ impl From<SensorErrorConvert> for MeasurementError {
             SensorError::DeviceUnavailable => Self::DeviceUnavailable,
             SensorError::DeviceTimeout => Self::DeviceTimeout,
             SensorError::DeviceOff => Self::DeviceOff,
+
+            SensorError::ServerDied => panic!(),
         }
     }
 }

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -503,7 +503,7 @@ impl ServerImpl {
 
             match dev.read_vout() {
                 Ok(reading) => {
-                    sensor.post_now(c.voltage, reading.0, now).unwrap();
+                    sensor.post_now(c.voltage, reading.0).unwrap();
                 }
                 Err(_) => {
                     sensor.nodata_now(c.voltage, NoData::DeviceError).unwrap();

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -482,65 +482,52 @@ impl ServerImpl {
             }
 
             if let Some(id) = c.temperature {
-                let r = dev.read_temperature();
-                let now = sys_get_timer().now;
-                match r {
+                match dev.read_temperature() {
                     Ok(reading) => {
-                        sensor.post(id, reading.0, now).unwrap();
+                        sensor.post_now(id, reading.0).unwrap();
                     }
                     Err(_) => {
-                        sensor.nodata(id, NoData::DeviceError, now).unwrap();
+                        sensor.nodata_now(id, NoData::DeviceError).unwrap();
                     }
                 }
             }
 
-            let r = dev.read_iout();
-            let now = sys_get_timer().now;
-            match r {
+            match dev.read_iout() {
                 Ok(reading) => {
-                    sensor.post(c.current, reading.0, now).unwrap();
+                    sensor.post_now(c.current, reading.0).unwrap();
                 }
                 Err(_) => {
-                    sensor.nodata(c.current, NoData::DeviceError, now).unwrap();
+                    sensor.nodata_now(c.current, NoData::DeviceError).unwrap();
                 }
             }
 
-            let r = dev.read_vout();
-            let now = sys_get_timer().now;
-            match r {
+            match dev.read_vout() {
                 Ok(reading) => {
-                    let now = sys_get_timer().now;
-                    sensor.post(c.voltage, reading.0, now).unwrap();
+                    sensor.post_now(c.voltage, reading.0, now).unwrap();
                 }
                 Err(_) => {
-                    sensor.nodata(c.voltage, NoData::DeviceError, now).unwrap();
+                    sensor.nodata_now(c.voltage, NoData::DeviceError).unwrap();
                 }
             }
 
             if let Some(id) = c.input_voltage {
-                let r = dev.read_vin();
-                let now = sys_get_timer().now;
-                match r {
+                match dev.read_vin() {
                     Ok(reading) => {
-                        let now = sys_get_timer().now;
-                        sensor.post(id, reading.0, now).unwrap();
+                        sensor.post_now(id, reading.0).unwrap();
                     }
                     Err(_) => {
-                        sensor.nodata(id, NoData::DeviceError, now).unwrap();
+                        sensor.nodata_now(id, NoData::DeviceError).unwrap();
                     }
                 }
             }
 
             if let Some(id) = c.input_current {
-                let r = dev.read_iin();
-                let now = sys_get_timer().now;
-                match r {
+                match dev.read_iin() {
                     Ok(reading) => {
-                        let now = sys_get_timer().now;
-                        sensor.post(id, reading.0, now).unwrap();
+                        sensor.post_now(id, reading.0).unwrap();
                     }
                     Err(_) => {
-                        sensor.nodata(id, NoData::DeviceError, now).unwrap();
+                        sensor.nodata_now(id, NoData::DeviceError).unwrap();
                     }
                 }
             }

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -115,6 +115,9 @@ pub enum SensorError {
     DeviceUnavailable = 5,
     DeviceTimeout = 6,
     DeviceOff = 7,
+
+    #[idol(server_death)]
+    ServerDied,
 }
 
 impl From<NoData> for SensorError {

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -131,6 +131,7 @@ impl From<NoData> for SensorError {
 
 impl Sensor {
     /// Post the given data with a timestamp of now
+    #[inline]
     pub fn post_now(
         &self,
         id: SensorId,
@@ -140,6 +141,7 @@ impl Sensor {
     }
 
     /// Post the given `NoData` error with a timestamp of now
+    #[inline]
     pub fn nodata_now(
         &self,
         id: SensorId,

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -129,5 +129,25 @@ impl From<NoData> for SensorError {
     }
 }
 
+impl Sensor {
+    /// Post the given data with a timestamp of now
+    pub fn post_now(
+        &self,
+        id: SensorId,
+        value: f32,
+    ) -> Result<(), SensorError> {
+        self.post(id, value, sys_get_timer().now)
+    }
+
+    /// Post the given `NoData` error with a timestamp of now
+    pub fn nodata_now(
+        &self,
+        id: SensorId,
+        nodata: NoData,
+    ) -> Result<(), SensorError> {
+        self.nodata(id, nodata, sys_get_timer().now)
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
 include!(concat!(env!("OUT_DIR"), "/sensor_config.rs"));

--- a/task/sensor-polling/src/main.rs
+++ b/task/sensor-polling/src/main.rs
@@ -74,14 +74,12 @@ impl TemperatureSensor {
             Device::Mwocp68 => {
                 for (i, &s) in self.temperature_sensors.iter().enumerate() {
                     let m = Mwocp68::new(&dev, i.try_into().unwrap());
-                    let r = m.read_temperature();
-                    let now = sys_get_timer().now;
-                    let post_result = match r {
-                        Ok(v) => sensor_api.post(s, v.0, now),
+                    let post_result = match m.read_temperature() {
+                        Ok(v) => sensor_api.post_now(s, v.0),
                         Err(e) => {
                             let e = Error::Mwocp68Error(e);
                             ringbuf_entry!(Trace::TemperatureReadFailed(s, e));
-                            sensor_api.nodata(s, e.into(), now)
+                            sensor_api.nodata_now(s, e.into())
                         }
                     };
                     if let Err(e) = post_result {
@@ -91,13 +89,12 @@ impl TemperatureSensor {
                 for (i, &s) in self.speed_sensors.iter().enumerate() {
                     let m = Mwocp68::new(&dev, i.try_into().unwrap());
                     let r = m.read_speed();
-                    let now = sys_get_timer().now;
-                    let post_result = match r {
-                        Ok(v) => sensor_api.post(s, v.0, now),
+                    let post_result = match m.read_speed() {
+                        Ok(v) => sensor_api.post_now(s, v.0),
                         Err(e) => {
                             let e = Error::Mwocp68Error(e);
                             ringbuf_entry!(Trace::SpeedReadFailed(s, e));
-                            sensor_api.nodata(s, e.into(), now)
+                            sensor_api.nodata_now(s, e.into())
                         }
                     };
                     if let Err(e) = post_result {

--- a/task/sensor-polling/src/main.rs
+++ b/task/sensor-polling/src/main.rs
@@ -88,7 +88,6 @@ impl TemperatureSensor {
                 }
                 for (i, &s) in self.speed_sensors.iter().enumerate() {
                     let m = Mwocp68::new(&dev, i.try_into().unwrap());
-                    let r = m.read_speed();
                     let post_result = match m.read_speed() {
                         Ok(v) => sensor_api.post_now(s, v.0),
                         Err(e) => {

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -78,4 +78,33 @@ pub struct ThermalProperties {
     pub temperature_slew_deg_per_sec: f32,
 }
 
+/// All of these functions take an **instantaneous** temperature; to convert a
+/// timestamped reading into an instantaneous temperature (using a thermal
+/// model), see `TimestampedTemperatureReading::worst_case`.
+impl ThermalProperties {
+    /// Returns whether this part is exceeding its power-down temperature
+    pub fn should_power_down(&self, t: Celsius) -> bool {
+        t.0 >= self.power_down_temperature.0
+    }
+
+    /// Returns whether this part is exceeding its critical temperature
+    pub fn is_critical(&self, t: Celsius) -> bool {
+        t.0 >= self.critical_temperature.0
+    }
+
+    /// Returns whether this part is below its critical temperature, with
+    /// a user-configured hysteresis band.
+    pub fn is_sub_critical(&self, t: Celsius, hysteresis: Celsius) -> bool {
+        t.0 < self.critical_temperature.0 - hysteresis.0
+    }
+
+    /// Returns the margin of this part, given a current temperature reading.
+    ///
+    /// Positive margin means that the part is below its max temperature;
+    /// negative means that it's overheating.
+    pub fn margin(&self, t: Celsius) -> Celsius {
+        Celsius(self.target_temperature.0 - t.0)
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/thermal/src/bsp/sidecar_ab.rs
+++ b/task/thermal/src/bsp/sidecar_ab.rs
@@ -222,6 +222,8 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
     ),
 ];
 
+// This must be in the same order as the `SENSOR_IDS` array in
+// `transceivers-srv/src/main.rs`
 const DYNAMIC_INPUTS: [SensorId; NUM_DYNAMIC_TEMPERATURE_INPUTS] = [
     other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
     other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,

--- a/task/thermal/src/bsp/sidecar_ab.rs
+++ b/task/thermal/src/bsp/sidecar_ab.rs
@@ -172,7 +172,8 @@ impl Bsp {
             },
 
             inputs: &INPUTS,
-            dynamic_inputs: &DYNAMIC_INPUTS,
+            dynamic_inputs:
+                &drv_transceivers_api::TRANSCEIVER_TEMPERATURE_SENSORS,
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,
@@ -220,43 +221,6 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
         PowerBitmask::A0_OR_A2,
         false,
     ),
-];
-
-// This must be in the same order as the `SENSOR_IDS` array in
-// `transceivers-srv/src/main.rs`
-const DYNAMIC_INPUTS: [SensorId; NUM_DYNAMIC_TEMPERATURE_INPUTS] = [
-    other_sensors::QSFP_XCVR0_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR1_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR2_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR3_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR4_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR5_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR6_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR7_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR8_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR9_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR10_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR11_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR12_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR13_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR14_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR15_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR16_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR17_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR18_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR19_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR20_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR21_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR22_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR23_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR24_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR25_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR26_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR27_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR28_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR29_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR30_TEMPERATURE_SENSOR,
-    other_sensors::QSFP_XCVR31_TEMPERATURE_SENSOR,
 ];
 
 const MISC_SENSORS: [TemperatureSensor; NUM_TEMPERATURE_SENSORS] = [

--- a/task/thermal/src/bsp/sidecar_ab.rs
+++ b/task/thermal/src/bsp/sidecar_ab.rs
@@ -19,7 +19,6 @@ use userlib::{task_slot, units::Celsius, TaskId};
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 use i2c_config::devices;
 use i2c_config::sensors;
-use task_sensor_api::config::other_sensors;
 
 task_slot!(SEQUENCER, sequencer);
 

--- a/task/thermal/src/bsp/sidecar_ab.rs
+++ b/task/thermal/src/bsp/sidecar_ab.rs
@@ -39,8 +39,8 @@ pub const NUM_DYNAMIC_TEMPERATURE_INPUTS: usize =
 
 const NUM_FANS: usize = sensors::NUM_MAX31790_SPEED_SENSORS;
 
-// The Sidecar controller hasn't been tuned yet, so boot into manual mode
-pub const USE_CONTROLLER: bool = false;
+// Run the PID loop on startup
+pub const USE_CONTROLLER: bool = true;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -517,9 +517,7 @@ impl<'a> ThermalControl<'a> {
     /// Resets the control state
     fn reset_state(&mut self) {
         self.state = ThermalControlState::Boot {
-            values: [None;
-                bsp::NUM_TEMPERATURE_INPUTS
-                    + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS],
+            values: [None; TEMPERATURE_ARRAY_SIZE],
         };
         ringbuf_entry!(Trace::AutoState(self.get_state()));
     }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -359,6 +359,8 @@ impl Default for OneSidedPidState {
     }
 }
 
+const TEMPERATURE_ARRAY_SIZE: usize =
+    bsp::NUM_TEMPERATURE_INPUTS + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS;
 /// This corresponds to states shown in RFD 276
 ///
 /// All of our temperature arrays contain, in order
@@ -370,14 +372,12 @@ enum ThermalControlState {
     /// (dynamic sensors must report in *if* they are present, i.e. not `None`
     /// in the `dynamic_inputs` array)
     Boot {
-        values: [Option<TemperatureReading>;
-            bsp::NUM_TEMPERATURE_INPUTS + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS],
+        values: [Option<TemperatureReading>; TEMPERATURE_ARRAY_SIZE],
     },
 
     /// Normal happy control loop
     Running {
-        values: [TemperatureReading;
-            bsp::NUM_TEMPERATURE_INPUTS + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS],
+        values: [TemperatureReading; TEMPERATURE_ARRAY_SIZE],
         pid: OneSidedPidState,
     },
 
@@ -386,8 +386,7 @@ enum ThermalControlState {
     /// the time at which we entered this state; at a certain point, we will
     /// timeout and drop into `Uncontrolled` if components do not recover.
     Overheated {
-        values: [TemperatureReading;
-            bsp::NUM_TEMPERATURE_INPUTS + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS],
+        values: [TemperatureReading; TEMPERATURE_ARRAY_SIZE],
         start_time: u64,
     },
 
@@ -445,9 +444,7 @@ impl<'a> ThermalControl<'a> {
             sensor_api,
             target_margin: Celsius(0.0f32),
             state: ThermalControlState::Boot {
-                values: [None;
-                    bsp::NUM_TEMPERATURE_INPUTS
-                        + bsp::NUM_DYNAMIC_TEMPERATURE_INPUTS],
+                values: [None; TEMPERATURE_ARRAY_SIZE],
             },
             pid_config: bsp.pid_config,
 


### PR DESCRIPTION
This PR refactors the `thermal` task to read temperature data from the `sensors`
task.  It still **writes** (most of) the data itself, but then reads it back, to
improve support for cases where other tasks provide temperature data.

The `sequencer` task now provides data to `sensors` directly, rather than
passing values through `thermal`.

In addition, it adds new APIs to the sensors task: `post_now` and `nodata_now`
send a reading and the current timestamp.  These APIs are used to reduce code in
a few unrelated tasks, e.g. `power` and `sensor-polling`.