### PR TITLE
Add Installinator Image ID plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#2bb2d22a6f80a1508f8e5e9038f9b78ca70dfce4"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -3944,6 +3944,7 @@ dependencies = [
  "mutable-statics",
  "num-traits",
  "ringbuf",
+ "static_assertions",
  "task-control-plane-agent-api",
  "task-host-sp-comms-api",
  "task-net-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#482bae9bfa704282e981008abae9328344150d36"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,8 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+# TODO revert to main branch before merging
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "installinator-id-plumbing" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-# TODO revert to main branch before merging
-gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "installinator-id-plumbing" }
+gateway-messages = {git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -225,7 +225,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 6
-max-sizes = {flash = 131072, ram = 16384}
+max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
 start = true
 uses = ["usart1"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -225,7 +225,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 6
-max-sizes = {flash = 131072, ram = 16384}
+max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
 start = true
 uses = ["usart1"]

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -212,7 +212,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-max-sizes = {flash = 131072, ram = 16384}
+max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
 start = true
 uses = ["usart1"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -192,7 +192,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-max-sizes = {flash = 65536, ram = 16384}
+max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
 start = true
 uses = ["usart1"]

--- a/idl/control-plane-agent.idol
+++ b/idl/control-plane-agent.idol
@@ -69,6 +69,14 @@ Interface(
             reply: Simple("UartClient"),
             idempotent: true,
         ),
+        "get_installinator_image_id": (
+            doc: "Get the current installinator image ID; writes 0 bytes if we have no ID.",
+            leases: {
+                "data": (type: "[u8]", write: true, max_len: Some(512)),
+            },
+            reply: Simple("usize"),
+            idempotent: true,
+        ),
         "set_humility_uart_client": (
             doc: "Attach or detach Humility as the host serial console client.",
             args: {

--- a/idl/control-plane-agent.idol
+++ b/idl/control-plane-agent.idol
@@ -70,7 +70,7 @@ Interface(
             idempotent: true,
         ),
         "get_installinator_image_id": (
-            doc: "Get the current installinator image ID; writes 0 bytes if we have no ID.",
+            doc: "Get the current installinator image ID, returning the number of bytes written. If we have no installinator image ID, does not modify the leased buffer and returns 0.",
             leases: {
                 "data": (type: "[u8]", write: true, max_len: Some(512)),
             },

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -30,6 +30,16 @@ pub const MAGIC: u32 = 0x01de_19cc;
 // `SpToHost` or `HostToSp`).
 pub const MAX_MESSAGE_SIZE: usize = 4123;
 
+/// Minimum amount of space available for data trailing after an `SpToHost`
+/// response.
+///
+/// The buffer passed to the `fill_data` callback of `serialize` is guaranteed
+/// to be _at least_ this long, regardless of the particular `SpToHost` response
+/// being sent. It will be longer than this for any `SpToHost` variants that
+/// serialize to a sequence shorter than `SpToHost::MAX_SIZE`.
+pub const MIN_SP_TO_HOST_FILL_DATA_LEN: usize =
+    MAX_MESSAGE_SIZE - Header::MAX_SIZE - CHECKSUM_SIZE - SpToHost::MAX_SIZE;
+
 const CHECKSUM_SIZE: usize = core::mem::size_of::<u16>();
 
 pub mod version {
@@ -148,8 +158,7 @@ pub enum SpToHost {
 pub enum Key {
     // Always sends back b"pong".
     Ping,
-    // Not yet implemented
-    // InstallinatorImageId,
+    InstallinatorImageId,
 }
 
 #[derive(

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -13,6 +13,9 @@ use static_assertions::const_assert;
 use userlib::*;
 use zerocopy::{AsBytes, FromBytes};
 
+/// Maximum length (in bytes) allowed for installinator image ID blobs.
+pub const MAX_INSTALLINATOR_IMAGE_ID_LEN: usize = 512;
+
 #[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
 pub enum ControlPlaneAgentError {
     DataUnavailable = 1,

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -10,9 +10,12 @@ use gateway_messages::{
     UpdateId,
 };
 use host_sp_messages::HostStartupOptions;
-use idol_runtime::{Leased, NotificationHandler, RequestError};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError,
+};
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
+use task_control_plane_agent_api::MAX_INSTALLINATOR_IMAGE_ID_LEN;
 use task_control_plane_agent_api::{
     ControlPlaneAgentError, UartClient, VpdIdentity,
 };
@@ -130,6 +133,10 @@ enum MgsMessage {
     },
     SerialConsoleBreak,
     SendHostNmi,
+    SetIpccKeyValue {
+        key: u8,
+        value_len: usize,
+    },
 }
 
 ringbuf!(Log, 16, Log::Empty);
@@ -242,6 +249,43 @@ impl idl::InOrderControlPlaneAgentImpl for ServerImpl {
         _msg: &userlib::RecvMessage,
     ) -> Result<VpdIdentity, RequestError<core::convert::Infallible>> {
         Ok(self.mgs_handler.identity())
+    }
+
+    #[cfg(feature = "gimlet")]
+    fn get_installinator_image_id(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        data: LenLimit<
+            Leased<idol_runtime::W, [u8]>,
+            MAX_INSTALLINATOR_IMAGE_ID_LEN,
+        >,
+    ) -> Result<usize, RequestError<core::convert::Infallible>> {
+        let image_id = self.mgs_handler.installinator_image_id();
+        if image_id.len() > data.len() {
+            // `image_id` is at most `MAX_INSTALLINATOR_IMAGE_ID_LEN`; if our
+            // client didn't send us that much space, fault them.
+            Err(RequestError::Fail(ClientError::BadLease))
+        } else {
+            data.write_range(0..image_id.len(), image_id)
+                .map_err(|()| RequestError::went_away())?;
+            Ok(image_id.len())
+        }
+    }
+
+    #[cfg(not(feature = "gimlet"))]
+    fn get_installinator_image_id(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        _data: LenLimit<
+            Leased<idol_runtime::W, [u8]>,
+            MAX_INSTALLINATOR_IMAGE_ID_LEN,
+        >,
+    ) -> Result<usize, RequestError<core::convert::Infallible>> {
+        // Non-gimlets should never request this function; fault them.
+        //
+        // TODO can we remove this op from our idol specification entirely for
+        // non-gimlets?
+        Err(RequestError::Fail(ClientError::BadMessageContents))
     }
 
     #[cfg(feature = "gimlet")]

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -935,15 +935,19 @@ impl SpHandler for MgsHandler {
 
         match Key::from_u8(key) {
             Some(Key::InstallinatorImageId) => {
-                if value.len() > self.installinator_image_id.capacity() {
+                // Check the incoming data length first; if this fails, we'll
+                // keep whatever existing image ID we have.
+                let max_len = self.installinator_image_id.capacity();
+                if value.len() > max_len {
                     return Err(SpError::SetIpccKeyLookupValueFailed(
                         IpccKeyLookupValueError::ValueTooLong {
-                            max_len: self.installinator_image_id.capacity()
-                                as u16,
+                            max_len: max_len as u16,
                         },
                     ));
                 }
 
+                // We now know `value` will fit, so replace our current
+                // installinator ID and unwrap the `extend_from_slice()`.
                 self.installinator_image_id.clear();
                 self.installinator_image_id
                     .extend_from_slice(value)

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -534,9 +534,21 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        // This can only fail if the `gimlet-seq` server is dead; in that
-        // case, send `Busy` because it should be rebooting.
         ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_ipcc_key_lookup_value(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        key: u8,
+        value: &[u8],
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
+            key,
+            value_len: value.len(),
+        }));
         Err(SpError::RequestUnsupportedForSp)
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -629,9 +629,21 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        // This can only fail if the `gimlet-seq` server is dead; in that
-        // case, send `Busy` because it should be rebooting.
         ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn set_ipcc_key_lookup_value(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        key: u8,
+        value: &[u8],
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
+            key,
+            value_len: value.len(),
+        }));
         Err(SpError::RequestUnsupportedForSp)
     }
 }

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cfg-if = { workspace = true }
-corncobs = { workspace = true }
-cortex-m = { workspace = true }
-enum-map = { workspace = true }
-heapless = { workspace = true }
-idol-runtime = { workspace = true }
-num-traits = { workspace = true }
-zerocopy = { workspace = true }
+cfg-if.workspace = true
+corncobs.workspace = true
+cortex-m.workspace = true
+enum-map.workspace = true
+heapless.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+static_assertions.workspace = true
+zerocopy.workspace = true
 
 drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api" }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api" }
@@ -28,7 +29,7 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
-idol = { workspace = true }
+idol.workspace = true
 
 [features]
 stm32h743 = ["drv-stm32h7-usart/h743", "drv-stm32xx-sys-api/h743"]

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -825,6 +825,10 @@ impl ServerImpl {
                     },
                 );
 
+                // A response length of 0 is how `control-plane-agent` indicates
+                // we do not have an installinator image ID; instead of
+                // returning a 0-length success to the host, convert it to the
+                // "we have no value for this key" error.
                 if response_len == 0 {
                     self.tx_buf.reset();
                     return Err(KeyLookupResult::NoValueForKey);

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -17,12 +17,16 @@ use heapless::Vec;
 use host_sp_messages::{
     Bsu, DecodeFailureReason, Header, HostToSp, HubpackError, Key,
     KeyLookupResult, SpToHost, Status, MAX_MESSAGE_SIZE,
+    MIN_SP_TO_HOST_FILL_DATA_LEN,
 };
 use idol_runtime::{NotificationHandler, RequestError};
 use multitimer::{Multitimer, Repeat};
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
-use task_control_plane_agent_api::ControlPlaneAgent;
+use static_assertions::const_assert;
+use task_control_plane_agent_api::{
+    ControlPlaneAgent, MAX_INSTALLINATOR_IMAGE_ID_LEN,
+};
 use task_host_sp_comms_api::HostSpCommsError;
 use task_net_api::Net;
 use userlib::{
@@ -86,6 +90,9 @@ enum Trace {
         now: u64,
         sequence: u64,
         message: HostToSp,
+    },
+    ResponseBufferReset {
+        now: u64,
     },
     Response {
         now: u64,
@@ -776,6 +783,55 @@ impl ServerImpl {
                         PONG.len()
                     },
                 );
+            }
+            Key::InstallinatorImageId => {
+                // Borrow `cp_agent` to avoid borrowing `self` in the closure
+                // below.
+                let cp_agent = &self.cp_agent;
+
+                // We don't want to have to set aside our own memory to copy the
+                // installinator image ID (other than our already-allocated
+                // outgoing tx buf), so we will optimistically serialize a
+                // successful response, including the image ID. After
+                // serializing this successful response, we'll check that
+                // `max_response_len` (i.e., the buffer length of the host
+                // process that requested this value) is sufficient; if it is
+                // not (or if we have no installinator image ID at all), we'll
+                // discard the optimistically-serialized response and return an
+                // error.
+                //
+                // We expect both of these "reset and replace the response with
+                // an error" to be extremely rare: host processes should not ask
+                // for an installinator ID with a too-small buffer, and should
+                // only ask for an installinator ID during a recovery process in
+                // which we expect MGS has already given us an ID.
+                let mut response_len = 0;
+                self.tx_buf.encode_response(
+                    sequence,
+                    &SpToHost::KeyLookupResult(KeyLookupResult::Ok),
+                    |mut buf| {
+                        // Statically guarantee we have sufficient space in
+                        // `buf` for the installinator image ID blob, and then
+                        // cap `buf` to that length to satisfy the idol
+                        // operation length limit.
+                        const_assert!(
+                            MIN_SP_TO_HOST_FILL_DATA_LEN
+                                >= MAX_INSTALLINATOR_IMAGE_ID_LEN
+                        );
+                        buf = &mut buf[..MAX_INSTALLINATOR_IMAGE_ID_LEN];
+
+                        response_len = cp_agent.get_installinator_image_id(buf);
+                        response_len
+                    },
+                );
+
+                if response_len == 0 {
+                    self.tx_buf.reset();
+                    return Err(KeyLookupResult::NoValueForKey);
+                } else if response_len > max_response_len {
+                    self.tx_buf.reset();
+                    return Err(KeyLookupResult::MaxResponseLenTooShort);
+                }
             }
         }
 

--- a/task/host-sp-comms/src/tx_buf.rs
+++ b/task/host-sp-comms/src/tx_buf.rs
@@ -50,6 +50,9 @@ impl TxBuf {
     /// terminator, but such a case means the host will receive an incomplete
     /// packet.
     pub(crate) fn reset(&mut self) {
+        ringbuf_entry!(Trace::ResponseBufferReset {
+            now: sys_get_timer().now
+        });
         self.state = State::Idle;
     }
 


### PR DESCRIPTION
Adds:

* Implementations for the new `set_ipcc_key_lookup_value()` handler for incoming MGS messages
  * sidecar/psc return errors - they have no IPCC
  * gimlet's implementation allows MGS to set the installinator image ID to any binary blob of at most 512 bytes
* The `host_sp_messages::Key::InstallinatorImageId` variant
* An idol call allowing `host_sp_comms` to ask `control_plane_agent` for the current installinator image ID when a host process requests it via the IPCC ioctl described on #1113 

Todo:

- [ ] Restore the `main` branch reference after https://github.com/oxidecomputer/management-gateway-service/pull/58 is merged
