### PR TITLE
Sign images with hubtools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,30 +555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,16 +562,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -693,28 +653,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
-
-[[package]]
-name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
-dependencies = [
- "const-oid",
  "zeroize",
 ]
 
@@ -772,7 +716,7 @@ dependencies = [
  "chrono",
  "dice-mfg-msgs",
  "hkdf",
- "hmac 0.12.1",
+ "hmac",
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
@@ -2007,30 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
-name = "ecdsa"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
-dependencies = [
- "der 0.4.4",
- "elliptic-curve 0.10.4",
- "hmac 0.11.0",
- "signature 1.3.2",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
-dependencies = [
- "der 0.7.1",
- "elliptic-curve 0.13.2",
- "rfc6979",
- "signature 2.0.0",
-]
-
-[[package]]
 name = "ed25519"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,40 +1964,6 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
-dependencies = [
- "crypto-bigint 0.2.5",
- "ff 0.10.1",
- "generic-array",
- "group 0.10.0",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
-dependencies = [
- "base16ct",
- "crypto-bigint 0.5.1",
- "digest 0.10.6",
- "ff 0.13.0",
- "generic-array",
- "group 0.13.0",
- "pkcs8 0.10.1",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embedded-crc-macros"
@@ -2154,26 +2040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,7 +2109,6 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2309,28 +2174,6 @@ dependencies = [
  "log",
  "plain",
  "scroll",
-]
-
-[[package]]
-name = "group"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
-dependencies = [
- "ff 0.10.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff 0.13.0",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -2414,17 +2257,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -2764,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#23d0c6591bc652cbca2c439aca19968b5f514474"
+source = "git+https://github.com/oxidecomputer/lpc55_support#4624aa2c04e3ce0e7c99ab9b97b2045fce108a6f"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2793,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#23d0c6591bc652cbca2c439aca19968b5f514474"
+source = "git+https://github.com/oxidecomputer/lpc55_support#4624aa2c04e3ce0e7c99ab9b97b2045fce108a6f"
 dependencies = [
  "byteorder",
  "clap 4.1.8",
@@ -2803,7 +2636,6 @@ dependencies = [
  "hex",
  "log",
  "lpc55_areas",
- "p256 0.13.0",
  "packed_struct",
  "rsa",
  "serde",
@@ -3078,29 +2910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
-dependencies = [
- "ecdsa 0.12.4",
- "elliptic-curve 0.10.4",
- "sha2 0.9.8",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
-dependencies = [
- "ecdsa 0.16.1",
- "elliptic-curve 0.13.2",
- "primeorder",
- "sha2 0.10.6",
-]
-
-[[package]]
 name = "packed_struct"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3188,9 +2997,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
  "zeroize",
 ]
 
@@ -3200,18 +3009,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
-dependencies = [
- "der 0.7.1",
- "spki 0.7.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3282,15 +3081,6 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
-
-[[package]]
-name = "primeorder"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
-dependencies = [
- "elliptic-curve 0.13.2",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -3436,16 +3226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,7 +3304,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.9.0",
+ "pkcs8",
  "rand_core",
  "sha2 0.10.6",
  "signature 2.0.0",
@@ -3628,19 +3408,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
-dependencies = [
- "base16ct",
- "der 0.7.1",
- "generic-array",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3818,10 +3585,6 @@ name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
-dependencies = [
- "digest 0.9.0",
- "rand_core",
-]
 
 [[package]]
 name = "signature"
@@ -3889,16 +3652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
-dependencies = [
- "der 0.7.1",
+ "der",
 ]
 
 [[package]]
@@ -3955,14 +3709,12 @@ dependencies = [
  "cortex-m-rt",
  "dice",
  "digest 0.10.6",
- "ecdsa 0.12.4",
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
  "lpc55-puf",
  "lpc55_romapi",
  "nb 1.0.0",
- "p256 0.9.0",
  "panic-halt",
  "panic-semihosting",
  "salty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#2a1a2cd5d8b6c2c2aa32819b58e0176a8814e7c8"
+source = "git+https://github.com/oxidecomputer/hubtools#3aa711b26fc179c130986bf41c13445a984e8adb"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#b05eb24e4d424b43089004e6ab625c49b2295013"
+source = "git+https://github.com/oxidecomputer/lpc55_support#23d0c6591bc652cbca2c439aca19968b5f514474"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#b05eb24e4d424b43089004e6ab625c49b2295013"
+source = "git+https://github.com/oxidecomputer/lpc55_support#23d0c6591bc652cbca2c439aca19968b5f514474"
 dependencies = [
  "byteorder",
  "clap 4.1.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,8 +2763,8 @@ dependencies = [
 
 [[package]]
 name = "lpc55_areas"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#10f10ecfc844fb2ca3eba9e23a71e2aa553ebe94"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#b05eb24e4d424b43089004e6ab625c49b2295013"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2792,8 +2792,8 @@ dependencies = [
 
 [[package]]
 name = "lpc55_sign"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#10f10ecfc844fb2ca3eba9e23a71e2aa553ebe94"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#b05eb24e4d424b43089004e6ab625c49b2295013"
 dependencies = [
  "byteorder",
  "clap 4.1.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#fad977c6aa20802e65e4c740deee380ee86f6b27"
+source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#2a1a2cd5d8b6c2c2aa32819b58e0176a8814e7c8"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#f29ce568a46c9866d652d471289e26663491a2ee"
+source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#fad977c6aa20802e65e4c740deee380ee86f6b27"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#f668c474c8d37523ca889f40497240e9722054f9"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#10f10ecfc844fb2ca3eba9e23a71e2aa553ebe94"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2793,14 +2793,12 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#f668c474c8d37523ca889f40497240e9722054f9"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#10f10ecfc844fb2ca3eba9e23a71e2aa553ebe94"
 dependencies = [
  "byteorder",
  "clap 4.1.8",
  "colored",
  "crc-any",
- "ecdsa 0.16.1",
- "elliptic-curve 0.13.2",
  "env_logger",
  "hex",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,15 +156,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
@@ -348,26 +339,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
+ "clap_derive",
+ "clap_lex",
  "indexmap",
  "once_cell",
  "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
-dependencies = [
- "bitflags",
- "clap_derive 4.1.8",
- "clap_lex 0.3.2",
- "is-terminal",
- "once_cell",
- "strsim",
- "termcolor",
 ]
 
 [[package]]
@@ -384,32 +360,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -746,20 +700,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -957,7 +902,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_json",
- "sha2 0.9.8",
+ "sha2",
  "static_assertions",
  "task-jefe-api",
  "userlib",
@@ -2266,7 +2211,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -2597,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#4624aa2c04e3ce0e7c99ab9b97b2045fce108a6f"
+source = "git+https://github.com/oxidecomputer/lpc55_support#2940a0f7fbae7b7cfb48ad6d3206ee754f9237d6"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2626,10 +2571,9 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#4624aa2c04e3ce0e7c99ab9b97b2045fce108a6f"
+source = "git+https://github.com/oxidecomputer/lpc55_support#2940a0f7fbae7b7cfb48ad6d3206ee754f9237d6"
 dependencies = [
  "byteorder",
- "clap 4.1.8",
  "colored",
  "crc-any",
  "env_logger",
@@ -2639,7 +2583,7 @@ dependencies = [
  "packed_struct",
  "rsa",
  "serde",
- "sha2 0.9.8",
+ "sha2",
  "thiserror",
  "x509-parser",
 ]
@@ -2878,12 +2822,6 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ordered-toml"
@@ -3298,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "digest 0.10.6",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
@@ -3306,7 +3244,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
- "sha2 0.10.6",
+ "sha2",
  "signature 2.0.0",
  "subtle",
  "zeroize",
@@ -3535,26 +3473,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -3563,7 +3488,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
 dependencies = [
- "digest 0.10.6",
+ "digest",
  "keccak",
 ]
 
@@ -3592,7 +3517,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
- "digest 0.10.6",
+ "digest",
  "rand_core",
 ]
 
@@ -3708,7 +3633,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "dice",
- "digest 0.10.6",
+ "digest",
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
@@ -5166,7 +5091,7 @@ dependencies = [
  "build-kconfig",
  "byteorder",
  "cargo_metadata",
- "clap 3.2.23",
+ "clap",
  "colored",
  "ctrlc",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +120,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bit_field"
@@ -253,9 +259,15 @@ dependencies = [
  "ordered-toml",
  "serde",
  "serde_json",
- "toml 0.7.2",
+ "toml",
  "toml-task",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -341,15 +353,27 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
+ "once_cell",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.1.8",
+ "clap_lex 0.3.2",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
@@ -357,6 +381,19 @@ name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -375,6 +412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,15 +433,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
-
-[[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "convert_case"
@@ -483,9 +523,6 @@ name = "crc-any"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "073375684a58dece169afbdc9879a027f3698118ad3814938316c6002b7aa921"
-dependencies = [
- "debug-helper",
-]
 
 [[package]]
 name = "crc-catalog"
@@ -537,12 +574,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
 dependencies = [
  "generic-array",
+ "rand_core",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -617,12 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
-name = "debug-helper"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fbd10dce159c002b9c688ae8ab7cd531151e185e0ad360f4bfea3b0eede3a8"
-
-[[package]]
 name = "demo-stm32f4-discovery"
 version = "0.1.0"
 dependencies = [
@@ -663,19 +696,26 @@ name = "der"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.6.2",
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
 dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint 0.3.2",
- "pem-rfc7468",
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -771,11 +811,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.2",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -972,7 +1013,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.8",
  "static_assertions",
  "task-jefe-api",
  "userlib",
@@ -1972,9 +2013,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der 0.4.4",
- "elliptic-curve",
+ "elliptic-curve 0.10.4",
  "hmac 0.11.0",
- "signature",
+ "signature 1.3.2",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
+dependencies = [
+ "der 0.7.1",
+ "elliptic-curve 0.13.2",
+ "rfc6979",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1983,7 +2036,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -1999,11 +2052,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
  "crypto-bigint 0.2.5",
- "ff",
+ "ff 0.10.1",
  "generic-array",
- "group",
- "pkcs8 0.7.6",
+ "group 0.10.0",
  "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.5.1",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.1",
+ "rand_core",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -2051,10 +2122,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "is-terminal",
+ "log",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -2124,12 +2237,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2203,7 +2317,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
- "ff",
+ "ff 0.10.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -2262,6 +2387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,7 +2433,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2354,14 +2485,17 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools#d117b3ff2eec9f494eaa66e0a389e219ac38f4bb"
+source = "git+https://github.com/oxidecomputer/hubtools?branch=lpc55-tools#f29ce568a46c9866d652d471289e26663491a2ee"
 dependencies = [
+ "lpc55_areas",
+ "lpc55_sign",
  "object",
+ "packed_struct",
  "path-slash",
  "thiserror",
  "tlvc",
  "tlvc-text",
- "toml 0.7.2",
+ "toml",
  "zerocopy",
  "zip",
 ]
@@ -2404,7 +2538,7 @@ dependencies = [
  "quote",
  "ron",
  "serde",
- "toml 0.7.2",
+ "toml",
 ]
 
 [[package]]
@@ -2434,6 +2568,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2603,15 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -2512,15 +2677,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -2593,17 +2764,10 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#0f4333183310f20f32cd28c688d393a996a1bf73"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#f668c474c8d37523ca889f40497240e9722054f9"
 dependencies = [
- "anyhow",
  "bitfield 0.14.0",
- "byteorder",
- "hex",
- "num-derive",
- "num-traits",
  "packed_struct",
- "packed_struct_codegen",
- "parse_int",
  "serde",
 ]
 
@@ -2629,23 +2793,24 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#0f4333183310f20f32cd28c688d393a996a1bf73"
+source = "git+https://github.com/oxidecomputer/lpc55_support?branch=library-ify#f668c474c8d37523ca889f40497240e9722054f9"
 dependencies = [
- "anyhow",
  "byteorder",
- "clap",
+ "clap 4.1.8",
+ "colored",
  "crc-any",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.1",
+ "elliptic-curve 0.13.2",
+ "env_logger",
  "hex",
+ "log",
  "lpc55_areas",
- "p256",
+ "p256 0.13.0",
  "packed_struct",
- "packed_struct_codegen",
  "rsa",
  "serde",
- "sha2",
- "toml 0.5.8",
+ "sha2 0.9.8",
+ "thiserror",
  "x509-parser",
 ]
 
@@ -2780,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -2920,9 +3085,21 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2",
+ "ecdsa 0.12.4",
+ "elliptic-curve 0.10.4",
+ "sha2 0.9.8",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
+dependencies = [
+ "ecdsa 0.16.1",
+ "elliptic-curve 0.13.2",
+ "primeorder",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -2964,15 +3141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse_int"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db48cac18f0963b10ddad303fa88447b95bbe0e6dbe3385f98402b63d0cc48"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,9 +3154,9 @@ checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
@@ -3018,34 +3186,34 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
  "zeroize",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.4.4",
- "spki 0.4.1",
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
 dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der 0.7.1",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -3118,6 +3286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
+name = "primeorder"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
+dependencies = [
+ "elliptic-curve 0.13.2",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,11 +3326,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3212,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -3259,6 +3436,31 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "ringbuf"
@@ -3313,20 +3515,21 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "digest 0.10.3",
+ "digest 0.10.6",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.8.0",
+ "pkcs8 0.9.0",
  "rand_core",
- "smallvec",
+ "sha2 0.10.6",
+ "signature 2.0.0",
  "subtle",
  "zeroize",
 ]
@@ -3356,6 +3559,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c52377bb2288aa522a0c8208947fada1e0c76397f108cc08f57efe6077b50d"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3413,6 +3630,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct",
+ "der 0.7.1",
+ "generic-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3552,12 +3782,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -3585,10 +3826,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.7.0"
+name = "signature"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smbus-pec"
@@ -3635,21 +3886,21 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
- "der 0.4.4",
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
- "base64ct",
- "der 0.5.1",
+ "der 0.7.1",
 ]
 
 [[package]]
@@ -3705,15 +3956,15 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "dice",
- "digest 0.10.3",
- "ecdsa",
+ "digest 0.10.6",
+ "ecdsa 0.12.4",
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
  "lpc55-puf",
  "lpc55_romapi",
  "nb 1.0.0",
- "p256",
+ "p256 0.9.0",
  "panic-halt",
  "panic-semihosting",
  "salty",
@@ -3721,7 +3972,7 @@ dependencies = [
  "sha3",
  "stage0-handoff",
  "static_assertions",
- "toml 0.7.2",
+ "toml",
  "unwrap-lite",
  "zerocopy",
  "zeroize",
@@ -3879,7 +4130,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.7.2",
+ "toml",
 ]
 
 [[package]]
@@ -4754,15 +5005,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
@@ -4828,10 +5070,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "unwrap-lite"
@@ -4956,6 +5210,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +5303,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
@@ -5017,6 +5401,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror",
 ]
@@ -5031,7 +5416,7 @@ dependencies = [
  "build-kconfig",
  "byteorder",
  "cargo_metadata",
- "clap",
+ "clap 3.2.23",
  "colored",
  "ctrlc",
  "dunce",
@@ -5056,7 +5441,7 @@ dependencies = [
  "strsim",
  "tlvc",
  "tlvc-text",
- "toml 0.7.2",
+ "toml",
  "toml-task",
  "walkdir",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ ctrlc = { version = "3.1.5", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["from", "into"] }
 digest = { version = "0.10", default-features = false }
 dunce = { version = "1.0.2", default-features = false }
-ecdsa = { version = "0.12.4", default-features = false, features = ["der"] }
 embedded-hal = { version = "0.2", default-features = false }
 enum-map = { version = "2.4.1", default-features = false }
 filetime = { version = "0.2.12", default-features = false }
@@ -78,7 +77,6 @@ nb = { version = "1", default-features = false }
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.3.3", default-features = false, features = ["full-syntax"] }
 num-traits = { version = "0.2.12", default-features = false }
-p256 = { version = "0.9.0", default-features = false, features = ["ecdsa", "ecdsa-core"] }
 panic-halt = { version = "0.2.0", default-features = false }
 panic-itm = { version = "0.4.1", default-features = false }
 panic-semihosting = { version = "0.5.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ byteorder = { version = "1.3.4", default-features = false }
 cargo_metadata = { version = "0.12.0", default-features = false }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false }
-clap = { version = "3.0.14", default-features = false, features = ["derive"] }
+clap = { version = "3.0.14", default-features = false, features = ["std", "derive"] }
 colored = { version = "2.0", default-features = false }
 convert_case = { version = "0.4", default-features = false }
 corncobs = { version = "0.1.1", default-features = false }
@@ -122,11 +122,11 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
-hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, branch = "lpc55-tools" }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.4", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_repr = { version = "0.1", default-features = false }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 smbus-pec = { version = "1.0.1", default-features = false }
 smoltcp = { version = "0.8.0", default-features = false, features = ["proto-ipv6", "medium-ethernet", "socket-udp", "async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,11 +122,11 @@ dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-fe
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
-hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, branch = "lpc55-tools" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", default-features = false }

--- a/app/gimlet-rot/stage0-b-lab.toml
+++ b/app/gimlet-rot/stage0-b-lab.toml
@@ -26,6 +26,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/gimlet-rot/stage0-b-lab.toml
+++ b/app/gimlet-rot/stage0-b-lab.toml
@@ -27,6 +27,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-b.toml
+++ b/app/gimlet-rot/stage0-b.toml
@@ -26,6 +26,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/gimlet-rot/stage0-b.toml
+++ b/app/gimlet-rot/stage0-b.toml
@@ -27,6 +27,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-c-lab.toml
+++ b/app/gimlet-rot/stage0-c-lab.toml
@@ -26,6 +26,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-c-lab.toml
+++ b/app/gimlet-rot/stage0-c-lab.toml
@@ -18,6 +18,7 @@ priority = 0
 max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true
+boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing]
 enable-secure-boot = true

--- a/app/gimlet-rot/stage0-c-lab.toml
+++ b/app/gimlet-rot/stage0-c-lab.toml
@@ -18,7 +18,6 @@ priority = 0
 max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true
-boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing]
 enable-secure-boot = true
@@ -26,6 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/gimlet-rot/stage0-c.toml
+++ b/app/gimlet-rot/stage0-c.toml
@@ -26,6 +26,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/gimlet-rot/stage0-c.toml
+++ b/app/gimlet-rot/stage0-c.toml
@@ -25,6 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/lpc55xpresso/stage0.toml
+++ b/app/lpc55xpresso/stage0.toml
@@ -26,6 +26,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/lpc55xpresso/stage0.toml
+++ b/app/lpc55xpresso/stage0.toml
@@ -25,6 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 0 }
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/lpc55xpresso/stage0.toml
+++ b/app/lpc55xpresso/stage0.toml
@@ -25,7 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 0 }
+boot-error-gpio = { port = 1, pin = 1 } # BOOT0_LED
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/rot-carrier/stage0-secure.toml
+++ b/app/rot-carrier/stage0-secure.toml
@@ -26,6 +26,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/rot-carrier/stage0-secure.toml
+++ b/app/rot-carrier/stage0-secure.toml
@@ -25,6 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 0 }
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/rot-carrier/stage0-secure.toml
+++ b/app/rot-carrier/stage0-secure.toml
@@ -25,7 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 0 }
+boot-error-gpio = { port = 0, pin = 15 } # SCT0_OUT2, red LED on carrier
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/rot-carrier/stage0.toml
+++ b/app/rot-carrier/stage0.toml
@@ -26,6 +26,7 @@ dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
 
-[[signing.certs]]
-cert-paths = ["../../support/fake_certs/fake_certificate.der.crt"  ]
-priv-key = "../../support/fake_certs/fake_private_key.pem"
+[signing.certs]
+signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
+private-key = "../../support/fake_certs/fake_private_key.pem"

--- a/app/rot-carrier/stage0.toml
+++ b/app/rot-carrier/stage0.toml
@@ -25,6 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
+boot-error-gpio = { port = 0, pin = 0 }
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/rot-carrier/stage0.toml
+++ b/app/rot-carrier/stage0.toml
@@ -25,7 +25,7 @@ enable-dice = true
 dice-inc-nxp-cfg = false
 dice-cust-cfg = false
 dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 0 }
+boot-error-gpio = { port = 0, pin = 15 } # SCT0_OUT2, red LED on carrier
 
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -583,6 +583,14 @@ pub struct RoTMfgSettings {
     pub rotk3: ROTKeyStatus,
     #[serde(default = "DefaultIsp::auto")]
     pub default_isp: DefaultIsp,
+    pub boot_error_gpio: RoTBootErrorPin,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoTBootErrorPin {
+    pub port: u8,
+    pub pin: u8,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -12,10 +12,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::auxflash::{build_auxflash, AuxFlash, AuxFlashData};
-use lpc55_areas::{
-    BootSpeed, CFPAPage, CMPAPage, DebugSettings, DefaultIsp, RKTHRevoke,
-    ROTKeyStatus, SecureBootCfg,
-};
+use lpc55_areas::{DebugSettings, DefaultIsp, ROTKeyStatus};
 
 /// A `PatchedConfig` allows a minimal form of inheritance between TOML files
 /// Specifically, it allows you to **add features** to specific tasks; nothing
@@ -565,38 +562,13 @@ impl MpuAlignment {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SigningMethod {
-    Crc,
-    Rsa,
-    Ecc,
-}
-
-impl std::fmt::Display for SigningMethod {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Crc => "crc",
-            Self::Rsa => "rsa",
-            Self::Ecc => "ecc",
-        };
-        write!(f, "{}", s)
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RoTMfgSettings {
-    pub certs: Vec<lpc55_sign::signed_image::CertChain>,
+    pub certs: lpc55_sign::signed_image::CertConfig,
     #[serde(default)]
     pub enable_secure_boot: bool,
-    #[serde(default)]
-    pub enable_dice: bool,
-    #[serde(default)]
-    pub dice_inc_nxp_cfg: bool,
-    #[serde(default)]
-    pub dice_cust_cfg: bool,
-    #[serde(default)]
-    pub dice_inc_sec_epoch: bool,
+    #[serde(default, flatten)]
+    pub dice: lpc55_sign::signed_image::DiceArgs,
     #[serde(default)]
     pub cmpa_settings: DebugSettings,
     #[serde(default)]
@@ -611,52 +583,6 @@ pub struct RoTMfgSettings {
     pub rotk3: ROTKeyStatus,
     #[serde(default = "DefaultIsp::auto")]
     pub default_isp: DefaultIsp,
-}
-
-impl RoTMfgSettings {
-    pub fn generate_cmpa(&self, rkth: &[u8; 32]) -> Result<CMPAPage> {
-        let mut cmpa = CMPAPage::new();
-        let mut sec_boot = SecureBootCfg::new();
-
-        if self.enable_dice && !self.enable_secure_boot {
-            bail!("Must set secure boot to use DICE");
-        }
-
-        sec_boot.set_sec_boot(self.enable_secure_boot);
-        sec_boot.set_dice(self.enable_dice);
-        sec_boot.set_dice_inc_nxp_cfg(self.dice_inc_nxp_cfg);
-        sec_boot.set_dice_inc_cust_cfg(self.dice_cust_cfg);
-        sec_boot.set_dice_inc_sec_epoch(self.dice_inc_sec_epoch);
-
-        cmpa.set_secure_boot_cfg(sec_boot)?;
-
-        cmpa.set_rotkh(rkth);
-        cmpa.set_boot_cfg(self.default_isp, BootSpeed::Fro96mhz)?;
-
-        cmpa.set_debug_fields(self.cmpa_settings)?;
-
-        Ok(cmpa)
-    }
-
-    pub fn generate_cfpa(&self) -> Result<CFPAPage> {
-        let mut cfpa: CFPAPage = Default::default();
-
-        // We always need to bump the version
-        cfpa.update_version();
-
-        let mut rkth = RKTHRevoke::new();
-
-        rkth.rotk0 = self.rotk0.into();
-        rkth.rotk1 = self.rotk1.into();
-        rkth.rotk2 = self.rotk2.into();
-        rkth.rotk3 = self.rotk3.into();
-
-        cfpa.update_rkth_revoke(rkth)?;
-
-        cfpa.set_debug_fields(self.cfpa_settings)?;
-
-        Ok(cfpa)
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -749,6 +675,7 @@ impl BuildConfig<'_> {
             "backtrace",
             "error_generic_member_access",
             "proc_macro_span",
+            "proc_macro_span_shrink",
             "provide_any",
         ]);
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -477,12 +477,21 @@ pub fn package(
                 &private_key,
                 0, // execution address (TODO)
             )?;
+
+            let boot_pin = lpc55_areas::BootErrorPin::new(
+                signing.boot_error_gpio.port,
+                signing.boot_error_gpio.pin,
+            )
+            .ok_or_else(|| {
+                anyhow!("invalid boot error pin {:?}", signing.boot_error_gpio)
+            })?;
             archive.set_cmpa(
                 signing.dice.clone(),
                 signing.enable_secure_boot,
                 signing.cmpa_settings,
                 signing.default_isp,
                 lpc55_areas::BootSpeed::Fro96mhz,
+                boot_pin,
                 root_certs,
             )?;
             archive.set_cfpa(

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -684,12 +684,9 @@ fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<PathBuf> {
 
     let img_dir = PathBuf::from("img");
 
-    for f in ["combined", "final"] {
-        for ext in ["elf", "bin"] {
-            let name = format!("{}.{}", f, ext);
-            archive
-                .copy(cfg.img_file(&name, image_name), img_dir.join(&name))?;
-        }
+    for ext in ["elf", "bin"] {
+        let name = format!("final.{}", ext);
+        archive.copy(cfg.img_file(&name, image_name), img_dir.join(&name))?;
     }
 
     //

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -13,11 +13,9 @@ cfg-if = { workspace = true }
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 digest = { workspace = true, optional = false}
-ecdsa = { workspace = true }
 hubpack = { workspace = true, optional = false}
 lpc55-pac = { workspace = true, features = ["rt"] }
 nb = { workspace = true }
-p256 = { workspace = true }
 panic-halt = { workspace = true }
 panic-semihosting = { workspace = true }
 salty = { workspace = true, optional = true }


### PR DESCRIPTION
This PR removes the Hubris-specific signing code in favor of calling into `hubtools`, which knows how to sign Hubris archives.

Depends on https://github.com/oxidecomputer/hubtools/pull/3/files and should be merged after it