### PR TITLE
Add the Hubris Caboose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,13 +3826,24 @@ version = "0.1.0"
 dependencies = [
  "build-util",
  "cfg-if",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "task-caboose-reader-api",
+ "tlvc",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "task-caboose-reader-api"
+version = "0.1.0"
+dependencies = [
  "derive-idol-err",
  "idol",
  "idol-runtime",
  "num-traits",
- "tlvc",
  "userlib",
- "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "ordered-toml",
  "serde",
  "serde_json",
- "toml 0.5.8",
+ "toml 0.7.2",
  "toml-task",
 ]
 
@@ -3719,7 +3719,7 @@ dependencies = [
  "sha3",
  "stage0-handoff",
  "static_assertions",
- "toml 0.5.8",
+ "toml 0.7.2",
  "unwrap-lite",
  "zerocopy",
  "zeroize",
@@ -3889,7 +3889,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.5.8",
+ "toml 0.7.2",
 ]
 
 [[package]]
@@ -5089,7 +5089,7 @@ dependencies = [
  "strsim",
  "tlvc",
  "tlvc-text",
- "toml 0.5.8",
+ "toml 0.7.2",
  "toml-task",
  "walkdir",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hubtools"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/hubtools#324d0ecf0ed5ec1785538e1cb5a49718ad52e444"
+dependencies = [
+ "anyhow",
+ "srec",
+ "zip",
+]
+
+[[package]]
 name = "humpty"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/humpty#bcb02bd530beadd296a3a80b0ec2c4dbc00403c1"
@@ -4945,6 +4955,7 @@ dependencies = [
  "fnv",
  "gnarle",
  "goblin",
+ "hubtools",
  "indexmap",
  "lpc55_areas",
  "lpc55_sign",
@@ -4958,7 +4969,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "srec",
  "strsim",
  "tlvc",
  "tlvc-text",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,9 +2340,11 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools#89f88f53f32c154f2f832728b1ac58f6600200ac"
+source = "git+https://github.com/oxidecomputer/hubtools#950fc8a0b05f7e1d26b80558d4c6c869ad5f768e"
 dependencies = [
+ "path-slash",
  "srec",
+ "tempfile",
  "thiserror",
  "toml 0.7.2",
  "zerocopy",
@@ -2405,6 +2416,15 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3222,6 +3242,15 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ringbuf"
@@ -4496,6 +4525,20 @@ dependencies = [
  "num-traits",
  "userlib",
  "zerocopy",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,6 +3821,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "task-caboose-reader"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cfg-if",
+ "derive-idol-err",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "tlvc",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "task-config"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "ordered-toml",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.8",
  "toml-task",
 ]
 
@@ -260,9 +260,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bzip2"
-version = "0.3.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -2331,10 +2331,12 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools#324d0ecf0ed5ec1785538e1cb5a49718ad52e444"
+source = "git+https://github.com/oxidecomputer/hubtools#89f88f53f32c154f2f832728b1ac58f6600200ac"
 dependencies = [
- "anyhow",
  "srec",
+ "thiserror",
+ "toml 0.7.2",
+ "zerocopy",
  "zip",
 ]
 
@@ -2376,7 +2378,7 @@ dependencies = [
  "quote",
  "ron",
  "serde",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -2617,7 +2619,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha2",
- "toml",
+ "toml 0.5.8",
  "x509-parser",
 ]
 
@@ -3056,12 +3058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "podio"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
-
-[[package]]
 name = "postcard"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,7 +3690,7 @@ dependencies = [
  "sha3",
  "stage0-handoff",
  "static_assertions",
- "toml",
+ "toml 0.5.8",
  "unwrap-lite",
  "zerocopy",
  "zeroize",
@@ -3855,7 +3860,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -4747,6 +4752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml-task"
 version = "0.1.0"
 dependencies = [
@@ -4754,6 +4771,28 @@ dependencies = [
  "indexmap",
  "ordered-toml",
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4938,6 +4977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "winnow"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdd927d1a3d5d98abcfc4cf8627371862ee6abfe52a988050621c50c66b4493"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wyz"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4998,7 +5046,7 @@ dependencies = [
  "strsim",
  "tlvc",
  "tlvc-text",
- "toml",
+ "toml 0.5.8",
  "toml-task",
  "walkdir",
  "zerocopy",
@@ -5049,13 +5097,14 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.6"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58287c28d78507f5f91f2a4cf1e8310e2c76fd4c6932f93ac60fd1ceb402db7d"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
+ "byteorder",
  "bzip2",
  "crc32fast",
  "flate2",
- "podio",
+ "thiserror",
  "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ sha3 = { version = "0.10", default-features = false }
 smbus-pec = { version = "1.0.1", default-features = false }
 smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }
 spin = { version = "0.9.4", default-features = false, features = ["mutex", "spin_mutex"]}
-srec = { version = "0.2.0", default-features = false }
 ssmarshal = { version = "1.0.0", default-features = false }
 static_assertions = { version = "1", default-features = false }
 stm32f3 = { version = "0.13.0", default-features = false }
@@ -122,6 +121,7 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ vcell = { version = "0.1.2", default-features = false }
 walkdir = { version = "2.0.0", default-features = false }
 zerocopy = { version = "0.6.1", default-features = false }
 zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_derive"] }
+zip = { version = "0.5", default-features = false }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ stm32h7 = { version = "0.14", default-features = false }
 stm32g0 = { version = "0.15.1", default-features = false }
 strsim = { version = "0.10.0", default-features = false }
 syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
-toml = { version = "0.5.6", default-features = false }
+toml = { version = "0.7", default-features = false, features = ["parse"] }
 vcell = { version = "0.1.2", default-features = false }
 walkdir = { version = "2.0.0", default-features = false }
 zerocopy = { version = "0.6.1", default-features = false }

--- a/app/demo-stm32g0-nucleo/app-g070-mini.toml
+++ b/app/demo-stm32g0-nucleo/app-g070-mini.toml
@@ -1,0 +1,33 @@
+# Tiny G0 image, useful for making small Humility archives
+name = "demo-stm32g070-nucleo"
+target = "thumbv6m-none-eabi"
+chip = "../../chips/stm32g0"
+memory = "memory-g070.toml"
+board = "stm32g070"
+stacksize = 944
+
+[kernel]
+name = "demo-stm32g0-nucleo"
+requires = {flash = 18048, ram = 1632}
+features = ["g070"]
+stacksize = 640
+
+[caboose]
+region = "flash"
+size = 128
+
+[tasks.jefe]
+name = "task-jefe"
+priority = 0
+max-sizes = {flash = 4096, ram = 512}
+start = true
+features = ["log-null"]
+stacksize = 352
+notifications = ["fault", "timer"]
+
+[tasks.idle]
+name = "task-idle"
+priority = 5
+max-sizes = {flash = 128, ram = 64}
+stacksize = 64
+start = true

--- a/app/demo-stm32g0-nucleo/app-g070-mini.toml
+++ b/app/demo-stm32g0-nucleo/app-g070-mini.toml
@@ -14,7 +14,7 @@ stacksize = 640
 
 [caboose]
 region = "flash"
-size = 128
+size = 256
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -7,7 +7,7 @@ stacksize = 944
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 18048, ram = 1632}
+requires = {flash = 18248, ram = 1632}
 features = ["g070"]
 stacksize = 640
 

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -7,7 +7,7 @@ stacksize = 944
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 18248, ram = 1632}
+requires = {flash = 18448, ram = 1632}
 features = ["g070"]
 stacksize = 640
 

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18000, ram = 1616}
+requires = {flash = 18144, ram = 1616}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18000, ram = 1820}
+requires = {flash = 18100, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18100, ram = 1820}
+requires = {flash = 18200, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18200, ram = 1820}
+requires = {flash = 18272, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/build/kernel-link.x
+++ b/build/kernel-link.x
@@ -62,7 +62,11 @@ SECTIONS
   } > FLASH
 
   __vector_size = SIZEOF(.vector_table);
-  /* Header containing data needed by the bootloader */
+  /* Header containing data needed by the bootloader.  We specify
+     _HUBRIS_IMAGE_HEADER_SIZE and _HUBRIS_IMAGE_HEADER_ALIGN in memory.x at
+     build time, then reserve enough space for the header here in the linker
+     script.
+   */
   .header :
   {
     ASSERT(. == ALIGN(_HUBRIS_IMAGE_HEADER_ALIGN), "error: header alignment is invalid");

--- a/build/kernel-link.x
+++ b/build/kernel-link.x
@@ -65,10 +65,8 @@ SECTIONS
   /* Header containing data needed by the bootloader */
   .header :
   {
-    _HEADER_UNALIGNED = .;
-    . = ALIGN(_HUBRIS_IMAGE_HEADER_ALIGN);
+    ASSERT(. == ALIGN(_HUBRIS_IMAGE_HEADER_ALIGN), "error: header alignment is invalid");
     HEADER = .;
-    ASSERT(_HEADER_UNALIGNED == HEADER, "error: header alignment is invalid");
     . = . + _HUBRIS_IMAGE_HEADER_SIZE;
   } > FLASH
 

--- a/build/kernel-link.x
+++ b/build/kernel-link.x
@@ -65,8 +65,11 @@ SECTIONS
   /* Header containing data needed by the bootloader */
   .header :
   {
-	__header_start = .;
-	KEEP(*(.image_header));
+    _HEADER_UNALIGNED = .;
+    . = ALIGN(_HUBRIS_IMAGE_HEADER_ALIGN);
+    HEADER = .;
+    ASSERT(_HEADER_UNALIGNED == HEADER, "error: header alignment is invalid");
+    . = . + _HUBRIS_IMAGE_HEADER_SIZE;
   } > FLASH
 
   /* Explicitly place text at vector table + size of header, deliberately ignoring

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -229,8 +229,8 @@ fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
         Ok(c) => c,
     };
 
-    let rval = toml::from_slice(config.as_bytes())
-        .context("deserializing configuration")?;
+    let rval =
+        toml::from_str(&config).context("deserializing configuration")?;
     Ok(Some(rval))
 }
 

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -20,6 +20,7 @@ dunce = { workspace = true }
 filetime = { workspace = true }
 fnv = { workspace = true }
 goblin = { workspace = true }
+hubtools = { workspace = true }
 indexmap = { workspace = true }
 path-slash = { workspace = true }
 rangemap = { workspace = true }
@@ -29,7 +30,6 @@ scroll = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }
-srec = { workspace = true }
 tlvc = { workspace = true }
 tlvc-text = { workspace = true }
 toml = { workspace = true }

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -35,10 +35,7 @@ tlvc-text = { workspace = true }
 toml = { workspace = true }
 walkdir = { workspace = true }
 zerocopy = { workspace = true }
-
-# a feature of zip we use is deprecated in 0.5.7, so let's make sure we stay
-# on the version that works for us
-zip = "=0.5.6"
+zip = { workspace = true }
 
 gnarle = { path = "../../lib/gnarle", features = ["std"] }
 abi.path = "../../sys/abi"

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -57,7 +57,11 @@ pub fn run(
                 .map(|name| (name.as_str(), fake_sizes.clone()))
                 .collect();
 
-            let allocated = crate::dist::allocate_all(&toml, &task_sizes)?;
+            let allocated = crate::dist::allocate_all(
+                &toml,
+                &task_sizes,
+                toml.caboose.as_ref(),
+            )?;
 
             let (allocs, _) = allocated
                 .get(&toml.image_names[0])

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -76,6 +76,7 @@ struct RawConfig {
     #[serde(default)]
     secure_task: Option<String>,
     auxflash: Option<AuxFlash>,
+    caboose: Option<CabooseConfig>,
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +104,13 @@ pub struct Config {
     pub secure_task: Option<String>,
     pub auxflash: Option<AuxFlashData>,
     pub dice_mfg: Option<Output>,
+    pub caboose: Option<CabooseConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CabooseConfig {
+    pub region: String,
+    pub size: u32,
 }
 
 impl Config {
@@ -219,6 +227,7 @@ impl Config {
             patches: None,
             secure_task: toml.secure_task,
             dice_mfg,
+            caboose: toml.caboose,
         })
     }
 

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -140,9 +140,9 @@ impl Config {
         hasher.write(&cfg_contents);
 
         // Minimal TOML file inheritance, to enable features on a per-task basis
-        if let Ok(inherited) = toml::de::from_str::<PatchedConfig>(
-            std::str::from_utf8(&cfg_contents)?,
-        ) {
+        if let Ok(inherited) =
+            toml::from_str::<PatchedConfig>(std::str::from_utf8(&cfg_contents)?)
+        {
             let file = cfg.parent().unwrap().join(&inherited.inherit);
             let mut original = Config::from_file_with_hasher(&file, hasher)
                 .context(format!("Could not load template from {file:?}"))?;
@@ -164,7 +164,7 @@ impl Config {
         }
 
         let toml: RawConfig =
-            toml::de::from_str(std::str::from_utf8(&cfg_contents)?)?;
+            toml::from_str(std::str::from_utf8(&cfg_contents)?)?;
         if toml.tasks.contains_key("kernel") {
             bail!("'kernel' is reserved and cannot be used as a task name");
         }
@@ -177,7 +177,7 @@ impl Config {
                 cfg.parent().unwrap().join(&toml.chip).join("chip.toml");
             let chip_contents = std::fs::read(chip_file)?;
             hasher.write(&chip_contents);
-            toml::de::from_str(std::str::from_utf8(&chip_contents)?)?
+            toml::from_str(std::str::from_utf8(&chip_contents)?)?
         };
 
         let outputs: IndexMap<String, Vec<Output>> = {
@@ -192,7 +192,7 @@ impl Config {
                     format!("reading chip file {}", chip_file.display())
                 })?;
             hasher.write(&chip_contents);
-            toml::de::from_str(std::str::from_utf8(&chip_contents)?)?
+            toml::from_str(std::str::from_utf8(&chip_contents)?)?
         };
 
         let buildhash = hasher.finish();

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -140,8 +140,9 @@ impl Config {
         hasher.write(&cfg_contents);
 
         // Minimal TOML file inheritance, to enable features on a per-task basis
-        if let Ok(inherited) = toml::from_slice::<PatchedConfig>(&cfg_contents)
-        {
+        if let Ok(inherited) = toml::de::from_str::<PatchedConfig>(
+            std::str::from_utf8(&cfg_contents)?,
+        ) {
             let file = cfg.parent().unwrap().join(&inherited.inherit);
             let mut original = Config::from_file_with_hasher(&file, hasher)
                 .context(format!("Could not load template from {file:?}"))?;
@@ -162,7 +163,8 @@ impl Config {
             return Ok(original);
         }
 
-        let toml: RawConfig = toml::from_slice(&cfg_contents)?;
+        let toml: RawConfig =
+            toml::de::from_str(std::str::from_utf8(&cfg_contents)?)?;
         if toml.tasks.contains_key("kernel") {
             bail!("'kernel' is reserved and cannot be used as a task name");
         }
@@ -175,7 +177,7 @@ impl Config {
                 cfg.parent().unwrap().join(&toml.chip).join("chip.toml");
             let chip_contents = std::fs::read(chip_file)?;
             hasher.write(&chip_contents);
-            toml::from_slice(&chip_contents)?
+            toml::de::from_str(std::str::from_utf8(&chip_contents)?)?
         };
 
         let outputs: IndexMap<String, Vec<Output>> = {
@@ -190,7 +192,7 @@ impl Config {
                     format!("reading chip file {}", chip_file.display())
                 })?;
             hasher.write(&chip_contents);
-            toml::from_slice::<IndexMap<String, Vec<Output>>>(&chip_contents)?
+            toml::de::from_str(std::str::from_utf8(&chip_contents)?)?
         };
 
         let buildhash = hasher.finish();

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -71,9 +71,7 @@ struct RawConfig {
     tasks: IndexMap<String, Task>,
     #[serde(default)]
     extratext: IndexMap<String, Peripheral>,
-    #[serde(default)]
     config: Option<ordered_toml::Value>,
-    #[serde(default)]
     secure_task: Option<String>,
     auxflash: Option<AuxFlash>,
     caboose: Option<CabooseConfig>,
@@ -109,7 +107,19 @@ pub struct Config {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CabooseConfig {
+    /// List of tasks that are allowed to access the caboose
+    #[serde(default)]
+    pub tasks: Vec<String>,
+
+    /// Name of the memory region in which the caboose is placed
+    ///
+    /// (this is almost certainly "flash")
     pub region: String,
+
+    /// Size of the caboose
+    ///
+    /// The system reserves two words (8 bytes) for the size and marker, so the
+    /// user-accessible space is 8 bytes less than this value.
     pub size: u32,
 }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -385,6 +385,9 @@ pub fn package(
         translate_srec_to_other_formats(&cfg.img_dir(image_name), "combined")?;
 
         if let Some(signing) = &cfg.toml.signing {
+            if cfg.toml.caboose.is_some() {
+                bail!("cannot sign an image with a caboose");
+            }
             let rkth = lpc55_sign::signed_image::sign_chain(
                 &cfg.img_file("combined.bin", image_name),
                 Some(&cfg.app_src_dir),

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -339,7 +339,7 @@ pub fn package(
             let (_, caboose_range) = allocs.caboose.as_ref().unwrap();
             // The caboose has the format
             // [CABOOSE_MAGIC, ..., MAX_LENGTH]
-            // where all words in between are initialize to u32::MAX
+            // where all words in between are initialized to u32::MAX
             //
             // The final word in the caboose is the caboose length, so that we
             // can decode the caboose start by looking at it while only knowing

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1361,8 +1361,6 @@ fn generate_kernel_linker_script(
     writeln!(linkscr, "_stack_base = {:#010x};", stack_base.unwrap()).unwrap();
     writeln!(linkscr, "_stack_start = {:#010x};", stack_start.unwrap())
         .unwrap();
-    writeln!(linkscr, "_stack_start = {:#010x};", stack_start.unwrap())
-        .unwrap();
     writeln!(
         linkscr,
         "_HUBRIS_IMAGE_HEADER_ALIGN = {:#x};",

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1336,6 +1336,20 @@ fn generate_kernel_linker_script(
     writeln!(linkscr, "_stack_base = {:#010x};", stack_base.unwrap()).unwrap();
     writeln!(linkscr, "_stack_start = {:#010x};", stack_start.unwrap())
         .unwrap();
+    writeln!(linkscr, "_stack_start = {:#010x};", stack_start.unwrap())
+        .unwrap();
+    writeln!(
+        linkscr,
+        "_HUBRIS_IMAGE_HEADER_ALIGN = {:#x};",
+        std::mem::align_of::<abi::ImageHeader>()
+    )
+    .unwrap();
+    writeln!(
+        linkscr,
+        "_HUBRIS_IMAGE_HEADER_SIZE = {:#x};",
+        std::mem::size_of::<abi::ImageHeader>()
+    )
+    .unwrap();
 
     append_image_names(&mut linkscr, images, image_name)?;
     Ok(())

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1045,6 +1045,12 @@ fn update_image_header(
                     epoch: cfg.toml.epoch,
                     magic: abi::HEADER_MAGIC,
                     total_image_len: len as u32,
+                    caboose_size: cfg
+                        .toml
+                        .caboose
+                        .as_ref()
+                        .map(|c| c.size)
+                        .unwrap_or(0),
                     ..Default::default()
                 };
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -334,6 +334,19 @@ pub fn package(
             None
         };
 
+        // Add an empty output section for the caboose
+        if let Some(caboose) = &cfg.toml.caboose {
+            let (_, caboose_range) = allocs.caboose.as_ref().unwrap();
+            // BTreeMap<u32, LoadSegment>,
+            all_output_sections.insert(
+                caboose_range.start,
+                LoadSegment {
+                    source_file: "caboose".into(),
+                    data: vec![0xFF; caboose.size as usize],
+                },
+            );
+        }
+
         // If we've done a partial build (which may have included the kernel), bail
         // out here before linking stuff.
         if partial_build {

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -16,7 +16,7 @@ use atty::Stream;
 use colored::*;
 use hubtools::LoadSegment;
 use indexmap::IndexMap;
-use path_slash::PathBufExt;
+use path_slash::{PathBufExt, PathExt};
 use zerocopy::AsBytes;
 
 use crate::{
@@ -2247,7 +2247,7 @@ impl Archive {
     ) -> Result<()> {
         let mut input = File::open(src_path)?;
         self.inner
-            .start_file_from_path(zip_path.as_ref(), self.opts)?;
+            .start_file(zip_path.as_ref().to_slash().unwrap(), self.opts)?;
         std::io::copy(&mut input, &mut self.inner)?;
         Ok(())
     }
@@ -2259,7 +2259,7 @@ impl Archive {
         contents: impl AsRef<str>,
     ) -> Result<()> {
         self.inner
-            .start_file_from_path(zip_path.as_ref(), self.opts)?;
+            .start_file(zip_path.as_ref().to_slash().unwrap(), self.opts)?;
         self.inner.write_all(contents.as_ref().as_bytes())?;
         Ok(())
     }

--- a/build/xtask/src/lsp.rs
+++ b/build/xtask/src/lsp.rs
@@ -316,7 +316,7 @@ fn inner(file: &PathBuf, clients: &[LspClient]) -> Result<LspConfig> {
         .read_to_end(&mut cargo_text)
         .context("failed to read Cargo.toml")?;
     let cargo_toml: Manifest =
-        toml::de::from_str(std::str::from_utf8(&cargo_text)?)?;
+        toml::from_str(std::str::from_utf8(&cargo_text)?)?;
     let package_name = cargo_toml.package.name;
 
     let metadata = cargo_metadata::MetadataCommand::new()

--- a/build/xtask/src/lsp.rs
+++ b/build/xtask/src/lsp.rs
@@ -315,7 +315,8 @@ fn inner(file: &PathBuf, clients: &[LspClient]) -> Result<LspConfig> {
     cargo
         .read_to_end(&mut cargo_text)
         .context("failed to read Cargo.toml")?;
-    let cargo_toml: Manifest = toml::from_slice(&cargo_text)?;
+    let cargo_toml: Manifest =
+        toml::de::from_str(std::str::from_utf8(&cargo_text)?)?;
     let package_name = cargo_toml.package.name;
 
     let metadata = cargo_metadata::MetadataCommand::new()

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -175,7 +175,14 @@ fn print_task_table(
     toml: &Config,
     map: &BTreeMap<&str, BTreeMap<u32, MemoryChunk>>,
 ) -> Result<()> {
-    let task_pad = toml.tasks.keys().map(|k| k.len()).max().unwrap_or(0);
+    let task_pad = toml
+        .tasks
+        .keys()
+        .map(|s| s.as_str())
+        .chain(std::iter::once("PROGRAM"))
+        .map(|k| k.len())
+        .max()
+        .unwrap_or(0);
     let mem_pad = map
         .values()
         .flat_map(|m| m.values())
@@ -247,7 +254,14 @@ fn print_memory_map(
     toml: &Config,
     map: &BTreeMap<&str, BTreeMap<u32, MemoryChunk>>,
 ) -> Result<()> {
-    let task_pad = toml.tasks.keys().map(|k| k.len()).max().unwrap_or(0);
+    let task_pad = toml
+        .tasks
+        .keys()
+        .map(|s| s.as_str())
+        .chain(std::iter::once("-padding-"))
+        .map(|k| k.len())
+        .max()
+        .unwrap_or(0);
     let mem_pad = map
         .values()
         .flat_map(|m| m.values())

--- a/doc/biblio.adoc
+++ b/doc/biblio.adoc
@@ -10,3 +10,4 @@
   Threats In Multiserver Operating Systems: A Fundamental Requirement for
   Dependability]. 2008. _This paper marked MINIX 3's transition from a teaching
   tool to a high-reliability research platform._
+- [[[`hubtools`]]] https://github.com/oxidecomputer/hubtools

--- a/doc/biblio.adoc
+++ b/doc/biblio.adoc
@@ -10,4 +10,3 @@
   Threats In Multiserver Operating Systems: A Fundamental Requirement for
   Dependability]. 2008. _This paper marked MINIX 3's transition from a teaching
   tool to a high-reliability research platform._
-- [[[`hubtools`]]] https://github.com/oxidecomputer/hubtools

--- a/doc/guide/caboose.adoc
+++ b/doc/guide/caboose.adoc
@@ -73,5 +73,5 @@ implemented by the <<_read_caboose_pos_6,`read_caboose_pos`>> kernel IPC call.
 Other than reserving the two words above, the Hubris build system is
 _deliberately agnostic_ to the contents of the caboose; it is left to a separate
 release engineering process to decide what to store there.  The
-<<hubtools,`hubtools`>> repository includes a library and CLI for modifying the
-caboose of a Hubris archive.
+https://github.com/oxidecomputer/hubtools[`hubtools` repository] includes a
+library and CLI for modifying the caboose of a Hubris archive.

--- a/doc/guide/caboose.adoc
+++ b/doc/guide/caboose.adoc
@@ -1,0 +1,77 @@
+[#caboose]
+= The caboose
+
+At times, users may wish for a Hubris archive to contain information with the
+following properties:
+
+* Decided **after** the image is built
+* Readable in a wide variety of situations:
+** A live system with well-known APIs to request it (e.g. over the network)
+** A Hubris build archive
+** A binary file, given the original build archive
+** A binary file, **without** the original build archive
+
+Note that a live system with a debugger attached is morally equivalent to "a
+binary file", because we can read arbitrary memory.
+
+The motivating example of this data is a component-level version: after building
+an image, a separate release engineering process wants to assign it a
+user-facing version (e.g. `1.2.3`) and store that informatio _somewhere_ in the
+image.
+
+The "caboose" is a region of flash allocated for this purpose. It is declared
+with a `[caboose]` section in an `app.toml`, e.g.
+
+[#caboose-words]
+```toml
+[caboose]
+region = "flash"
+size = 128
+tasks = ["caboose_reader"]
+```
+
+If this section is present in an `app.toml`, the build system reserves an
+appropriately-aligned section of memory for the caboose.  The caboose is located
+at the **end** of flash (after the final task), and is aligned so that it can be
+mapped as an MPU region. Only tasks declared in `caboose.tasks` are allowed to
+read data from the caboose region of flash.  If other tasks attempt to read from
+this memory region, they will experience the typical memory fault.
+
+Hubris does not have strong opinions about the contents of the caboose, other
+than reserving two words.  At build time, the caboose is loaded with the
+following data (shown here as `u32` words):
+
+[cols="1,3"]
+|===
+| **Start** | `abi::CABOOSE_MAGIC`
+| ...       | _(filled with `0xFFFFFFFF`)_
+| **End**   | Caboose size (little-endian `u32`)
+|===
+
+The caboose's length is included in the `total_image_len` field of
+`abi::ImageHeader`.  Because the caboose is located at the end of flash, its
+presence and size can be determined as follows:
+
+* Read total image length from the `ImageHeader`
+** At runtime, this is a variable that can be read by the kernel
+** At rest, the image header is at a known location (depending on
+   microcontroller) and includes a distinctive magic number
+   (`abi::HEADER_MAGIC`)
+* Read the final word of the image, which may be the caboose length
+* Subtract this value from total image length to get the (presumptive) caboose
+  start
+** If this subtraction underflows or exceeds the bounds of flash, the caboose is
+   not present.
+* Read the first word of the (presumptive) caboose
+** If this word is not `abi::CABOOSE_MAGIC`, then the caboose is not present
+** Otherwise, the caboose position and length is now known
+
+Note that this procedure works both at runtime and from a binary file, with or
+without an associated Hubris archive.  In a live system, this logic is
+implemented by the <<_read_caboose_pos_6,`read_caboose_pos`>> kernel IPC call.
+
+Other than reserving the two words above, the Hubris build system is
+_deliberately agnostic_ to the contents of the caboose; it is left to a separate
+release engineering process to decide what to store there.  The
+<<hubtools,`hubtools`>> repository includes a library and CLI for modifying the
+caboose of a Hubris archive.

--- a/doc/guide/index.adoc
+++ b/doc/guide/index.adoc
@@ -3,3 +3,4 @@
 include::servers.adoc[leveloffset=+1]
 include::supervision.adoc[leveloffset=+1]
 include::drivers.adoc[leveloffset=+1]
+include::caboose.adoc[leveloffset=+1]

--- a/doc/kipc.adoc
+++ b/doc/kipc.adoc
@@ -215,6 +215,38 @@ you apply `fault_task` to an already-faulted task, the task will be marked as
 double-faulted and the previous fault will be replaced with the new injected
 fault.
 
+=== `read_image_id` (4)
+=== `reset` (5)
+=== `read_caboose_pos` (6)
+[source,rust]
+----
+struct ReadCaboosePos = ();
+----
+
+==== Preconditions
+
+None
+
+==== Response
+
+[source,rust]
+----
+type CaboosePos = core::ops::Range<u32>;
+----
+
+==== Notes
+
+`read_caboose_pos` allows tasks to get the location of <<caboose,the caboose>>
+at runtime. It is necessary because the caboose is positioned at the end of
+flash, so its location can only be known after an entire image is built.
+
+If the image does not include a caboose or the caboose does not contain the
+<<caboose-words,expected words>>, this call will return `(0, 0)`.
+
+Note that this call will return the caboose address even if a task is not
+configured for caboose access!  In that case, reading from the given memory
+range will cause a memory fault and the task will be killed.
+
 == Receiving from the kernel
 
 The kernel never sends messages to tasks. It's simply not equipped to do so.

--- a/idl/caboose.idol
+++ b/idl/caboose.idol
@@ -1,0 +1,15 @@
+// API for the Caboose reader task
+Interface(
+    name: "Caboose",
+    ops: {
+        "caboose_addr": (
+            doc: "reads the caboose address from the kernel",
+            reply: Result(
+                ok: "u32",
+                err: CLike("CabooseError"),
+            ),
+            idempotent: true,
+        ),
+    }
+)
+

--- a/idl/caboose.idol
+++ b/idl/caboose.idol
@@ -10,6 +10,34 @@ Interface(
             ),
             idempotent: true,
         ),
+
+        "get_key_by_tag": (
+            doc: "Scans the caboose for a key with the given tag",
+            args: {
+                "name": "[u8; 4]",
+            },
+            leases: {
+                "data": (type: "[u8]", write: true),
+            },
+            reply: Result(
+                ok: "u32",
+                err: CLike("CabooseError"),
+            ),
+            idempotent: true,
+        ),
+        "get_key_by_u32": (
+            doc: "Scans the caboose for a key with the given tag",
+            args: {
+                "tag": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", write: true),
+            },
+            reply: Result(
+                ok: "u32",
+                err: CLike("CabooseError"),
+            ),
+            idempotent: true,
+        ),
     }
 )
-

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -478,7 +478,7 @@ pub enum Kipcnum {
     FaultTask = 3,
     ReadImageId = 4,
     Reset = 5,
-    ReadHeader = 6,
+    ReadCaboosePos = 6,
 }
 
 impl core::convert::TryFrom<u16> for Kipcnum {
@@ -491,7 +491,7 @@ impl core::convert::TryFrom<u16> for Kipcnum {
             3 => Ok(Self::FaultTask),
             4 => Ok(Self::ReadImageId),
             5 => Ok(Self::Reset),
-            6 => Ok(Self::ReadHeader),
+            6 => Ok(Self::ReadCaboosePos),
             _ => Err(()),
         }
     }
@@ -518,7 +518,6 @@ pub struct ImageHeader {
     pub sau_entries: [SAUEntry; 8],
     pub version: u32,
     pub epoch: u32,
-    pub caboose_size: u32,
 }
 
 // Corresponds to the ARM vector table, limited to what we need

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -514,6 +514,7 @@ pub struct ImageHeader {
     pub sau_entries: [SAUEntry; 8],
     pub version: u32,
     pub epoch: u32,
+    pub caboose_size: u32,
 }
 
 // Corresponds to the ARM vector table, limited to what we need

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -478,6 +478,7 @@ pub enum Kipcnum {
     FaultTask = 3,
     ReadImageId = 4,
     Reset = 5,
+    ReadHeader = 6,
 }
 
 impl core::convert::TryFrom<u16> for Kipcnum {
@@ -490,13 +491,16 @@ impl core::convert::TryFrom<u16> for Kipcnum {
             3 => Ok(Self::FaultTask),
             4 => Ok(Self::ReadImageId),
             5 => Ok(Self::Reset),
+            6 => Ok(Self::ReadHeader),
             _ => Err(()),
         }
     }
 }
 
 #[repr(C)]
-#[derive(Default, Copy, Clone, Debug, FromBytes, AsBytes)]
+#[derive(
+    Default, Copy, Clone, Debug, FromBytes, AsBytes, Serialize, Deserialize,
+)]
 pub struct SAUEntry {
     pub rbar: u32,
     pub rlar: u32,
@@ -507,7 +511,7 @@ pub const HEADER_MAGIC: u32 = 0x1535_6637;
 /// TODO: Add hash for integrity check
 /// Later this will also be a signature block
 #[repr(C)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, Serialize, Deserialize)]
 pub struct ImageHeader {
     pub magic: u32,
     pub total_image_len: u32,

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -498,9 +498,7 @@ impl core::convert::TryFrom<u16> for Kipcnum {
 }
 
 #[repr(C)]
-#[derive(
-    Default, Copy, Clone, Debug, FromBytes, AsBytes, Serialize, Deserialize,
-)]
+#[derive(Default, Copy, Clone, Debug, FromBytes, AsBytes)]
 pub struct SAUEntry {
     pub rbar: u32,
     pub rlar: u32,
@@ -512,7 +510,7 @@ pub const CABOOSE_MAGIC: u32 = 0xCAB0_005E;
 /// TODO: Add hash for integrity check
 /// Later this will also be a signature block
 #[repr(C)]
-#[derive(Default, AsBytes, FromBytes, Serialize, Deserialize)]
+#[derive(Default, AsBytes, FromBytes)]
 pub struct ImageHeader {
     pub magic: u32,
     pub total_image_len: u32,

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -507,6 +507,7 @@ pub struct SAUEntry {
 }
 
 pub const HEADER_MAGIC: u32 = 0x1535_6637;
+pub const CABOOSE_MAGIC: u32 = 0xCAB0_005E;
 
 /// TODO: Add hash for integrity check
 /// Later this will also be a signature block

--- a/sys/kern/src/header.rs
+++ b/sys/kern/src/header.rs
@@ -3,10 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use abi::ImageHeader;
-use core::mem::MaybeUninit;
 
-// This is updated by build scripts (which is why this is marked as no_mangle)
-#[used]
-#[no_mangle]
-#[link_section = ".image_header"]
-pub static HEADER: MaybeUninit<ImageHeader> = MaybeUninit::uninit();
+// Filled with dummy data by the linker, then populated by the build system
+extern "C" {
+    pub static HEADER: ImageHeader;
+}

--- a/sys/kern/src/header.rs
+++ b/sys/kern/src/header.rs
@@ -6,9 +6,7 @@ use abi::ImageHeader;
 use core::mem::MaybeUninit;
 
 // This is updated by build scripts (which is why this is marked as no_mangle)
-// Although we don't access any fields of the header from hubris right now, it
-// is safer to treat this as MaybeUninit in case we need to do so in the future.
 #[used]
 #[no_mangle]
 #[link_section = ".image_header"]
-static HEADER: MaybeUninit<ImageHeader> = MaybeUninit::uninit();
+pub static HEADER: MaybeUninit<ImageHeader> = MaybeUninit::uninit();

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -242,5 +242,3 @@ fn read_caboose_pos(
         .set_send_response_and_length(0, response_len);
     Ok(NextTask::Same)
 }
-
-

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -226,21 +226,37 @@ fn read_caboose_pos(
     // The end-of-image position is given as an image length, so we need to
     // apply it as an offset to the start-of-image.
     extern "C" {
-        static __start_vector: u8;
+        static __start_vector: u32;
     }
-    let image_start = unsafe { &__start_vector } as *const u8 as u32;
+    // SAFETY: populated by the linker script
+    let image_start = unsafe { &__start_vector } as *const u32 as u32;
     let image_end = image_start + header.total_image_len;
 
     // The caboose records its own size in its last word.  The recorded size is
     // **inclusive** of this word.
+    //
+    // SAFETY: populated by the build system to a valid value
     let caboose_size: u32 =
         unsafe { core::ptr::read_volatile((image_end - 4) as *const u32) };
 
-    let response_len = serialize_response(
-        &mut tasks[caller],
-        response,
-        &(image_end - caboose_size),
-    )?;
+    // Calculate the beginning of the caboose.  If the caboose is unpopulated,
+    // then we expect a random value (or 0xFFFFFFFF) as its size, which we can
+    // catch because it will give us an obviously invalid start location.
+    let caboose_start = image_end.saturating_sub(caboose_size);
+    let out = if caboose_start <= image_start {
+        (0, 0)
+    } else {
+        // SAFETY: we know this pointer is within the image flash region
+        let v =
+            unsafe { core::ptr::read_volatile(caboose_start as *const u32) };
+        if v == abi::CABOOSE_MAGIC {
+            (caboose_start + 4, image_end - 4)
+        } else {
+            (0, 0)
+        }
+    };
+
+    let response_len = serialize_response(&mut tasks[caller], response, &out)?;
     tasks[caller]
         .save_mut()
         .set_send_response_and_length(0, response_len);

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -220,8 +220,8 @@ fn read_caboose_pos(
     caller: usize,
     response: USlice<u8>,
 ) -> Result<NextTask, UserError> {
-    // TODO YOLO?
-    let header = unsafe { crate::header::HEADER.assume_init_ref() };
+    // SAFETY: populated by the linker + build system
+    let header = unsafe { &crate::header::HEADER };
 
     // The end-of-image position is given as an image length, so we need to
     // apply it as an offset to the start-of-image.

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -226,7 +226,7 @@ fn read_caboose_pos(
     // The end-of-image position is given as an image length, so we need to
     // apply it as an offset to the start-of-image.
     extern "C" {
-        static __start_vector: u32;
+        static __start_vector: [u32; 0];
     }
     // SAFETY: populated by the linker script
     let image_start = unsafe { &__start_vector } as *const u32 as u32;

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -81,6 +81,5 @@ pub fn read_header() -> abi::ImageHeader {
         &[],
     );
     assert_eq!(rc, 0);
-    assert_eq!(len, 8); // we *really* expect this to be 2x u32
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -72,7 +72,7 @@ pub fn read_image_id() -> u64 {
 }
 
 pub fn read_caboose_pos() -> core::ops::Range<u32> {
-    let mut response = [0; core::mem::size_of::<u32>()];
+    let mut response = [0; core::mem::size_of::<core::ops::Range<u32>>()];
     let (rc, len) = sys_send(
         TaskId::KERNEL,
         Kipcnum::ReadCaboosePos as u16,

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -71,7 +71,7 @@ pub fn read_image_id() -> u64 {
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
 
-pub fn read_caboose_pos() -> u32 {
+pub fn read_caboose_pos() -> core::ops::Range<u32> {
     let mut response = [0; core::mem::size_of::<u32>()];
     let (rc, len) = sys_send(
         TaskId::KERNEL,
@@ -81,6 +81,6 @@ pub fn read_caboose_pos() -> u32 {
         &[],
     );
     assert_eq!(rc, 0);
-    assert_eq!(len, 4); // we *really* expect this to be a u32
+    assert_eq!(len, 8); // we *really* expect this to be a (u32, u32)
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -71,15 +71,16 @@ pub fn read_image_id() -> u64 {
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
 
-pub fn read_header() -> abi::ImageHeader {
-    let mut response = [0; core::mem::size_of::<u64>()];
+pub fn read_caboose_pos() -> u32 {
+    let mut response = [0; core::mem::size_of::<u32>()];
     let (rc, len) = sys_send(
         TaskId::KERNEL,
-        Kipcnum::ReadHeader as u16,
+        Kipcnum::ReadCaboosePos as u16,
         &[],
         &mut response,
         &[],
     );
     assert_eq!(rc, 0);
+    assert_eq!(len, 4); // we *really* expect this to be a u32
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -70,3 +70,17 @@ pub fn read_image_id() -> u64 {
     assert_eq!(len, 8); // we *really* expect this to be a u64
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
+
+pub fn read_header() -> abi::ImageHeader {
+    let mut response = [0; core::mem::size_of::<u64>()];
+    let (rc, len) = sys_send(
+        TaskId::KERNEL,
+        Kipcnum::ReadHeader as u16,
+        &[],
+        &mut response,
+        &[],
+    );
+    assert_eq!(rc, 0);
+    assert_eq!(len, 8); // we *really* expect this to be 2x u32
+    ssmarshal::deserialize(&response[..len]).unwrap_lite().0
+}

--- a/task/caboose-reader-api/Cargo.toml
+++ b/task/caboose-reader-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "task-caboose-reader-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+idol-runtime.workspace = true
+num-traits.workspace = true
+
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
+
+[build-dependencies]
+idol.workspace = true

--- a/task/caboose-reader-api/build.rs
+++ b/task/caboose-reader-api/build.rs
@@ -3,10 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    idol::server::build_server_support(
+    idol::client::build_client_stub(
         "../../idl/caboose.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
+        "client_stub.rs",
     )?;
     Ok(())
 }

--- a/task/caboose-reader-api/src/lib.rs
+++ b/task/caboose-reader-api/src/lib.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API crate for the caboose reader task
+
+#![no_std]
+use derive_idol_err::IdolError;
+use userlib::FromPrimitive;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
+pub enum CabooseError {
+    MissingCaboose = 1,
+    TlvcReaderBeginFailed = 2,
+    TlvcReadExactFailed = 3,
+    NoSuchTag = 4,
+}

--- a/task/caboose-reader/Cargo.toml
+++ b/task/caboose-reader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "task-caboose-reader"
+description = "tiny task to read from the caboose with Idol APIs"
+version = "0.1.0"
+authors = ["Matt Keeter <matt@oxide.computer>"]
+edition = "2021"
+
+[dependencies]
+cfg-if.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+tlvc.workspace = true
+zerocopy.workspace = true
+
+derive-idol-err.path = "../../lib/derive-idol-err"
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+idol = { workspace = true }

--- a/task/caboose-reader/Cargo.toml
+++ b/task/caboose-reader/Cargo.toml
@@ -12,7 +12,7 @@ num-traits.workspace = true
 tlvc.workspace = true
 zerocopy.workspace = true
 
-derive-idol-err.path = "../../lib/derive-idol-err"
+task-caboose-reader-api.path = "../caboose-reader-api"
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]

--- a/task/caboose-reader/build.rs
+++ b/task/caboose-reader/build.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use std::io::Write;
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    idol::server::build_server_support(
+        "../../idl/caboose.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+    Ok(())
+}

--- a/task/caboose-reader/src/main.rs
+++ b/task/caboose-reader/src/main.rs
@@ -5,15 +5,18 @@
 #![no_std]
 #![no_main]
 
-use derive_idol_err::IdolError;
-use idol_runtime::{ClientError, Leased, RequestError, R, W};
+use idol_runtime::{ClientError, Leased, RequestError, W};
+use task_caboose_reader_api::CabooseError;
 use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
 use userlib::*;
 
 #[export_name = "main"]
 fn main() -> ! {
     let mut buffer = [0; idl::INCOMING_SIZE];
-    let mut server = ServerImpl;
+
+    let pos = kipc::read_caboose_pos();
+
+    let mut server = ServerImpl { pos };
 
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
@@ -22,21 +25,89 @@ fn main() -> ! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO: move this to a caboose-api crate
-#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
-pub enum CabooseError {
-    MissingCaboose = 1,
+/// Simple handle which points to the beginning of the TLV-C region of the
+/// caboose and allows us to implement `TlvcRead`
+#[derive(Copy, Clone)]
+struct CabooseReader {
+    base: u32,
+    size: u32,
 }
 
-struct ServerImpl;
+impl TlvcRead for CabooseReader {
+    fn extent(&self) -> Result<u64, TlvcReadError> {
+        Ok(self.size as u64)
+    }
+    fn read_exact(
+        &self,
+        offset: u64,
+        dest: &mut [u8],
+    ) -> Result<(), TlvcReadError> {
+        let addr: u32 = self.base + u32::try_from(offset).unwrap_lite();
+        for (i, out) in dest.iter_mut().enumerate() {
+            *out = unsafe { *((addr as usize + i) as *const u8) };
+        }
+        Ok(())
+    }
+}
+
+struct ServerImpl {
+    pos: core::ops::Range<u32>,
+}
 
 impl idl::InOrderCabooseImpl for ServerImpl {
     fn caboose_addr(
         &mut self,
         _: &RecvMessage,
     ) -> Result<u32, RequestError<CabooseError>> {
-        let p = kipc::read_caboose_pos();
-        Ok(p)
+        if self.pos.is_empty() {
+            Err(CabooseError::MissingCaboose.into())
+        } else {
+            Ok(self.pos.start)
+        }
+    }
+
+    fn get_key_by_tag(
+        &mut self,
+        _: &userlib::RecvMessage,
+        name: [u8; 4],
+        data: Leased<W, [u8]>,
+    ) -> Result<u32, RequestError<CabooseError>> {
+        if self.pos.is_empty() {
+            return Err(CabooseError::MissingCaboose.into());
+        }
+        let reader = CabooseReader {
+            base: self.pos.start,
+            size: self.pos.len() as u32,
+        };
+
+        let mut reader = TlvcReader::begin(reader)
+            .map_err(|_| CabooseError::TlvcReaderBeginFailed)?;
+        while let Ok(Some(chunk)) = reader.next() {
+            if chunk.header().tag == name {
+                // TODO: verify checksum
+                // TODO: make this not one byte at a time
+                let mut buf = [0u8];
+                for i in 0..chunk.len() {
+                    chunk
+                        .read_exact(i, &mut buf)
+                        .map_err(|_| CabooseError::TlvcReadExactFailed)?;
+                    data.write_at(i as usize, buf[0]).map_err(|_| {
+                        RequestError::Fail(ClientError::BadLease)
+                    })?;
+                }
+                return Ok(chunk.len() as u32);
+            }
+        }
+        return Err(CabooseError::NoSuchTag.into());
+    }
+
+    fn get_key_by_u32(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        tag: u32,
+        data: Leased<W, [u8]>,
+    ) -> Result<u32, RequestError<CabooseError>> {
+        self.get_key_by_tag(msg, tag.to_le_bytes(), data)
     }
 }
 

--- a/task/caboose-reader/src/main.rs
+++ b/task/caboose-reader/src/main.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use derive_idol_err::IdolError;
+use idol_runtime::{ClientError, Leased, RequestError, R, W};
+use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
+use userlib::*;
+
+#[export_name = "main"]
+fn main() -> ! {
+    let mut buffer = [0; idl::INCOMING_SIZE];
+    let mut server = ServerImpl;
+
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// TODO: move this to a caboose-api crate
+#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError)]
+pub enum CabooseError {
+    MissingCaboose = 1,
+}
+
+struct ServerImpl;
+
+impl idl::InOrderCabooseImpl for ServerImpl {
+    fn caboose_addr(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<CabooseError>> {
+        let p = kipc::read_caboose_pos();
+        Ok(p)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+mod idl {
+    use super::CabooseError;
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}


### PR DESCRIPTION
Closes #1157, which has discussion of this design.

This PR does several things!

Primarily, it adds an optional `caboose` to Hubris images.  The caboose is located at the end of flash and contains (1) two words indicating that it's a caboose and (2) extra space for user data.

It is documented in a newly added section of the [Hubris manual](https://github.com/oxidecomputer/hubris/blob/caboose/doc/guide/caboose.adoc).

This also accomplishes _some_ of the goals of #1004 , namely having a "commit point" at the end of flashing.  For the moment, this implementation still requires having an `ImageHeader` after the vector table.  The caboose is after everything else in flash, but is not at the last page; this means that we need a way to find it, which is specified in the `ImageHeader`.

(We could work around this by using [NXP-style overloading spare vector table entries](https://github.com/oxidecomputer/hubris/issues/1157#issuecomment-1440878674), but this ends up feeling hacky on the STM32 and tightly couples us to a Cortex-M-flavored MCU)

--------------------------------------------------------------------------------

In addition, this PR moves common Hubris archive functionality to a new [`hubtools` repository](https://github.com/oxidecomputer/hubtools).  This is because both Hubris `xtask` and `permission-slip` want to do certain manipulations of Hubris archives – most notably, going from `srec` to all the other binary formats.

`hubtools` contains this common functionality, as well as a minimal CLI to edit the caboose.

--------------------------------------------------------------------------------

Finally, the PR adds a new `caboose-reader` task, which is a minimal task to read from the caboose.  It's mostly useful for development and debugging.