### PR TITLE
Fix Update.status on RoT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,6 +3073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9283c6b06096b47afc7109834fdedab891175bb5241ee5d4f7d2546549f263"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,6 +4820,7 @@ dependencies = [
  "memchr",
  "ordered-toml",
  "path-slash",
+ "rangemap",
  "ron 0.7.0",
  "scroll",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 rand_core = { version = "0.6", default-features = false }
+rangemap = { version = "1.3", default-features = false }
 ron = { version = "0.7", default-features = false }
 scroll = { version = "0.10", default-features = false }
 serde = { version = "1.0.114", default-features = false, features = ["derive"] }

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -33,6 +33,7 @@ scroll = { workspace = true }
 walkdir = { workspace = true }
 fnv = { workspace = true }
 zerocopy = { workspace = true }
+rangemap = { workspace = true }
 
 # a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
 # on the version that works for us

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -179,6 +179,10 @@ enum Xtask {
         /// If there are multiple possible images, print this one
         #[clap(long)]
         image_name: Option<String>,
+
+        /// Print the expanded configuration
+        #[clap(long)]
+        expanded_config: bool,
     },
 }
 
@@ -341,8 +345,9 @@ fn run(xtask: Xtask) -> Result<()> {
             cfg,
             archive,
             image_name,
+            expanded_config,
         } => {
-            print::run(&cfg, archive, image_name)
+            print::run(&cfg, archive, image_name, expanded_config)
                 .context("could not print information about the build")?;
         }
     }

--- a/build/xtask/src/print.rs
+++ b/build/xtask/src/print.rs
@@ -6,12 +6,13 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Error, Result};
 
-use crate::dist::PackageConfig;
+use crate::{config::Config, dist::PackageConfig};
 
 pub fn run(
     cfg: &Path,
     archive: bool,
     image_name: Option<String>,
+    expanded_config: bool,
 ) -> Result<()> {
     if archive {
         let config = PackageConfig::new(cfg, false, false)
@@ -30,6 +31,10 @@ pub fn run(
             .img_file(format!("build-{}.zip", config.toml.name), image_name);
 
         println!("{}", final_path.display());
+    } else if expanded_config {
+        let config = Config::from_file(cfg)
+            .context("could not load build configuration")?;
+        println!("{:#?}", config);
     } else {
         bail!("I'm not sure what to print. Currently supported: --archive");
     }

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -183,8 +183,8 @@ impl idl::InOrderUpdateImpl for ServerImpl {
         _: &RecvMessage,
     ) -> Result<UpdateStatus, RequestError<Infallible>> {
         // Safety: Data is published by stage0
-        let addr: &[u8] = unsafe { BOOTSTATE.assume_init_ref() };
-        let status = match RotBootState::load_from_addr(&addr) {
+        let addr = unsafe { BOOTSTATE.assume_init_ref() };
+        let status = match RotBootState::load_from_addr(addr) {
             Ok(details) => UpdateStatus::Rot(details),
             Err(e) => UpdateStatus::LoadError(e),
         };

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -22,7 +22,7 @@ use userlib::*;
 static BOOTSTATE: MaybeUninit<[u8; 0x1000]> = MaybeUninit::uninit();
 
 cfg_if::cfg_if! {
-    if #[cfg(target_board = "lpcxpresso55s69")] {
+    if #[cfg(any(target_board = "lpcxpresso55s69", target_board = "gimlet-c"))]{
         declare_tz_table!();
     } else {
         declare_not_tz_table!();


### PR DESCRIPTION
On the lpc55s69, ARM trustzone is in use which was triggering a secure fault when accessing `sram3` used by the `BOOTSTATE` static variable in the lpc55-update server. This was due to the having overlapping ranges for the region defined in the SAU for this memory. Overlapping ranges cause the memory to automatically be accessible in secure mode only, when we needed it in non-secure mode.

Per the ARM v8m manual section B10.3:
> An address that matches multiple SAU regions is marked as Secure and not Not-secure callable regardless of the
attributes specified by the regions that matched the address.

@kc8apf fixed it with judicious use of rangemap.

This PR also:
 * Changes stage0 to configure the MPU *before* dumping the BOOTSTATE to USB SRAM
 * Removes an unnecessary reference
 * Ensures the `tz_table` is used for Rev-C boards in addition to the xpresso
 * Adds a flag to dump app config to the build
 