### PR TITLE
Fix Sidecar direct read/write Idol spec

### DIFF
--- a/idl/sidecar-seq.idol
+++ b/idl/sidecar-seq.idol
@@ -192,7 +192,7 @@ Interface(
             args: {
                 "segment": (
                     type: "DirectBarSegment",
-                    recv: FromPrimitive("u8"),
+                    recv: FromPrimitive("u32"),
                 ),
                 "offset": "u32",
             },
@@ -207,7 +207,7 @@ Interface(
             args: {
                 "segment": (
                     type: "DirectBarSegment",
-                    recv: FromPrimitive("u8"),
+                    recv: FromPrimitive("u32"),
                 ),
                 "offset": "u32",
                 "value": "u32",


### PR DESCRIPTION
The Idol spec for functions enabling reading/writing the Tofino address map are out of sync with the actual type. This causes a size mismatch when Humility looks up the type information.