### PR TITLE
Bump Idolatry and adjust error return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#9c0464500d1217d45cb98ab7617ee89e2914eb22"
+source = "git+https://github.com/oxidecomputer/idolatry.git#fe1610237bead97908526e4abcb3b23e081a472f"
 dependencies = [
  "userlib",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/idolatry.git#9c0464500d1217d45cb98ab7617ee89e2914eb22"
+source = "git+https://github.com/oxidecomputer/idolatry.git?branch=send-sync-err#2f314d1aad8460c18054cd275ff5646d93bc2c3a"
 dependencies = [
  "indexmap",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/idolatry.git?branch=send-sync-err#2f314d1aad8460c18054cd275ff5646d93bc2c3a"
+source = "git+https://github.com/oxidecomputer/idolatry.git#fe1610237bead97908526e4abcb3b23e081a472f"
 dependencies = [
  "indexmap",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
-idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "send-sync-err" }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
-idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "send-sync-err" }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -259,7 +259,9 @@ pub mod Reg {{"
 
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn fpga_regs(regs: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn fpga_regs(
+    regs: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let mut output = String::new();
 
     let node: Node = serde_json::from_str(regs)?;

--- a/build/net/src/lib.rs
+++ b/build/net/src/lib.rs
@@ -65,7 +65,8 @@ pub struct TaskNote {
     pub notification: u32,
 }
 
-pub fn load_net_config() -> Result<NetConfig, Box<dyn std::error::Error>> {
+pub fn load_net_config(
+) -> Result<NetConfig, Box<dyn std::error::Error + Send + Sync>> {
     let cfg = build_util::config::<GlobalConfig>()?.net;
 
     match (cfg!(feature = "vlan"), cfg.vlan.is_some()) {

--- a/drv/auxflash-api/build.rs
+++ b/drv/auxflash-api/build.rs
@@ -5,7 +5,7 @@
 use serde::Deserialize;
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let global_config = build_util::config::<GlobalConfig>()?;
     generate_auxflash_config(&global_config.auxflash)?;
 
@@ -33,7 +33,7 @@ struct AuxFlashConfig {
 
 fn generate_auxflash_config(
     config: &AuxFlashConfig,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let out_dir = build_util::out_dir();
     let dest_path = out_dir.join("auxflash_config.rs");
 

--- a/drv/auxflash-server/build.rs
+++ b/drv/auxflash-server/build.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/auxflash.idol",
         "server_stub.rs",

--- a/drv/eeprom/build.rs
+++ b/drv/eeprom/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_i2c::codegen(build_i2c::Disposition::Devices)?;
 
     idol::server::build_server_support(

--- a/drv/fpga-api/build.rs
+++ b/drv/fpga-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/fpga.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/fpga-server/build.rs
+++ b/drv/fpga-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     if cfg!(feature = "front_io") {

--- a/drv/gimlet-hf-api/build.rs
+++ b/drv/gimlet-hf-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/gimlet-hf.idol",
         "client_stub.rs",

--- a/drv/gimlet-hf-server/build.rs
+++ b/drv/gimlet-hf-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/drv/gimlet-seq-api/build.rs
+++ b/drv/gimlet-seq-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/gimlet-seq.idol",
         "client_stub.rs",

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -14,7 +14,7 @@ struct Config {
     register_defs: String,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     let config = build_util::task_config::<Config>()?;

--- a/drv/hash-api/build.rs
+++ b/drv/hash-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/hash.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/ignition-api/build.rs
+++ b/drv/ignition-api/build.rs
@@ -5,7 +5,7 @@
 use build_fpga_regmap::fpga_regs;
 use std::{fs, io::Write};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/ignition.idol",
         "client_stub.rs",

--- a/drv/ignition-server/build.rs
+++ b/drv/ignition-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/ignition.idol",
         "server_stub.rs",

--- a/drv/local-vpd/build.rs
+++ b/drv/local-vpd/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_i2c::codegen(build_i2c::Disposition::Devices)?;
     Ok(())
 }

--- a/drv/lpc55-gpio-api/build.rs
+++ b/drv/lpc55-gpio-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     idol::client::build_client_stub(
         "../../idl/lpc55-pins.idol",

--- a/drv/lpc55-gpio/build.rs
+++ b/drv/lpc55-gpio/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/lpc55-pins.idol",
         "server_stub.rs",

--- a/drv/lpc55-rng/build.rs
+++ b/drv/lpc55-rng/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/rng.idol",
         "server_stub.rs",

--- a/drv/lpc55-swd/build.rs
+++ b/drv/lpc55-swd/build.rs
@@ -88,7 +88,7 @@ fn generate_swd_functions(config: &TaskConfig) -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/sp-ctrl.idol",
         "server_stub.rs",

--- a/drv/lpc55-syscon-api/build.rs
+++ b/drv/lpc55-syscon-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     idol::client::build_client_stub("../../idl/syscon.idol", "client_stub.rs")?;
     Ok(())

--- a/drv/lpc55-syscon/build.rs
+++ b/drv/lpc55-syscon/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/syscon.idol",
         "server_stub.rs",

--- a/drv/lpc55-update-server/build.rs
+++ b/drv/lpc55-update-server/build.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/drv/meanwell-api/build.rs
+++ b/drv/meanwell-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/meanwell.idol",
         "client_stub.rs",

--- a/drv/meanwell/build.rs
+++ b/drv/meanwell/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/drv/mock-gimlet-hf-server/build.rs
+++ b/drv/mock-gimlet-hf-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/gimlet-hf.idol",
         "server_stub.rs",

--- a/drv/mock-gimlet-seq-server/build.rs
+++ b/drv/mock-gimlet-seq-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/gimlet-seq.idol",
         "server_stub.rs",

--- a/drv/monorail-api/build.rs
+++ b/drv/monorail-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/monorail.idol",
         "client_stub.rs",

--- a/drv/rng-api/build.rs
+++ b/drv/rng-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/rng.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/sidecar-front-io/build.rs
+++ b/drv/sidecar-front-io/build.rs
@@ -5,7 +5,7 @@
 use build_fpga_regmap::fpga_regs;
 use std::{fs, io::Write};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     let board = build_util::env_var("HUBRIS_BOARD")?;

--- a/drv/sidecar-mainboard-controller/build.rs
+++ b/drv/sidecar-mainboard-controller/build.rs
@@ -5,7 +5,7 @@
 use build_fpga_regmap::fpga_regs;
 use std::{fs, io::Write};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     let out_dir = build_util::out_dir();

--- a/drv/sidecar-seq-api/build.rs
+++ b/drv/sidecar-seq-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/sidecar-seq.idol",
         "client_stub.rs",

--- a/drv/sidecar-seq-server/build.rs
+++ b/drv/sidecar-seq-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     let disposition = build_i2c::Disposition::Devices;

--- a/drv/sp-ctrl-api/build.rs
+++ b/drv/sp-ctrl-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/sp-ctrl.idol",
         "client_stub.rs",

--- a/drv/spi-api/build.rs
+++ b/drv/spi-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/sprot-api/build.rs
+++ b/drv/sprot-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/sprot.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/stm32h7-hash-server/build.rs
+++ b/drv/stm32h7-hash-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/drv/stm32h7-rng/build.rs
+++ b/drv/stm32h7-rng/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/rng.idol",
         "server_stub.rs",

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/spi.idol",
         "server_stub.rs",

--- a/drv/stm32h7-sprot-server/build.rs
+++ b/drv/stm32h7-sprot-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/drv/stm32h7-update-server/build.rs
+++ b/drv/stm32h7-update-server/build.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/update.idol",
         "server_stub.rs",

--- a/drv/stm32xx-sys-api/build.rs
+++ b/drv/stm32xx-sys-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/stm32xx-sys.idol",
         "client_stub.rs",

--- a/drv/stm32xx-sys/build.rs
+++ b/drv/stm32xx-sys/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/stm32xx-sys.idol",
         "server_stub.rs",

--- a/drv/transceivers-api/build.rs
+++ b/drv/transceivers-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/transceivers.idol",
         "client_stub.rs",

--- a/drv/transceivers-server/build.rs
+++ b/drv/transceivers-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     let disposition = build_i2c::Disposition::Devices;

--- a/drv/update-api/build.rs
+++ b/drv/update-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/update.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/drv/user-leds-api/build.rs
+++ b/drv/user-leds-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/user-leds.idol",
         "client_stub.rs",

--- a/drv/user-leds/build.rs
+++ b/drv/user-leds/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/task/control-plane-agent-api/build.rs
+++ b/task/control-plane-agent-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/control-plane-agent.idol",
         "client_stub.rs",

--- a/task/control-plane-agent/build.rs
+++ b/task/control-plane-agent/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/control-plane-agent.idol",
         "server_stub.rs",

--- a/task/dump-agent-api/build.rs
+++ b/task/dump-agent-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/dump-agent.idol",
         "client_stub.rs",

--- a/task/dump-agent/build.rs
+++ b/task/dump-agent/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/dump-agent.idol",
         "server_stub.rs",

--- a/task/dumper-api/build.rs
+++ b/task/dumper-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/dumper.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/task/dumper/build.rs
+++ b/task/dumper/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/dumper.idol",
         "server_stub.rs",

--- a/task/host-sp-comms-api/build.rs
+++ b/task/host-sp-comms-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/host-sp-comms.idol",
         "client_stub.rs",

--- a/task/host-sp-comms/build.rs
+++ b/task/host-sp-comms/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/task/jefe-api/build.rs
+++ b/task/jefe-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/jefe.idol", "client_stub.rs")?;
 
     Ok(())

--- a/task/monorail-server/build.rs
+++ b/task/monorail-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/task/net-api/build.rs
+++ b/task/net-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/net.idol", "client_stub.rs")?;
 
     let out_dir = build_util::out_dir();

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -6,7 +6,7 @@ use build_net::{BufSize, NetConfig, SocketConfig};
 use proc_macro2::TokenStream;
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::server::build_server_support(
         "../../idl/net.idol",
         "server_stub.rs",
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn generate_net_config(
     config: &NetConfig,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let out_dir = build_util::out_dir();
     let dest_path = out_dir.join("net_config.rs");
 
@@ -72,7 +72,7 @@ fn generate_net_config(
 
 fn generate_port_table(
     config: &NetConfig,
-) -> Result<TokenStream, Box<dyn std::error::Error>> {
+) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
     let consts = config.sockets.values().map(|socket| {
         let port = socket.port;
         quote::quote! { #port }
@@ -89,7 +89,7 @@ fn generate_port_table(
 
 fn generate_owner_info(
     config: &NetConfig,
-) -> Result<TokenStream, Box<dyn std::error::Error>> {
+) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
     let consts = config.sockets.values().map(|socket| {
         let task: syn::Ident = syn::parse_str(&socket.owner.name).unwrap();
         let note = socket.owner.notification;
@@ -117,7 +117,7 @@ fn generate_socket_state(
     name: &str,
     config: &SocketConfig,
     vlan_count: usize,
-) -> Result<TokenStream, Box<dyn std::error::Error>> {
+) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
     if config.kind != "udp" {
         return Err("unsupported socket kind".into());
     }
@@ -160,7 +160,7 @@ fn generate_state_struct(config: &NetConfig) -> TokenStream {
 
 fn generate_constructor(
     config: &NetConfig,
-) -> Result<TokenStream, Box<dyn std::error::Error>> {
+) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
     let name_to_sockets = |name: &String, i: usize| {
         let upname = name.to_ascii_uppercase();
         let rxhdrs: syn::Ident =

--- a/task/power-api/build.rs
+++ b/task/power-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/power.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/task/power/build.rs
+++ b/task/power/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(

--- a/task/sensor/build.rs
+++ b/task/sensor/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     idol::server::build_server_support(
         "../../idl/sensor.idol",

--- a/task/thermal-api/build.rs
+++ b/task/thermal-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub(
         "../../idl/thermal.idol",
         "client_stub.rs",

--- a/task/thermal/build.rs
+++ b/task/thermal/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_i2c::codegen(build_i2c::Disposition::Sensors)?;
 

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -4,7 +4,7 @@
 
 use std::io::Write;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     write_pub_device_descriptions()?;
 
     idol::client::build_client_stub(
@@ -14,7 +14,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn write_pub_device_descriptions() -> Result<(), Box<dyn std::error::Error>> {
+fn write_pub_device_descriptions(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let devices = build_i2c::device_descriptions().collect::<Vec<_>>();
 
     let out_dir = std::env::var("OUT_DIR")?;

--- a/task/validate/build.rs
+++ b/task/validate/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_i2c::codegen(build_i2c::Disposition::Validation)?;
 

--- a/task/vpd-api/build.rs
+++ b/task/vpd-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("../../idl/vpd.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/task/vpd/build.rs
+++ b/task/vpd/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_i2c::codegen(build_i2c::Disposition::Devices)?;
 

--- a/test/test-idol-api/build.rs
+++ b/test/test-idol-api/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     idol::client::build_client_stub("api.idol", "client_stub.rs")?;
     Ok(())
 }

--- a/test/test-idol-server/build.rs
+++ b/test/test-idol-server/build.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
     idol::server::build_server_support(


### PR DESCRIPTION
This will allow us to mix Idolatry and `anyhow::Result` in `build.rs` files.

Depends on https://github.com/oxidecomputer/idolatry/pull/32, and `Cargo.toml` needs to be adjusted after that's merged.