### PR TITLE
Add support for 0XV2 barcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "oxide-barcode"
+version = "0.1.0"
+dependencies = [
+ "host-sp-messages",
+ "static_assertions",
+ "zerocopy",
+]
+
+[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,9 +3947,9 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "oxide-barcode",
  "serde",
  "ssmarshal",
- "static_assertions",
  "userlib",
  "zerocopy",
 ]

--- a/drv/local-vpd/src/lib.rs
+++ b/drv/local-vpd/src/lib.rs
@@ -21,7 +21,7 @@ use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
 use userlib::*;
 use zerocopy::{AsBytes, FromBytes};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LocalVpdError {
     DeviceError,
     NoSuchChunk,

--- a/lib/oxide-barcode/Cargo.toml
+++ b/lib/oxide-barcode/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "oxide-barcode"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+static_assertions.workspace = true
+zerocopy.workspace = true
+
+host-sp-messages.path = "../host-sp-messages"

--- a/lib/oxide-barcode/src/lib.rs
+++ b/lib/oxide-barcode/src/lib.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Parsing VPD barcode strings.
+
+#![cfg_attr(not(test), no_std)]
+
+use static_assertions::const_assert;
+use zerocopy::{AsBytes, FromBytes};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseError {
+    MissingVersion,
+    MissingPartNumber,
+    MissingRevision,
+    MissingSerial,
+    UnexpectedFields,
+    UnknownVersion,
+    WrongPartNumberLength,
+    WrongSerialLength,
+    BadRevision,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, FromBytes, AsBytes)]
+#[repr(C, packed)]
+pub struct VpdIdentity {
+    pub part_number: [u8; Self::PART_NUMBER_LEN],
+    pub revision: u32,
+    pub serial: [u8; Self::SERIAL_LEN],
+}
+
+impl VpdIdentity {
+    pub const PART_NUMBER_LEN: usize = 11;
+    pub const SERIAL_LEN: usize = 11;
+}
+
+impl From<VpdIdentity> for host_sp_messages::Identity {
+    fn from(id: VpdIdentity) -> Self {
+        // The Host/SP protocol has larger fields for model/serial than we
+        // use currently; statically assert that we haven't outgrown them.
+        const_assert!(
+            VpdIdentity::PART_NUMBER_LEN
+                <= host_sp_messages::Identity::MODEL_LEN
+        );
+        const_assert!(
+            VpdIdentity::SERIAL_LEN <= host_sp_messages::Identity::SERIAL_LEN
+        );
+
+        let mut new_id = Self::default();
+        new_id.model[..id.part_number.len()].copy_from_slice(&id.part_number);
+        new_id.revision = id.revision;
+        new_id.serial[..id.serial.len()].copy_from_slice(&id.serial);
+        new_id
+    }
+}
+
+impl VpdIdentity {
+    pub fn parse(barcode: &[u8]) -> Result<Self, ParseError> {
+        let mut fields = barcode.split(|&b| b == b':');
+
+        let version = fields.next().ok_or(ParseError::MissingVersion)?;
+        let part_number = fields.next().ok_or(ParseError::MissingPartNumber)?;
+        let revision = fields.next().ok_or(ParseError::MissingRevision)?;
+        let serial = fields.next().ok_or(ParseError::MissingSerial)?;
+        if fields.next().is_some() {
+            return Err(ParseError::UnexpectedFields);
+        }
+
+        let mut out = VpdIdentity::new_zeroed();
+
+        match version {
+            // V1 does not include the hyphen in the part number; we need to
+            // insert it.
+            b"OXV1" | b"0XV1" => {
+                if part_number.len() != out.part_number.len() - 1 {
+                    return Err(ParseError::WrongPartNumberLength);
+                }
+                out.part_number[..3].copy_from_slice(&part_number[..3]);
+                out.part_number[3] = b'-';
+                out.part_number[4..].copy_from_slice(&part_number[3..]);
+            }
+            // V2 part number includes the hyphen; copy it as-is.
+            b"OXV2" | b"0XV2" => {
+                if part_number.len() != out.part_number.len() {
+                    return Err(ParseError::WrongPartNumberLength);
+                }
+                out.part_number.copy_from_slice(part_number);
+            }
+            _ => return Err(ParseError::UnknownVersion),
+        }
+
+        out.revision = core::str::from_utf8(revision)
+            .ok()
+            .and_then(|rev| rev.parse().ok())
+            .ok_or(ParseError::BadRevision)?;
+
+        if serial.len() != out.serial.len() {
+            return Err(ParseError::WrongSerialLength);
+        }
+
+        out.serial.copy_from_slice(serial);
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_oxv1() {
+        let expected = VpdIdentity {
+            part_number: *b"123-0000456",
+            revision: 23,
+            serial: *b"TST01234567",
+        };
+
+        assert_eq!(
+            expected,
+            VpdIdentity::parse(b"0XV1:1230000456:023:TST01234567").unwrap()
+        );
+        assert_eq!(
+            expected,
+            VpdIdentity::parse(b"OXV1:1230000456:023:TST01234567").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_oxv2() {
+        let expected = VpdIdentity {
+            part_number: *b"123-0000456",
+            revision: 23,
+            serial: *b"TST01234567",
+        };
+
+        assert_eq!(
+            expected,
+            VpdIdentity::parse(b"0XV2:123-0000456:023:TST01234567").unwrap()
+        );
+        assert_eq!(
+            expected,
+            VpdIdentity::parse(b"OXV2:123-0000456:023:TST01234567").unwrap()
+        );
+    }
+}

--- a/task/control-plane-agent-api/Cargo.toml
+++ b/task/control-plane-agent-api/Cargo.toml
@@ -8,12 +8,12 @@ idol-runtime.workspace = true
 num-traits.workspace = true
 serde.workspace = true
 ssmarshal.workspace = true
-static_assertions.workspace = true
 zerocopy.workspace = true
 
-derive-idol-err = {path = "../../lib/derive-idol-err" }
-host-sp-messages = {path = "../../lib/host-sp-messages"}
-userlib = {path = "../../sys/userlib"}
+derive-idol-err.path = "../../lib/derive-idol-err"
+host-sp-messages.path = "../../lib/host-sp-messages"
+oxide-barcode.path = "../../lib/oxide-barcode"
+userlib.path = "../../sys/userlib"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use userlib::*;
 
 pub use host_sp_messages::HostStartupOptions;
+pub use oxide_barcode::ParseError as BarcodeParseError;
 pub use oxide_barcode::VpdIdentity;
 
 /// Maximum length (in bytes) allowed for installinator image ID blobs.

--- a/task/control-plane-agent-api/src/lib.rs
+++ b/task/control-plane-agent-api/src/lib.rs
@@ -7,11 +7,11 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
-pub use host_sp_messages::HostStartupOptions;
 use serde::{Deserialize, Serialize};
-use static_assertions::const_assert;
 use userlib::*;
-use zerocopy::{AsBytes, FromBytes};
+
+pub use host_sp_messages::HostStartupOptions;
+pub use oxide_barcode::VpdIdentity;
 
 /// Maximum length (in bytes) allowed for installinator image ID blobs.
 pub const MAX_INSTALLINATOR_IMAGE_ID_LEN: usize = 512;
@@ -31,39 +31,6 @@ pub enum ControlPlaneAgentError {
 pub enum UartClient {
     Mgs,
     Humility,
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, FromBytes, AsBytes)]
-#[repr(C, packed)]
-pub struct VpdIdentity {
-    pub part_number: [u8; Self::PART_NUMBER_LEN],
-    pub revision: u32,
-    pub serial: [u8; Self::SERIAL_LEN],
-}
-
-impl VpdIdentity {
-    pub const PART_NUMBER_LEN: usize = 11;
-    pub const SERIAL_LEN: usize = 11;
-}
-
-impl From<VpdIdentity> for host_sp_messages::Identity {
-    fn from(id: VpdIdentity) -> Self {
-        // The Host/SP protocol has larger fields for model/serial than we
-        // use currently; statically assert that we haven't outgrown them.
-        const_assert!(
-            VpdIdentity::PART_NUMBER_LEN
-                <= host_sp_messages::Identity::MODEL_LEN
-        );
-        const_assert!(
-            VpdIdentity::SERIAL_LEN <= host_sp_messages::Identity::SERIAL_LEN
-        );
-
-        let mut new_id = Self::default();
-        new_id.model[..id.part_number.len()].copy_from_slice(&id.part_number);
-        new_id.revision = id.revision;
-        new_id.serial[..id.serial.len()].copy_from_slice(&id.serial);
-        new_id
-    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -5,6 +5,7 @@
 #![no_std]
 #![no_main]
 
+use drv_local_vpd::LocalVpdError;
 use gateway_messages::{
     sp_impl, IgnitionCommand, MgsError, PowerState, SpComponent, SpPort,
     UpdateId,
@@ -17,7 +18,7 @@ use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
 use task_control_plane_agent_api::MAX_INSTALLINATOR_IMAGE_ID_LEN;
 use task_control_plane_agent_api::{
-    ControlPlaneAgentError, UartClient, VpdIdentity,
+    BarcodeParseError, ControlPlaneAgentError, UartClient, VpdIdentity,
 };
 use task_net_api::{
     Address, LargePayloadBehavior, Net, RecvError, SendError, SocketName,
@@ -48,6 +49,8 @@ task_slot!(SYS, sys);
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Log {
     Empty,
+    VpdReadError(LocalVpdError),
+    BarcodeParseError(BarcodeParseError),
     Rx(UdpMetadata),
     SendError(SendError),
     MgsMessage(MgsMessage),

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 
-use drv_local_vpd::LocalVpdError;
 use gateway_messages::{
     sp_impl, IgnitionCommand, MgsError, PowerState, SpComponent, SpPort,
     UpdateId,
@@ -49,18 +48,30 @@ task_slot!(SYS, sys);
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Log {
     Empty,
-    VpdReadError(LocalVpdError),
     BarcodeParseError(BarcodeParseError),
     Rx(UdpMetadata),
     SendError(SendError),
     MgsMessage(MgsMessage),
-    UsartTxFull { remaining: usize },
+    UsartTxFull {
+        remaining: usize,
+    },
     UsartRxOverrun,
-    UsartRxBufferDataDropped { num_bytes: u64 },
-    SerialConsoleSend { buffered: usize },
-    UpdatePartial { bytes_written: u32 },
+    UsartRxBufferDataDropped {
+        num_bytes: u64,
+    },
+    SerialConsoleSend {
+        buffered: usize,
+    },
+    UpdatePartial {
+        bytes_written: u32,
+    },
     UpdateComplete,
-    HostFlashSectorsErased { num_sectors: usize },
+    HostFlashSectorsErased {
+        num_sectors: usize,
+    },
+
+    #[cfg(feature = "vpd-identity")]
+    VpdReadError(drv_local_vpd::LocalVpdError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -169,62 +169,31 @@ impl From<RotImageDetailsConvert> for RotImageDetails {
 fn identity() -> VpdIdentity {
     #[cfg(feature = "vpd-identity")]
     fn identity_from_vpd() -> Option<VpdIdentity> {
-        use core::{mem, str};
-        use zerocopy::{AsBytes, FromBytes};
-
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, AsBytes, FromBytes)]
-        #[repr(C, packed)]
-        pub struct BarcodeVpd {
-            pub version: [u8; 4],
-            pub delim0: u8,
-            // VPD omits the hyphen 3 bytes into the part number, which we add
-            // back into `VpdIdentity` below, hence the "minus 1".
-            pub part_number: [u8; VpdIdentity::PART_NUMBER_LEN - 1],
-            pub delim1: u8,
-            pub revision: [u8; 3],
-            pub delim2: u8,
-            pub serial: [u8; VpdIdentity::SERIAL_LEN],
-        }
-        static_assertions::const_assert_eq!(mem::size_of::<BarcodeVpd>(), 31);
+        // 0XV1 barcodes are 31 bytes and 0XV2 barcodes are 32 bytes; those are
+        // the only two version we know how to parse today, so we're safe with a
+        // 32-byte output buffer.
+        let mut barcode = [0; 32];
 
         let i2c_task = I2C.get_task_id();
-        let barcode: BarcodeVpd =
-            drv_local_vpd::read_config(i2c_task, *b"BARC").ok()?;
+        let barcode = match drv_local_vpd::read_config_into(
+            i2c_task,
+            *b"BARC",
+            &mut barcode,
+        ) {
+            Ok(n) => &barcode[..n],
+            Err(err) => {
+                ringbuf_entry!(Log::VpdReadError(err));
+                return None;
+            }
+        };
 
-        // Check expected values of fields, since `barcode` was created
-        // via zerocopy (i.e., memcopying a byte array).
-        if barcode.delim0 != b':'
-            || barcode.delim1 != b':'
-            || barcode.delim2 != b':'
-        {
-            return None;
+        match VpdIdentity::parse(barcode) {
+            Ok(identity) => Some(identity),
+            Err(err) => {
+                ringbuf_entry!(Log::BarcodeParseError(err));
+                None
+            }
         }
-
-        // Allow `0` or `O` for the first byte of the version (which isn't
-        // part of the identity we return, but tells us the format of the
-        // barcode string itself).
-        if barcode.version != *b"0XV1" && barcode.version != *b"OXV1" {
-            return None;
-        }
-
-        let mut identity = VpdIdentity::default();
-
-        // Parse revision into a u32
-        identity.revision =
-            str::from_utf8(&barcode.revision).ok()?.parse().ok()?;
-
-        // Insert a hyphen 3 characters into the part number (which we know we
-        // have room for based on the size of the `part_number` fields)
-        identity.part_number[..3].copy_from_slice(&barcode.part_number[..3]);
-        identity.part_number[3] = b'-';
-        identity.part_number[4..][..barcode.part_number.len() - 3]
-            .copy_from_slice(&barcode.part_number[3..]);
-
-        // Copy the serial as-is.
-        identity.serial[..barcode.serial.len()]
-            .copy_from_slice(&barcode.serial);
-
-        Some(identity)
     }
 
     #[cfg(feature = "vpd-identity")]


### PR DESCRIPTION
The actual changes to support 0XV2 barcodes (which have the hyphen in the part number) are minimal, so most of the changes in this PR are organizational:

* Adds `local_vpd::read_config_into()` so we can read into an array without knowing the exact size ahead of time
* Adds `oxide-barcode` lib (primarily for easy unit testing)
* Moves `VpdIdentity` from `control-plane-agent-api` to `oxide-barcode`

Fixes #1183 