### PR TITLE
xtask graph: fix priority ranking

### DIFF
--- a/build/xtask/src/graph.rs
+++ b/build/xtask/src/graph.rs
@@ -87,7 +87,7 @@ pub fn task_graph(app_toml: &Path, path: &Path) -> Result<()> {
     }
     for edge in edges {
         let attr = if edge.inverted {
-            " [color=red, penwidth=3]"
+            " [color=red, penwidth=3, constraint=false]"
         } else {
             " [color=green]"
         };


### PR DESCRIPTION
The graphs we were generating did not reliably put different priorities on different tiers. As far as I can tell, this turns out to be due to backwards (priority inversion) edges causing it to throw up its hands and collapse ranks.

This marks backwards edges as constraint=false to exempt them from the rank calculation.