### PR TITLE
xtask graph: improve visual accessibility

### DIFF
--- a/build/xtask/src/graph.rs
+++ b/build/xtask/src/graph.rs
@@ -87,7 +87,7 @@ pub fn task_graph(app_toml: &Path, path: &Path) -> Result<()> {
     }
     for edge in edges {
         let attr = if edge.inverted {
-            " [color=red, penwidth=3, constraint=false]"
+            r#" [color=red, style=dashed, penwidth=3, constraint=false, label="BAD"]"#
         } else {
             " [color=green]"
         };


### PR DESCRIPTION
@lzrd noted that the edges in the graph were relying on red and green to distinguish correct from inverted priority relationships, which isn't very useful for folks with atypical color vision.

With this commit, they are still red vs green, but
- The inverted edges are also dashed
- And labeled with the word "BAD"