### PR TITLE
Fail on oversized host flash update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#57c680212c98f311be43f18cc8859eaefa7126e4"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=add-update-too-large#e56a2c53e712f401169fb7f54a6b14639803d435"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#fcc97f207413cc59d2662b474261f86e35d85855"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#583101f3b41907e5dbc4478f2d21e8286e8eaa1c"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=add-update-too-large#e56a2c53e712f401169fb7f54a6b14639803d435"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#fcc97f207413cc59d2662b474261f86e35d85855"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "add-update-too-large" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "add-update-too-large" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -111,7 +111,10 @@ impl ComponentUpdater for HostFlashUpdate {
         // a safe assumption for future parts as well. We'll fail here if that's
         // untrue, which will require reworking how we erase the target slot.
         if capacity % SECTOR_SIZE_BYTES != 0 {
-            return Err(SpError::UpdateHasPartialSectors);
+            // We don't have an error case for "our assumptions are wrong", so
+            // we'll fill in an easily-greppable update failure code. In case it
+            // shows up in logs in base 10, 0x1de_0001 == 31326209.
+            return Err(SpError::UpdateFailed(0x1de_0001));
         }
         let num_sectors = (capacity / SECTOR_SIZE_BYTES) as u32;
 

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -102,6 +102,10 @@ impl ComponentUpdater for HostFlashUpdate {
             .capacity()
             .map_err(|err| SpError::UpdateFailed(err as u32))?;
 
+        if update.total_size as usize > capacity {
+            return Err(SpError::UpdateIsTooLarge);
+        }
+
         // How many total sectors do we need to erase? For gimlet, we know that
         // capacity is an exact multiple of the sector size, which is probably
         // a safe assumption for future parts as well. We'll fail here if that's

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -111,10 +111,7 @@ impl ComponentUpdater for HostFlashUpdate {
         // a safe assumption for future parts as well. We'll fail here if that's
         // untrue, which will require reworking how we erase the target slot.
         if capacity % SECTOR_SIZE_BYTES != 0 {
-            // We don't have an error case for "our assumptions are wrong", so
-            // we'll fill in an easily-greppable update failure code. In case it
-            // shows up in logs in base 10, 0x1de_0001 == 31326209.
-            return Err(SpError::UpdateFailed(0x1de_0001));
+            return Err(SpError::UpdateHasPartialSectors);
         }
         let num_sectors = (capacity / SECTOR_SIZE_BYTES) as u32;
 


### PR DESCRIPTION
Depends on https://github.com/oxidecomputer/management-gateway-service/pull/53 ; we should switch the dependency back to `main` once that's merged.

Closes #1098