### PR TITLE
Add caboose to build system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,6 +2295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hubtools"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/hubtools#324d0ecf0ed5ec1785538e1cb5a49718ad52e444"
+dependencies = [
+ "anyhow",
+ "srec",
+ "zip",
+]
+
+[[package]]
 name = "humpty"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/humpty#bcb02bd530beadd296a3a80b0ec2c4dbc00403c1"
@@ -4911,6 +4921,7 @@ dependencies = [
  "fnv",
  "gnarle",
  "goblin",
+ "hubtools",
  "indexmap",
  "lpc55_areas",
  "lpc55_sign",
@@ -4924,7 +4935,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "srec",
  "strsim",
  "tlvc",
  "tlvc-text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ sha3 = { version = "0.10", default-features = false }
 smbus-pec = { version = "1.0.1", default-features = false }
 smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
 spin = { version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
-srec = { version = "0.2.0", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
 static_assertions = { version = "1", default-features = false }
 stm32f3 = { version = "0.13.0", default-features = false }
@@ -122,6 +121,7 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/app/demo-stm32g0-nucleo/app-g070-mini.toml
+++ b/app/demo-stm32g0-nucleo/app-g070-mini.toml
@@ -1,0 +1,33 @@
+# Tiny G0 image, useful for making small Humility archives
+name = "demo-stm32g070-nucleo"
+target = "thumbv6m-none-eabi"
+chip = "../../chips/stm32g0"
+memory = "memory-g070.toml"
+board = "stm32g070"
+stacksize = 944
+
+[kernel]
+name = "demo-stm32g0-nucleo"
+requires = {flash = 18048, ram = 1632}
+features = ["g070"]
+stacksize = 640
+
+[caboose]
+region = "flash"
+size = 128
+
+[tasks.jefe]
+name = "task-jefe"
+priority = 0
+max-sizes = {flash = 4096, ram = 512}
+start = true
+features = ["log-null"]
+stacksize = 352
+notifications = ["fault", "timer"]
+
+[tasks.idle]
+name = "task-idle"
+priority = 5
+max-sizes = {flash = 128, ram = 64}
+stacksize = 64
+start = true

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -20,6 +20,7 @@ dunce = { workspace = true }
 filetime = { workspace = true }
 fnv = { workspace = true }
 goblin = { workspace = true }
+hubtools = { workspace = true }
 indexmap = { workspace = true }
 path-slash = { workspace = true }
 rangemap = { workspace = true }
@@ -29,7 +30,6 @@ scroll = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }
-srec = { workspace = true }
 tlvc = { workspace = true }
 tlvc-text = { workspace = true }
 toml = { workspace = true }

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -57,7 +57,11 @@ pub fn run(
                 .map(|name| (name.as_str(), fake_sizes.clone()))
                 .collect();
 
-            let allocated = crate::dist::allocate_all(&toml, &task_sizes)?;
+            let allocated = crate::dist::allocate_all(
+                &toml,
+                &task_sizes,
+                toml.caboose.as_ref(),
+            )?;
 
             let (allocs, _) = allocated
                 .get(&toml.image_names[0])

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -76,6 +76,7 @@ struct RawConfig {
     #[serde(default)]
     secure_task: Option<String>,
     auxflash: Option<AuxFlash>,
+    caboose: Option<CabooseConfig>,
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +104,13 @@ pub struct Config {
     pub secure_task: Option<String>,
     pub auxflash: Option<AuxFlashData>,
     pub dice_mfg: Option<Output>,
+    pub caboose: Option<CabooseConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CabooseConfig {
+    pub region: String,
+    pub size: u32,
 }
 
 impl Config {
@@ -219,6 +227,7 @@ impl Config {
             patches: None,
             secure_task: toml.secure_task,
             dice_mfg,
+            caboose: toml.caboose,
         })
     }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -385,6 +385,9 @@ pub fn package(
         translate_srec_to_other_formats(&cfg.img_dir(image_name), "combined")?;
 
         if let Some(signing) = &cfg.toml.signing {
+            if cfg.toml.caboose.is_some() {
+                bail!("cannot sign an image with a caboose");
+            }
             let rkth = lpc55_sign::signed_image::sign_chain(
                 &cfg.img_file("combined.bin", image_name),
                 Some(&cfg.app_src_dir),

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1045,6 +1045,12 @@ fn update_image_header(
                     epoch: cfg.toml.epoch,
                     magic: abi::HEADER_MAGIC,
                     total_image_len: len as u32,
+                    caboose_size: cfg
+                        .toml
+                        .caboose
+                        .as_ref()
+                        .map(|c| c.size)
+                        .unwrap_or(0),
                     ..Default::default()
                 };
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -334,6 +334,19 @@ pub fn package(
             None
         };
 
+        // Add an empty output section for the caboose
+        if let Some(caboose) = &cfg.toml.caboose {
+            let (_, caboose_range) = allocs.caboose.as_ref().unwrap();
+            // BTreeMap<u32, LoadSegment>,
+            all_output_sections.insert(
+                caboose_range.start,
+                LoadSegment {
+                    source_file: "caboose".into(),
+                    data: vec![0xFF; caboose.size as usize],
+                },
+            );
+        }
+
         // If we've done a partial build (which may have included the kernel), bail
         // out here before linking stuff.
         if partial_build {

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -175,7 +175,14 @@ fn print_task_table(
     toml: &Config,
     map: &BTreeMap<&str, BTreeMap<u32, MemoryChunk>>,
 ) -> Result<()> {
-    let task_pad = toml.tasks.keys().map(|k| k.len()).max().unwrap_or(0);
+    let task_pad = toml
+        .tasks
+        .keys()
+        .map(|s| s.as_str())
+        .chain(std::iter::once("PROGRAM"))
+        .map(|k| k.len())
+        .max()
+        .unwrap_or(0);
     let mem_pad = map
         .values()
         .flat_map(|m| m.values())
@@ -247,7 +254,14 @@ fn print_memory_map(
     toml: &Config,
     map: &BTreeMap<&str, BTreeMap<u32, MemoryChunk>>,
 ) -> Result<()> {
-    let task_pad = toml.tasks.keys().map(|k| k.len()).max().unwrap_or(0);
+    let task_pad = toml
+        .tasks
+        .keys()
+        .map(|s| s.as_str())
+        .chain(std::iter::once("-padding-"))
+        .map(|k| k.len())
+        .max()
+        .unwrap_or(0);
     let mem_pad = map
         .values()
         .flat_map(|m| m.values())

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -514,6 +514,7 @@ pub struct ImageHeader {
     pub sau_entries: [SAUEntry; 8],
     pub version: u32,
     pub epoch: u32,
+    pub caboose_size: u32,
 }
 
 // Corresponds to the ARM vector table, limited to what we need

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -478,6 +478,7 @@ pub enum Kipcnum {
     FaultTask = 3,
     ReadImageId = 4,
     Reset = 5,
+    ReadHeader = 6,
 }
 
 impl core::convert::TryFrom<u16> for Kipcnum {
@@ -490,13 +491,16 @@ impl core::convert::TryFrom<u16> for Kipcnum {
             3 => Ok(Self::FaultTask),
             4 => Ok(Self::ReadImageId),
             5 => Ok(Self::Reset),
+            6 => Ok(Self::ReadHeader),
             _ => Err(()),
         }
     }
 }
 
 #[repr(C)]
-#[derive(Default, Copy, Clone, Debug, FromBytes, AsBytes)]
+#[derive(
+    Default, Copy, Clone, Debug, FromBytes, AsBytes, Serialize, Deserialize,
+)]
 pub struct SAUEntry {
     pub rbar: u32,
     pub rlar: u32,
@@ -507,7 +511,7 @@ pub const HEADER_MAGIC: u32 = 0x1535_6637;
 /// TODO: Add hash for integrity check
 /// Later this will also be a signature block
 #[repr(C)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, Serialize, Deserialize)]
 pub struct ImageHeader {
     pub magic: u32,
     pub total_image_len: u32,

--- a/sys/kern/src/header.rs
+++ b/sys/kern/src/header.rs
@@ -6,9 +6,7 @@ use abi::ImageHeader;
 use core::mem::MaybeUninit;
 
 // This is updated by build scripts (which is why this is marked as no_mangle)
-// Although we don't access any fields of the header from hubris right now, it
-// is safer to treat this as MaybeUninit in case we need to do so in the future.
 #[used]
 #[no_mangle]
 #[link_section = ".image_header"]
-static HEADER: MaybeUninit<ImageHeader> = MaybeUninit::uninit();
+pub static HEADER: MaybeUninit<ImageHeader> = MaybeUninit::uninit();

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -81,6 +81,5 @@ pub fn read_header() -> abi::ImageHeader {
         &[],
     );
     assert_eq!(rc, 0);
-    assert_eq!(len, 8); // we *really* expect this to be 2x u32
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -70,3 +70,17 @@ pub fn read_image_id() -> u64 {
     assert_eq!(len, 8); // we *really* expect this to be a u64
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
+
+pub fn read_header() -> abi::ImageHeader {
+    let mut response = [0; core::mem::size_of::<u64>()];
+    let (rc, len) = sys_send(
+        TaskId::KERNEL,
+        Kipcnum::ReadHeader as u16,
+        &[],
+        &mut response,
+        &[],
+    );
+    assert_eq!(rc, 0);
+    assert_eq!(len, 8); // we *really* expect this to be 2x u32
+    ssmarshal::deserialize(&response[..len]).unwrap_lite().0
+}


### PR DESCRIPTION
This PR does ~two~ ~three~ four things:

- Reserves space for a `caboose` (#1157) when building an image
- Adds the caboose size to the `ImageHeader`
- Pulls a bunch of generic Hubris-archive-manipulatey stuff into the new `hubtools` repo.  We'll soon be manipulating Hubris archives from `permission-slip`, so want to move this code out.
- Adds a new (very small) G0 image to test the caboose in its `app.toml`