### PR TITLE
Write header block last on lpc55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
 name = "lpc55-update-server"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "build-util",
  "cfg-if",
  "drv-update-api",

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+abi = { path = "../../sys/abi" }
 drv-update-api = {  path = "../update-api/"  }
 hypocalls = { path = "../../lib/hypocalls" }
 ringbuf = { path = "../../lib/ringbuf" }

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -122,6 +122,7 @@ pub enum SprotError {
     UpdateFlashError,
     UpdateSpRotError,
     UpdateMissingHeaderBlock,
+    UpdateInvalidHeaderBlock,
     UpdateUnknown,
     // The status was returned for the SP, which is not what we asked about
     UpdateBadStatus,
@@ -159,6 +160,9 @@ impl From<UpdateError> for SprotError {
             UpdateError::SpRotError => SprotError::UpdateSpRotError,
             UpdateError::MissingHeaderBlock => {
                 SprotError::UpdateMissingHeaderBlock
+            }
+            UpdateError::InvalidHeaderBlock => {
+                SprotError::UpdateInvalidHeaderBlock
             }
             UpdateError::Unknown => SprotError::UpdateUnknown,
         }

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -121,7 +121,10 @@ pub enum SprotError {
     UpdateRunningImage,
     UpdateFlashError,
     UpdateSpRotError,
+    UpdateMissingHeaderBlock,
     UpdateUnknown,
+    // The status was returned for the SP, which is not what we asked about
+    UpdateBadStatus,
 
     // An error relating to Stage0 handoff of image data
     Stage0HandoffError,
@@ -154,6 +157,9 @@ impl From<UpdateError> for SprotError {
             UpdateError::RunningImage => SprotError::UpdateRunningImage,
             UpdateError::FlashError => SprotError::UpdateFlashError,
             UpdateError::SpRotError => SprotError::UpdateSpRotError,
+            UpdateError::MissingHeaderBlock => {
+                SprotError::UpdateMissingHeaderBlock
+            }
             UpdateError::Unknown => SprotError::UpdateUnknown,
         }
     }

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -73,8 +73,9 @@ pub enum UpdateError {
     UpdateNotStarted = 16,
     RunningImage = 17,
     FlashError = 18,
+    MissingHeaderBlock = 19,
     // Specific to RoT (LPC55)
-    SpRotError = 19,
+    SpRotError = 20,
     Unknown = 0xff,
 }
 

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -74,8 +74,9 @@ pub enum UpdateError {
     RunningImage = 17,
     FlashError = 18,
     MissingHeaderBlock = 19,
+    InvalidHeaderBlock = 20,
     // Specific to RoT (LPC55)
-    SpRotError = 20,
+    SpRotError = 21,
     Unknown = 0xff,
 }
 


### PR DESCRIPTION
Zero out the header block in flash, cache it in the lpc55-update-server, then write it during update finish.

This strategy prevents boot loops during partial RoT updates by invalidating the header magic.