### PR TITLE
Switch to names for SPI devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-spi"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "build-util"
 version = "0.1.0"
 dependencies = [
@@ -1439,6 +1450,9 @@ dependencies = [
 name = "drv-spi-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "build-spi",
+ "build-util",
  "derive-idol-err",
  "idol",
  "idol-runtime",
@@ -1601,6 +1615,7 @@ name = "drv-stm32h7-spi-server-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "build-spi",
  "build-util",
  "call_rustfmt",
  "cfg-if",

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -89,7 +89,7 @@ outputs = [
 ]
 input = {port = "I", pin = 2, af = 5}
 
-[config.spi.spi2.devices.spi2_header]
+[config.spi.spi2.devices.ksz8463]
 mux = "port_i"
 cs = [{port = "I", pin = 0}]
 

--- a/build/spi/Cargo.toml
+++ b/build/spi/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "build-spi"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+indexmap.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+serde.workspace = true
+syn.workspace = true

--- a/build/spi/src/lib.rs
+++ b/build/spi/src/lib.rs
@@ -1,0 +1,252 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use indexmap::IndexMap;
+use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// This represents our _subset_ of global config and _must not_ be marked with
+/// `deny_unknown_fields`!
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SpiGlobalConfig {
+    pub spi: BTreeMap<String, SpiConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpiConfig {
+    pub controller: usize,
+    pub fifo_depth: Option<usize>,
+    pub mux_options: BTreeMap<String, SpiMuxOptionConfig>,
+    pub devices: IndexMap<String, DeviceDescriptorConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpiMuxOptionConfig {
+    pub outputs: Vec<AfPinSetConfig>,
+    pub input: AfPinConfig,
+    #[serde(default)]
+    pub swap_data: bool,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+pub enum ConfigPort {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct AfPinSetConfig {
+    pub port: ConfigPort,
+    pub pins: Vec<usize>,
+    pub af: Af,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct AfPinConfig {
+    #[serde(flatten)]
+    pub pc: GpioPinConfig,
+    pub af: Af,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct GpioPinConfig {
+    pub port: ConfigPort,
+    pub pin: usize,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(transparent)]
+pub struct Af(pub usize);
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeviceDescriptorConfig {
+    pub mux: String,
+    #[serde(default)]
+    pub clock_divider: ClockDivider,
+    pub cs: Vec<GpioPinConfig>,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+pub enum ClockDivider {
+    DIV2,
+    DIV4,
+    DIV8,
+    DIV16,
+    DIV32,
+    DIV64,
+    DIV128,
+    DIV256,
+}
+
+impl Default for ClockDivider {
+    fn default() -> ClockDivider {
+        // When this config mechanism was introduced, we had everything set at
+        // DIV64 for a ~1.5625 MHz SCK rate.
+        Self::DIV64
+    }
+}
+
+impl ToTokens for SpiConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        // Work out the mapping from mux names to indices so we can dereference
+        // the mux names used in devices.
+        let mux_indices: BTreeMap<_, usize> = self
+            .mux_options
+            .keys()
+            .enumerate()
+            .map(|(i, k)| (k, i))
+            .collect();
+
+        // The svd2rust PAC can't decide whether acronyms are words, so we get
+        // to produce both identifiers.
+        let devname: syn::Ident =
+            syn::parse_str(&format!("SPI{}", self.controller)).unwrap();
+        let pname: syn::Ident =
+            syn::parse_str(&format!("Spi{}", self.controller)).unwrap();
+
+        // We don't derive ToTokens for DeviceDescriptorConfig because it needs
+        // extra knowledge (the mux_indices map) to do the conversion. Instead,
+        // convert it here:
+        let device_code = self.devices.values().map(|dev| {
+            let mux_index = mux_indices[&dev.mux];
+            let cs = &dev.cs;
+            let div: syn::Ident =
+                syn::parse_str(&format!("{:?}", dev.clock_divider)).unwrap();
+            quote::quote! {
+                DeviceDescriptor {
+                    mux_index: #mux_index,
+                    cs: &[ #(#cs),* ],
+                    // `spi1` here is _not_ a typo/oversight, the PAC calls all
+                    // SPI types spi1.
+                    clock_divider: device::spi1::cfg1::MBR_A::#div,
+                }
+            }
+        });
+
+        let device_names = self.devices.keys().enumerate().map(|(i, name)| {
+            let name: syn::Ident =
+                syn::parse_str(&name.to_uppercase()).unwrap();
+            let i: u8 = i.try_into().unwrap();
+            quote::quote! { pub const #name: u8 = #i; }
+        });
+
+        let muxes = self.mux_options.values();
+
+        // If the user does not specify a fifo depth, we default to the
+        // _minimum_ on any SPI block on the STM32H7, which is 8.
+        let fifo_depth = self.fifo_depth.unwrap_or(8);
+
+        tokens.append_all(quote::quote! {
+            const FIFO_DEPTH: usize = #fifo_depth;
+            const CONFIG: ServerConfig = ServerConfig {
+                registers: device::#devname::ptr(),
+                peripheral: sys_api::Peripheral::#pname,
+                mux_options: &[ #(#muxes),* ],
+                devices: &[ #(#device_code),* ],
+            };
+            pub mod devices {
+                #(#device_names)*
+            }
+        });
+    }
+}
+
+impl ToTokens for SpiMuxOptionConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let outputs = &self.outputs;
+        let input = &self.input;
+        let swap_data = self.swap_data;
+        tokens.append_all(quote::quote! {
+            SpiMuxOption {
+                outputs: &[ #(#outputs),* ],
+                input: #input,
+                swap_data: #swap_data,
+            }
+        });
+    }
+}
+
+impl ToTokens for ConfigPort {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let port: syn::Ident = syn::parse_str(&format!("{:?}", self)).unwrap();
+        tokens.append_all(quote::quote! {
+            sys_api::Port::#port
+        });
+    }
+}
+
+impl ToTokens for AfPinSetConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let port = self.port;
+        let pins = self.pins.iter().map(|pin| {
+            quote::quote! {
+                (1 << #pin)
+            }
+        });
+        let af = &self.af;
+        tokens.append_all(quote::quote! {
+            (
+                PinSet {
+                    port: #port,
+                    pin_mask: #( #pins )|*,
+                },
+                #af,
+            )
+        });
+    }
+}
+
+impl ToTokens for AfPinConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let pc = &self.pc;
+        let af = &self.af;
+        tokens.append_all(quote::quote! {
+            (
+                #pc,
+                #af,
+            )
+        });
+    }
+}
+
+impl ToTokens for GpioPinConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let port = &self.port;
+        let pin = self.pin;
+        tokens.append_all(quote::quote! {
+            PinSet {
+                port: #port,
+                pin_mask: 1 << #pin,
+            }
+        });
+    }
+}
+
+impl ToTokens for Af {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let name: syn::Ident =
+            syn::parse_str(&format!("AF{}", self.0)).unwrap();
+        tokens.append_all(quote::quote! {
+            sys_api::Alternate::#name
+        });
+    }
+}

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -62,8 +62,10 @@ ringbuf!(Trace, 64, Trace::None);
 fn main() -> ! {
     let sys = Sys::from(SYS.get_task_id());
     let spi = claim_spi(&sys);
-    let configuration_port = spi.device(0);
-    let user_design = spi.device(1);
+    let configuration_port =
+        spi.device(drv_spi_api::devices::ECP5_FRONT_IO_FPGA);
+    let user_design =
+        spi.device(drv_spi_api::devices::ECP5_FRONT_IO_USER_DESIGN);
 
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "mainboard", feature = "front_io"))] {

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -62,10 +62,6 @@ ringbuf!(Trace, 64, Trace::None);
 fn main() -> ! {
     let sys = Sys::from(SYS.get_task_id());
     let spi = claim_spi(&sys);
-    let configuration_port =
-        spi.device(drv_spi_api::devices::ECP5_FRONT_IO_FPGA);
-    let user_design =
-        spi.device(drv_spi_api::devices::ECP5_FRONT_IO_USER_DESIGN);
 
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "mainboard", feature = "front_io"))] {
@@ -73,6 +69,11 @@ fn main() -> ! {
         } else if #[cfg(all(any(target_board = "sidecar-a",
                                 target_board = "sidecar-b"),
                             feature = "mainboard"))] {
+            let configuration_port =
+                spi.device(drv_spi_api::devices::ECP5_MAINBOARD_FPGA);
+            let user_design =
+                spi.device(drv_spi_api::devices::ECP5_MAINBOARD_USER_DESIGN);
+
             let driver = drv_fpga_devices::ecp5_spi::Ecp5UsingSpi {
                 sys,
                 done: sys_api::Port::J.pin(15),
@@ -89,6 +90,11 @@ fn main() -> ! {
         } else if #[cfg(all(any(target_board = "sidecar-a",
                                 target_board = "sidecar-b"),
                             feature = "front_io"))] {
+            let configuration_port =
+                spi.device(drv_spi_api::devices::ECP5_FRONT_IO_FPGA);
+            let user_design =
+                spi.device(drv_spi_api::devices::ECP5_FRONT_IO_USER_DESIGN);
+
             use drv_i2c_devices::pca9538::*;
             use drv_fpga_devices::ecp5_spi_mux_pca9538::*;
 
@@ -126,6 +132,9 @@ fn main() -> ! {
                 }
             };
         } else if #[cfg(target_board = "gimletlet-2")] {
