### PR TITLE
Add more net server death error codes

### DIFF
--- a/drv/fpga-devices/src/ecp5_spi.rs
+++ b/drv/fpga-devices/src/ecp5_spi.rs
@@ -53,7 +53,6 @@ impl From<Ecp5UsingSpiError> for u8 {
                 SpiError::ServerRestarted => 4,
                 SpiError::NothingToRelease => 5,
                 SpiError::BadDevice => 6,
-                SpiError::DataOverrun => 7,
             },
         }
     }

--- a/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
+++ b/drv/fpga-devices/src/ecp5_spi_mux_pca9538.rs
@@ -52,7 +52,6 @@ impl From<Error> for u8 {
                 SpiError::ServerRestarted => 4,
                 SpiError::NothingToRelease => 5,
                 SpiError::BadDevice => 6,
-                SpiError::DataOverrun => 7,
             },
             Error::I2cError(e) => 8 + (e as u8),
         }

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -16,6 +16,7 @@ pub enum SpiError {
     BadTransferSize = 1,
 
     /// Server restarted
+    #[idol(server_death)]
     ServerRestarted = 2,
 
     /// Release without successful Lock
@@ -26,9 +27,6 @@ pub enum SpiError {
     ///
     /// This is almost certainly a programming error on the client side.
     BadDevice = 4,
-
-    /// Receive FIFO overflow
-    DataOverrun = 5,
 }
 
 #[derive(

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -92,9 +92,9 @@ impl ServerImpl {
             rx_data_buf,
         ) {
             Ok(meta) => self.handle_packet(meta, rx_data_buf, tx_data_buf),
-            Err(RecvError::QueueEmpty) => {
-                // Our incoming queue is empty. Wait for more packets
-                // in dispatch_n, back in the main loop.
+            Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
+                // Our incoming queue is empty or `net` restarted. Wait for more
+                // packets in dispatch_n, back in the main loop.
             }
             Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -39,6 +39,9 @@ pub enum RecvError {
     QueueEmpty = 2,
 
     Other = 3,
+
+    #[idol(server_death)]
+    ServerRestarted = 4,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
@@ -51,6 +54,9 @@ pub enum PhyError {
     NotImplemented = 2,
 
     Other = 3,
+
+    #[idol(server_death)]
+    ServerRestarted = 4,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError)]
@@ -65,29 +71,8 @@ pub enum KszError {
 
     WrongChipId,
 
-    // Errors copied from SpiError
-    BadTransferSize,
+    #[idol(server_death)]
     ServerRestarted,
-    NothingToRelease,
-    BadDevice,
-    DataOverrun,
-}
-
-#[cfg(feature = "ksz8463")]
-impl From<ksz8463::Error> for KszError {
-    fn from(e: ksz8463::Error) -> Self {
-        use drv_spi_api::SpiError;
-        match e {
-            ksz8463::Error::SpiError(e) => match e {
-                SpiError::BadTransferSize => KszError::BadTransferSize,
-                SpiError::ServerRestarted => KszError::ServerRestarted,
-                SpiError::NothingToRelease => KszError::NothingToRelease,
-                SpiError::BadDevice => KszError::BadDevice,
-                SpiError::DataOverrun => KszError::DataOverrun,
-            },
-            ksz8463::Error::WrongChipId(..) => KszError::WrongChipId,
-        }
-    }
 }
 
 #[derive(Copy, Clone, Debug, AsBytes, FromBytes)]

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -160,7 +160,7 @@ where
         let ksz8463 = bsp.ksz8463();
         let out = ksz8463
             .read_dynamic_mac_table(0)
-            .map_err(KszError::from)?
+            .unwrap_lite()
             .map(|mac| mac.count as usize)
             .unwrap_or(0);
         Ok(out)
@@ -179,7 +179,7 @@ where
         let ksz8463 = bsp.ksz8463();
         let out = ksz8463
             .read_dynamic_mac_table(i)
-            .map_err(KszError::from)?
+            .unwrap_lite()
             .map(KszMacTableEntry::from)
             .unwrap_or(KszMacTableEntry {
                 mac: [0; 6],
@@ -200,7 +200,7 @@ where
         let ksz8463 = bsp.ksz8463();
         let reg =
             ksz8463::Register::from_u16(i).ok_or(KszError::BadRegister)?;
-        let out = ksz8463.read(reg).map_err(KszError::from)?;
+        let out = ksz8463.read(reg).unwrap_lite();
         Ok(out)
     }
 

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -54,6 +54,9 @@ fn main() -> ! {
                 // Our incoming queue is empty. Wait for more packets.
                 sys_recv_closed(&mut [], 1, TaskId::KERNEL).unwrap();
             }
+            Err(RecvError::ServerRestarted) => {
+                // `net` restarted (probably due to the watchdog); just retry.
+            }
             Err(RecvError::NotYours) => panic!(),
             Err(RecvError::Other) => panic!(),
         }

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -152,6 +152,9 @@ fn main() -> ! {
                 // Our incoming queue is empty. Wait for more packets.
                 sys_recv_closed(&mut [], 1, TaskId::KERNEL).unwrap();
             }
+            Err(RecvError::ServerRestarted) => {
+                // `net` restarted (probably due to the watchdog); just retry.
+            }
             Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }
         // Try again.


### PR DESCRIPTION
This is a followup to #1050; the primary change is adding `ServerRestarted` variants to the rest of the `net-api` error types. Changes that came along for the ride:

* Removed `SpiError::DataOverrun` (unused)
* Added the `#[idol(server_death)]` annotation to `SpiError::ServerRestarted`
* Removed all the transferred `SpiError` variants in `KszError`; the `read_ksz*` idol functions (only called by humility) now panic if there's a SPI error.
* Updated all the net clients that handle `RecvError` to handle `RecvError::ServerRestarted` (treating it the same as `QueueEmpty`; i.e., retry).
* Added a handler in control-plane-agent to retry sends that fail with `SendError::ServerRestarted` instead of discarding them.