### PR TITLE
if/when resume of SP fails, reinitialize and retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 cargo-features = ["resolver", "named-profiles"]
 
+
 [workspace]
 members = [
     "build/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 cargo-features = ["resolver", "named-profiles"]
 
-
 [workspace]
 members = [
     "build/*",


### PR DESCRIPTION
Draft commit message:

```
In stress testing the in situ dumping facility, a disturbing pathology
was discovered:  a significant fraction of the time (as much as 15%),
the SWD facility would fail after the target was stopped -- and it
would fail to resume.  This is Bad.  Fortunately, reinitializing SWD
and re-attempting the resume seems to always correctly resume the
target (at which point the dump will fail, but at least the SP will be
alive!).
```