### PR TITLE
Pass full task config to build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml-task",
 ]
 
 [[package]]
@@ -4626,6 +4627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml-task"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
+ "ordered-toml",
+ "serde",
+]
+
+[[package]]
 name = "transceiver-messages"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/transceiver-control/#92c85c2732de2fcdb2b1e98dba97172f69e5bf5b"
@@ -4867,6 +4877,7 @@ dependencies = [
  "tlvc",
  "tlvc-text",
  "toml",
+ "toml-task",
  "walkdir",
  "zerocopy",
  "zip",

--- a/build/util/Cargo.toml
+++ b/build/util/Cargo.toml
@@ -9,3 +9,5 @@ indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+
+toml-task.path = "../../lib/toml-task"

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -114,6 +114,15 @@ pub fn task_maybe_config<T: DeserializeOwned>() -> Result<Option<T>> {
     Ok(t.and_then(|t| t.config))
 }
 
+/// Pulls the full task configuration block
+///
+/// (compare with `task_maybe_config`, which returns the `config` subsection)
+pub fn task_full_config<T: DeserializeOwned>() -> Result<toml_task::Task<T>> {
+    let t = toml_from_env::<toml_task::Task<T>>("HUBRIS_TASK_CONFIG")?
+        .ok_or_else(|| anyhow!("HUBRIS_TASK_CONFIG is not defined"))?;
+    Ok(t)
+}
+
 /// Returns a map of task names to their IDs.
 pub fn task_ids() -> TaskIds {
     let tasks = crate::env_var("HUBRIS_TASKS").expect("missing HUBRIS_TASKS");

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -110,7 +110,8 @@ pub fn task_config<T: DeserializeOwned>() -> Result<T> {
 /// Pulls the task configuration, or `None` if the configuration is not
 /// provided.
 pub fn task_maybe_config<T: DeserializeOwned>() -> Result<Option<T>> {
-    toml_from_env("HUBRIS_TASK_CONFIG")
+    let t = toml_from_env::<toml_task::Task<T>>("HUBRIS_TASK_CONFIG")?;
+    Ok(t.and_then(|t| t.config))
 }
 
 /// Returns a map of task names to their IDs.

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -40,8 +40,9 @@ rangemap = { workspace = true }
 zip = "=0.5.6"
 
 gnarle = { path = "../../lib/gnarle", features = ["std"] }
-build-kconfig = { path = "../kconfig" }
-abi = { path = "../../sys/abi" }
+abi.path = "../../sys/abi"
+build-kconfig.path = "../kconfig"
+toml-task.path = "../../lib/toml-task"
 
 # For NXP signing
 lpc55_sign = { workspace = true }

--- a/lib/toml-task/Cargo.toml
+++ b/lib/toml-task/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "toml-task"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+indexmap.workspace = true
+ordered-toml.workspace = true
+serde.workspace = true

--- a/lib/toml-task/src/lib.rs
+++ b/lib/toml-task/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! `toml-task` allows for `xtask` and `build.rs` scripts to share a common
 //! definition of a `task` within a TOML file.
 use indexmap::IndexMap;

--- a/lib/toml-task/src/lib.rs
+++ b/lib/toml-task/src/lib.rs
@@ -1,0 +1,118 @@
+//! `toml-task` allows for `xtask` and `build.rs` scripts to share a common
+//! definition of a `task` within a TOML file.
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+/// Represents a single `task` in a Hubris TOML file.
+///
+/// Parameterized by `T`, which is a type representing the configuration block.
+/// In cases where this isn't strongly typed, `T` defaults to
+/// [`ordered_toml::Value`], which can contain anything.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Task<T = ordered_toml::Value> {
+    pub name: String,
+    pub priority: u8,
+    pub stacksize: Option<u32>,
+    #[serde(default)]
+    pub uses_secure_entry: bool,
+    #[serde(default)]
+    pub start: bool,
+
+    #[serde(default)]
+    pub uses: Vec<String>,
+    #[serde(default)]
+    pub features: Vec<String>,
+
+    // Order matters here:
+    // TOML serialization doesn't allow us to put a value type after any Table
+    // type, so we put all of our `IndexMap` (and `config`, which often contains
+    // a map under the hood)
+    //
+    // Note that `task_slots` serializes to a Sequence, not a Table, so it's not
+    // grouped with the other `IndexMap`s below.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_task_slots",
+        serialize_with = "serialize_task_slots"
+    )]
+    pub task_slots: IndexMap<String, String>,
+
+    #[serde(default = "Option::default")]
+    pub config: Option<T>,
+
+    #[serde(default)]
+    pub interrupts: IndexMap<String, u32>,
+    #[serde(default)]
+    pub sections: IndexMap<String, String>,
+    #[serde(default)]
+    pub max_sizes: IndexMap<String, u32>,
+}
+
+/// In the common case, task slots map back to a task of the same name (e.g.
+/// `gpio_driver`, `rcc_driver`).  However, certain tasks need generic task
+/// slot names, e.g. they'll have a task slot named `spi_driver` which will
+/// be mapped to a specific SPI driver task (`spi2_driver`).
+///
+/// This deserializer lets us handle both cases, while making the common case
+/// easiest to write.  In `app.toml`, you can write something like
+/// ```toml
+/// task-slots = [
+///     "gpio_driver",
+///     "i2c_driver",
+///     "rcc_driver",
+///     {spi_driver: "spi2_driver"},
+/// ]
+/// ```
+fn deserialize_task_slots<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(untagged)]
+    enum ArrayItem {
+        Identity(String),
+        Remap(IndexMap<String, String>),
+    }
+    let s: Vec<ArrayItem> = serde::Deserialize::deserialize(deserializer)?;
+    let mut out = IndexMap::new();
+    for a in s {
+        match a {
+            ArrayItem::Identity(s) => {
+                out.insert(s.clone(), s.clone());
+            }
+            ArrayItem::Remap(m) => {
+                if m.len() != 1 {
+                    return Err(serde::de::Error::invalid_length(
+                        m.len(),
+                        &"a single key-value pair",
+                    ));
+                }
+                let (k, v) = m.iter().next().unwrap();
+                out.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Reverses `deserialize_task_slots`, turning each slot into a 1-item map
+fn serialize_task_slots<S>(
+    slots: &IndexMap<String, String>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeSeq;
+
+    let mut seq = s.serialize_seq(Some(slots.len()))?;
+    for (k, v) in slots.iter() {
+        let mut i = IndexMap::new();
+        i.insert(k, v);
+        seq.serialize_element(&i)?;
+    }
+    seq.end()
+}


### PR DESCRIPTION
This will allow tasks to check their configuration more robustly – checking `interrupts`, `uses`, etc.

I'm open to suggestions about names, since "task config" is increasingly overloaded.