### PR TITLE
When starting an LPC55 update, erase block 0, but do not write any data.

### DIFF
--- a/lib/hypocalls/src/lib.rs
+++ b/lib/hypocalls/src/lib.rs
@@ -8,7 +8,7 @@
 //! Hypovisor calls
 
 pub use lpc55_flash::{
-    HypoStatus, UpdateTarget, __write_block, FLASH_PAGE_SIZE,
+    HypoStatus, UpdateTarget, __write_block, __erase_block, FLASH_PAGE_SIZE,
 };
 
 pub const TABLE_MAGIC: u32 = 0xabcd_abcd;
@@ -22,6 +22,7 @@ macro_rules! declare_tz_table {
         static TZ_TABLE: SecureTable = SecureTable {
             magic: 0,
             write_to_flash: None,
+            erase_flash: None,
         };
     };
 }
@@ -35,6 +36,7 @@ macro_rules! declare_not_tz_table {
         static TZ_TABLE: SecureTable = SecureTable {
             magic: TABLE_MAGIC,
             write_to_flash: Some(__write_block),
+            erase_flash: Some(__erase_block),
         };
     };
 }
@@ -54,6 +56,8 @@ pub struct SecureTable {
     // function
     pub write_to_flash:
         Option<unsafe extern "C" fn(UpdateTarget, u32, *mut u8) -> HypoStatus>,
+    pub erase_flash:
+        Option<unsafe extern "C" fn(UpdateTarget, u32) -> HypoStatus>,
 }
 
 impl SecureTable {
@@ -81,6 +85,33 @@ impl SecureTable {
         }
         if let Some(func) = core::ptr::read_volatile(&self.write_to_flash) {
             return func(img, block_num, buf);
+        }
+        unreachable!()
+    }
+
+    pub unsafe fn erase_flash(
+        &self,
+        img: UpdateTarget,
+        block_num: u32,
+    ) -> HypoStatus {
+        // SAFETY
+        // This entire function gets marked as unsafe because it takes a
+        // raw pointer (necessary for TrustZone ABI reasons)
+        //
+        // The table of applicable secure function calls is updated
+        // at build time. The compiler doesn't know this and wants to
+        // optimize this function based on the initial state which isn't
+        // what we want.
+        //
+        // We're doing a volatile read of the magic and comparing it to
+        // what we expect. If it is what we expect, we can assume the
+        // function table is what we generated at build time.
+        let magic = core::ptr::read_volatile(&self.magic);
+        if magic != TABLE_MAGIC {
+            panic!();
+        }
+        if let Some(func) = core::ptr::read_volatile(&self.erase_flash) {
+            return func(img, block_num);
         }
         unreachable!()
     }


### PR DESCRIPTION
Some testing and research is needed, but here is a draft PR.

On the LPC55, stage0 handles the case where block 0 is erase, i.e. block 0 is not zero or any other pattern.

It's important to invalidate the header as the first step in updating the bank. However, it's the erase/write cycle that causes wear in most flash parts. LPC55's data sheet claims 10k erase/write cycles (IIRC). So, a pathological update fail/retry loop where each iteration takes 10 seconds could burn out the flash in just over a day.

If the first step is only erase, and the LPC55 will not erase an erased block, or we can test for that, or erase on top of erase doesn't cause wear, then not writing any data to block
zero would eliminate wear in this pathological case.