### PR TITLE
Initial support for host flash persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,11 @@ dependencies = [
  "derive-idol-err",
  "drv-hash-api",
  "drv-qspi-api",
+ "hubpack",
  "idol",
  "idol-runtime",
  "num-traits",
+ "serde",
  "userlib",
  "zerocopy",
 ]
@@ -896,13 +898,16 @@ name = "drv-gimlet-hf-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
+ "crc",
  "drv-gimlet-hf-api",
  "drv-hash-api",
  "drv-stm32h7-qspi",
  "drv-stm32xx-sys-api",
+ "hubpack",
  "idol",
  "idol-runtime",
  "num-traits",
+ "serde",
  "stm32h7",
  "userlib",
  "zerocopy",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -153,8 +153,8 @@ notifications = ["hash-irq"]
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
-max-sizes = {flash = 16384, ram = 2048 }
-stacksize = 1920
+max-sizes = {flash = 16384, ram = 4096 }
+stacksize = 3000
 start = true
 uses = ["quadspi"]
 interrupts = {"quadspi.irq" = "qspi-irq"}

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -153,8 +153,8 @@ notifications = ["hash-irq"]
 name = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
-max-sizes = {flash = 16384, ram = 2048 }
-stacksize = 1920
+max-sizes = {flash = 16384, ram = 4096 }
+stacksize = 3000
 start = true
 uses = ["quadspi"]
 interrupts = {"quadspi.irq" = "qspi-irq"}

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hubpack.workspace = true
 idol-runtime.workspace = true
 num-traits.workspace = true
+serde.workspace = true
 zerocopy.workspace = true
 
 derive-idol-err = { path = "../../lib/derive-idol-err"  }

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -72,6 +72,25 @@ impl core::ops::Not for HfDevSelect {
     }
 }
 
