### PR TITLE
stm32xx: Change I2C slew rates to Low

### DIFF
--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -391,7 +391,7 @@ fn configure_port(
             sys.gpio_configure_alternate(
                 pin.gpio_pins,
                 OutputType::OpenDrain,
-                Speed::High,
+                Speed::Low,
                 Pull::None,
                 pin.function,
             );
@@ -427,7 +427,7 @@ fn configure_pins(
         sys.gpio_configure_alternate(
             pin.gpio_pins,
             OutputType::OpenDrain,
-            Speed::High,
+            Speed::Low,
             Pull::None,
             pin.function,
         );

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -184,7 +184,7 @@ impl I2cMux<'_> {
             sys.gpio_configure_output(
                 pin.gpio_pins,
                 sys_api::OutputType::PushPull,
-                sys_api::Speed::High,
+                sys_api::Speed::Low,
                 sys_api::Pull::None,
             );
         }


### PR DESCRIPTION
High is for ~100+MHz signals and will be producing annoyingly sharp edges. Low is good up into the MHz+range which is fine for I2C.