### PR TITLE
Add `Power.read_mode`

### DIFF
--- a/drv/i2c-devices/src/bmr491.rs
+++ b/drv/i2c-devices/src/bmr491.rs
@@ -62,7 +62,7 @@ impl Bmr491 {
         }
     }
 
-    fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
         Ok(match self.mode.get() {
             None => {
                 let mode = pmbus_read!(self.device, VOUT_MODE)?;

--- a/drv/i2c-devices/src/isl68224.rs
+++ b/drv/i2c-devices/src/isl68224.rs
@@ -70,7 +70,7 @@ impl Isl68224 {
         }
     }
 
-    fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
         Ok(match self.mode.get() {
             None => {
                 let mode = pmbus_read!(self.device, commands::VOUT_MODE)?;

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -76,7 +76,7 @@ impl Mwocp68 {
         pmbus_write!(self.device, PAGE, page)
     }
 
-    fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
         Ok(match self.mode.get() {
             None => {
                 let mode = pmbus_read!(self.device, commands::VOUT_MODE)?;

--- a/drv/i2c-devices/src/raa229618.rs
+++ b/drv/i2c-devices/src/raa229618.rs
@@ -70,7 +70,7 @@ impl Raa229618 {
         }
     }
 
-    fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
         Ok(match self.mode.get() {
             None => {
                 let mode = pmbus_read!(self.device, commands::VOUT_MODE)?;

--- a/drv/i2c-devices/src/tps546b24a.rs
+++ b/drv/i2c-devices/src/tps546b24a.rs
@@ -62,7 +62,7 @@ impl Tps546B24A {
         }
     }
 
-    fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
         Ok(match self.mode.get() {
             None => {
                 let mode = pmbus_read!(self.device, VOUT_MODE)?;

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -18,6 +18,20 @@ Interface(
             ),
             idempotent: true,
         ),
+        "read_mode": (
+            doc: "reads the VOUT_MODE value for the given device",
+            encoding: Hubpack,
+            args: {
+                "dev": "Device",
+                "rail": "u8",
+                "index": "u32",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
         "bmr491_event_log_read": (
             doc: "reads an event from the BMR491's combined fault and lifecycle event log",
             args: {

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -15,6 +15,7 @@ use zerocopy::{AsBytes, FromBytes};
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]
 pub enum Device {
     PowerShelf,
+    Bmr491,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]


### PR DESCRIPTION
Currently, we read the BMR491 black-box through raw I2C in Humility.

We'd like to switch to using the `bmr491_*` APIs, which are Idol functions that could be called remotely – initially via `humility rpc`, and later by MGS.

However, to interpret IBC blackbox data, we need to know `VOUT_MODE`.  This PR adds an Idol function to read it!