### PR TITLE
RoT Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ version = "0.1.0"
 dependencies = [
  "crc",
  "derive-idol-err",
+ "drv-spi-api",
  "drv-update-api",
  "hubpack",
  "idol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#fb739009e0584e6185b352c3cf4390968e112f8f"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#57c680212c98f311be43f18cc8859eaefa7126e4"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/drv/lpc55-spi/src/lib.rs
+++ b/drv/lpc55-spi/src/lib.rs
@@ -140,6 +140,15 @@ impl Spi {
         self.reg.stat.read().mstidle().bit_is_set()
     }
 
+    // This should really be upstreamed into the lpc55-pac crate For some
+    // reason the SSD and SSA flags are not supported as readable However,
+    // this is useful in polling mode when we don't want to rely on interrupts
+    // necessarily, or don't want to worry about the flags automatically being
+    // cleared in `intstat` if we only care about one interrupt type.
+    pub fn ssd(&self) -> bool {
+        (self.reg.stat.read().bits() >> 5) & 0x01 != 0
+    }
+
     pub fn can_tx(&self) -> bool {
         self.reg.fifostat.read().txnotfull().bit_is_set()
     }
@@ -268,6 +277,10 @@ impl Spi {
     // NXP Document UM11126 35.6.8 SPI interrupt status register
     pub fn intstat(&self) -> device::spi0::intstat::R {
         self.reg.intstat.read()
+    }
+
+    pub fn stat(&self) -> device::spi0::stat::R {
+        self.reg.stat.read()
     }
 
     pub fn fifostat(&mut self) -> device::spi0::fifostat::R {

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -2,228 +2,128 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod sprockets;
-
-use crate::{IoStatus, LocalState};
-use drv_sprot_api::*;
-use drv_update_api::*;
+use crate::Trace;
+use crc::{Crc, CRC_32_CKSUM};
+use drv_sprot_api::{
+    IoStats, MsgType, Protocol, RxMsg, SprotError, SprotStatus, TxMsg,
+    UpdateRspHeader, VerifiedTxMsg, BUF_SIZE,
+};
+use drv_update_api::{Update, UpdateStatus, UpdateTarget};
 use dumper_api::Dumper;
-use ringbuf::*;
-use userlib::*;
+use lpc55_romapi::bootrom;
+use ringbuf::ringbuf_entry_root as ringbuf_entry;
+use sprockets_rot::RotSprocket;
+use static_assertions::const_assert;
+use userlib::{task_slot, UnwrapLite};
+
+mod sprockets;
 
 task_slot!(UPDATE_SERVER, update_server);
 task_slot!(DUMPER, dumper);
 
-#[derive(Copy, Clone, PartialEq)]
-enum PrevMsg {
-    None,
-    Flush,
-    Good(MsgType),
-    Overrun,
+pub const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
+const_assert!(Protocol::V1 as u8 > 0 && (Protocol::V1 as u8) < 32);
+
+/// State that is set once at the start of the driver
+pub struct StartupState {
+    /// All supported versions 'v' from 1 to 32 as a mask of (1 << v-1)
+    pub supported: u32,
+    /// CRC32 of the LPC55 boot ROM contents.
+    /// The LPC55 does not have machine readable version information for
+    /// its boot ROM contents and there are known issues with old boot ROMs.
+    /// TODO: This should live in the stage0 handoff info
+    pub bootrom_crc32: u32,
+
+    /// Maxiumum message size that the RoT can handle.
+    pub buffer_size: u32,
 }
 
-pub(crate) struct Handler {
-    sprocket: sprockets_rot::RotSprocket,
-    pub update: Update,
-    count: usize,
-    prev: PrevMsg,
+pub struct Handler {
+    sprocket: RotSprocket,
+    update: Update,
+    startup_state: StartupState,
 }
-
-pub(crate) fn new() -> Handler {
-    Handler {
-        sprocket: crate::handler::sprockets::init(),
-        update: drv_update_api::Update::from(UPDATE_SERVER.get_task_id()),
-        prev: PrevMsg::None,
-        count: 0,
-    }
-}
-
-#[derive(Copy, Clone, PartialEq)]
-enum Trace {
-    None,
-    HeaderSizeMismatch(MsgType, u16, usize),
-    Prev(usize, PrevMsg),
-    ErrHeader(usize, PrevMsg, u8, u8, u8, u8),
-    Dump(u32),
-    Overrun(usize),
-}
-ringbuf!(Trace, 16, Trace::None);
 
 impl Handler {
-    /// The Sp RoT target message handler processes the incoming message
-    /// and returns the length of the response placed in the Tx buffer.
-    /// If the length of the Tx buffer is greater than zero, the driver
-    /// will interrupt the SP to notify it of the response.
-    /// The driver will pad the unused portion of the Tx buffer with
-    /// zeros to satisfy IO needs when the SP clocks out more bytes than
-    /// available.
-    ///
-    /// Returns the number of bytes to transmit out of the Tx buffer.
-    pub fn handle(
+    pub fn new() -> Handler {
+        Handler {
+            sprocket: crate::handler::sprockets::init(),
+            update: Update::from(UPDATE_SERVER.get_task_id()),
+            startup_state: StartupState {
+                supported: 1_u32 << (Protocol::V1 as u8 - 1),
+                bootrom_crc32: CRC32.checksum(&bootrom().data[..]),
+                buffer_size: BUF_SIZE as u32,
+            },
+        }
+    }
+
+    /// Serialize and return a `SprotError::FlowError`
+    pub fn flow_error<'a>(&self, tx_buf: TxMsg<'a>) -> VerifiedTxMsg<'a> {
+        tx_buf.error_rsp(SprotError::FlowError)
+    }
+
+    pub fn handle<'a>(
         &mut self,
-        tx_prev: bool,
-        iostat: IoStatus,
-        rx_buf: &RxMsg,
-        rx_bytes: usize,
-        tx_buf: &mut TxMsg,
-        state: &mut LocalState, // for responses and updating
-    ) -> Option<VerifiedTxMsg> {
-        self.count = self.count.wrapping_add(1);
-
-        // Before looking at the received message, check for explicit flush or
-        // a receive overrun condition.
-        // Reject received messages if we had an overrun.
-        match iostat {
-            IoStatus::IOResult { overrun, underrun } => {
-                if tx_prev && underrun {
-                    state.tx_underrun = state.tx_underrun.wrapping_add(1);
-                    // If the flow error was in the message as opposed to
-                    // possible post-message trailing bytes, then the SP will
-                    // see the CRC error and can try again.
-                    // We discard our own possibly-failed Tx data and the SP
-                    // can retry if it wants to.
-                }
-                // In all known cases, the first ${FIFO_LENGTH}-bytes in the
-                // FIFO will be received correctly.
-                // That includes the protocol identifier.
-                // If it is not an ignored protocol, then send an error.
-                if overrun {
-                    if rx_bytes != 0 {
-                        if Protocol::from(rx_buf.as_slice()[0])
-                            != Protocol::Ignore
-                        {
-                            let rx_buf = rx_buf.as_slice();
-                            state.rx_overrun = state.rx_overrun.wrapping_add(1);
-                            ringbuf_entry!(Trace::Prev(self.count, self.prev));
-                            self.prev = PrevMsg::Overrun;
-                            ringbuf_entry!(Trace::ErrHeader(
-                                self.count, self.prev, rx_buf[0], rx_buf[1],
-                                rx_buf[2], rx_buf[3]
-                            ));
-                            return Some(
-                                tx_buf.error_rsp(SprotError::FlowError),
-                            );
-                        }
-                    } else {
-                        ringbuf_entry!(Trace::Prev(self.count, self.prev));
-                        ringbuf_entry!(Trace::Overrun(self.count));
-                        self.prev = PrevMsg::Overrun;
-                        return None;
-                    }
-                }
-            }
-            IoStatus::Flush => {
-                if tx_prev {
-                    state.tx_incomplete = state.tx_incomplete.wrapping_add(1);
-                    // Our message was not delivered
-                }
-                self.prev = PrevMsg::Flush;
-                return None;
-            }
-        }
-
-        // Check for the minimum receive length being satisfied.
-        if rx_bytes < MIN_MSG_SIZE {
-            return Some(tx_buf.error_rsp(SprotError::BadMessageLength));
-        }
-
-        // Parse the header which also checks the CRC.
-        let rxmsg = match rx_buf.parse_header(rx_bytes) {
-            Ok(header) => {
-                // We want to ensure the number of bytes received matches the
-                // header's expected payload size.
-                let expected_payload = rx_bytes - MIN_MSG_SIZE;
-                if header.payload_len as usize != expected_payload {
-                    ringbuf_entry!(Trace::HeaderSizeMismatch(
-                        header.msgtype,
-                        header.payload_len,
-                        expected_payload
-                    ));
-                    return Some(
-                        tx_buf.error_rsp(SprotError::BadMessageLength),
-                    );
-                }
-
-                self.prev = PrevMsg::Good(header.msgtype);
-                VerifiedRxMsg(header)
-            }
-            Err(msgerr) => {
+        rx_buf: RxMsg,
+        mut tx_buf: TxMsg<'a>,
+        stats: &mut IoStats,
+    ) -> Option<VerifiedTxMsg<'a>> {
+        // Parse the header and validate the CRC
+        let rx_msg = match rx_buf.parse() {
+            Ok(rxmsg) => rxmsg,
+            Err((header_bytes, msgerr)) => {
                 if msgerr == SprotError::NoMessage {
-                    self.prev = PrevMsg::None;
+                    // We were just returning a reply, so clocked out zeros
+                    // from the SP.
                     return None;
                 }
-                let rx_buf = rx_buf.as_slice();
-                ringbuf_entry!(Trace::ErrHeader(
-                    self.count, self.prev, rx_buf[0], rx_buf[1], rx_buf[2],
-                    rx_buf[3]
-                ));
+                ringbuf_entry!(Trace::ErrWithHeader(msgerr, header_bytes));
+                stats.rx_invalid = stats.rx_invalid.wrapping_add(1);
                 return Some(tx_buf.error_rsp(msgerr));
             }
         };
 
-        // At this point, the header and payload are known to be
-        // consistent with the CRC and the length is known to be good.
-        state.rx_received = state.rx_received.wrapping_add(1);
-
-        match self.run(rx_buf, rxmsg, tx_buf, state) {
-            Ok((msgtype, payload_size)) => {
-                tx_buf.from_existing(msgtype, payload_size).ok()
-            }
-            Err(err) if err == SprotError::NoMessage => None,
-            Err(err) => Some(tx_buf.error_rsp(err)),
-        }
-    }
-
-    // Run the command for the given MsgType, serialize the reply into
-    // `tx_output` and return the response MsgType and payload size or return
-    // an error.
-    fn run(
-        &mut self,
-        rxbuf: &RxMsg,
-        rxmsg: VerifiedRxMsg,
-        tx_buf: &mut TxMsg,
-        state: &mut LocalState,
-    ) -> Result<(MsgType, usize), SprotError> {
-        let rx_payload = rxbuf.payload(&rxmsg);
-        let tx_payload = tx_buf.payload_mut();
-        // The CRC validate header and range checked length can be trusted now.
-        let size = match rxmsg.0.msgtype {
+        // The CRC validated header and range checked length of the receiver can
+        // be trusted now.
+        let rx_payload = rx_msg.payload();
+        let res = match rx_msg.header().msgtype {
             MsgType::EchoReq => {
                 // We know payload_len is within bounds since the received
                 // header was parsed successfully and the send and receive
                 // buffers are the same size.
-                let dst = &mut tx_payload[..rxmsg.0.payload_len as usize];
+                let tx_payload = tx_buf.payload_mut();
+                let dst = &mut tx_payload[..rx_payload.len()];
                 dst.copy_from_slice(rx_payload);
-                dst.len()
+                let payload_len = dst.len();
+                tx_buf.from_existing(MsgType::EchoRsp, payload_len)
             }
-            MsgType::StatusReq => {
-                let rot_updates = match self.update.status() {
-                    UpdateStatus::Rot(rot_updates) => rot_updates,
-                    UpdateStatus::LoadError(e) => return Err(e.into()),
-                    _ => unreachable!(),
-                };
-                let status = SprotStatus {
-                    supported: state.supported,
-                    bootrom_crc32: state.bootrom_crc32,
-                    buffer_size: state.buffer_size,
-                    rot_updates,
-                };
-                hubpack::serialize(tx_payload, &status)?
-            }
+            MsgType::StatusReq => match self.update.status() {
+                UpdateStatus::Rot(rot_updates) => {
+                    let msg = SprotStatus {
+                        supported: self.startup_state.supported,
+                        bootrom_crc32: self.startup_state.bootrom_crc32,
+                        buffer_size: self.startup_state.buffer_size,
+                        rot_updates,
+                    };
+                    tx_buf.serialize(MsgType::StatusRsp, msg)
+                }
+                UpdateStatus::LoadError(_) => {
+                    Err((tx_buf, SprotError::Stage0HandoffError))
+                }
+                UpdateStatus::Sp => Err((tx_buf, SprotError::UpdateBadStatus)),
+            },
             MsgType::IoStatsReq => {
-                let stats = IoStats {
-                    rx_received: state.rx_received,
-                    rx_overrun: state.rx_overrun,
-                    tx_underrun: state.tx_underrun,
-                    rx_invalid: state.rx_invalid,
-                    tx_incomplete: state.tx_incomplete,
-                };
-                hubpack::serialize(tx_payload, &stats)?
+                tx_buf.serialize(MsgType::IoStatsRsp, *stats)
             }
             MsgType::SprocketsReq => {
-                self.sprocket.handle(rx_payload, tx_payload).unwrap_or_else(
-                    |_| crate::handler::sprockets::bad_encoding_rsp(tx_payload),
-                )
+                let tx_payload = tx_buf.payload_mut();
+                let n = self
+                    .sprocket
+                    .handle(rx_payload, tx_payload)
+                    .unwrap_or_else(|_| {
+                        crate::handler::sprockets::bad_encoding_rsp(tx_payload)
+                    });
+                tx_buf.from_existing(MsgType::SprocketsRsp, n)
             }
             MsgType::UpdBlockSizeReq => {
                 let rsp: UpdateRspHeader = self
@@ -231,27 +131,34 @@ impl Handler {
                     .block_size()
                     .map(|size| Some(size.try_into().unwrap_lite()))
                     .map_err(|err| err.into());
-                hubpack::serialize(tx_payload, &rsp)?
+                tx_buf.serialize(MsgType::UpdBlockSizeRsp, rsp)
             }
             MsgType::UpdPrepImageUpdateReq => {
-                let (image_type, _n) =
-                    hubpack::deserialize::<UpdateTarget>(rx_payload)?;
-                let rsp: UpdateRspHeader = self
-                    .update
-                    .prep_image_update(image_type)
-                    .map(|_| None)
-                    .map_err(|e| e.into());
-                hubpack::serialize(tx_payload, &rsp)?
+                match hubpack::deserialize::<UpdateTarget>(rx_payload) {
+                    Ok((image_type, _n)) => {
+                        let rsp: UpdateRspHeader = self
+                            .update
+                            .prep_image_update(image_type)
+                            .map(|_| None)
+                            .map_err(|e| e.into());
+                        tx_buf.serialize(MsgType::UpdPrepImageUpdateRsp, rsp)
+                    }
+                    Err(e) => Err((tx_buf, e.into())),
+                }
             }
             MsgType::UpdWriteOneBlockReq => {
-                let (block_num, block) =
-                    hubpack::deserialize::<u32>(rx_payload)?;
-                let rsp: UpdateRspHeader = self
-                    .update
-                    .write_one_block(block_num as usize, block)
-                    .map(|_| None)
-                    .map_err(|e| e.into());
-                hubpack::serialize(tx_payload, &rsp)?
+                match hubpack::deserialize::<u32>(rx_payload) {
+                    Ok((block_num, block)) => {
+                        let rsp: UpdateRspHeader = self
+                            .update
+                            .write_one_block(block_num as usize, block)
+                            .map(|_| None)
+                            .map_err(|e| e.into());
+
+                        tx_buf.serialize(MsgType::UpdWriteOneBlockRsp, rsp)
+                    }
+                    Err(e) => Err((tx_buf, e.into())),
+                }
             }
 
             MsgType::UpdAbortUpdateReq => {
@@ -260,7 +167,7 @@ impl Handler {
                     .abort_update()
                     .map(|_| None)
                     .map_err(|e| e.into());
-                hubpack::serialize(tx_payload, &rsp)?
+                tx_buf.serialize(MsgType::UpdAbortUpdateRsp, rsp)
             }
             MsgType::UpdFinishImageUpdateReq => {
                 let rsp: UpdateRspHeader = self
@@ -268,13 +175,18 @@ impl Handler {
                     .finish_image_update()
                     .map(|_| None)
                     .map_err(|e| e.into());
-                hubpack::serialize(tx_payload, &rsp)?
+                tx_buf.serialize(MsgType::UpdFinishImageUpdateRsp, rsp)
             }
             MsgType::SinkReq => {
                 // The first two bytes of a SinkReq payload are the U16
                 // mod 2^16 sequence number.
-                tx_payload[0..2].copy_from_slice(&rx_payload[0..2]);
-                2
+                if rx_payload.len() >= 2 {
+                    let tx_payload = tx_buf.payload_mut();
+                    tx_payload[..2].copy_from_slice(&rx_payload[..2]);
+                    tx_buf.from_existing(MsgType::SinkRsp, 2)
+                } else {
+                    Ok(tx_buf.no_payload(MsgType::SinkRsp))
+                }
             }
             MsgType::DumpReq => {
                 let addr =
@@ -289,8 +201,9 @@ impl Handler {
                     0
                 };
 
+                let tx_payload = tx_buf.payload_mut();
                 tx_payload[0..4].copy_from_slice(&rval.to_le_bytes());
-                4
+                tx_buf.from_existing(MsgType::DumpRsp, 4)
             }
 
             // All of the unexpected messages
@@ -308,46 +221,21 @@ impl Handler {
             | MsgType::IoStatsRsp
             | MsgType::DumpRsp
             | MsgType::Unknown => {
-                state.rx_invalid = state.rx_invalid.wrapping_add(1);
-                return Err(SprotError::BadMessageType);
+                stats.rx_invalid = stats.rx_invalid.wrapping_add(1);
+                return Some(tx_buf.error_rsp(SprotError::BadMessageType));
             }
         };
 
-        Ok((req_msgtype_to_rsp_msgtype(rxmsg.0.msgtype), size))
-    }
-}
-
-// Translate a request msg type to a response msg type
-fn req_msgtype_to_rsp_msgtype(msgtype: MsgType) -> MsgType {
-    match msgtype {
-        MsgType::EchoReq => MsgType::EchoRsp,
-        MsgType::StatusReq => MsgType::StatusRsp,
-        MsgType::SprocketsReq => MsgType::SprocketsRsp,
-        MsgType::UpdBlockSizeReq => MsgType::UpdBlockSizeRsp,
-        MsgType::UpdPrepImageUpdateReq => MsgType::UpdPrepImageUpdateRsp,
-        MsgType::UpdWriteOneBlockReq => MsgType::UpdWriteOneBlockRsp,
-        MsgType::UpdAbortUpdateReq => MsgType::UpdAbortUpdateRsp,
-        MsgType::UpdFinishImageUpdateReq => MsgType::UpdFinishImageUpdateRsp,
-        MsgType::SinkReq => MsgType::SinkRsp,
-        MsgType::IoStatsReq => MsgType::IoStatsRsp,
-        MsgType::DumpReq => MsgType::DumpRsp,
-
-        // All of the unexpected messages
-        MsgType::Invalid
-        | MsgType::EchoRsp
-        | MsgType::ErrorRsp
-        | MsgType::SinkRsp
-        | MsgType::SprocketsRsp
-        | MsgType::StatusRsp
-        | MsgType::UpdBlockSizeRsp
-        | MsgType::UpdPrepImageUpdateRsp
-        | MsgType::UpdWriteOneBlockRsp
-        | MsgType::UpdAbortUpdateRsp
-        | MsgType::UpdFinishImageUpdateRsp
-        | MsgType::IoStatsRsp
-        | MsgType::DumpRsp
-        | MsgType::Unknown => {
-            panic!("MsgType is not a request: {}", msgtype as u8)
+        match res {
+            Ok(verified_tx_msg) => {
+                stats.rx_received = stats.rx_received.wrapping_add(1);
+                Some(verified_tx_msg)
+            }
+            Err((tx_buf, err)) => {
+                stats.rx_invalid = stats.rx_invalid.wrapping_add(1);
+                ringbuf_entry!(Trace::ErrWithTypedHeader(err, rx_msg.header()));
+                Some(tx_buf.error_rsp(err))
+            }
         }
     }
 }

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -5,7 +5,7 @@
 use crate::Trace;
 use crc::{Crc, CRC_32_CKSUM};
 use drv_sprot_api::{
-    IoStats, MsgType, Protocol, RxMsg, SprotError, SprotStatus, TxMsg,
+    MsgType, Protocol, RotIoStats, RxMsg, SprotError, SprotStatus, TxMsg,
     UpdateRspHeader, VerifiedTxMsg, BUF_SIZE,
 };
 use drv_update_api::{Update, UpdateStatus, UpdateTarget};
@@ -66,7 +66,7 @@ impl Handler {
         &mut self,
         rx_buf: RxMsg,
         mut tx_buf: TxMsg<'a>,
-        stats: &mut IoStats,
+        stats: &mut RotIoStats,
     ) -> Option<VerifiedTxMsg<'a>> {
         // Parse the header and validate the CRC
         let rx_msg = match rx_buf.parse() {

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -42,7 +42,7 @@ use drv_lpc55_gpio_api::{Direction, Value};
 use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use drv_sprot_api::{
-    IoStats, MsgHeader, Protocol, RxMsg, SprotError, TxMsg, BUF_SIZE,
+    MsgHeader, Protocol, RotIoStats, RxMsg, SprotError, TxMsg, BUF_SIZE,
     HEADER_SIZE,
 };
 use lpc55_pac as device;
@@ -60,7 +60,7 @@ pub(crate) enum Trace {
     None,
     ErrWithHeader(SprotError, [u8; HEADER_SIZE]),
     ErrWithTypedHeader(SprotError, MsgHeader),
-    Stats(IoStats),
+    Stats(RotIoStats),
     Dump(u32),
 }
 ringbuf!(Trace, 16, Trace::None);
@@ -135,7 +135,7 @@ fn configure_spi() -> Io {
     Io {
         spi,
         gpio,
-        stats: IoStats::default(),
+        stats: RotIoStats::default(),
     }
 }
 
@@ -143,7 +143,7 @@ fn configure_spi() -> Io {
 struct Io {
     spi: crate::spi_core::Spi,
     gpio: drv_lpc55_gpio_api::Pins,
-    stats: IoStats,
+    stats: RotIoStats,
 }
 
 enum IoError {

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -4,37 +4,66 @@
 
 //! A driver for the LPC55 HighSpeed SPI interface.
 //!
+//! See drv/sprot-api/README.md
+//! Messages are received from the Service Processor (SP) over a SPI interface.
+//!
+//! Only one request from the SP or one reply from the RoT will be handled
+//! inside the io loop. This pattern does allow for potential pipelining of up
+//! to 2 requests from the SP, with no changes on the RoT. Currently, however,
+//! in the happy path, the SP will only send one request, wait for ROT_IRQ,
+//! to be asserted by the RoT, and then clock in a response while clocking
+//! out zeros. In this common case, the RoT will be clocking out zeros while
+//! clocking in the request from the SP.
+//!
+//! See drv/sprot-api for message layout.
+//!
+//! If the payload length exceeds the maximum size or not all bytes are received
+//! before CSn is de-asserted, the message is malformed and an ErrorRsp message
+//! will be sent to the SP in the next message exchange.
+//!
+//! Messages from the SP are not processed until the SPI chip-select signal
+//! is deasserted.
+//!
+//! ROT_IRQ is intended to be an edge triggered interrupt on the SP.
+//! TODO: ROT_IRQ is currently sampled by the SP.
+//! ROT_IRQ is de-asserted only after CSn is deasserted.
+//!
+//! TODO: SP RESET needs to be monitored, otherwise, any
+//! forced looping here could be a denial of service attack against
+//! observation of SP resetting. SP resetting without invalidating
+//! security related state means a compromised SP could operate using
+//! the trust gained in the previous session.
+//! Upper layers may mitigate that, but check on it.
 
 #![no_std]
 #![no_main]
 
-mod handler;
-
 use drv_lpc55_gpio_api::{Direction, Value};
 use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
-use drv_sprot_api::{Protocol, RxMsg, TxMsg, BUF_SIZE};
+use drv_sprot_api::{
+    IoStats, MsgHeader, Protocol, RxMsg, SprotError, TxMsg, BUF_SIZE,
+    HEADER_SIZE,
+};
 use lpc55_pac as device;
-use static_assertions::const_assert;
+use ringbuf::{ringbuf, ringbuf_entry};
+use userlib::{
+    sys_irq_control, sys_recv_closed, task_slot, TaskId, UnwrapLite,
+};
 
-use crc::{Crc, CRC_32_CKSUM};
-use lpc55_romapi::bootrom;
-use ringbuf::*;
-use userlib::*;
+mod handler;
+
+use handler::Handler;
 
 #[derive(Copy, Clone, PartialEq)]
-enum Trace {
+pub(crate) enum Trace {
     None,
-    HandleReturnNone,
-    HandlerReturnSize(usize),
-    Overrun(usize),
-    Pio(bool),
-    RotIrqAssert,
-    RotIrqDeassert,
-    Transmit(usize, usize),
-    Underrun(usize),
+    ErrWithHeader(SprotError, [u8; HEADER_SIZE]),
+    ErrWithTypedHeader(SprotError, MsgHeader),
+    Stats(IoStats),
+    Dump(u32),
 }
-ringbuf!(Trace, 32, Trace::None);
+ringbuf!(Trace, 16, Trace::None);
 
 task_slot!(SYSCON, syscon_driver);
 task_slot!(GPIO, gpio_driver);
@@ -42,100 +71,8 @@ task_slot!(GPIO, gpio_driver);
 // Notification mask for Flexcomm8 hs_spi IRQ; must match config in app.toml
 const SPI_IRQ: u32 = 1;
 
-// See drv/sprot-api/README.md
-// Messages are received from the Service Processor (SP) over a SPI interface.
-//
-// The RoT indicates that a response is ready by asserting ROT_IRQ to the SP.
-//
-// It is possible for the SP to send a new message to the SP while receiving
-// the RoT's reponse to the SP's previous message.
-//
-// See drv/sprot-api for message layout.
-//
-// If the payload length exceeds the maximum size or not all bytes are received
-// before CSn is de-asserted, the message is malformed and an ErrorRsp message
-// will be sent to the SP.
-//
-// Messages from the SP are not processed until the SPI chip-select signal
-// is deasserted.
-//
-// ROT_IRQ is intended to be an edge triggered interrupt on the SP.
-// ROT_IRQ is de-asserted only after CSn is deasserted.
-//
-// The RoT sets up to transfer the full Tx buffer contents to SP
-// even if it is longer than the valid message or if there is no valid message.
-// Extra bytes are set to zero.
-// This keeps the inner IO loop simple and ensures that there are no bytes from
-// any previous Tx message still in the Tx buffer.
-//
-
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub(crate) enum IoStatus {
-    Flush,
-    IOResult { overrun: bool, underrun: bool },
-}
-
-#[repr(C)]
-struct IO {
-    spi: crate::spi_core::Spi,
-    gpio: drv_lpc55_gpio_api::Pins,
-    // Transmit Buffer
-    tx_buf: TxMsg,
-    // Receive Buffer
-    rx_buf: RxMsg,
-    // Number of bytes copied into the receive buffer
-    rxcount: usize,
-    // Number of bytes copied from the transmit buffer into the FIFO
-    txcount: usize,
-    // Failed to keep up with FIFORD
-    overrun: bool,
-    // Failed to keep up with FIFOWR
-    underrun: bool,
-}
-
-struct Server<'a> {
-    io: &'a mut IO,
-    state: &'a mut LocalState,
-    handler: &'a mut handler::Handler,
-}
-
-// A combination of things generated and/or mutated by the the lpc55 side of sprot
-// and returned from the `drv_sprot_api::Status` and `drv_sprot_api::IoStats` types.
-//
-// Comments copied directly from the `drv_sprot_api` types.
-//
-// This type exists as a mechanism to split the functionality provided by the
-// previous `Status` message into two messages returned by two different API
-// calls, without having to change a lot of other things right now.
-pub(crate) struct LocalState {
-    /// All supported versions 'v' from 1 to 32 as a mask of (1 << v-1)
-    supported: u32,
-    /// CRC32 of the LPC55 boot ROM contents.
-    /// The LPC55 does not have machine readable version information for
-    /// its boot ROM contents and there are known issues with old boot ROMs.
-    /// TODO: This should live in the stage0 handoff info
-    bootrom_crc32: u32,
-
-    /// Maxiumum message size that the RoT can handle.
-    buffer_size: u32,
-    /// Number of messages received
-    pub rx_received: u32,
-
-    /// Number of messages where the RoT failed to service the Rx FIFO in time.
-    pub rx_overrun: u32,
-
-    /// Number of messages where the RoT failed to service the Tx FIFO in time.
-    pub tx_underrun: u32,
-
-    /// Number of invalid messages received
-    pub rx_invalid: u32,
-
-    /// Number of incomplete transmissions (valid data not fetched by SP).
-    pub tx_incomplete: u32,
-}
-
-#[export_name = "main"]
-fn main() -> ! {
+/// Setup spi and its associated GPIO pins
+fn configure_spi() -> Io {
     let syscon = Syscon::from(SYSCON.get_task_id());
 
     // Turn the actual peripheral on so that we can interact with it.
@@ -151,7 +88,6 @@ fn main() -> ! {
     // Ensure that ROT_IRQ is not asserted
     gpio.set_dir(ROT_IRQ, Direction::Output);
     gpio.set_val(ROT_IRQ, Value::One);
-    ringbuf_entry!(Trace::RotIrqDeassert);
 
     // We have two blocks to worry about: the FLEXCOMM for switching
     // between modes and the actual SPI block. These are technically
@@ -175,279 +111,242 @@ fn main() -> ! {
     );
     // Set SPI mode for Flexcomm
     flexcomm.pselid.write(|w| w.persel().spi());
-    spi.enable(); // Drain and configure FIFOs
-    spi.ssa_enable(); // Interrupt on CSn changing to asserted.
-    spi.ssd_enable(); // Interrupt on CSn changing to deasserted.
-    spi.drain(); // Probably not necessary, drain Rx and Tx after config.
 
-    pub const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
+    // Drain and configure FIFOs
+    spi.enable();
+
+    // We only want interrupts on CSn assert
+    // Once we see that interrupt we enter polling mode
+    // and check the registers manually.
+    spi.ssa_enable();
+
+    // Probably not necessary, drain Rx and Tx after config.
+    spi.drain();
+
+    // Disable the interrupts triggered by the `self.spi.drain_tx()`, which
+    // unneccessarily causes spurious interrupts. We really only need to to
+    // respond to CSn asserted interrupts, because after that we always enter a
+    // tight loop.
+    spi.disable_tx();
+    spi.disable_rx();
+
     let gpio = drv_lpc55_gpio_api::Pins::from(gpio_driver);
 
-    let mut io = IO {
-        tx_buf: TxMsg::new(),
-        rx_buf: RxMsg::new(),
-        gpio,
+    Io {
         spi,
-        rxcount: 0,
-        txcount: 0,
-        overrun: false,
-        underrun: false,
-    };
+        gpio,
+        stats: IoStats::default(),
+    }
+}
 
-    const_assert!(Protocol::V1 as u8 > 0 && (Protocol::V1 as u8) < 32);
+// Container for spi and gpio
+struct Io {
+    spi: crate::spi_core::Spi,
+    gpio: drv_lpc55_gpio_api::Pins,
+    stats: IoStats,
+}
 
-    let mut state = LocalState {
-        supported: 1_u32 << (Protocol::V1 as u8 - 1),
-        bootrom_crc32: CRC32.checksum(&bootrom().data[..]),
-        buffer_size: BUF_SIZE as u32,
-        rx_received: 0,
-        rx_overrun: 0,
-        tx_underrun: 0,
-        rx_invalid: 0,
-        tx_incomplete: 0,
-    };
+enum IoError {
+    Flush,
+    Flow,
+}
 
-    let server = &mut Server {
-        io: &mut io,
-        state: &mut state,
-        handler: &mut handler::new(),
-    };
+#[export_name = "main"]
+fn main() -> ! {
+    let mut io = configure_spi();
 
-    let mut transmit = false;
+    let mut rx_buf = [0u8; BUF_SIZE];
+    let mut tx_buf = [0u8; BUF_SIZE];
 
-    // Process a null message as if it had been just received.
-    // Expect that the Tx buffer is cleared.
-    let bytes_read = 0;
-    server.handler.handle(
-        transmit,
-        IoStatus::Flush,
-        &server.io.rx_buf,
-        bytes_read,
-        &mut server.io.tx_buf,
-        server.state,
-    );
+    let mut handler = Handler::new();
+    let mut signal_reply = false;
 
     loop {
-        server.io.pio(transmit);
-        let iostat = if server.io.rxcount == 0
-            && !server.io.underrun
-            && !server.io.overrun
-        {
-            IoStatus::Flush
-        } else {
-            IoStatus::IOResult {
-                underrun: server.io.underrun,
-                overrun: server.io.overrun,
+        ringbuf_entry!(Trace::Stats(io.stats));
+
+        // Every time through the io loop we receive a fresh request
+        let mut rx_msg = RxMsg::new(&mut rx_buf[..]);
+
+        let reply = match io.next(signal_reply, &tx_buf[..], &mut rx_msg) {
+            Ok(()) => {
+                // Put a busy byte in the tx_fifo before we handle the result,
+                // which may take some time.
+                io.mark_busy();
+                // Clear the buffer in preparation for a reply
+                let tx_msg = TxMsg::new(&mut tx_buf[..]);
+                handler.handle(rx_msg, tx_msg, &mut io.stats)
+            }
+            Err(IoError::Flush) => None,
+            Err(IoError::Flow) => {
+                io.mark_busy();
+                let tx_msg = TxMsg::new(&mut tx_buf[..]);
+                Some(handler.flow_error(tx_msg))
             }
         };
-        transmit = match server.handler.handle(
-            transmit, // true if previous loop transmitted.
-            iostat,
-            &server.io.rx_buf,
-            server.io.rxcount,
-            &mut server.io.tx_buf,
-            server.state,
-        ) {
-            Some(txlen) => {
-                ringbuf_entry!(Trace::HandlerReturnSize(txlen.0));
-                true
-            }
-            None => {
-                ringbuf_entry!(Trace::HandleReturnNone);
-                false
-            }
+
+        if reply.is_none() {
+            // There's no reply to send, so we should clear the Tx buffer.
+            tx_buf.fill(0);
+            signal_reply = false;
+        } else {
+            signal_reply = true;
         }
     }
 }
 
-impl IO {
-    /// Wait for chip select to be asserted then service the FIFOs until end of frame.
-    /// Returns false on spurious interrupt.
-    fn pio(&mut self, transmit: bool) {
-        ringbuf_entry!(Trace::Pio(transmit));
-        let tx_end = self.tx_buf.as_slice().len(); // Available bytes and trailing zeros
-        let rx_end = self.rx_buf.as_slice().len(); // All of the available bytes
-        self.txcount = 0;
-        self.rxcount = 0;
-        self.overrun = false;
-        self.underrun = false;
+impl Io {
+    /// Put a Protocol::Busy value in FIFOWR so that SP/logic analyzer knows
+    /// we're away.
+    pub fn mark_busy(&mut self) {
+        self.spi.drain_tx();
+        self.spi.send_u8(Protocol::Busy as u8);
+    }
 
-        if !transmit {
-            // Ensure that unused Tx buffer is zero-filled.
-            self.tx_buf.as_mut().fill(0);
+    pub fn next<'a>(
+        &mut self,
+        signal_reply: bool,
+        tx_buf: &[u8],
+        rx_msg: &mut RxMsg<'a>,
+    ) -> Result<(), IoError> {
+        let mut tx_iter = tx_buf.iter();
+        self.prime_tx_fifo(&mut tx_iter);
+        let result = loop {
+            sys_irq_control(SPI_IRQ, true);
+
+            if signal_reply {
+                self.assert_rot_irq();
+            }
+
+            sys_recv_closed(&mut [], SPI_IRQ, TaskId::KERNEL).unwrap_lite();
+
+            // Is CSn asserted by the SP?
+            let intstat = self.spi.intstat();
+            if intstat.ssa().bit() {
+                self.spi.ssa_clear();
+                break self.tight_loop(&mut tx_iter, rx_msg);
+            }
+        };
+
+        if signal_reply {
+            self.deassert_rot_irq();
         }
 
-        // Prime FIFOWR in order to be ready for start of frame.
-        //
-        // All our interrupts are left enabled for the sake of simplicity.
-        // The downside is that the following drain will elicit a spurious
-        // interrupt. But, that interrupt will occur before the start of any
-        // frame when we are not in a realtime situation.
-        self.spi.drain_tx(); // FIFOWR is now empty; we'll get an interrupt.
+        result
+    }
+
+    // Read data in a tight loop until we see CSn de-asserted
+    //
+    // XXX Denial of service by forever asserting CSn?
+    // We could mitigate by imposing a time limit
+    // and resetting the SP if it is exceeded.
+    // But, the management plane is going to notice that
+    // the RoT is not available. So, does it matter?
+    fn tight_loop<'a>(
+        &mut self,
+        tx_iter: &mut dyn Iterator<Item = &u8>,
+        rx_msg: &mut RxMsg<'a>,
+    ) -> Result<(), IoError> {
+        let mut err = None;
+
+        let mut csn_deasserted = false;
+        let mut too_many_bytes_received = false;
+
         loop {
-            if self.txcount >= tx_end || !self.spi.can_tx() {
+            // Let's exchange some bytes
+            let mut io = true;
+            while io == true {
+                io = false;
+                if self.spi.can_tx() {
+                    io = true;
+                    if let Some(b) = tx_iter.next().copied() {
+                        self.spi.send_u8(b);
+                    } else {
+                        // Just clock out zeros and prevent an unnecessary underrun
+                        self.spi.send_u8(0);
+                    }
+                }
+
+                if self.spi.has_byte() {
+                    io = true;
+                    let b = self.spi.read_u8();
+                    if rx_msg.push(b).is_err() {
+                        too_many_bytes_received = true;
+                    }
+                }
+            }
+
+            // Let's check for any problems
+            let fifostat = self.spi.fifostat();
+
+            if fifostat.txerr().bit() {
+                // We don't do anything with tx errors other than record them
+                // The SP will see a checksum error if this is a reply, or the
+                // underrun happened after the number of reply bytes and it
+                // doesn't matter.
+                self.spi.txerr_clear();
+                self.stats.tx_underrun = self.stats.tx_underrun.wrapping_add(1);
+            }
+
+            if fifostat.rxerr().bit() {
+                // Rx errors are more important. They mean we're missing
+                // data. We should report this to the SP. This can be used to
+                // potentially throttle sends in the future.
+                self.spi.rxerr_clear();
+                self.stats.rx_overrun = self.stats.rx_overrun.wrapping_add(1);
+                err = Some(IoError::Flow);
+            }
+
+            // Are we done?
+            if csn_deasserted {
+                self.spi.ssd_clear();
+
+                if rx_msg.is_empty() {
+                    // This was a CSn pulse
+                    self.stats.csn_pulses =
+                        self.stats.csn_pulses.wrapping_add(1);
+                    err = Some(IoError::Flush);
+                }
+
                 break;
             }
-            let b = self.tx_buf.as_slice()[self.txcount];
-            self.spi.send_u8(b);
-            self.txcount += 1;
+
+            // Read the CSn flag *after* checking if CSn is deasserted.
+            //
+            // This ordering allows us to loop one more time to exchange data
+            // and empty our fifos. Putting the check at the end also minimizes
+            // the time to access the fifos the first time through the loop.
+            // The goal here is to reduce overrun/underrun after already
+            // waiting for the CSn asserted interrupt to fire.
+            csn_deasserted = self.spi.ssd();
         }
 
-        if transmit {
-            ringbuf_entry!(Trace::Transmit(self.txcount, tx_end));
-            ringbuf_entry!(Trace::RotIrqAssert);
-            self.gpio.set_val(ROT_IRQ, Value::Zero);
+        if too_many_bytes_received {
+            self.stats.rx_protocol_error_too_many_bytes =
+                self.stats.rx_protocol_error_too_many_bytes.wrapping_add(1);
         }
 
-        // TODO: SP RESET needs to be monitored, otherwise, any
-        // forced looping here could be a denial of service attack against
-        // observation of SP resetting. SP resetting without invalidating
-        // security related state means a compromised SP could operate using
-        // the trust gained in the previous session.
-        // Upper layers may mitigate that, but check on it.
+        err.map_or(Ok(()), |e| Err(e))
+    }
 
-        // Wait for chip select to be asserted and perform all subsequent I/O
-        // for that frame.
-        // Track the state of chip select (CSn)
-        let mut inframe = false;
-        'outer: loop {
-            // restart here on the one expected spurious interrupt.
-            sys_irq_control(SPI_IRQ, true);
-            sys_recv_closed(&mut [], SPI_IRQ, TaskId::KERNEL).unwrap_lite();
-            loop {
-                // Get frame start/end interrupt from intstat (SSA/SSD).
-                let intstat = self.spi.intstat();
-                let fifostat = self.spi.fifostat();
-
-                // During bulk data transfer, we'll be polling and not servicing
-                // the interrupts that the kernel is collecting.
-                // As a result, there can be a left-over kernel interrupt to handle
-                // even after the HW interrupts are retired.
-                if !intstat.ssa().bit()
-                    && !intstat.ssd().bit()
-                    && !fifostat.txnotfull().bit()
-                    && !fifostat.rxnotempty().bit()
-                    && !inframe
-                {
-                    // This is a spurious interrupt.
-                    // These are only happening just after queuing a
-                    // response.
-                    // TODO: It would be nice to eliminate the spurious interrupt.
-                    continue 'outer;
-                }
-
-                // Track Spi Select Asserted and Deasserted to determine if
-                // we are in frame and update Rx/Tx state as needed.
-                if intstat.ssa().bit() {
-                    self.spi.ssa_clear();
-                    inframe = true;
-                }
-
-                // Note that while Tx is done at end of frame,
-                // FIFORD may still have bytes to read.
-                if intstat.ssd().bit() {
-                    self.spi.ssd_clear();
-                    if transmit {
-                        self.gpio.set_val(ROT_IRQ, Value::One);
-                    }
-                    inframe = false;
-                }
-
-                // Note that `fifostat` is fresh from waking from interrupt or
-                // the re-read at the end of this loop.
-                // Check for Rx overrun.
-                if fifostat.rxerr().bit() {
-                    self.spi.rxerr_clear();
-                    self.overrun = true;
-                    ringbuf_entry!(Trace::Overrun(self.rxcount));
-                    // Overrun accounting is done in handler.
-                }
-                if fifostat.txerr().bit() {
-                    self.spi.txerr_clear();
-                    // Underrun accounting is done in handler.
-                    ringbuf_entry!(Trace::Underrun(self.rxcount));
-                    self.underrun = true;
-                }
-                // Service the FIFOs
-                //   - inframe: normal service
-                //   - !inframe: this is the last service needed for FIFORD
-                loop {
-                    let mut io = false;
-                    if self.spi.can_tx() {
-                        let (b, incr) = if self.txcount < tx_end {
-                            io = true;
-                            (self.tx_buf.as_slice()[self.txcount], 1)
-                        } else {
-                            (0, 0)
-                        };
-                        self.spi.send_u8(b);
-                        self.txcount += incr;
-                    }
-                    if self.spi.has_byte() {
-                        let b = self.spi.read_u8();
-                        let incr = if self.rxcount < rx_end {
-                            io = true;
-                            self.rx_buf.as_mut()[self.rxcount] = b;
-                            1
-                        } else {
-                            0
-                        };
-                        self.rxcount += incr;
-                    }
-                    if !io {
-                        break;
-                    }
-                }
-                if !inframe {
-                    // If CSn was deasserted, then the IO loop that was just
-                    // completed would have fetched the remaining bytes out of
-                    // FIFORD and our work is done.
-                    //
-                    // The SP is allowed to send a long message to us at the
-                    // same time it is retrieving a short response from us.
-                    //
-                    // We keep FIFOWR full with zeros when we run out of Tx data
-                    // in order to avoid Tx underrun errors.
-                    //
-                    // So, there will always be "unsent" bytes in FIFOWR.
-                    //
-                    // Actual transmitted bytes are always going to equal the
-                    // number of received bytes. Since the rx_count is not
-                    // skewed by the Tx trailing bytes still in FIFOWR, just
-                    // use rx_count for both.
-
-                    // Update Tx state and account for trailing bytes
-                    // left in FIFOWR if present.
-                    //
-                    // If we cared about those remaining FIFOWR bytes:
-                    // let txremainder = fifostat.txlvl().bits() as usize;
-                    break 'outer;
-                }
-            } // FIFO polling loop
-        }
-        // Done, deassert ROT_IRQ
-
-        // XXX Denial of service by forever asserting CSn?
-        // We could mitigate by imposing a time limit
-        // and resetting the SP if it is exceeded.
-        // But, the management plane is going to notice that
-        // the RoT is not available. So, does it matter?
-
-        // Any data remaining in FIFORD that could be comsumed,
-        // has been consumed. So, close out the received message.
-
-        // The following drain should be redundant with the one at the
-        // beginning of this function.
-        // However, if SP sends/receives while we're away processing
-        // a message, then we will see an underrun, and possibly an
-        // overrun, when we come back instead of just a Tx not full interrupt.
+    // Prime the fifo with the first part of the response to prevent
+    // underrun while waiting for an interrupt.
+    fn prime_tx_fifo(&mut self, tx_iter: &mut dyn Iterator<Item = &u8>) {
         self.spi.drain_tx();
-        // Put a Protocol::Busy value in FIFOWR so that SP/logic analyzer knows we're away.
-        self.spi.send_u8(Protocol::Busy as u8);
-        if transmit {
-            self.gpio.set_val(ROT_IRQ, Value::One);
-            ringbuf_entry!(Trace::RotIrqDeassert);
+        while self.spi.can_tx() {
+            if let Some(b) = tx_iter.next().copied() {
+                self.spi.send_u8(b);
+            } else {
+                self.spi.send_u8(0);
+            }
         }
+    }
+
+    fn assert_rot_irq(&self) {
+        self.gpio.set_val(ROT_IRQ, Value::Zero);
+    }
+
+    fn deassert_rot_irq(&self) {
+        self.gpio.set_val(ROT_IRQ, Value::One);
     }
 }
 

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -210,6 +210,18 @@ impl<S: SpiServer> SpiDevice<S> {
     pub fn release(&self) -> Result<(), SpiError> {
         self.server.release()
     }
+
+    /// Variant of `lock` that returns a resource management object that, when
+    /// dropped, will issue `release`. This makes it much easier to do fallible
+    /// operations while locked.
+    ///
+    /// Otherwise, the rules are the same as for `lock`.
+    pub fn lock_auto(
+        &self,
+        assert_cs: CsState,
+    ) -> Result<ControllerLock<'_, S>, SpiError> {
+        self.server.lock_auto(self.device_index, assert_cs)
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -15,6 +15,7 @@ ssmarshal = { workspace = true }
 zerocopy = { workspace = true }
 
 derive-idol-err = { path = "../../lib/derive-idol-err" }
+drv-spi-api = { path = "../../drv/spi-api" }
 drv-update-api = { path = "../../drv/update-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
@@ -22,3 +23,7 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol = { workspace = true }
+
+[features]
+sink_test = []
+

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -265,7 +265,7 @@ pub struct SprotStatus {
 #[derive(
     Default, Copy, Clone, PartialEq, Serialize, Deserialize, SerializedSize,
 )]
-pub struct IoStats {
+pub struct RotIoStats {
     /// Number of messages received
     pub rx_received: u32,
 
@@ -288,6 +288,50 @@ pub struct IoStats {
 
     /// Number of incomplete transmissions (valid data not fetched by SP).
     pub tx_incomplete: u32,
+}
+
+/// Stats from the SP side of sprot
+///
+/// All of the counters will wrap around.
+#[derive(
+    Default, Copy, Clone, PartialEq, Serialize, Deserialize, SerializedSize,
+)]
+pub struct SpIoStats {
+    // Number of messages sent successfully
+    pub tx_sent: u32,
+
+    // Number of messages that failed to be sent
+    pub tx_errors: u32,
+
+    // Number of messages received successfully
+    pub rx_received: u32,
+
+    // Number of error replies received
+    pub rx_errors: u32,
+
+    // Number of invalid messages received. They don't parse properly.
+    pub rx_invalid: u32,
+
+    // Total Number of retries issued
+    pub retries: u32,
+
+    // Number of times the SP pulsed CSn
+    pub csn_pulses: u32,
+
+    // Number of times pulsing CSn failed.
+    pub csn_pulse_failures: u32,
+
+    // Number of timeouts, while waiting for a reply
+    pub timeouts: u32,
+}
+
+/// Sprot related stats
+#[derive(
+    Default, Copy, Clone, PartialEq, Serialize, Deserialize, SerializedSize,
+)]
+pub struct IoStats {
+    pub rot: RotIoStats,
+    pub sp: SpIoStats,
 }
 
 #[derive(

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -13,7 +13,7 @@ ssmarshal = { workspace = true }
 zerocopy = { workspace = true }
 
 drv-spi-api = { path = "../../drv/spi-api" }
-drv-sprot-api = { path = "../../drv/sprot-api" }
+drv-sprot-api = { path = "../../drv/sprot-api", features = ["sink_test"] }
 drv-stm32h7-spi-server-core = { path = "../../drv/stm32h7-spi-server-core", optional = true }
 drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
 drv-update-api = { path = "../../drv/update-api" }

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -101,4 +101,18 @@ pub mod stm32h7 {
     pub const BLOCK_SIZE_BYTES: usize = FLASH_WORD_BYTES * 32;
 }
 
+pub mod lpc55 {
+    // This value is currently set to `lpc55_romapi::FLASH_PAGE_SIZE`
+    //
+    // We hardcode it for simplicity, and because we cannot,and should not,
+    // directly include the `lpc55_romapi` crate. While we could transfer
+    // arbitrary amounts of data over spi and have the update server on
+    // the RoT split it up, this makes the code more complicated than
+    // necessary and is only an optimization. For now, especially since we
+    // only have 1 RoT and we must currently define a constant for use the
+    // `control_plane_agent::ComponentUpdater` trait, we do the simple thing
+    // and hardcode according to hardware requirements.
+    pub const BLOCK_SIZE_BYTES: usize = 512;
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     mgs_common::MgsCommon, update::host_flash::HostFlashUpdate,
-    update::sp::SpUpdate, update::ComponentUpdater, usize_max,
-    vlan_id_from_sp_port, Log, MgsMessage, SYS, USART_IRQ,
+    update::rot::RotUpdate, update::sp::SpUpdate, update::ComponentUpdater,
+    usize_max, vlan_id_from_sp_port, Log, MgsMessage, SYS, USART_IRQ,
 };
 use core::convert::Infallible;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -39,8 +39,10 @@ use host_phase2::HostPhase2Requester;
 
 // How big does our shared update buffer need to be? Has to be able to handle SP
 // update blocks or host flash pages.
-const UPDATE_BUFFER_SIZE: usize =
-    usize_max(SpUpdate::BLOCK_SIZE, HostFlashUpdate::BLOCK_SIZE);
+const UPDATE_BUFFER_SIZE: usize = usize_max(
+    usize_max(SpUpdate::BLOCK_SIZE, HostFlashUpdate::BLOCK_SIZE),
+    RotUpdate::BLOCK_SIZE,
+);
 
 // Create type aliases that include our `UpdateBuffer` size (i.e., the size of
 // the largest update chunk of all the components we update).
@@ -86,6 +88,7 @@ pub(crate) struct MgsHandler {
     common: MgsCommon,
     sequencer: Sequencer,
     sp_update: SpUpdate,
+    rot_update: RotUpdate,
     host_flash_update: HostFlashUpdate,
     host_phase2: HostPhase2Requester,
     usart: UsartHandler,
@@ -111,6 +114,7 @@ impl MgsHandler {
             host_flash_update: HostFlashUpdate::new(),
             host_phase2: HostPhase2Requester::claim_static_resources(),
             sp_update: SpUpdate::new(),
+            rot_update: RotUpdate::new(),
             sequencer: Sequencer::from(GIMLET_SEQ.get_task_id()),
             usart,
             startup_options,
@@ -522,6 +526,7 @@ impl SpHandler for MgsHandler {
             SpComponent::HOST_CPU_BOOT_FLASH => {
                 self.host_flash_update.prepare(&UPDATE_MEMORY, update)
             }
+            SpComponent::ROT => self.rot_update.prepare(&UPDATE_MEMORY, update),
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }
@@ -545,6 +550,9 @@ impl SpHandler for MgsHandler {
             SpComponent::HOST_CPU_BOOT_FLASH => self
                 .host_flash_update
                 .ingest_chunk(&chunk.id, chunk.offset, data),
+            SpComponent::ROT => {
+                self.rot_update.ingest_chunk(&chunk.id, chunk.offset, data)
+            }
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }
@@ -567,6 +575,7 @@ impl SpHandler for MgsHandler {
             // update, not an `SP_AUX_FLASH` update (which isn't a thing).
             SpComponent::SP_ITSELF => self.sp_update.status(),
             SpComponent::HOST_CPU_BOOT_FLASH => self.host_flash_update.status(),
+            SpComponent::ROT => self.rot_update.status(),
             _ => return Err(SpError::RequestUnsupportedForComponent),
         };
 
@@ -594,6 +603,7 @@ impl SpHandler for MgsHandler {
             SpComponent::HOST_CPU_BOOT_FLASH => {
                 self.host_flash_update.abort(&id)
             }
+            SpComponent::ROT => self.rot_update.abort(&id),
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }

--- a/task/control-plane-agent/src/update/mod.rs
+++ b/task/control-plane-agent/src/update/mod.rs
@@ -11,6 +11,7 @@ use gateway_messages::{
 pub(crate) mod host_flash;
 
 mod common;
+pub(crate) mod rot;
 pub(crate) mod sp;
 
 // TODO Currently we only have one implementor of this trait

--- a/task/control-plane-agent/src/update/rot.rs
+++ b/task/control-plane-agent/src/update/rot.rs
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::{common::CurrentUpdate, ComponentUpdater};
+use crate::mgs_handler::{BorrowedUpdateBuffer, UpdateBuffer};
+use drv_sprot_api::{SpRot, SprotError};
+use drv_update_api::lpc55::BLOCK_SIZE_BYTES;
+use drv_update_api::UpdateTarget;
+use ringbuf::{ringbuf, ringbuf_entry};
+
+use gateway_messages::{
+    ComponentUpdatePrepare, SpComponent, SpError, UpdateId,
+    UpdateInProgressStatus, UpdateStatus,
+};
+
+userlib::task_slot!(SPROT, sprot);
+
+ringbuf!(Trace, 64, Trace::None);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Trace {
+    None,
+    IngestChunkInput { offset: u32, len: usize },
+    IngestChunkState { offset: u32, len: usize },
+    WriteOneBlock(u32, usize, usize),
+}
+
+pub(crate) struct RotUpdate {
+    task: SpRot,
+    current: Option<CurrentUpdate<State>>,
+}
+
+impl RotUpdate {
+    pub(crate) fn new() -> Self {
+        RotUpdate {
+            task: SpRot::from(SPROT.get_task_id()),
+            current: None,
+        }
+    }
+}
+
+enum State {
+    AcceptingData {
+        buffer: BorrowedUpdateBuffer,
+        next_write_offset: u32,
+    },
+    Complete,
+    Aborted,
+    Failed(SprotError),
+}
+
+impl ComponentUpdater for RotUpdate {
+    const BLOCK_SIZE: usize = BLOCK_SIZE_BYTES;
+
+    fn prepare(
+        &mut self,
+        buffer: &'static UpdateBuffer,
+        update: ComponentUpdatePrepare,
+    ) -> Result<(), SpError> {
+        match self.current.as_ref().map(CurrentUpdate::state) {
+            Some(State::AcceptingData { .. }) => {
+                return Err(SpError::UpdateInProgress(self.status()));
+            }
+            Some(State::Complete)
+            | Some(State::Aborted)
+            | Some(State::Failed(_))
+            | None => {
+                // All of these states are "done", and we're fine to start a new
+                // update.
+            }
+        }
+        // Can we lock the update buffer?
+        let buffer =
+            buffer.borrow(SpComponent::ROT, Self::BLOCK_SIZE).map_err(
+                |component| SpError::OtherComponentUpdateInProgress(component),
+            )?;
+
+        // Which target are we updating?
+        let target = match update.slot {
+            0 => UpdateTarget::ImageA,
+            1 => UpdateTarget::ImageB,
+            _ => return Err(SpError::InvalidSlotForComponent),
+        };
+
+        self.task
+            .prep_image_update(target)
+            .map_err(|err| SpError::UpdateFailed(err as u32))?;
+
+        self.current = Some(CurrentUpdate::new(
+            update.id,
+            update.total_size,
+            State::AcceptingData {
+                buffer,
+                next_write_offset: 0,
+            },
+        ));
+
+        Ok(())
+    }
+
+    fn is_preparing(&self) -> bool {
+        false
+    }
+
+    fn step_preparation(&mut self) {
+        // There's no stepping for an RoT update
+        // Unreachable because `is_preparing` always returns `false`.
+        unreachable!();
+    }
+
+    fn status(&self) -> UpdateStatus {
+        let current = match self.current.as_ref() {
+            Some(current) => current,
+            None => return UpdateStatus::None,
+        };
+
+        match current.state() {
+            State::AcceptingData {
+                buffer,
+                next_write_offset,
+            } => UpdateStatus::InProgress(UpdateInProgressStatus {
+                id: current.id(),
+                bytes_received: next_write_offset + buffer.len() as u32,
+                total_size: current.total_size(),
+            }),
+            State::Complete => UpdateStatus::Complete(current.id()),
+            State::Aborted => UpdateStatus::Aborted(current.id()),
+            State::Failed(err) => UpdateStatus::Failed {
+                id: current.id(),
+                code: *err as u32,
+            },
+        }
+    }
+
+    fn ingest_chunk(
+        &mut self,
+        id: &UpdateId,
+        offset: u32,
+        mut data: &[u8],
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Trace::IngestChunkInput {
+            offset,
+            len: data.len()
+        });
+
+        // Ensure we are expecting data.
+        let current =
+            self.current.as_mut().ok_or(SpError::UpdateNotPrepared)?;
+
+        let current_id = current.id();
+        let total_size = current.total_size();
+
+        let (buffer, next_write_offset) = match current.state_mut() {
+            State::AcceptingData {
+                buffer,
+                next_write_offset,
+            } => (buffer, next_write_offset),
+            State::Complete | State::Aborted => {
+                return Err(SpError::UpdateNotPrepared)
+            }
+            State::Failed(err) => {
+                return Err(SpError::UpdateFailed(*err as u32))
+            }
+        };
+
+        ringbuf_entry!(Trace::IngestChunkState {
+            offset: *next_write_offset,
+            len: buffer.len()
+        });
+
+        // Reject chunks that don't match our current update ID.
+        if *id != current_id {
+            return Err(SpError::InvalidUpdateId {
+                sp_update_id: current_id,
+            });
+        }
+
+        // Reject chunks that don't match the offset we expect or that would go
+        // past the total size we're expecting.
+        let expected_offset = *next_write_offset + buffer.len() as u32;
+        if offset != expected_offset
+            || expected_offset + data.len() as u32 > total_size
+        {
+            return Err(SpError::InvalidUpdateChunk);
+        }
+
+        while !data.is_empty() {
+            data = buffer.extend_from_slice(data);
+
+            // Flush this block if it's full or it's the last one.
+            if buffer.len() == buffer.capacity()
+                || *next_write_offset + buffer.len() as u32 == total_size
+            {
+                let block_num = *next_write_offset / Self::BLOCK_SIZE as u32;
+                ringbuf_entry!(Trace::WriteOneBlock(
+                    block_num,
+                    buffer.len(),
+                    buffer.capacity()
+                ));
+                if let Err(err) = self.task.write_one_block(block_num, buffer) {
+                    *current.state_mut() = State::Failed(err);
+                    return Err(SpError::UpdateFailed(err as u32));
+                }
+
+                *next_write_offset += buffer.len() as u32;
+                buffer.clear();
+            }
+        }
+
+        // Finish the update if we just wrote the last block.
+        if *next_write_offset == total_size {
+            if let Err(err) = self.task.finish_image_update() {
+                *current.state_mut() = State::Failed(err);
+                return Err(SpError::UpdateFailed(err as u32));
+            }
+            *current.state_mut() = State::Complete;
+        }
+
+        Ok(())
+    }
+
+    fn abort(&mut self, id: &UpdateId) -> Result<(), SpError> {
+        // Ensure we are expecting data.
+        let current =
+            self.current.as_mut().ok_or(SpError::UpdateNotPrepared)?;
+
+        // Only proceed if the requested ID matches ours.
+        if *id != current.id() {
+            return Err(SpError::UpdateInProgress(self.status()));
+        }
+
+        match current.state() {
+            State::AcceptingData { .. } | State::Failed(_) => {
+                match self.task.abort_update() {
+                    // Aborting an update that hasn't started yet is fine;
+                    // either way our caller is clear to start a new update.
+                    Ok(()) | Err(SprotError::UpdateNotStarted) => {
+                        *current.state_mut() = State::Aborted;
+                        Ok(())
+                    }
+                    Err(other) => Err(SpError::UpdateFailed(other as u32)),
+                }
+            }
+            // Update already aborted - aborting it again is a no-op.
+            State::Aborted => Ok(()),
+            // Update has already completed - too late to abort.
+            State::Complete => Err(SpError::UpdateInProgress(self.status())),
+        }
+    }
+}


### PR DESCRIPTION
This PR contains sprot enhancements which serve as a follow up to #965 and also support successful RoT update from faux-mgs. It also contains the changes to control-plane-agent necessary to use sprot for RoT update.

This code has been split into four logical commits. The first three commits are all sprot related changes, and only the third commit will compile. They were split only to aid in reviewing, and will be collapsed for merge. The last commit is the related control-plane-agent changes.

Please see the individual commit messages for full details.