### PR TITLE
app.toml: Fix priority inversions in RoT app tomls.

### DIFF
--- a/app/gimlet-rot/app-b.toml
+++ b/app/gimlet-rot/app-b.toml
@@ -80,7 +80,7 @@ pins = [
 
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
-priority = 4
+priority = 6
 max-sizes = {flash = 32768, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
@@ -108,7 +108,7 @@ pins = [
 
 [tasks.swd]
 name = "drv-lpc55-swd"
-priority = 3
+priority = 4
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm5", "iocon"]
 start = true
@@ -141,7 +141,7 @@ spi_num = 5
 
 [tasks.dumper]
 name = "task-dumper"
-priority = 4
+priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
 stacksize = 2600

--- a/app/gimlet-rot/app-c.toml
+++ b/app/gimlet-rot/app-c.toml
@@ -71,7 +71,7 @@ task-slots = ["syscon_driver"]
 
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
-priority = 4
+priority = 6
 max-sizes = {flash = 32768, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
@@ -99,7 +99,7 @@ pins = [
 
 [tasks.swd]
 name = "drv-lpc55-swd"
-priority = 3
+priority = 4
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm5", "iocon"]
 start = true
@@ -132,7 +132,7 @@ spi_num = 5
 
 [tasks.dumper]
 name = "task-dumper"
-priority = 4
+priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
 stacksize = 2600

--- a/app/rot-carrier/app-secure.toml
+++ b/app/rot-carrier/app-secure.toml
@@ -166,7 +166,7 @@ task-slots = ["gpio_driver", "swd"]
 
 [tasks.sp_measure]
 name = "task-sp-measure"
-priority = 3
+priority = 5
 max-sizes = {flash = 131072, ram = 8192}
 task-slots = ["swd"]
 stacksize = 2048

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -88,7 +88,7 @@ task-slots = ["syscon_driver"]
 
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
-priority = 4
+priority = 6
 max-sizes = {flash = 32768, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
@@ -116,7 +116,7 @@ pins = [
 
 [tasks.swd]
 name = "drv-lpc55-swd"
-priority = 3
+priority = 4
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm3", "iocon"]
 start = true
@@ -149,7 +149,7 @@ spi_num = 3
 
 [tasks.dumper]
 name = "task-dumper"
-priority = 4
+priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
 stacksize = 2600


### PR DESCRIPTION
Most of these changes come from the `gpio_driver` and `swd` tasks operating with the same priority. `swd` talks  to `gpio_driver` so it must be at a lower (numerically higher) priority. This trickles down to other tasks that use `swd` like `dumper`, and tasks that use `dumper` like `sprot`.