### PR TITLE
stm32xx-i2c-server: don't glitch pins on mux swaps

### DIFF
--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -149,6 +149,12 @@ impl Sys {
 
     /// Configures the pins in `PinSet` as high-impedance digital inputs, with
     /// optional pull resistors.
+    ///
+    /// This chooses arbitrary settings for all the other fields (output type,
+    /// slew rate, alternate function), and so it is not suitable for
+    /// pins that need to be repeatedly reconfigured between high-impedance and
+    /// alternate without intermediate glitching. In such cases you probably
+    /// want to use the raw `gpio_configure`.
     pub fn gpio_configure_input(&self, pinset: PinSet, pull: Pull) {
         self.gpio_configure(
             pinset.port,


### PR DESCRIPTION
By alternating between `configure_alternate` (for normal operation) and `configure_input` (to shut off pins and switch to a different set of pads), the I2C driver was introducing a subtle and brief glitch in the output lines -- as a side effect of how `configure_input` is defined.

Concretely, `configure_input` implies setting the pin's alternate function mux (AF) to an arbitrary value, under the assumption that the configuration will be set once and not changed.

The `configure_alternate_input` operation lets us preserve the AF during reconfiguration and should prevent the glitch. However, the STM32 docs are ambiguous on whether the peripheral selected by the AF mux can still see inputs when the pin is set to input -- and the block diagrams strongly suggest that it can.

And so, rather than input, this change sets it to _analog_ mode. This disconnects the input buffer completely, preventing _anything_ in the chip from responding to the state. We can do this while preserving the AF mux to avoid the glitch when switching back.

This glitch appears to date to the original I2C commit, but it seems we haven't noticed it until now -- all the more reason to have people looking at behavior on scopes!