### PR TITLE
hubris#1163 gimlet NMI output GPIO back-powers A0 rail

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -352,7 +352,7 @@ fn main() -> ! {
     sys.gpio_set(SP_TO_SP3_NMI_SYNC_FLOOD_L);
     sys.gpio_configure_output(
         SP_TO_SP3_NMI_SYNC_FLOOD_L,
-        sys_api::OutputType::PushPull,
+        sys_api::OutputType::OpenDrain,
         sys_api::Speed::Low,
         sys_api::Pull::None,
     );


### PR DESCRIPTION
Testing notes: measured `SP3_VDD33_SENSE` at TP454 in A2 and A0 on rev B s/n 15.  Before this change, it was at 1.87 V in A2 and 3.34 V in A0.  After this change, it is at 0.036 V in A2 and 3.34 V in A0.  Verified that no NMI is asserted by default when the host boots.  Verified default disposition of pin J:2 with `hiffy gpio -i` is 1.  Then asserted NMI via hiffy (`gpio -p J:2 -r`) which worked as expected.