### PR TITLE
Plumb SPI features through tasks to improve rebuild

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -63,9 +63,6 @@ interrupts = {"spi1.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
 
-[tasks.spi_driver.config.spi]
-global_config = "spi1"
-
 [tasks.net]
 name = "task-net"
 stacksize = 3000

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -63,9 +63,6 @@ interrupts = {"spi1.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
 
-[tasks.spi_driver.config.spi]
-global_config = "spi1"
-
 [tasks.net]
 name = "task-net"
 stacksize = 3000

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -60,9 +60,6 @@ interrupts = {"spi2.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
 
-[tasks.spi2_driver.config.spi]
-global_config = "spi2"
-
 [tasks.user_leds]
 name = "drv-user-leds"
 features = ["stm32h7"]
@@ -120,10 +117,9 @@ stacksize = 4096
 start = true
 task-slots = ["sys"]
 uses = ["spi4"]
-features = ["use-spi-core", "h753"]
+features = ["use-spi-core", "h753", "spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.validate]
 name = "task-validate"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -62,9 +62,6 @@ stacksize = 872
 task-slots = ["sys"]
 notifications = ["spi-irq"]
 
-[tasks.spi2_driver.config.spi]
-global_config = "spi2"
-
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
@@ -261,11 +258,10 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
 start = true
 task-slots = ["sys"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 uses = ["spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.validate]
 name = "task-validate"

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -62,9 +62,6 @@ stacksize = 872
 task-slots = ["sys"]
 notifications = ["spi-irq"]
 
-[tasks.spi2_driver.config.spi]
-global_config = "spi2"
-
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
@@ -261,11 +258,10 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
 start = true
 task-slots = ["sys"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 uses = ["spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.validate]
 name = "task-validate"

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -67,9 +67,6 @@ interrupts = {"spi3.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
 
-[tasks.spi3_driver.config.spi]
-global_config = "spi3"
-
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
@@ -81,9 +78,6 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
-
-[tasks.spi_driver.config.spi]
-global_config = "spi4"
 
 [tasks.user_leds]
 name = "drv-user-leds"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -51,14 +51,13 @@ task-slots = ["sys", "user_leds"]
 name = "task-net"
 stacksize = 3000
 priority = 3
-features = ["mgmt", "h753", "use-spi-core"]
+features = ["mgmt", "h753", "use-spi-core", "spi2"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 task-slots = ["sys", "user_leds"]
-config.spi.global_config = "spi2"
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -59,9 +59,6 @@ interrupts = {"spi4.irq" = "spi-irq"}
 stacksize = 880
 task-slots = ["sys"]
 
-[tasks.spi_driver.config.spi]
-global_config = "spi4"
-
 [tasks.user_leds]
 name = "drv-user-leds"
 features = ["stm32h7"]

--- a/app/gimletlet/app-vsc7448.toml
+++ b/app/gimletlet/app-vsc7448.toml
@@ -67,14 +67,13 @@ task-slots = ["sys", "i2c_driver", "user_leds"]
 name = "task-monorail-server"
 priority = 3
 max-sizes = {flash = 131072, ram = 8192}
-features = ["leds", "use-spi-core", "h753"]
+features = ["leds", "use-spi-core", "h753", "spi4"]
 stacksize = 4096
 start = true
 task-slots = ["sys", "user_leds"]
 notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 uses = ["spi4"]
-config.spi.global_config = "spi4"
 
 [tasks.idle]
 name = "task-idle"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -146,13 +146,12 @@ notifications = ["hash-irq"]
 name = "task-net"
 stacksize = 6040
 priority = 3
-features = ["h753", "vlan", "gimletlet-nic", "use-spi-core"]
+features = ["h753", "vlan", "gimletlet-nic", "use-spi-core", "spi4"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi4"]
 start = true
 task-slots = ["sys"]
-config.spi.global_config = "spi4"
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 
 [tasks.net.interrupts]
@@ -228,11 +227,10 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
 start = true
 task-slots = ["sys"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi3"]
 uses = ["spi3"]
 notifications = ["spi-irq"]
 interrupts = {"spi3.irq" = "spi-irq"}
-config.spi.global_config = "spi3"
 
 [tasks.validate]
 name = "task-validate"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -80,7 +80,7 @@ task-slots = ["i2c_driver"]
 name = "task-net"
 stacksize = 6040
 priority = 3
-features = ["mgmt", "h753", "vlan", "vpd-mac", "use-spi-core"]
+features = ["mgmt", "h753", "vlan", "vpd-mac", "use-spi-core", "spi2"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
@@ -88,7 +88,6 @@ start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "spi-irq"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq", "spi2.irq" = "spi-irq"}
 task-slots = ["sys", "i2c_driver"]
-config.spi.global_config = "spi2"
 
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
@@ -118,10 +117,9 @@ stacksize = 16384
 start = true
 task-slots = ["sys"]
 uses = ["spi4"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -78,7 +78,7 @@ task-slots = ["i2c_driver"]
 name = "task-net"
 stacksize = 6040
 priority = 3
-features = ["mgmt", "h753", "vlan", "vpd-mac", "use-spi-core"]
+features = ["mgmt", "h753", "vlan", "vpd-mac", "use-spi-core", "spi2"]
 max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
@@ -90,7 +90,6 @@ notifications = [
     "spi-irq"
 ]
 task-slots = ["sys", "i2c_driver"]
-config.spi.global_config = "spi2"
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"
@@ -126,10 +125,9 @@ stacksize = 16384
 start = true
 task-slots = ["sys"]
 uses = ["spi4"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -57,7 +57,7 @@ notifications = ["qspi-irq"]
 name = "task-net"
 stacksize = 6040
 priority = 5
-features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core"]
+features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi3"]
@@ -65,7 +65,6 @@ start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "spi-irq"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq", "spi3.irq" = "spi-irq"}
 task-slots = ["sys", "i2c_driver", { seq = "sequencer" }]
-config.spi.global_config = "spi3"
 
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
@@ -98,11 +97,10 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
 start = true
 task-slots = ["sys"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 uses = ["spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.udpecho]
 name = "task-udpecho"
@@ -138,14 +136,13 @@ notifications = ["socket"]
 name = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 8192}
-features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753"]
+features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753", "spi2"]
 stacksize = 4096
 start = true
 task-slots = ["sys", "net", "ecp5_front_io", { seq = "sequencer" }]
 uses = ["spi2"]
 notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
-config.spi.global_config = "spi2"
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
@@ -187,7 +184,7 @@ notifications = ["timer"]
 
 [tasks.ecp5_mainboard]
 name = "drv-fpga-server"
-features = ["mainboard", "use-spi-core", "h753"]
+features = ["mainboard", "use-spi-core", "h753", "spi5"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 2048
@@ -196,11 +193,10 @@ uses = ["spi5"]
 task-slots = ["sys"]
 notifications = ["spi-irq"]
 interrupts = {"spi5.irq" = "spi-irq"}
-config.spi.global_config = "spi5"
 
 [tasks.ecp5_front_io]
 name = "drv-fpga-server"
-features = ["front_io", "use-spi-core", "h753"]
+features = ["front_io", "use-spi-core", "h753", "spi1"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 2048
@@ -209,7 +205,6 @@ uses = ["spi1"]
 task-slots = ["sys", "i2c_driver"]
 notifications = ["spi-irq"]
 interrupts = {"spi1.irq" = "spi-irq"}
-config.spi.global_config = "spi1"
 
 [tasks.transceivers]
 name = "drv-transceivers-server"

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -57,7 +57,7 @@ task-slots = ["sys"]
 name = "task-net"
 stacksize = 6040
 priority = 5
-features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core"]
+features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi3"]
@@ -65,7 +65,6 @@ start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 task-slots = ["sys", "i2c_driver",
               { seq = "sequencer" }]
-config.spi.global_config = "spi3"
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"
@@ -103,11 +102,10 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
 start = true
 task-slots = ["sys"]
-features = ["sink_test", "use-spi-core", "h753"]
+features = ["sink_test", "use-spi-core", "h753", "spi4"]
 uses = ["spi4"]
 notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
-config.spi.global_config = "spi4"
 
 [tasks.udpecho]
 name = "task-udpecho"
@@ -143,14 +141,13 @@ notifications = ["socket"]
 name = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 8192}
-features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753"]
+features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753", "spi2"]
 stacksize = 4096
 start = true
 task-slots = ["ecp5_front_io", "sys", { seq = "sequencer" }]
 uses = ["spi2"]
 notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
-config.spi.global_config = "spi2"
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
@@ -192,7 +189,7 @@ notifications = ["timer"]
 
 [tasks.ecp5_mainboard]
 name = "drv-fpga-server"
-features = ["mainboard", "use-spi-core", "h753"]
+features = ["mainboard", "use-spi-core", "h753", "spi5"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 2048
@@ -201,11 +198,10 @@ uses = ["spi5"]
 task-slots = ["sys"]
 notifications = ["spi-irq"]
 interrupts = {"spi5.irq" = "spi-irq"}
-config.spi.global_config = "spi5"
 
 [tasks.ecp5_front_io]
 name = "drv-fpga-server"
-features = ["front_io", "use-spi-core", "h753"]
+features = ["front_io", "use-spi-core", "h753", "spi1"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 2048
@@ -214,7 +210,6 @@ uses = ["spi1"]
 task-slots = ["sys", "i2c_driver"]
 notifications = ["spi-irq"]
 interrupts = {"spi1.irq" = "spi-irq"}
-config.spi.global_config = "spi1"
 
 [tasks.transceivers]
 name = "drv-transceivers-server"

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2178,7 +2178,7 @@ impl Archive {
 
         let archive = File::create(&tmp_path)?;
         let mut inner = zip::ZipWriter::new(archive);
-        inner.set_comment("hubris build archive v6");
+        inner.set_comment("hubris build archive v7");
         Ok(Self {
             final_path,
             tmp_path,

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -32,6 +32,13 @@ use-spi-core = ["drv-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
 
+spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -32,7 +32,8 @@ build-util = { path = "../../build/util" }
 call_rustfmt = { path = "../../build/call_rustfmt" }
 
 [features]
-# These features are used to select a global SPI peripheral block; making this
+# These features are used in `build.rs` to select a global SPI peripheral block,
+# which modifies the generated code that's compiled in the crate.  Making this
 # choice based on features prevents extra rebuilds when building a complete
 # Hubris app.
 spi1 = []

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -32,5 +32,14 @@ build-util = { path = "../../build/util" }
 call_rustfmt = { path = "../../build/call_rustfmt" }
 
 [features]
+# These features are used to select a global SPI peripheral block; making this
+# choice based on features prevents extra rebuilds when building a complete
+# Hubris app.
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-spi/h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -33,8 +33,9 @@ call_rustfmt = { path = "../../build/call_rustfmt" }
 
 [features]
 # These features are used in `build.rs` to select a global SPI peripheral block,
-# which modifies the generated code that's compiled in the crate.  Making this
-# choice based on features prevents extra rebuilds when building a complete
+# which modifies the generated code that's compiled in the crate.  As such, they
+# don't appear in the crate's source code, but are load-bearing!  Making this
+# choice based on features also prevents extra rebuilds when building a complete
 # Hubris app.
 spi1 = []
 spi2 = []

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -18,14 +18,15 @@ idol.workspace = true
 build-util.path = "../../build/util"
 
 [features]
-# These features are unused in the app itself, but Humility uses them to decide
-# which SPI server task to address for a given peripheral.
-spi1 = []
-spi2 = []
-spi3 = []
-spi4 = []
-spi5 = []
-spi6 = []
+# These features are used to select a global SPI configuration block; in
+# addition, Humility uses them to decide which SPI server task to address for a
+# given peripheral.
+spi1 = ["drv-stm32h7-spi-server-core/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core/spi6"]
 h743 = ["drv-stm32h7-spi-server-core/h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["drv-stm32h7-spi-server-core/h753", "drv-stm32xx-sys-api/h753"]
 

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -25,10 +25,17 @@ build-util = { path = "../../build/util" }
 idol = { workspace = true }
 
 [features]
+sink_test = []
 use-spi-core = ["drv-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
-sink_test = []
+
+spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -34,6 +34,13 @@ use-spi-core = ["drv-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
 
+spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+
 [build-dependencies]
 build-util = {path = "../../build/util"}
 idol = { workspace = true }

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -48,6 +48,13 @@ h753 = ["drv-stm32h7-eth/h753", "stm32h7/stm32h753", "drv-stm32xx-sys-api/h753",
 vlan = ["task-net-api/vlan", "build-net/vlan", "drv-stm32h7-eth/vlan"]
 gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/ksz8463"]
 
+spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+
 [build-dependencies]
 anyhow.workspace = true
 idol.workspace = true


### PR DESCRIPTION
Previously, Sidecar took 19 seconds to rebuild, because `drv-stm32h7-spi-server-core` was being

- instantiated more than once
- with identical features
- but dependent on environmental variables that are changing

This caused it to be rebuilt – and more importantly, the tasks using it to be re-linked – multiple times per full Hubris build.

Because Cargo caches builds based on features, we can fix this by activating a `spiX` feature in this crate, based on the SPI peripheral being used.

This requires a little plumbing to propagate the feature through other crates which depend on `drv-stm32h7-spi-server-core`.

This brings a Sidecar rebuild down to **7 seconds**, which is much more tolerable.

In addition, the feature is used to select the global SPI configuration block, eliminating the old `global_config`.  This couples the global configuration block name to SPI peripherals, which seems... fine?  We were already naming those blocks based on peripherals, and this removes a bunch of copy-pasta.