+            // Hard-coding because the TOML file doesn't specify great names
+            let configuration_port = spi.device(0);
+            let user_design = spi.device(1);
             let driver = drv_fpga_devices::ecp5_spi::Ecp5UsingSpi {
                 sys,
                 done: sys_api::Port::E.pin(15),

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -228,7 +228,9 @@ fn main() -> ! {
     // If the sequencer is already loaded and operational, the design loaded
     // into it should be willing to talk to us over SPI, and should be able to
     // serve up a recognizable ident code.
-    let seq = seq_spi::SequencerFpga::new(spi.device(SEQ_SPI_DEVICE));
+    let seq = seq_spi::SequencerFpga::new(
+        spi.device(drv_spi_api::devices::SEQUENCER),
+    );
 
     // If the image announces the correct identifier and has a matching
     // bitstream checksum, then we can skip reprogramming;
@@ -252,7 +254,7 @@ fn main() -> ! {
 
         // Reprogramming will continue until morale improves -- to a point.
         loop {
-            let prog = spi.device(ICE40_SPI_DEVICE);
+            let prog = spi.device(drv_spi_api::devices::ICE40);
             ringbuf_entry!(Trace::Programming);
             match reprogram_fpga(&prog, &sys, &ICE40_CONFIG) {
                 Ok(()) => {
@@ -684,9 +686,6 @@ cfg_if::cfg_if! {
         target_board = "gimlet-b",
         target_board = "gimlet-c",
     ))] {
-        const SEQ_SPI_DEVICE: u8 = 0;
-        const ICE40_SPI_DEVICE: u8 = 1;
-
         const ICE40_CONFIG: ice40::Config = ice40::Config {
             // CRESET net is SEQ_TO_SP_CRESET_L and hits PD5.
             creset: sys_api::Port::D.pin(5),

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -8,8 +8,8 @@ idol-runtime.workspace = true
 num-traits.workspace = true
 zerocopy.workspace = true
 
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-userlib = {path = "../../sys/userlib"}
+derive-idol-err.path = "../../lib/derive-idol-err"
+userlib.path = "../../sys/userlib"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
@@ -18,4 +18,7 @@ test = false
 bench = false
 
 [build-dependencies]
+anyhow.workspace = true
 idol.workspace = true
+build-spi.path = "../../build/spi"
+build-util.path = "../../build/util"

--- a/drv/spi-api/build.rs
+++ b/drv/spi-api/build.rs
@@ -11,21 +11,25 @@ fn main() -> Result<()> {
     idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")
         .map_err(|e| anyhow!(e))?;
 
-    let global_config = build_util::config::<SpiGlobalConfig>()?;
-
     let out_dir = build_util::out_dir();
     let dest_path = out_dir.join("spi_devices.rs");
     let mut file = File::create(dest_path)?;
 
-    writeln!(&mut file, "pub mod devices {{")?;
-    for (periph, p) in global_config.spi {
-        writeln!(&mut file, "    // {periph} ({} devices)", p.devices.len())?;
-        for (i, name) in p.devices.keys().enumerate() {
-            let name = name.to_uppercase();
-            writeln!(&mut file, "    pub const {name}: u8 = {i};")?;
+    if let Ok(global_config) = build_util::config::<SpiGlobalConfig>() {
+        writeln!(&mut file, "pub mod devices {{")?;
+        for (periph, p) in global_config.spi {
+            writeln!(
+                &mut file,
+                "    // {periph} ({} devices)",
+                p.devices.len()
+            )?;
+            for (i, name) in p.devices.keys().enumerate() {
+                let name = name.to_uppercase();
+                writeln!(&mut file, "    pub const {name}: u8 = {i};")?;
+            }
         }
+        writeln!(&mut file, "}}")?;
     }
-    writeln!(&mut file, "}}")?;
 
     Ok(())
 }

--- a/drv/spi-api/build.rs
+++ b/drv/spi-api/build.rs
@@ -2,7 +2,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")?;
+use anyhow::{anyhow, Result};
+use build_spi::SpiGlobalConfig;
+use std::fs::File;
+use std::io::Write;
+
+fn main() -> Result<()> {
+    idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")
+        .map_err(|e| anyhow!(e))?;
+
+    let global_config = build_util::config::<SpiGlobalConfig>()?;
+
+    let out_dir = build_util::out_dir();
+    let dest_path = out_dir.join("spi_devices.rs");
+    let mut file = File::create(dest_path)?;
+
+    writeln!(&mut file, "pub mod devices {{")?;
+    for (periph, p) in global_config.spi {
+        writeln!(&mut file, "    // {periph} ({} devices)", p.devices.len())?;
+        for (i, name) in p.devices.keys().enumerate() {
+            let name = name.to_uppercase();
+            writeln!(&mut file, "    pub const {name}: u8 = {i};")?;
+        }
+    }
+    writeln!(&mut file, "}}")?;
+
     Ok(())
 }

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -225,3 +225,4 @@ impl<S: SpiServer> SpiDevice<S> {
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
+include!(concat!(env!("OUT_DIR"), "/spi_devices.rs"));

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 syn.workspace = true
 
 build-util = { path = "../../build/util" }
+build-spi = { path = "../../build/spi" }
 call_rustfmt = { path = "../../build/call_rustfmt" }
 
 [features]

--- a/drv/stm32h7-spi-server-core/build.rs
+++ b/drv/stm32h7-spi-server-core/build.rs
@@ -3,10 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{anyhow, bail, Result};
+use build_spi::*;
 use indexmap::IndexMap;
-use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
-use serde::Deserialize;
+use quote::ToTokens;
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -36,111 +35,11 @@ fn main() -> Result<()> {
         );
     }
 
-    let global_config = build_util::config::<GlobalConfig>()?;
+    let global_config = build_util::config::<SpiGlobalConfig>()?;
     check_spi_config(&global_config.spi, &spi)?;
     generate_spi_config(&global_config.spi, &spi)?;
 
     Ok(())
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// SPI config schema definition.
-
-/// This represents our _subset_ of global config and _must not_ be marked with
-/// `deny_unknown_fields`!
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct GlobalConfig {
-    spi: BTreeMap<String, SpiConfig>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct SpiConfig {
-    controller: usize,
-    fifo_depth: Option<usize>,
-    mux_options: BTreeMap<String, SpiMuxOptionConfig>,
-    devices: IndexMap<String, DeviceDescriptorConfig>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct SpiMuxOptionConfig {
-    outputs: Vec<AfPinSetConfig>,
-    input: AfPinConfig,
-    #[serde(default)]
-    swap_data: bool,
-}
-
-#[derive(Copy, Clone, Debug, Deserialize)]
-enum ConfigPort {
-    A,
-    B,
-    C,
-    D,
-    E,
-    F,
-    G,
-    H,
-    I,
-    J,
-    K,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
-struct AfPinSetConfig {
-    port: ConfigPort,
-    pins: Vec<usize>,
-    af: Af,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
-struct AfPinConfig {
-    #[serde(flatten)]
-    pc: GpioPinConfig,
-    af: Af,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
-struct GpioPinConfig {
-    port: ConfigPort,
-    pin: usize,
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(transparent)]
-struct Af(usize);
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct DeviceDescriptorConfig {
-    mux: String,
-    #[serde(default)]
-    clock_divider: ClockDivider,
-    cs: Vec<GpioPinConfig>,
-}
-
-#[derive(Copy, Clone, Debug, Deserialize)]
-enum ClockDivider {
-    DIV2,
-    DIV4,
-    DIV8,
-    DIV16,
-    DIV32,
-    DIV64,
-    DIV128,
-    DIV256,
-}
-
-impl Default for ClockDivider {
-    fn default() -> ClockDivider {
-        // When this config mechanism was introduced, we had everything set at
-        // DIV64 for a ~1.5625 MHz SCK rate.
-        Self::DIV64
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -175,142 +74,6 @@ fn generate_spi_config(
     call_rustfmt::rustfmt(&dest_path)?;
 
     Ok(())
-}
-
-impl ToTokens for SpiConfig {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        // Work out the mapping from mux names to indices so we can dereference
-        // the mux names used in devices.
-        let mux_indices: BTreeMap<_, usize> = self
-            .mux_options
-            .keys()
-            .enumerate()
-            .map(|(i, k)| (k, i))
-            .collect();
-
-        // The svd2rust PAC can't decide whether acronyms are words, so we get
-        // to produce both identifiers.
-        let devname: syn::Ident =
-            syn::parse_str(&format!("SPI{}", self.controller)).unwrap();
-        let pname: syn::Ident =
-            syn::parse_str(&format!("Spi{}", self.controller)).unwrap();
-
-        // We don't derive ToTokens for DeviceDescriptorConfig because it needs
-        // extra knowledge (the mux_indices map) to do the conversion. Instead,
-        // convert it here:
-        let device_code = self.devices.values().map(|dev| {
-            let mux_index = mux_indices[&dev.mux];
-            let cs = &dev.cs;
-            let div: syn::Ident =
-                syn::parse_str(&format!("{:?}", dev.clock_divider)).unwrap();
-            quote::quote! {
-                DeviceDescriptor {
-                    mux_index: #mux_index,
-                    cs: &[ #(#cs),* ],
-                    // `spi1` here is _not_ a typo/oversight, the PAC calls all
-                    // SPI types spi1.
-                    clock_divider: device::spi1::cfg1::MBR_A::#div,
-                }
-            }
-        });
-
-        let muxes = self.mux_options.values();
-
-        // If the user does not specify a fifo depth, we default to the
-        // _minimum_ on any SPI block on the STM32H7, which is 8.
-        let fifo_depth = self.fifo_depth.unwrap_or(8);
-
-        tokens.append_all(quote::quote! {
-            const FIFO_DEPTH: usize = #fifo_depth;
-            const CONFIG: ServerConfig = ServerConfig {
-                registers: device::#devname::ptr(),
-                peripheral: sys_api::Peripheral::#pname,
-                mux_options: &[ #(#muxes),* ],
-                devices: &[ #(#device_code),* ],
-            };
-        });
-    }
-}
-
-impl ToTokens for SpiMuxOptionConfig {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let outputs = &self.outputs;
-        let input = &self.input;
-        let swap_data = self.swap_data;
-        tokens.append_all(quote::quote! {
-            SpiMuxOption {
-                outputs: &[ #(#outputs),* ],
-                input: #input,
-                swap_data: #swap_data,
-            }
-        });
-    }
-}
-
-impl ToTokens for ConfigPort {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let port: syn::Ident = syn::parse_str(&format!("{:?}", self)).unwrap();
-        tokens.append_all(quote::quote! {
-            sys_api::Port::#port
-        });
-    }
-}
-
-impl ToTokens for AfPinSetConfig {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let port = self.port;
-        let pins = self.pins.iter().map(|pin| {
-            quote::quote! {
-                (1 << #pin)
-            }
-        });
-        let af = &self.af;
-        tokens.append_all(quote::quote! {
-            (
-                PinSet {
-                    port: #port,
-                    pin_mask: #( #pins )|*,
-                },
-                #af,
-            )
-        });
-    }
-}
-
-impl ToTokens for AfPinConfig {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let pc = &self.pc;
-        let af = &self.af;
-        tokens.append_all(quote::quote! {
-            (
-                #pc,
-                #af,
-            )
-        });
-    }
-}
-
-impl ToTokens for GpioPinConfig {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let port = &self.port;
-        let pin = self.pin;
-        tokens.append_all(quote::quote! {
-            PinSet {
-                port: #port,
-                pin_mask: 1 << #pin,
-            }
-        });
-    }
-}
-
-impl ToTokens for Af {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let name: syn::Ident =
-            syn::parse_str(&format!("AF{}", self.0)).unwrap();
-        tokens.append_all(quote::quote! {
-            sys_api::Alternate::#name
-        });
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -75,8 +75,6 @@ enum Trace {
 }
 ringbuf!(Trace, 64, Trace::None);
 
-const SP_TO_ROT_SPI_DEVICE: u8 = 0;
-
 // TODO:These timeouts are somewhat arbitrary.
 // TODO: Make timeouts configurable
 // All timeouts are in 'ticks'
@@ -183,7 +181,7 @@ pub struct ServerImpl<S: SpiServer> {
 #[export_name = "main"]
 fn main() -> ! {
     let sys = sys_api::Sys::from(SYS.get_task_id());
-    let spi = claim_spi(&sys).device(SP_TO_ROT_SPI_DEVICE);
+    let spi = claim_spi(&sys).device(drv_spi_api::devices::ROT);
 
     sys.gpio_configure_input(ROT_IRQ, sys_api::Pull::None);
     debug_config(&sys);

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -126,6 +126,7 @@ cfg_if::cfg_if! {
             port: sys_api::Port::E,
             pin_mask: 1 << 3,
         };
+        const ROT_SPI_DEVICE: u8 = drv_spi_api::devices::ROT;
         fn debug_config(_sys: &sys_api::Sys) { }
         fn debug_set(_sys: &sys_api::Sys, _asserted: bool) { }
     } else if #[cfg(target_board = "gimletlet-2")] {
@@ -151,6 +152,7 @@ cfg_if::cfg_if! {
             ringbuf_entry!(Trace::Debug(asserted));
             sys.gpio_set_to(DEBUG_PIN, asserted);
         }
+        const ROT_SPI_DEVICE: u8 = drv_spi_api::devices::SPI3_HEADER;
     } else {
         compile_error!("No configuration for ROT_IRQ");
     }
@@ -181,7 +183,7 @@ pub struct ServerImpl<S: SpiServer> {
 #[export_name = "main"]
 fn main() -> ! {
     let sys = sys_api::Sys::from(SYS.get_task_id());
-    let spi = claim_spi(&sys).device(drv_spi_api::devices::ROT);
+    let spi = claim_spi(&sys).device(ROT_SPI_DEVICE);
 
     sys.gpio_configure_input(ROT_IRQ, sys_api::Pull::None);
     debug_config(&sys);

--- a/task/monorail-server/src/main.rs
+++ b/task/monorail-server/src/main.rs
@@ -41,8 +41,6 @@ cfg_if::cfg_if! {
     }
 }
 
-const VSC7448_SPI_DEVICE: u8 = 0;
-
 task_slot!(SYS, sys);
 
 #[derive(Copy, Clone, PartialEq)]
@@ -59,7 +57,7 @@ ringbuf!(Trace, 2, Trace::None);
 #[export_name = "main"]
 fn main() -> ! {
     let sys = Sys::from(SYS.get_task_id());
-    let spi = claim_spi(&sys).device(VSC7448_SPI_DEVICE);
+    let spi = claim_spi(&sys).device(drv_spi_api::devices::VSC7448);
     let mut vsc7448_spi = Vsc7448Spi::new(spi);
     let vsc7448 = Vsc7448::new(&mut vsc7448_spi);
 

--- a/task/net/src/bsp/gimlet_bc.rs
+++ b/task/net/src/bsp/gimlet_bc.rs
@@ -88,7 +88,7 @@ impl crate::bsp_support::Bsp for BspImpl {
 
     fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(2); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
         Self(
             mgmt::Config {
                 // SP_TO_MGMT_V1P0_EN, SP_TO_MGMT_V2P5_EN

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -127,7 +127,7 @@ impl bsp_support::Bsp for BspImpl {
         leds.led_on(3).unwrap();
 
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(0); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
 
         let mgmt = mgmt::Config {
             power_en: None,

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -59,8 +59,7 @@ impl bsp_support::Bsp for BspImpl {
     fn new(_eth: &eth::Ethernet, sys: &Sys) -> Self {
         let ksz8463 = loop {
             let spi = bsp_support::claim_spi(sys);
-            // SPI device is based on ordering in app.toml
-            let ksz8463_spi = spi.device(0);
+            let ksz8463_spi = spi.device(drv_spi_api::devices::KSZ8463);
 
             // Initialize the KSZ8463 (using SPI4_RESET, PB10)
             sys.gpio_init_reset_pulse(Port::B.pin(10), 10, 1);

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -59,7 +59,8 @@ impl bsp_support::Bsp for BspImpl {
     fn new(_eth: &eth::Ethernet, sys: &Sys) -> Self {
         let ksz8463 = loop {
             let spi = bsp_support::claim_spi(sys);
-            let ksz8463_spi = spi.device(drv_spi_api::devices::KSZ8463);
+            // SPI4_HEADER is shared by both the SPI4 header and the NIC
+            let ksz8463_spi = spi.device(drv_spi_api::devices::SPI4_HEADER);
 
             // Initialize the KSZ8463 (using SPI4_RESET, PB10)
             sys.gpio_init_reset_pulse(Port::B.pin(10), 10, 1);

--- a/task/net/src/bsp/psc_a.rs
+++ b/task/net/src/bsp/psc_a.rs
@@ -50,7 +50,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(0); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
         let bsp = mgmt::Config {
             // SP_TO_MGMT_V1P0_EN / SP_TO_MGMT_V2P5_EN
             // (note that the latter also enables the MGMT_PHY_REFCLK)

--- a/task/net/src/bsp/psc_b.rs
+++ b/task/net/src/bsp/psc_b.rs
@@ -50,7 +50,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(0); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
         let bsp = mgmt::Config {
             // SP_TO_MGMT_PHY_A2_PWR_EN
             power_en: Some(Port::I.pin(10)),

--- a/task/net/src/bsp/sidecar_a.rs
+++ b/task/net/src/bsp/sidecar_a.rs
@@ -64,7 +64,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(0); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
         let bsp = mgmt::Config {
             // SP_TO_LDO_PHY2_EN (turns on both P2V5 and P1V0)
             power_en: Some(Port::I.pin(11)),

--- a/task/net/src/bsp/sidecar_b.rs
+++ b/task/net/src/bsp/sidecar_b.rs
@@ -69,7 +69,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn new(eth: &eth::Ethernet, sys: &Sys) -> Self {
         let spi = bsp_support::claim_spi(sys);
-        let ksz8463_dev = spi.device(0); // from app.toml
+        let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
         let bsp = mgmt::Config {
             // SP_TO_LDO_PHY2_EN (turns on both P2V5 and P1V0)
             power_en: Some(Port::I.pin(11)),


### PR DESCRIPTION
This isn't as strongly-typed as possible, but it's an improvement over the status quo!

I pulled the `GlobalConfig` from `stm32h7-drv-spi-server-core` to a new `build/spi` crate, then reused it in `spi-api`.