### PR TITLE
Stack size and dump_agent housekeeping

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -289,7 +289,7 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 4
+priority = 5
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
 task-slots = ["sprot"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -226,7 +226,7 @@ notifications = ["socket"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
-stacksize = 4096
+stacksize = 6144
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -226,7 +226,7 @@ notifications = ["socket"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
-stacksize = 6144
+stacksize = 4096
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -289,7 +289,7 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 4
+priority = 5
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
 task-slots = ["sprot"]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -192,6 +192,15 @@ max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["i2c_driver", "sensor"]
 
+[tasks.dump_agent]
+name = "task-dump-agent"
+priority = 4
+max-sizes = {flash = 8192, ram = 2048 }
+start = true
+task-slots = ["sprot"]
+stacksize = 1200
+uses = [ "sram2", "sram3", "sram4" ]
+
 [tasks.idle]
 name = "task-idle"
 priority = 6

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -200,6 +200,15 @@ max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["i2c_driver", "sensor"]
 
+[tasks.dump_agent]
+name = "task-dump-agent"
+priority = 4
+max-sizes = {flash = 8192, ram = 2048 }
+start = true
+task-slots = ["sprot"]
+stacksize = 1200
+uses = [ "sram2", "sram3", "sram4" ]
+
 [tasks.idle]
 name = "task-idle"
 priority = 6

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -274,6 +274,15 @@ start = true
 task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 notifications = ["timer"]
 
+[tasks.dump_agent]
+name = "task-dump-agent"
+priority = 5
+max-sizes = {flash = 8192, ram = 2048 }
+start = true
+task-slots = ["sprot"]
+stacksize = 1200
+uses = [ "sram2", "sram3", "sram4" ]
+
 [tasks.idle]
 name = "task-idle"
 priority = 8

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -70,7 +70,7 @@ task-slots = ["sys", "i2c_driver", { seq = "sequencer" }]
 name = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 131072, ram = 16384}
-stacksize = 4096
+stacksize = 6144
 start = true
 uses = []
 task-slots = [

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -75,7 +75,7 @@ task-slots = ["sys", "i2c_driver",
 name = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 131072, ram = 16384}
-stacksize = 4096
+stacksize = 6144
 start = true
 uses = []
 task-slots = [

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -287,6 +287,15 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
+[tasks.dump_agent]
+name = "task-dump-agent"
+priority = 5
+max-sizes = {flash = 8192, ram = 2048 }
+start = true
+task-slots = ["sprot"]
+stacksize = 1200
+uses = [ "sram2", "sram3", "sram4" ]
+
 [tasks.idle]
 name = "task-idle"
 priority = 8


### PR DESCRIPTION
Several small changes to make sidecar SPs happy:

* Bump up `control-plane-agent`'s stack; we were overflowing by ~600 bytes; this bumps us up 2 KiB
* On gimlet, change `dump_agent`'s priority to be lower (i.e., numerically higher) than sprot by 1
* Add `dump_agent` to sidecar and PSC