### PR TITLE
Fix broken test apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,6 +3765,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "task-config"
 version = "0.1.0"
 dependencies = [
+ "build-util",
  "proc-macro2",
  "quote",
  "serde",
@@ -4436,7 +4437,9 @@ dependencies = [
 name = "test-idol-api"
 version = "0.1.0"
 dependencies = [
+ "derive-idol-err",
  "idol",
+ "idol-runtime",
  "num-traits",
  "serde",
  "ssmarshal",

--- a/lib/task-config/Cargo.toml
+++ b/lib/task-config/Cargo.toml
@@ -9,6 +9,7 @@ quote = { workspace = true }
 serde = { workspace = true }
 syn = { workspace = true }
 toml = { workspace = true }
+build-util = { path = "../../build/util" }
 
 [lib]
 proc-macro = true

--- a/lib/task-config/src/lib.rs
+++ b/lib/task-config/src/lib.rs
@@ -139,10 +139,7 @@ fn config_to_token(
 /// cannot be configured using this macro).
 #[proc_macro]
 pub fn task_config(tokens: TokenStream) -> TokenStream {
-    let task_config_str = std::env::var("HUBRIS_TASK_CONFIG")
-        .expect("Missing HUBRIS_TASK_CONFIG variable");
-    let config = toml::from_str::<toml::Value>(&task_config_str)
-        .expect("Could not parse HUBRIS_TASK_CONFIG");
+    let config = build_util::task_config::<toml::Value>().unwrap();
 
     let input = parse_macro_input!(tokens as Config);
     let values = input

--- a/test/test-idol-api/Cargo.toml
+++ b/test/test-idol-api/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+idol-runtime = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 ssmarshal = { workspace = true }
 zerocopy = { workspace = true }
 
+derive-idol-err = { path = "../../lib/derive-idol-err"  }
 userlib = { path = "../../sys/userlib" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -6,24 +6,16 @@
 
 #![no_std]
 
+use derive_idol_err::IdolError;
 use serde::{Deserialize, Serialize};
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive, IdolError)]
 pub enum IdolTestError {
     UhOh = 1,
     YouAskedForThis = 2,
-}
-impl TryFrom<u32> for IdolTestError {
-    type Error = ();
-    fn try_from(x: u32) -> Result<Self, Self::Error> {
-        Self::from_u32(x).ok_or(())
-    }
-}
-impl From<IdolTestError> for u16 {
-    fn from(rc: IdolTestError) -> Self {
-        rc as u16
-    }
+    #[idol(server_death)]
+    RipServer = 3,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize)]

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -6,7 +6,7 @@ memory = "memory-g070.toml"
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 17148, ram = 2808}
+requires = {flash = 17344, ram = 2808}
 features = ["g070"]
 stacksize = 2048
 


### PR DESCRIPTION
They were broken by
- Changes to `HUBRIS_TASK_CONFIG` to include the full config
- `idol_runtime::IHaveConsideredServerDeathWithThisErrorType`

(`test/tests-psc/app.toml` is still broken, but it was broken before)