### PR TITLE
Use Option to hold intermediate cert in CertData.

### DIFF
--- a/lib/dice/src/handoff.rs
+++ b/lib/dice/src/handoff.rs
@@ -36,7 +36,7 @@ sa::const_assert!(RNG_RANGE.end <= MEM_RANGE.end);
 pub struct CertData {
     pub deviceid_cert: DeviceIdCert,
     pub persistid_cert: PersistIdCert,
-    pub intermediate_cert: IntermediateCert,
+    pub intermediate_cert: Option<IntermediateCert>,
 }
 
 // Handoff DICE cert chain.
@@ -59,7 +59,7 @@ impl CertData {
     pub fn new(
         deviceid_cert: DeviceIdCert,
         persistid_cert: PersistIdCert,
-        intermediate_cert: IntermediateCert,
+        intermediate_cert: Option<IntermediateCert>,
     ) -> Self {
         Self {
             deviceid_cert,

--- a/lib/dice/src/mfg.rs
+++ b/lib/dice/src/mfg.rs
@@ -48,7 +48,7 @@ pub struct DiceMfgState {
     pub cert_serial_number: CertSerialNumber,
     pub serial_number: SerialNumber,
     pub persistid_cert: PersistIdCert,
-    pub intermediate_cert: IntermediateCert,
+    pub intermediate_cert: Option<IntermediateCert>,
 }
 
 pub trait DiceMfg {
@@ -82,7 +82,7 @@ impl DiceMfg for SelfMfg<'_> {
             serial_number: dname_sn,
             // TODO: static assert deviceid_cert size < SizedBuf max
             persistid_cert: persistid_cert,
-            intermediate_cert: IntermediateCert(SizedBlob::default()),
+            intermediate_cert: None,
         }
     }
 }
@@ -242,7 +242,7 @@ impl DiceMfg for SerialMfg<'_> {
             cert_serial_number: Default::default(),
             serial_number: self.serial_number.unwrap(),
             persistid_cert: self.persistid_cert.unwrap(),
-            intermediate_cert: self.intermediate_cert.unwrap(),
+            intermediate_cert: Some(self.intermediate_cert.unwrap()),
         }
     }
 }

--- a/stage0/src/dice.rs
+++ b/stage0/src/dice.rs
@@ -30,7 +30,7 @@ pub struct MfgResult {
     pub serial_number: SerialNumber,
     pub persistid_keypair: Keypair,
     pub persistid_cert: PersistIdCert,
-    pub intermediate_cert: IntermediateCert,
+    pub intermediate_cert: Option<IntermediateCert>,
 }
 
 /// Generate stuff associated with the manufacturing process.
@@ -107,7 +107,7 @@ fn gen_deviceid_artifacts(
     serial_number: &SerialNumber,
     persistid_keypair: Keypair,
     persistid_cert: PersistIdCert,
-    intermediate_cert: IntermediateCert,
+    intermediate_cert: Option<IntermediateCert>,
     handoff: &Handoff,
 ) -> Keypair {
     let devid_okm = DeviceIdOkm::from_cdi(cdi);

--- a/stage0/src/dice_mfg_usart.rs
+++ b/stage0/src/dice_mfg_usart.rs
@@ -70,7 +70,7 @@ struct DiceState {
     pub persistid_key_code: [u32; KEYCODE_LEN],
     pub serial_number: SerialNumber,
     pub persistid_cert: PersistIdCert,
-    pub intermediate_cert: IntermediateCert,
+    pub intermediate_cert: Option<IntermediateCert>,
 }
 
 impl DiceState {


### PR DESCRIPTION
Across the DICE mfg options the intermediate cert is only present if the identity cert has been manufactured (not self signed). Using an Option to represent this makes code on the consumer side less bad.