+/// Flag which allows sector 0 to be modified
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    FromPrimitive,
+    Eq,
+    PartialEq,
+    AsBytes,
+    Serialize,
+    Deserialize,
+    SerializedSize,
+)]
+#[repr(u8)]
+pub enum HfProtectMode {
+    ProtectSector0,
+    AllowModificationsToSector0,
+}
+
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, SerializedSize)]
 pub struct HfPersistentData {
     pub startup_options: u64,

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -91,9 +91,9 @@ pub enum HfProtectMode {
     AllowModificationsToSector0,
 }
 
+/// Persistent data associated with host flash
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, SerializedSize)]
 pub struct HfPersistentData {
-    pub startup_options: u64,
     pub dev_select: HfDevSelect,
 }
 

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -25,6 +25,7 @@ pub enum HfError {
     HashNotConfigured,
     NoDevSelect,
     NotMuxedToSP,
+    Sector0IsReserved,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -75,7 +75,7 @@ impl core::ops::Not for HfDevSelect {
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, SerializedSize)]
 pub struct HfPersistentData {
     pub startup_options: u64,
-    pub slot: HfDevSelect,
+    pub dev_select: HfDevSelect,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -29,6 +29,7 @@ pub enum HfError {
     NotMuxedToSP,
     Sector0IsReserved,
     NoPersistentData,
+    MonotonicCounterOverflow,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-idol-runtime = { workspace = true }
-num-traits = { workspace = true }
-stm32h7 = { workspace = true }
-zerocopy = { workspace = true }
+crc.workspace = true
+hubpack.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+stm32h7.workspace = true
+zerocopy.workspace = true
 
 drv-gimlet-hf-api = { path = "../gimlet-hf-api" }
 drv-hash-api = { path = "../hash-api" }

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -183,7 +183,7 @@ struct RawPersistentData {
     /// Must always be `HF_PERSISTENT_DATA_MAGIC`.
     oxide_magic: u32,
 
-    /// Must always be 1 (for now)
+    /// Must always be `HF_PERSISTENT_DATA_HEADER_VERSION` (for now)
     header_version: u32,
 
     /// Monotonically increasing counter

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -735,7 +735,9 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
                 return Ok(());
             }
 
-            let epoch = prev_epoch + 1;
+            let epoch = prev_epoch
+                .checked_add(1)
+                .ok_or(HfError::MonotonicCounterOverflow)?;
             let raw = RawPersistentData::new(data, epoch);
 
             // Write the persistent data to the currently inactive flash.
@@ -766,7 +768,9 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
                 return Ok(());
             }
 
-            let epoch = prev_epoch + 1;
+            let epoch = prev_epoch
+                .checked_add(1)
+                .ok_or(HfError::MonotonicCounterOverflow)?;
             let raw = RawPersistentData::new(data, epoch);
             self.write_raw_persistent_data_to_addr(next, &raw)?;
         }

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -207,9 +207,6 @@ struct RawPersistentData {
     /// Monotonically increasing counter
     epoch: u64,
 
-    /// Equivalent to `host_sp_messages::HostStartupOptions`
-    host_startup_options: u64,
-
     /// Either 0 or 1; directly translatable to `gimlet_hf_api::HfDevSelect`
     dev_select: u32,
 
@@ -224,7 +221,6 @@ impl RawPersistentData {
             oxide_magic: HF_PERSISTENT_DATA_MAGIC,
             header_version: HF_PERSISTENT_DATA_HEADER_VERSION,
             epoch,
-            host_startup_options: data.startup_options,
             dev_select: data.dev_select as u32,
             checksum: 0,
         };
@@ -506,7 +502,6 @@ impl ServerImpl {
     fn get_persistent_data(&mut self) -> Result<HfPersistentData, HfError> {
         let out = self.get_raw_persistent_data()?;
         Ok(HfPersistentData {
-            startup_options: out.host_startup_options,
             dev_select: HfDevSelect::from_u8(out.dev_select as u8).unwrap(),
         })
     }
@@ -710,13 +705,9 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
     fn write_persistent_data(
         &mut self,
         _: &RecvMessage,
-        startup_options: u64,
         dev_select: HfDevSelect,
     ) -> Result<(), RequestError<HfError>> {
-        let data = HfPersistentData {
-            startup_options,
-            dev_select,
-        };
+        let data = HfPersistentData { dev_select };
         self.check_muxed_to_sp()?;
         if self.dev_select_pin.is_some() {
             let prev_slot = self.dev_state;

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -660,14 +660,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             };
             let epoch = prev_epoch + 1;
             let raw = RawPersistentData::new(data, epoch);
-            let addr = match next {
-                Some(v) => v,
-                None => {
-                    self.raw_sector0_erase()?;
-                    0
-                }
-            };
-            Self::page_program_raw(&self.qspi, addr, raw.as_bytes())?;
+            self.write_raw_persistent_data_to_addr(next, &raw)?;
         }
         Ok(())
     }

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -180,7 +180,7 @@ struct RawPersistentData {
     /// may look at under certain circumstances.
     amd_reserved_must_be_all_ones: u64,
 
-    /// Must always be 0x1dea_bcde.
+    /// Must always be `HF_PERSISTENT_DATA_MAGIC`.
     oxide_magic: u32,
 
     /// Must always be 1 (for now)

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -349,7 +349,7 @@ impl ServerImpl {
             if data.is_valid()
                 && best.map(|b| b.epoch < data.epoch).unwrap_or(true)
             {
-                best = Some(data)
+                best = Some(data);
             }
             if empty_slot.is_none()
                 && data.as_bytes().iter().all(|b| *b == 0xFF)

--- a/drv/stm32h7-hash-server/src/main.rs
+++ b/drv/stm32h7-hash-server/src/main.rs
@@ -28,10 +28,8 @@ fn hash_hw_reset() {
     let sys = sys_api::Sys::from(SYS.get_task_id());
     sys.enter_reset(sys_api::Peripheral::Hash);
     sys.disable_clock(sys_api::Peripheral::Hash);
-    hl::sleep_for(1);
     sys.enable_clock(sys_api::Peripheral::Hash);
     sys.leave_reset(sys_api::Peripheral::Hash);
-    hl::sleep_for(1);
 }
 
 #[export_name = "main"]

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -141,5 +141,24 @@ Interface(
                 err: CLike("HfError"),
             ),
         ),
+        "get_persistent_data": (
+            doc: "looks up persistent configuration data",
+            reply: Result(
+                ok: "HfPersistentData",
+                err: CLike("HfError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "write_persistent_data": (
+            doc: "stores persistent configuration data to flash",
+            args: {
+                "data": "HfPersistentData",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+            encoding: Hubpack,
+        ),
     },
 )

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -44,6 +44,19 @@ Interface(
                 err: CLike("HfError"),
             ),
         ),
+        "page_program_sector0": (
+            doc: "Programs data to a flash page, allowing writes to sector 0",
+            args: {
+                "address": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
         "read": (
             args: {
                 "address": "u32",
@@ -60,6 +73,13 @@ Interface(
             args: {
                 "address": "u32",
             },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "sector0_erase": (
+            doc: "erases sector 0, which is normally reserved",
             reply: Result(
                 ok: "()",
                 err: CLike("HfError"),

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -152,7 +152,8 @@ Interface(
         "write_persistent_data": (
             doc: "stores persistent configuration data to flash",
             args: {
-                "data": "HfPersistentData",
+                "startup_options": "u64",
+                "dev_select": "HfDevSelect",
             },
             reply: Result(
                 ok: "()",

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -145,7 +145,6 @@ Interface(
         "write_persistent_data": (
             doc: "stores persistent configuration data to flash",
             args: {
-                "startup_options": "u64",
                 "dev_select": (
                     type: "HfDevSelect",
                     recv: FromPrimitive("u8"),

--- a/idl/gimlet-hf.idol
+++ b/idl/gimlet-hf.idol
@@ -26,7 +26,12 @@ Interface(
             ),
         ),
         "bulk_erase": (
-            args: {},
+            args: {
+                "protect": (
+                    type: "HfProtectMode",
+                    recv: FromPrimitive("u8"),
+                ),
+            },
             reply: Result(
                 ok: "()",
                 err: CLike("HfError"),
@@ -35,19 +40,10 @@ Interface(
         "page_program": (
             args: {
                 "address": "u32",
-            },
-            leases: {
-                "data": (type: "[u8]", read: true, max_len: Some(256)),
-            },
-            reply: Result(
-                ok: "()",
-                err: CLike("HfError"),
-            ),
-        ),
-        "page_program_sector0": (
-            doc: "Programs data to a flash page, allowing writes to sector 0",
-            args: {
-                "address": "u32",
+                "protect": (
+                    type: "HfProtectMode",
+                    recv: FromPrimitive("u8"),
+                ),
             },
             leases: {
                 "data": (type: "[u8]", read: true, max_len: Some(256)),
@@ -72,14 +68,11 @@ Interface(
         "sector_erase": (
             args: {
                 "address": "u32",
+                "protect": (
+                    type: "HfProtectMode",
+                    recv: FromPrimitive("u8"),
+                ),
             },
-            reply: Result(
-                ok: "()",
-                err: CLike("HfError"),
-            ),
-        ),
-        "sector0_erase": (
-            doc: "erases sector 0, which is normally reserved",
             reply: Result(
                 ok: "()",
                 err: CLike("HfError"),
@@ -153,13 +146,15 @@ Interface(
             doc: "stores persistent configuration data to flash",
             args: {
                 "startup_options": "u64",
-                "dev_select": "HfDevSelect",
+                "dev_select": (
+                    type: "HfDevSelect",
+                    recv: FromPrimitive("u8"),
+                ),
             },
             reply: Result(
                 ok: "()",
                 err: CLike("HfError"),
             ),
-            encoding: Hubpack,
         ),
     },
 )

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -171,8 +171,9 @@ impl ComponentUpdater for HostFlashUpdate {
 
             let addr = sectors_to_erase.start * SECTOR_SIZE_BYTES as u32;
 
-            // We trust that the caller is aware of the sector 0 restrictions
-            // and will not write to it; this will return an error otherwise.
+            // During construction of the State::ErasingSectors object, we
+            // should have configured it to start at sector 1; using
+            // HfProtectMode::ProtectSector0 guards against mistakes.
             match self.task.sector_erase(addr, HfProtectMode::ProtectSector0) {
                 Ok(()) => {
                     sectors_to_erase.start += 1;

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -6,7 +6,8 @@ use super::{common::CurrentUpdate, ComponentUpdater};
 use crate::mgs_handler::{BorrowedUpdateBuffer, UpdateBuffer};
 use core::ops::Range;
 use drv_gimlet_hf_api::{
-    HfDevSelect, HfError, HostFlash, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES,
+    HfDevSelect, HfError, HfProtectMode, HostFlash, PAGE_SIZE_BYTES,
+    SECTOR_SIZE_BYTES,
 };
 use gateway_messages::{
     ComponentUpdatePrepare, SpComponent, SpError, UpdateId,
@@ -163,7 +164,10 @@ impl ComponentUpdater for HostFlashUpdate {
             };
 
             let addr = sectors_to_erase.start * SECTOR_SIZE_BYTES as u32;
-            match self.task.sector_erase(addr) {
+
+            // We trust that the caller is aware of the sector 0 restrictions
+            // and will not write to it; this will return an error otherwise.
+            match self.task.sector_erase(addr, HfProtectMode::ProtectSector0) {
                 Ok(()) => {
                     sectors_to_erase.start += 1;
                     if sectors_to_erase.start == sectors_to_erase.end {
@@ -265,9 +269,16 @@ impl ComponentUpdater for HostFlashUpdate {
             if buffer.len() == buffer.capacity()
                 || *next_write_offset + buffer.len() as u32 == total_size
             {
-                if let Err(err) =
-                    self.task.page_program(*next_write_offset, buffer)
-                {
+                // TODO: skip bytes in sector 0 here, after checking that
+                // they're all 0xFF.
+
+                // We trust that the caller will not be trying to write to
+                // sector 0; this will return an error otherwise.
+                if let Err(err) = self.task.page_program(
+                    *next_write_offset,
+                    HfProtectMode::ProtectSector0,
+                    buffer,
+                ) {
                     *current.state_mut() = State::Failed(err);
                     return Err(SpError::UpdateFailed(err as u32));
                 }

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -811,6 +811,35 @@ pub(crate) fn qspi_page_program(
 }
 
 #[cfg(feature = "qspi")]
+pub(crate) fn qspi_page_program_sector0(
+    stack: &[Option<u32>],
+    data: &[u8],
+    _rval: &mut [u8],
+) -> Result<usize, Failure> {
+    use drv_gimlet_hf_api as hf;
+
+    if stack.len() < 3 {
+        return Err(Failure::Fault(Fault::MissingParameters));
+    }
+    let frame = &stack[stack.len() - 3..];
+    let addr = frame[0].ok_or(Failure::Fault(Fault::MissingParameters))?;
+    let offset =
+        frame[1].ok_or(Failure::Fault(Fault::MissingParameters))? as usize;
+    let len =
+        frame[2].ok_or(Failure::Fault(Fault::MissingParameters))? as usize;
+
+    if offset + len > data.len() {
+        return Err(Failure::Fault(Fault::AccessOutOfBounds));
+    }
+
+    let data = &data[offset..offset + len];
+
+    let server = hf::HostFlash::from(HF.get_task_id());
+    func_err(server.page_program_sector0(addr, data))?;
+    Ok(0)
+}
+
+#[cfg(feature = "qspi")]
 pub(crate) fn qspi_read(
     stack: &[Option<u32>],
     _data: &[u8],
@@ -903,6 +932,19 @@ pub(crate) fn qspi_sector_erase(
 
     let server = hf::HostFlash::from(HF.get_task_id());
     func_err(server.sector_erase(addr))?;
+    Ok(0)
+}
+
+#[cfg(feature = "qspi")]
+pub(crate) fn qspi_sector0_erase(
+    _stack: &[Option<u32>],
+    _data: &[u8],
+    _rval: &mut [u8],
+) -> Result<usize, Failure> {
+    use drv_gimlet_hf_api as hf;
+
+    let server = hf::HostFlash::from(HF.get_task_id());
+    func_err(server.sector0_erase())?;
     Ok(0)
 }
 

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -108,9 +108,13 @@ pub enum Functions {
     #[cfg(feature = "qspi")]
     QspiPageProgram((u32, usize, usize), drv_gimlet_hf_api::HfError),
     #[cfg(feature = "qspi")]
+    QspiPageProgramSector0((u32, usize, usize), drv_gimlet_hf_api::HfError),
+    #[cfg(feature = "qspi")]
     QspiRead((u32, usize), drv_gimlet_hf_api::HfError),
     #[cfg(feature = "qspi")]
     QspiSectorErase(u32, drv_gimlet_hf_api::HfError),
+    #[cfg(feature = "qspi")]
+    QspiSector0Erase((), drv_gimlet_hf_api::HfError),
     #[cfg(feature = "qspi")]
     QspiVerify((u32, usize, usize), drv_gimlet_hf_api::HfError),
     #[cfg(all(feature = "qspi", feature = "hash"))]
@@ -633,9 +637,13 @@ pub(crate) static HIFFY_FUNCS: &[Function] = &[
     #[cfg(feature = "qspi")]
     crate::common::qspi_page_program,
     #[cfg(feature = "qspi")]
+    crate::common::qspi_page_program_sector0,
+    #[cfg(feature = "qspi")]
     crate::common::qspi_read,
     #[cfg(feature = "qspi")]
     crate::common::qspi_sector_erase,
+    #[cfg(feature = "qspi")]
+    crate::common::qspi_sector0_erase,
     #[cfg(feature = "qspi")]
     crate::common::qspi_verify,
     #[cfg(all(feature = "qspi", feature = "hash"))]


### PR DESCRIPTION
This PR implements the scheme described in https://github.com/oxidecomputer/hubris/issues/985 for storing persistent host flash data (current slot and boot flags).

It reserves the lowest sector (64 KiB) of QSPI flash for Hubris, adding new HIF functions if you _really_ want to overwrite it and returning an error code otherwise.  Within sector 0, we store up to 512 copies of `RawPersistentData`; the one with the largest `epoch` field is our current value.

A new Idol API is added to write this persistent data, by scanning sector 0 on both flash ICs, finding the highest `epoch`, and incrementing it.

`control-plane-agent` is modified to avoid writing sector 0, but checks that any bytes that we _try_ to write in that sector are `0xFF` and returns an error otherwise.