### PR TITLE
Add API to read BMR491 event log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
  "mutable-statics",
  "num-traits",
  "paste",
+ "pmbus",
  "ringbuf",
  "serde",
  "task-power-api",

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -229,8 +229,6 @@ fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
         Ok(c) => c,
     };
 
-    println!("--- toml for ${} ---", var);
-    println!("{}", config);
     let rval = toml::from_slice(config.as_bytes())
         .context("deserializing configuration")?;
     Ok(Some(rval))

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -18,5 +18,35 @@ Interface(
             ),
             idempotent: true,
         ),
+        "bmr491_event_log_read": (
+            doc: "reads an event from the BMR491's combined fault and lifecycle event log",
+            encoding: Hubpack,
+            args: {
+                "index": "u8",
+            },
+            reply: Result(
+                ok: "Bmr491Event",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "bmr491_max_fault_event_index": (
+            doc: "returns the index of the most recent fault event in the BMR491's event log",
+            encoding: Hubpack,
+            reply: Result(
+                ok: "u8",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "bmr491_max_lifecycle_event_index": (
+            doc: "returns the index of the most recent lifecycle event in the BMR491's event log",
+            encoding: Hubpack,
+            reply: Result(
+                ok: "u8",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
     },
 )

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -20,7 +20,6 @@ Interface(
         ),
         "bmr491_event_log_read": (
             doc: "reads an event from the BMR491's combined fault and lifecycle event log",
-            encoding: Hubpack,
             args: {
                 "index": "u8",
             },
@@ -32,7 +31,6 @@ Interface(
         ),
         "bmr491_max_fault_event_index": (
             doc: "returns the index of the most recent fault event in the BMR491's event log",
-            encoding: Hubpack,
             reply: Result(
                 ok: "u8",
                 err: CLike("ResponseCode"),
@@ -41,7 +39,6 @@ Interface(
         ),
         "bmr491_max_lifecycle_event_index": (
             doc: "returns the index of the most recent lifecycle event in the BMR491's event log",
-            encoding: Hubpack,
             reply: Result(
                 ok: "u8",
                 err: CLike("ResponseCode"),

--- a/task/power-api/Cargo.toml
+++ b/task/power-api/Cargo.toml
@@ -11,8 +11,8 @@ serde.workspace = true
 static_assertions.workspace = true
 zerocopy.workspace = true
 
-drv-i2c-api = { path = "../../drv/i2c-api" }
-userlib = { path = "../../sys/userlib" }
+drv-i2c-api.path = "../../drv/i2c-api"
+userlib.path = "../../sys/userlib"
 
 [build-dependencies]
 idol.workspace = true

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -10,6 +10,7 @@ pub use drv_i2c_api::ResponseCode;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 use userlib::sys_send;
+use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]
 pub enum Device {
@@ -126,5 +127,22 @@ impl From<pmbus::units::Percent> for PmbusValue {
         Self::Percent(value.0)
     }
 }
+
+/// Simple wrapper type for the BMR491 event log
+///
+/// To simplify the implementation, this is the result of a raw PMBus read;
+/// this means the first byte is the length of the remaining data (i.e. 23).
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    SerializedSize,
+    AsBytes,
+    FromBytes,
+)]
+#[repr(C)]
+pub struct Bmr491Event([u8; 24]);
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -10,6 +10,7 @@ hubpack.workspace = true
 idol-runtime.workspace = true
 num-traits.workspace = true
 paste.workspace = true
+pmbus.workspace = true
 serde.workspace = true
 zerocopy.workspace = true
 

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -663,6 +663,9 @@ impl idl::InOrderPowerImpl for ServerImpl {
         _msg: &userlib::RecvMessage,
         index: u8,
     ) -> Result<Bmr491Event, idol_runtime::RequestError<ResponseCode>> {
+        // The BMR491 has 48 event log slots:
+        // - 0-23 are reserved for faults
+        // - 24-47 are reserved for lifecycle events
         if index >= 48 {
             return Err(ResponseCode::BadArg.into());
         }
@@ -705,8 +708,9 @@ impl idl::InOrderPowerImpl for ServerImpl {
     ) -> Result<u8, idol_runtime::RequestError<ResponseCode>> {
         let dev = self.bmr491()?;
 
-        // 255 is a special value, setting MFR_EVENT_INDEX to the index of the
-        // newest record in the lifecycle event section of the event recorder.
+        // 254 is *also* a special value, setting MFR_EVENT_INDEX to the index
+        // of the newest record in the lifecycle event section of the event
+        // recorder.
         dev.write(&[
             pmbus::commands::bmr491::CommandCode::MFR_EVENT_INDEX as u8,
             254,


### PR DESCRIPTION
This will let us implement https://github.com/oxidecomputer/humility/pull/325 without raw I2C, which in turns lets us (a) call it over the network and (b) plumb it into `control-plane-agent`.

Tested on a rev B Gimlet:

```console
matt@niles ~ (gimlet) $ h hiffy -c Power.bmr491_max_lifecycle_event_index
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.bmr491_max_lifecycle_event_index() => 0x2b
matt@niles ~ (gimlet) $ h hiffy -c Power.bmr491_max_fault_event_index
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.bmr491_max_fault_event_index() => 0x6
matt@niles ~ (gimlet) $ h hiffy -c Power.bmr491_event_log_read -aindex=42
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.bmr491_event_log_read() => Bmr491Event([ 0x17, 0x3, 0x5a, 0x3, 0x9d, 0x8, 0x1a, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf8, 0x0, 0x0, 0x0, 0x7, 0xdd, 0x0, 0x0 ])
matt@niles ~ (gimlet) $ h hiffy -c Power.bmr491_event_log_read -aindex=6
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.bmr491_event_log_read() => Bmr491Event([ 0x17, 0x0, 0x6, 0x28, 0x9, 0xd3, 0xff, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0xf8, 0x6b, 0x5f, 0x0, 0x0, 0x0, 0x0, 0x1d ])
matt@niles ~ (gimlet) $ h hiffy -c Power.bmr491_event_log_read -aindex=7
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.bmr491_event_log_read() => Bmr491Event([ 0x17, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ])
```