### PR TITLE
Add VPD task to PSC

### DIFF
--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -59,7 +59,7 @@ max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 800
-features = ["g031"]
+features = ["g031", "tmp117-eeprom"]
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -159,6 +159,14 @@ stacksize = 256
 start = true
 task-slots = ["i2c_driver"]
 
+[tasks.vpd]
+name = "task-vpd"
+priority = 3
+max-sizes = {flash = 8192, ram = 1024}
+start = true
+task-slots = ["sys", "i2c_driver"]
+stacksize = 800
+
 [tasks.power]
 name = "task-power"
 priority = 4

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -167,6 +167,14 @@ stacksize = 256
 start = true
 task-slots = ["i2c_driver"]
 
+[tasks.vpd]
+name = "task-vpd"
+priority = 3
+max-sizes = {flash = 8192, ram = 1024}
+start = true
+task-slots = ["sys", "i2c_driver"]
+stacksize = 800
+
 [tasks.power]
 name = "task-power"
 priority = 4

--- a/task/vpd-api/src/lib.rs
+++ b/task/vpd-api/src/lib.rs
@@ -22,6 +22,7 @@ pub enum VpdError {
     BadBuffer,
     BadRead,
     BadWrite,
+    NotImplemented,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/task/vpd/Cargo.toml
+++ b/task/vpd/Cargo.toml
@@ -31,6 +31,7 @@ build-i2c = { path = "../../build/i2c" }
 itm = [ "userlib/log-itm" ]
 semihosting = [ "userlib/log-semihosting" ]
 g031 = ["build-i2c/g031", "ringbuf/disabled"]
+tmp117-eeprom = []
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/vpd/src/main.rs
+++ b/task/vpd/src/main.rs
@@ -38,7 +38,7 @@ impl idl::InOrderVpdImpl for ServerImpl {
 
             match dev.read_eeprom() {
                 Err(err) => {
-                    let code: drv_i2c_api::ResponseCode = err.into();
+                    let code: ResponseCode = err.into();
                     let err: VpdError = code.into();
                     Err(err.into())
                 }

--- a/task/vpd/src/main.rs
+++ b/task/vpd/src/main.rs
@@ -7,9 +7,7 @@
 #![no_std]
 #![no_main]
 
-use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::at24csw080::{At24Csw080, EEPROM_SIZE};
-use drv_i2c_devices::tmp117::Tmp117;
 use idol_runtime::RequestError;
 use task_vpd_api::VpdError;
 use userlib::*;
@@ -21,11 +19,15 @@ struct ServerImpl;
 task_slot!(I2C, i2c_driver);
 
 impl idl::InOrderVpdImpl for ServerImpl {
+    #[cfg(feature = "tmp117-eeprom")]
     fn read_tmp117_eeprom(
         &mut self,
         _: &RecvMessage,
         index: u8,
     ) -> Result<[u8; 6], RequestError<VpdError>> {
+        use drv_i2c_api::ResponseCode;
+        use drv_i2c_devices::tmp117::Tmp117;
+
         let devs = i2c_config::devices::tmp117(I2C.get_task_id());
         let index = index as usize;
 
@@ -36,13 +38,22 @@ impl idl::InOrderVpdImpl for ServerImpl {
 
             match dev.read_eeprom() {
                 Err(err) => {
-                    let code: ResponseCode = err.into();
+                    let code: drv_i2c_api::ResponseCode = err.into();
                     let err: VpdError = code.into();
                     Err(err.into())
                 }
                 Ok(rval) => Ok(rval),
             }
         }
+    }
+
+    #[cfg(not(feature = "tmp117-eeprom"))]
+    fn read_tmp117_eeprom(
+        &mut self,
+        _: &RecvMessage,
+        _index: u8,
+    ) -> Result<[u8; 6], RequestError<VpdError>> {
+        Err(VpdError::NotImplemented.into())
     }
 
     fn read(


### PR DESCRIPTION
This adds a feature to stub out `read_tmp117_eeprom`, which is unused as far as I can tell (but may be relevant for Donglet?)