### PR TITLE
Add support for host NMI and UART break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#49a269d8850d90b859dd1e16b0f5d64ec8a772ec"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#2bb2d22a6f80a1508f8e5e9038f9b78ca70dfce4"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "nmi-and-break" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "nmi-and-break" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -334,6 +334,7 @@ fn main() -> ! {
     let mut buffer = [0; idl::INCOMING_SIZE];
     let mut server = ServerImpl {
         state: PowerState::A2,
+        sys: sys.clone(),
         seq,
         jefe,
         hf,
@@ -345,6 +346,15 @@ fn main() -> ! {
         server.set_state_internal(PowerState::A0).unwrap();
     }
 
+    // Configure the NMI pin, leaving it high (i.e. not sending an NMI)
+    sys.gpio_set(SP_TO_SP3_NMI_SYNC_FLOOD_L);
+    sys.gpio_configure_output(
+        SP_TO_SP3_NMI_SYNC_FLOOD_L,
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Low,
+        sys_api::Pull::None,
+    );
+
     loop {
         idol_runtime::dispatch_n(&mut buffer, &mut server);
     }
@@ -352,6 +362,7 @@ fn main() -> ! {
 
 struct ServerImpl<S: SpiServer> {
     state: PowerState,
+    sys: sys_api::Sys,
     seq: seq_spi::SequencerFpga<S>,
     jefe: Jefe,
     hf: hf_api::HostFlash,
@@ -627,6 +638,19 @@ impl<S: SpiServer> idl::InOrderSequencerImpl for ServerImpl<S> {
             .unwrap();
         Ok(())
     }
+
+    fn send_hardware_nmi(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<core::convert::Infallible>> {
+        // The required length for an NMI pulse is apparently not documented.
+        //
+        // Let's try 25 ms!
+        self.sys.gpio_reset(SP_TO_SP3_NMI_SYNC_FLOOD_L);
+        hl::sleep_for(25);
+        self.sys.gpio_set(SP_TO_SP3_NMI_SYNC_FLOOD_L);
+        Ok(())
+    }
 }
 
 fn reprogram_fpga<S: SpiServer>(
@@ -674,6 +698,9 @@ cfg_if::cfg_if! {
         const GLOBAL_RESET: Option<sys_api::PinSet> = Some(
             sys_api::Port::A.pin(6)
         );
+
+        const SP_TO_SP3_NMI_SYNC_FLOOD_L: sys_api::PinSet =
+            sys_api::Port::J.pin(2);
 
         // gimlet-a needs to have a pin flipped to mux the iCE40 SPI flash out
         // of circuit to be able to program the FPGA, because we accidentally

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -85,6 +85,13 @@ impl idl::InOrderSequencerImpl for ServerImpl {
     ) -> Result<(), RequestError<SeqError>> {
         Ok(())
     }
+
+    fn send_hardware_nmi(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<core::convert::Infallible>> {
+        Ok(())
+    }
 }
 
 mod idl {

--- a/drv/stm32h7-usart/src/lib.rs
+++ b/drv/stm32h7-usart/src/lib.rs
@@ -148,4 +148,9 @@ impl Usart {
     pub fn disable_tx_fifo_empty_interrupt(&self) {
         self.usart.cr3.modify(|_, w| w.txftie().clear_bit());
     }
+
+    pub fn send_break(&self) {
+        self.usart.rqr.write(|w| w.sbkrq().set_bit());
+        // TODO: should we wait for the flag (SBKF) to clear?
+    }
 }

--- a/idl/gimlet-seq.idol
+++ b/idl/gimlet-seq.idol
@@ -40,5 +40,13 @@ Interface(
                 err: CLike("SeqError"),
             ),
         ),
+        "send_hardware_nmi": (
+            doc: "Triggers a hardware NMI by toggling LPC_SMI_L",
+            args: {},
+            reply: Result(
+                ok: "()",
+                err: ServerDeath,
+            ),
+        ),
     },
 )

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -128,6 +128,8 @@ enum MgsMessage {
         component: SpComponent,
         slot: u16,
     },
+    SerialConsoleBreak,
+    SendHostNmi,
 }
 
 ringbuf!(Log, 16, Log::Empty);

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -377,6 +377,15 @@ impl SpHandler for MgsHandler {
         Err(SpError::RequestUnsupportedForSp)
     }
 
+    fn serial_console_break(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
     fn reset_prepare(
         &mut self,
         _sender: SocketAddrV6,
@@ -518,5 +527,16 @@ impl SpHandler for MgsHandler {
             offset,
             data_len: data.len(),
         }));
+    }
+
+    fn send_host_nmi(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        // This can only fail if the `gimlet-seq` server is dead; in that
+        // case, send `Busy` because it should be rebooting.
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        Err(SpError::RequestUnsupportedForSp)
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -434,6 +434,15 @@ impl SpHandler for MgsHandler {
         Err(SpError::RequestUnsupportedForSp)
     }
 
+    fn serial_console_break(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
     fn reset_prepare(
         &mut self,
         _sender: SocketAddrV6,
@@ -613,6 +622,17 @@ impl SpHandler for MgsHandler {
             offset,
             data_len: data.len(),
         }));
+    }
+
+    fn send_host_nmi(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        // This can only fail if the `gimlet-seq` server is dead; in that
+        // case, send `Busy` because it should be rebooting.
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        Err(SpError::RequestUnsupportedForSp)
     }
 }
 


### PR DESCRIPTION
Depends on https://github.com/oxidecomputer/management-gateway-service/pull/56 and should be updated back to `management-gateway-service:main` after that lands.