### PR TITLE
Bump idol to guard against the recv+Hubpack bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/idolatry.git#c71e6b15fad23b7132aa3c581a76682b2d279676"
+source = "git+https://github.com/oxidecomputer/idolatry.git#61d63774ab43c5f704bc955a06951ad47dee5fdb"
 dependencies = [
  "indexmap",
  "quote",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#c71e6b15fad23b7132aa3c581a76682b2d279676"
+source = "git+https://github.com/oxidecomputer/idolatry.git#61d63774ab43c5f704bc955a06951ad47dee5fdb"
 dependencies = [
  "userlib",
  "zerocopy",

--- a/idl/sensor.idol
+++ b/idl/sensor.idol
@@ -20,7 +20,6 @@ Interface(
             args: {
                 "id": (
                     type: "SensorId",
-                    recv: From("u32", None),
                 )
             },
             reply: Result(


### PR DESCRIPTION
Only one checked-in service appears to have been affected by this bug, which would cause a method that specified both Hubpack/Ssmarshal and a recv strategy that didn't _happen_ to bitwise-match how the argument was going to be serialized to become uncallable.