### PR TITLE
Stop sending serial console packets to MGS if it has stopped talking to us

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=serial-console-keepalive#280b4cfbff2b5b270d92b05bf93a09b3240d6d8d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#84869ae87ddccc45b4500652fd1bc22841ae1dd3"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#a5d729f1236f61206977bf0f9479323ebbe52989"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=serial-console-keepalive#280b4cfbff2b5b270d92b05bf93a09b3240d6d8d"
 dependencies = [
  "bitflags",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "serial-console-keepalive" } # TODO revert to main
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "serial-console-keepalive" } # TODO revert to main
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -74,6 +74,10 @@ enum Log {
     VpdReadError(drv_local_vpd::LocalVpdError),
 }
 
+// This enum does not define the actual MGS protocol - it is only used in the
+// `Log` enum above (which itself is only used by our ringbuf logs). The MGS
+// protocol is defined in the `gateway-messages` crate (which is shared with
+// MGS proper and other tools like `sp-sim` in the omicron repository).
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum MgsMessage {
     Discovery,

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -104,6 +104,7 @@ enum MgsMessage {
         offset: u64,
         length: u16,
     },
+    SerialConsoleKeepAlive,
     SerialConsoleDetach,
     UpdatePrepare {
         component: SpComponent,

--- a/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
@@ -167,7 +167,7 @@ impl HostPhase2Requester {
 
         let message = Message {
             header: Header {
-                version: gateway_messages::version::V2,
+                version: gateway_messages::version::CURRENT,
                 message_id,
             },
             kind: MessageKind::SpRequest(SpRequest::HostPhase2Data {

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -368,6 +368,15 @@ impl SpHandler for MgsHandler {
         Err(SpError::RequestUnsupportedForSp)
     }
 
+    fn serial_console_keepalive(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleKeepAlive));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
     fn serial_console_detach(
         &mut self,
         _sender: SocketAddrV6,

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -425,6 +425,15 @@ impl SpHandler for MgsHandler {
         Err(SpError::RequestUnsupportedForSp)
     }
 
+    fn serial_console_keepalive(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+    ) -> Result<(), SpError> {
+        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleKeepAlive));
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
     fn serial_console_detach(
         &mut self,
         _sender: SocketAddrV6,


### PR DESCRIPTION
The Gimlet SP handler now keeps track of the last serial-console-related packet (attach, write, break, or the new keepalive) it receives from an attached MGS; when it wants to send a serial console packet, we now first check to see if it's been long enough since we heard from MGS that we think the connection is stale. If it is, we effectively "detach" - if MGS comes back, it will get an error and have to reattach.

TODO:
- [x] fix Cargo.toml/Cargo.lock after merging https://github.com/oxidecomputer/management-gateway-service/pull/69