### PR TITLE
Rename and rework secure rot-carrier build.

### DIFF
--- a/app/rot-carrier/app-secure.toml
+++ b/app/rot-carrier/app-secure.toml
@@ -1,10 +1,11 @@
-name = "rot-carrier"
+name = "rot-carrier-secure"
 target = "thumbv8m.main-none-eabihf"
 board = "rot-carrier-2"
 chip = "../../chips/lpc55"
 stacksize = 1024
 secure-separation = true
 image-names = ["a", "b"]
+secure-task = "secure"
 
 [kernel]
 name = "rot-carrier"
@@ -24,6 +25,12 @@ priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
+
+[tasks.secure]
+name = "task-secure"
+priority = 6
+max-sizes = {flash = 8192, ram = 512}
+stacksize = 256
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"

--- a/app/rot-carrier/stage0-secure.toml
+++ b/app/rot-carrier/stage0-secure.toml
@@ -1,16 +1,16 @@
-name = "rot-carrier"
+name = "rot-carrier-secure-stage0"
 target = "thumbv8m.main-none-eabihf"
 board = "rot-carrier-2"
 chip = "../../chips/lpc55"
-stacksize = 1024
 secure-separation = true
 image-names = ["stage0"]
 external-images = ["a", "b"]
 
 [kernel]
 name = "stage0"
-requires = {flash = 0x4000, ram = 4096}
-features = ["tz_support"]
+requires = {flash = 0x9000, ram = 16000}
+features = ["tz_support", "dice-self"]
+stacksize = 13000
 
 [tasks.idle]
 name = "task-idle"
@@ -21,7 +21,7 @@ start = true
 
 [signing]
 enable-secure-boot = true
-enable-dice = false
+enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false


### PR DESCRIPTION
Currently, the rot-carrier/stage0-fixed-rom bootloader builds an image that isn't correctly configured for trustzone and won't actually boot on an LPC55S69.

This commit fixes that by harmonizing its configuration with the (working) bootloader from app/lpc55xpresso.

While debugging this, I noticed that
- rot-carrier nonsecure build produced a file called rot-carrier
- rot-carrier secure build also produced a file called rot-carrier
- rot-carrier stage0 also produced a file called rot-carrier

This seemed really error prone so I've renamed them all to be distinct.

I've also renamed "fixed-rom" to "secure" to more accurately reflect its purpose.