### PR TITLE
Prefer static over const for device description arrays.

### DIFF
--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -212,7 +212,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-max-sizes = {flash = 65536, ram = 16384}
+max-sizes = {flash = 131072, ram = 16384}
 stacksize = 4096
 start = true
 uses = ["usart1"]

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -360,14 +360,14 @@ mod devices_with_static_validation {
 
         if encoded_len > MIN_TRAILING_DATA_LEN {
             panic!(concat!(
-            "The device details (device and description) of at least one ",
-            "device in the current app.toml are too long to fit in a single ",
-            "TLV triple to send to MGS. Current Rust restrictions prevent us ",
-            "from being able to specific the specific device in this error ",
-            "message. Change this panic to `panic!(\"{{}}\", description)` ",
-            "and rebuild to see the description of the too-long device ",
-            "instead."
-        ))
+                "The device details (device and description) of at least one ",
+                "device in the current app.toml are too long to fit in a ",
+                "single TLV triple to send to MGS. Current Rust restrictions ",
+                "prevent us from being able to specific the specific device ",
+                "in this error message. Change this panic to ",
+                "`panic!(\"{{}}\", description)` and rebuild to see the ",
+                "description of the too-long device instead."
+            ));
         }
     }
 

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -26,7 +26,7 @@ fn write_pub_device_descriptions(
 
     writeln!(
         file,
-        "pub const DEVICES: [DeviceDescription; {}] = [",
+        "pub const DEVICES_CONST: [DeviceDescription; {}] = [",
         devices.len()
     )?;
 
@@ -47,6 +47,12 @@ fn write_pub_device_descriptions(
     }
 
     writeln!(file, "];")?;
+
+    writeln!(
+        file,
+        "pub static DEVICES: [DeviceDescription; DEVICES_CONST.len()] = DEVICES_CONST;"
+    )?;
+
     file.flush()?;
 
     Ok(())


### PR DESCRIPTION
We keep the const versions around (with `_CONST` appended to their names) for use by static assertions, but use the `static` variant in all real code.