### PR TITLE
Add default caboose

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -9,6 +9,12 @@ stacksize = 896
 name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -9,6 +9,12 @@ stacksize = 896
 name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -15,6 +15,7 @@ requires = {flash = 32768, ram = 8192}
 tasks = ["control_plane_agent", "caboose_reader"]
 region = "flash"
 size = 256
+default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -9,6 +9,12 @@ stacksize = 896
 name = "psc"
 requires = {flash = 32768, ram = 4800}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -9,6 +9,12 @@ stacksize = 896
 name = "psc"
 requires = {flash = 32768, ram = 4800}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/app/sidecar/rev-a.toml
+++ b/app/sidecar/rev-a.toml
@@ -9,6 +9,12 @@ memory = "memory-large.toml"
 name = "sidecar"
 requires = {flash = 22776, ram = 6256}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -9,6 +9,12 @@ memory = "memory-large.toml"
 name = "sidecar"
 requires = {flash = 22776, ram = 6256}
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+default = true
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -121,6 +121,10 @@ pub struct CabooseConfig {
     /// The system reserves two words (8 bytes) for the size and marker, so the
     /// user-accessible space is 8 bytes less than this value.
     pub size: u32,
+
+    /// If `true`, populates the caboose with default values using `hubtools`
+    #[serde(default)]
+    pub default: bool,
 }
 
 impl Config {

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -481,7 +481,16 @@ pub fn package(
             }
         }
         write_gdb_script(&cfg, image_name)?;
-        build_archive(&cfg, image_name)?;
+        let archive_name = build_archive(&cfg, image_name)?;
+
+        if let Some(caboose) = &cfg.toml.caboose {
+            if caboose.default {
+                let mut archive =
+                    hubtools::RawHubrisArchive::load(&archive_name)?;
+                archive.write_default_caboose("0.0.0-git")?;
+                archive.overwrite()?;
+            }
+        }
     }
     Ok(allocated)
 }
@@ -626,11 +635,11 @@ fn write_gdb_script(cfg: &PackageConfig, image_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<()> {
+fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<PathBuf> {
     // Bundle everything up into an archive.
-    let mut archive = Archive::new(
-        cfg.img_file(format!("build-{}.zip", cfg.toml.name), image_name),
-    )?;
+    let archive_path =
+        cfg.img_file(format!("build-{}.zip", cfg.toml.name), image_name);
+    let mut archive = Archive::new(&archive_path)?;
 
     archive.text(
         "README.TXT",
@@ -738,7 +747,7 @@ fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<()> {
     }
 
     archive.finish()?;
-    Ok(())
+    Ok(archive_path)
 }
 
 fn check_task_names(toml: &Config, task_names: &[String]) -> Result<()> {

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -487,7 +487,7 @@ pub fn package(
             if caboose.default {
                 let mut archive =
                     hubtools::RawHubrisArchive::load(&archive_name)?;
-                archive.write_default_caboose("0.0.0-git")?;
+                archive.write_default_caboose(Some(&"0.0.0-git".to_owned()))?;
                 archive.overwrite()?;
             }
         }

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -487,6 +487,8 @@ pub fn package(
             if caboose.default {
                 let mut archive =
                     hubtools::RawHubrisArchive::load(&archive_name)?;
+                // The Git hash is included in the default caboose under the key
+                // `GITC`, so we don't include it in the pseudo-version.
                 archive.write_default_caboose(Some(&"0.0.0-git".to_owned()))?;
                 archive.overwrite()?;
             }

--- a/doc/guide/caboose.adoc
+++ b/doc/guide/caboose.adoc
@@ -68,10 +68,23 @@ presence and size can be determined as follows:
 
 Note that this procedure works both at runtime and from a binary file, with or
 without an associated Hubris archive.  In a live system, this logic is
-implemented by the <<_read_caboose_pos_6,`read_caboose_pos`>> kernel IPC call.
+implemented by the <<_read_caboose_pos_6,`read_caboose_pos`>> kernel IPC call,
+which is wrapped by `get_caboose` to yield an `Option<&'static [u8]>`.
 
 Other than reserving the two words above, the Hubris build system is
 _deliberately agnostic_ to the contents of the caboose; it is left to a separate
 release engineering process to decide what to store there.  The
 https://github.com/oxidecomputer/hubtools[`hubtools` repository] includes a
 library and CLI for modifying the caboose of a Hubris archive.
+
+However, for convenience, it's possible to enable a default caboose:
+```toml
+[caboose]
+region = "flash"
+size = 128
+tasks = ["caboose_reader"]
+default = true
+```
+
+If the `default` parameter is `true`, then Hubris will itself use `hubtools` to
+populate the caboose with default values.


### PR DESCRIPTION
If `default = true` in the `[caboose]` section of TOML, populates a default caboose with `VERS = "0.0.0-git"`.