### PR TITLE
Update reset with intent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "sprockets-common",
  "sprockets-rot",
  "static_assertions",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]
@@ -1851,10 +1852,12 @@ version = "0.1.0"
 dependencies = [
  "derive-idol-err",
  "drv-caboose",
+ "gateway-messages",
  "hubpack",
  "idol",
  "idol-runtime",
  "num-traits",
+ "ringbuf",
  "serde",
  "serde_repr",
  "stage0-handoff",
@@ -2054,7 +2057,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#2dcc63c645005a7184ba754b5c42c341a0777c66"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=reset-component"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -2569,6 +2572,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "stage0-handoff",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]
@@ -3773,6 +3777,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "stm32h7",
+ "task-jefe-api",
  "userlib",
  "zerocopy",
 ]
@@ -3966,6 +3971,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "static-cell",
+ "unwrap-lite",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "reset-component" } # TODO revert to main
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,8 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "reset-component" } # TODO revert to main
+# Revert gateway-messages to main when management-gateway-service PR lands
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "reset-component" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -19,7 +19,7 @@ notifications = ["fault", "timer"]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy"]
+request_reset = ["hiffy", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -156,6 +156,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [config]
 [[config.i2c.controllers]]

--- a/app/gimlet-rot/app-b.toml
+++ b/app/gimlet-rot/app-b.toml
@@ -21,6 +21,9 @@ features = ["itm"]
 stacksize = 1536
 notifications = ["fault", "timer"]
 
+[tasks.jefe.config.allowed-callers]
+request_reset = ["hiffy", "update_server"]
+
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 6
@@ -45,6 +48,7 @@ stacksize = 2048
 start = true
 uses = ["rom", "secure_syscon", "syscon", "flash"]
 sections = {bootstate = "sram3"}
+task-slots = ["jefe"]
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"

--- a/app/gimlet-rot/app-c.toml
+++ b/app/gimlet-rot/app-c.toml
@@ -22,6 +22,9 @@ features = ["itm"]
 stacksize = 1536
 notifications = ["fault", "timer"]
 
+[tasks.jefe.config.allowed-callers]
+request_reset = ["hiffy", "update_server"]
+
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 6
@@ -52,6 +55,7 @@ stacksize = 2048
 start = true
 uses = ["rom", "secure_syscon", "syscon", "flash"]
 sections = {bootstate = "sram3"}
+task-slots = ["jefe"]
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -32,7 +32,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.net]
 name = "task-net"
@@ -186,6 +186,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.sensor]
 name = "task-sensor"

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -32,7 +32,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.net]
 name = "task-net"
@@ -186,6 +186,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.sensor]
 name = "task-sensor"

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -32,7 +32,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.net]
 name = "task-net"
@@ -186,6 +186,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.sensor]
 name = "task-sensor"

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -26,7 +26,7 @@ host_sp_comms = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -225,15 +225,16 @@ stacksize = 4096
 start = true
 uses = ["usart1"]
 task-slots = [
+    "gimlet_seq",
+    "hf",
     "jefe",
     "net",
-    "update_server",
-    "sys",
-    "hf",
-    "gimlet_seq",
-    "validate",
+    "packrat",
     "sensor",
     "sprot",
+    "sys",
+    "update_server",
+    "validate",
 ]
 features = ["gimlet", "usart1-gimletlet", "vlan", "baud_rate_3M"]
 notifications = ["usart-irq", "socket", "timer"]
@@ -302,6 +303,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
+task-slots = ["jefe"]
 
 [config]
 [[config.i2c.controllers]]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -32,7 +32,7 @@ host_sp_comms = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -288,6 +288,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
+task-slots = ["jefe"]
 
 [config]
 [[config.i2c.controllers]]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -20,6 +20,9 @@ features = ["itm"]
 stacksize = 1536
 notifications = ["fault", "timer"]
 
+[tasks.jefe.config.allowed-callers]
+request_reset = ["hiffy", "update_server"]
+
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 5
@@ -49,6 +52,7 @@ max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
 uses-secure-entry = true
+task-slots = ["jefe"]
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -29,7 +29,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -83,6 +83,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -29,7 +29,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -81,6 +81,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -29,7 +29,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -81,6 +81,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
+task-slots = ["jefe"]
 
 [tasks.hiffy]
 name = "task-hiffy"
@@ -444,4 +445,3 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
-

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -21,6 +21,9 @@ features = ["itm"]
 stacksize = 1536
 notifications = ["fault", "timer"]
 
+[tasks.jefe.config.allowed-callers]
+request_reset = ["hiffy", "update_server"]
+
 [tasks.idle]
 name = "task-idle"
 priority = 9
@@ -36,6 +39,7 @@ stacksize = 2048
 start = true
 uses = ["rom", "secure_syscon", "syscon", "flash"]
 sections = {bootstate = "sram3"}
+task-slots = ["jefe"]
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
@@ -160,7 +164,7 @@ name = "task-ping"
 features = ["uart"]
 priority = 8
 max-sizes = {flash = 8192, ram = 2048}
-start = true
+start = false
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -26,7 +26,7 @@ notifications = ["fault", "timer"]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -47,6 +47,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
+task-slots = ["jefe"]
 
 [tasks.auxflash]
 name = "drv-auxflash-server"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -26,7 +26,7 @@ notifications = ["fault", "timer"]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "update_server"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -47,6 +47,7 @@ uses = ["flash_controller"]
 extern-regions = ["bank2"]
 notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
+task-slots = ["jefe"]
 
 [tasks.auxflash]
 name = "drv-auxflash-server"

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -21,6 +21,7 @@ drv-lpc55-spi = { path = "../lpc55-spi" }
 drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
 drv-sprot-api = { path = "../sprot-api" }
 drv-update-api = { path = "../update-api" }
+task-jefe-api = { path="../../task/jefe-api" }
 dumper-api = { path = "../../task/dumper-api" }
 lpc55_romapi = { path = "../../lib/lpc55-romapi" }
 ringbuf = { path = "../../lib/ringbuf" }

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -189,8 +189,6 @@ impl Handler {
                             .reset_component(intent, target)
                             .map(|_| None)
                             .map_err(|e| e.into());
-                        // TODO: Some sort of error if we didn't reset.
-
                         tx_buf.serialize(MsgType::UpdResetComponentRsp, rsp)
                     }
                     Err(e) => Err((tx_buf, e.into())),

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -181,17 +181,12 @@ impl Handler {
                 match hubpack::deserialize::<drv_sprot_api::ResetComponentHeader>(
                     rx_payload,
                 ) {
-                    Ok((header, auth_data)) => {
+                    Ok((header, _trailing_data)) => {
                         let intent = header.intent;
                         let target = header.target;
                         let rsp: UpdateRspHeader = self
                             .update
-                            .reset_component(
-                                intent,
-                                target,
-                                auth_data.len() as u16,
-                                &auth_data[..],
-                            )
+                            .reset_component(intent, target)
                             .map(|_| None)
                             .map_err(|e| e.into());
                         // TODO: Some sort of error if we didn't reset.
@@ -231,7 +226,7 @@ impl Handler {
             }
 
             // All of the unexpected messages
-            MsgType::Invalid
+            MsgType::_Invalid
             | MsgType::EchoRsp
             | MsgType::ErrorRsp
             | MsgType::SinkRsp

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -113,7 +113,7 @@ impl Handler {
                 UpdateStatus::Sp => Err((tx_buf, SprotError::UpdateBadStatus)),
             },
             MsgType::IoStatsReq => {
-                tx_buf.serialize(MsgType::IoStatsRsp, *stats)
+                tx_buf.serialize(MsgType::IoStatsRsp, stats.clone())
             }
             MsgType::SprocketsReq => {
                 let tx_payload = tx_buf.payload_mut();
@@ -237,8 +237,7 @@ impl Handler {
             | MsgType::UpdFinishImageUpdateRsp
             | MsgType::UpdResetComponentRsp
             | MsgType::IoStatsRsp
-            | MsgType::DumpRsp
-            | MsgType::Unknown => {
+            | MsgType::DumpRsp => {
                 stats.rx_invalid = stats.rx_invalid.wrapping_add(1);
                 return Some(tx_buf.error_rsp(SprotError::BadMessageType));
             }

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -25,11 +25,12 @@
 //! is deasserted.
 //!
 //! ROT_IRQ is intended to be an edge triggered interrupt on the SP.
-//! TODO: ROT_IRQ is currently sampled by the SP.
+//!
+//! ROT_IRQ is currently sampled by the SP.
 //! ROT_IRQ is de-asserted only after CSn is deasserted.
 //!
-//! TODO: SP RESET needs to be monitored, otherwise, any
-//! forced looping here could be a denial of service attack against
+//! SP RESET is not currently monitored.
+//! Any forced looping here could be a denial of service attack against
 //! observation of SP resetting. SP resetting without invalidating
 //! security related state means a compromised SP could operate using
 //! the trust gained in the previous session.
@@ -78,7 +79,7 @@ fn configure_spi() -> Io {
     let gpio_driver = GPIO.get_task_id();
     setup_pins(gpio_driver).unwrap_lite();
     let gpio = drv_lpc55_gpio_api::Pins::from(gpio_driver);
-    // TODO: It should never happen but, initialization should be able to deal
+    // It should never happen but, initialization should be able to deal
     // with CSn being asserted at init time.
 
     // Configure ROT_IRQ
@@ -293,7 +294,7 @@ impl Io {
                 // potentially throttle sends in the future.
                 self.spi.rxerr_clear();
                 self.stats.rx_overrun = self.stats.rx_overrun.wrapping_add(1);
-                // TODO: If we were just sending our response, and SP was
+                // If we were just sending our response, and SP was
                 // just sending zeros and we received the first byte
                 // correctly and that first byte was zero, then
                 // our Rx overrun is inconsequential and does not

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -11,6 +11,7 @@ hypocalls.path = "../../lib/hypocalls"
 ringbuf.path = "../../lib/ringbuf"
 stage0-handoff.path = "../../lib/stage0-handoff"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+task-jefe-api = { path = "../../task/jefe-api" }
 
 cfg-if = { workspace = true }
 hubpack = { workspace = true }

--- a/drv/sprot-api/README.md
+++ b/drv/sprot-api/README.md
@@ -257,7 +257,6 @@ Message types include:
     to test the RoT's ability to exchange messages without error.
     The `SinkRsp` is just a header, no payload.
     On error, an `ErrorRsp` message is sent.
-  - _Unknown_ - 0xff A reserved, internal representation for an unsupported message type.
 
 ### SP Timeouts
 

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -757,7 +757,7 @@ impl<'a> RxMsg<'a> {
     /// This should only be used after a successful non-consuming parse, or
     /// else the data will be meaningless.
     pub fn payload_error_byte(&self) -> u8 {
-        assert!(self.len >= MIN_MSG_SIZE + 1);
+        assert!(self.len > MIN_MSG_SIZE);
         self.buf[HEADER_SIZE]
     }
 
@@ -795,7 +795,7 @@ impl<'a> RxMsg<'a> {
         if self.len < HEADER_SIZE {
             return Err(SprotError::Incomplete);
         }
-        let (header, _) = hubpack::deserialize::<MsgHeader>(&self.buf[..])?;
+        let (header, _) = hubpack::deserialize::<MsgHeader>(self.buf)?;
         if header.payload_len as usize > PAYLOAD_SIZE_MAX {
             return Err(SprotError::BadMessageLength);
         }
@@ -814,7 +814,7 @@ impl<'a> RxMsg<'a> {
             return Err((self.header_bytes(), SprotError::Incomplete));
         }
 
-        let (header, _) = hubpack::deserialize::<MsgHeader>(&self.buf[..])
+        let (header, _) = hubpack::deserialize::<MsgHeader>(self.buf)
             .map_err(|e| (self.header_bytes(), e.into()))?;
         if header.payload_len as usize > PAYLOAD_SIZE_MAX {
             return Err((self.header_bytes(), SprotError::BadMessageLength));

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -137,9 +137,6 @@ pub enum SprotError {
 
     #[idol(server_death)]
     ServerRestarted,
-
-    /// Unknown Errors are mapped to 0xff
-    Unknown = 0xff,
 }
 
 impl From<SpiError> for SprotError {
@@ -179,17 +176,10 @@ impl From<UpdateError> for SprotError {
                 SprotError::UpdateInvalidHeaderBlock
             }
             UpdateError::ServerRestarted => SprotError::UpdateServerRestarted,
-            UpdateError::Unknown
-            | UpdateError::ImageBoardMismatch // TODO add new error codes here
+            UpdateError::ImageBoardMismatch // TODO add new error codes here
             | UpdateError::ImageBoardUnknown => SprotError::UpdateUnknown,
             UpdateError::NotImplemented => SprotError::NotImplemented,
         }
-    }
-}
-
-impl From<u8> for SprotError {
-    fn from(byte: u8) -> SprotError {
-        Self::from_u8(byte).unwrap_or(SprotError::Unknown)
     }
 }
 

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -91,7 +91,6 @@ pub enum SprotError {
     BadResponse,
     RotBusy,
 
-    /// Feature is not implemented
     NotImplemented,
     /// An error code reserved for the SP was used by the Rot
     NonRotError,
@@ -104,6 +103,11 @@ pub enum SprotError {
     Serialization,
     /// Sequence number mismatch in Sink test
     Sequence,
+
+    /// Transient boot image selection not implemented for component
+    TransientNotImplemented,
+    /// Persistent boot image selection not implemented for component
+    PersistentNotImplemented,
 
     //
     // Update Related Errors
@@ -142,6 +146,9 @@ pub enum SprotError {
 
     // Used if no explicit error code is available.
     Unknown,
+
+    // Rot sink test not configured
+    RotSinkTestNotConfigured,
 }
 
 impl From<SpiError> for SprotError {
@@ -183,7 +190,13 @@ impl From<UpdateError> for SprotError {
             UpdateError::ServerRestarted => SprotError::UpdateServerRestarted,
             UpdateError::ImageBoardMismatch
             | UpdateError::ImageBoardUnknown => SprotError::UpdateUnknown,
-            UpdateError::NotImplemented => SprotError::NotImplemented,
+            UpdateError::TransientNotImplemented => {
+                SprotError::TransientNotImplemented
+            }
+            UpdateError::PersistentNotImplemented => {
+                SprotError::PersistentNotImplemented
+            }
+            // Version skew means that one side may not know about new variants
             UpdateError::Unknown => SprotError::Unknown,
         }
     }
@@ -460,9 +473,6 @@ pub enum MsgType {
     // Reset
     UpdResetComponentReq = 24,
     UpdResetComponentRsp = 25,
-
-    // Reserved value.
-    Unknown = 0x25,
 }
 
 /// A builder/serializer for messages that wraps the transmit buffer

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -261,9 +261,7 @@ pub struct SprotStatus {
 /// Stats from the RoT side of sprot
 ///
 /// All of the counters will wrap around.
-#[derive(
-    Default, Copy, Clone, PartialEq, Serialize, Deserialize, SerializedSize,
-)]
+#[derive(Default, Clone, Serialize, Deserialize, SerializedSize)]
 pub struct RotIoStats {
     /// Number of messages received
     pub rx_received: u32,
@@ -325,9 +323,7 @@ pub struct SpIoStats {
 }
 
 /// Sprot related stats
-#[derive(
-    Default, Copy, Clone, PartialEq, Serialize, Deserialize, SerializedSize,
-)]
+#[derive(Default, Clone, Serialize, Deserialize, SerializedSize)]
 pub struct IoStats {
     pub rot: RotIoStats,
     pub sp: SpIoStats,

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -9,7 +9,7 @@ use core::convert::Into;
 use drv_spi_api::{CsState, SpiDevice, SpiServer};
 use drv_sprot_api::*;
 use drv_stm32xx_sys_api as sys_api;
-use drv_update_api::{ResetIntent, UpdateError, UpdateTarget, AUTH_MAX_SZ};
+use drv_update_api::{ResetIntent, UpdateError, UpdateTarget};
 use idol_runtime::{ClientError, Leased, RequestError, R, W};
 use ringbuf::*;
 use userlib::*;
@@ -74,17 +74,8 @@ enum Trace {
     Recoverable(SprotError),
     Header(MsgHeader),
     ErrWithHeader(SprotError, [u8; HEADER_SIZE]),
-    ResetComponent {
-        component: UpdateTarget,
-        slot: Option<u16>,
-        intent: ResetIntent,
-        auth_len: u16,
-    },
     Intent {
         intent: ResetIntent,
-    },
-    AuthLen {
-        auth_len: u16,
     },
     Upd {
         rsp: MsgType,
@@ -387,10 +378,13 @@ impl<S: SpiServer> Io<S> {
         retries: u16,
     ) -> Result<MsgHeader, SprotError> {
         let mut attempts_left = retries;
-        let mut errcode = SprotError::Unknown;
+        let mut errcode: Option<SprotError> = None;
         loop {
             if attempts_left == 0 {
-                ringbuf_entry!(Trace::FailedRetries { retries, errcode });
+                ringbuf_entry!(Trace::FailedRetries {
+                    retries,
+                    errcode: errcode.unwrap_or(SprotError::Unknown)
+                });
                 break;
             }
 
@@ -407,7 +401,7 @@ impl<S: SpiServer> Io<S> {
                 Err(err) => {
                     ringbuf_entry!(Trace::SprotError(err));
                     if is_recoverable_error(err) {
-                        errcode = err;
+                        errcode = Some(err);
                         hl::sleep_for(RETRY_TIMEOUT);
                         continue;
                     } else {
@@ -431,21 +425,24 @@ impl<S: SpiServer> Io<S> {
                                 ringbuf_entry!(Trace::ErrRespNoPayload);
                                 continue;
                             }
-                            errcode =
-                                SprotError::from(rxmsg.payload_error_byte());
-                            ringbuf_entry!(Trace::SprotError(errcode));
-                            if is_recoverable_error(errcode) {
-                                // TODO: There are rare cases where
-                                // the RoT dose not receive
-                                // a 0x01 as the first byte in a message.
-                                // See issue #929.
+                            let err =
+                                SprotError::from_u8(rxmsg.payload_error_byte())
+                                    .unwrap_or(SprotError::Unknown);
+                            errcode = Some(err);
+                            ringbuf_entry!(Trace::SprotError(err));
+                            if is_recoverable_error(err) {
+                                // There is no "RoT ready to receive" signal.
+                                // There could be relative timing issues between the SP and RoT
+                                // tasks that result in the RoT not being ready to
+                                // receive the first byte of a message from the SP.
+                                // The CRC on the message will catch the case.
                                 hl::sleep_for(RETRY_TIMEOUT);
-                                ringbuf_entry!(Trace::Recoverable(errcode));
+                                ringbuf_entry!(Trace::Recoverable(err));
                                 continue;
                             }
                             // Other errors from RoT are not recoverable with
                             // a retry.
-                            return Err(errcode);
+                            return Err(err);
                         }
                         // All of the non-error message types are ok here.
                         _ => return Ok(header),
@@ -453,10 +450,10 @@ impl<S: SpiServer> Io<S> {
                 }
             }
         }
-        Err(errcode)
+        Err(errcode.unwrap_lite())
     }
 
-    // TODO: Move README.md to RFD 317 and discuss:
+    // Move README.md to RFD 317 and discuss:
     //   - Unsolicited messages from RoT to SP.
     //   - Ignoring message from RoT to SP.
     //   - Should we send a message telling RoT that SP has booted?
@@ -465,7 +462,7 @@ impl<S: SpiServer> Io<S> {
     // But it would be ok to overlap our new request with receiving
     // of a previous response.
     //
-    // TODO: The RoT must be able to observe SP resets. During the
+    // The RoT must be able to observe SP resets. During the
     // normal start-up seqeunce, the RoT is controlling the SP's boot
     // up sequence. However, the SP can reset itself and individual
     // Hubris tasks may fail and be restarted.
@@ -474,7 +471,7 @@ impl<S: SpiServer> Io<S> {
     // response is still in the RoT's transmit FIFO, then we can also see
     // ROT_IRQ asserted when not expected.
     //
-    // TODO: configuration parameters for delays below
+    // Consider making configuration parameters for delays below
     fn handle_rot_irq(&mut self) -> Result<(), SprotError> {
         if self.is_rot_irq_asserted() {
             // See if the ROT_IRQ completes quickly.
@@ -723,9 +720,10 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
                                             SprotError::BadMessageLength,
                                         );
                                     }
-                                    break Err(SprotError::from(
+                                    break Err(SprotError::from_u8(
                                         verified_rxmsg.payload()[0],
-                                    ));
+                                    )
+                                    .unwrap_or(SprotError::Unknown));
                                 }
                                 _ => {
                                     // Other non-SinkRsp messages from the RoT
@@ -917,17 +915,11 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         _msg: &userlib::RecvMessage,
         intent: ResetIntent,
         target: UpdateTarget,
-        auth_len: u16,
-        auth: idol_runtime::LenLimit<
-            idol_runtime::Leased<idol_runtime::R, [u8]>,
-            AUTH_MAX_SZ,
-        >,
     ) -> Result<(), idol_runtime::RequestError<SprotError>> {
-        ringbuf_entry!(Trace::Intent { intent });
-        ringbuf_entry!(Trace::AuthLen { auth_len });
-        let txmsg = TxMsg::new(&mut self.tx_buf[..])
-            .reset_component(intent, target, auth_len, auth)?;
+        let txmsg =
+            TxMsg::new(&mut self.tx_buf[..]).reset_component(intent, target)?;
         let rxmsg = RxMsg::new(&mut self.rx_buf[..]);
+        // If successful, upd() will return RspTimeout
         let _ = self.io.upd(
             &txmsg,
             rxmsg,

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -753,7 +753,7 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         _count: u16,
         _size: u16,
     ) -> Result<SinkStatus, RequestError<SprotError>> {
-        Err(RequestError::Runtime(SprotError::NotImplemented))
+        Err(RequestError::Runtime(SprotError::RotSinkTestNotConfigured))
     }
 
     /// Retrieve status from the RoT.

--- a/drv/stm32h7-update-server/Cargo.toml
+++ b/drv/stm32h7-update-server/Cargo.toml
@@ -15,6 +15,7 @@ drv-caboose.path = "../../drv/caboose"
 drv-update-api.path = "../update-api/"
 ringbuf.path = "../../lib/ringbuf"
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+task-jefe-api = { path = "../../task/jefe-api" }
 
 [build-dependencies]
 idol = { workspace = true }

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -546,7 +546,12 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
                 jefe.request_reset();
                 panic!()
             }
-            _ => return Err(UpdateError::NotImplemented.into()),
+            ResetIntent::Transient => {
+                Err(UpdateError::TransientNotImplemented.into())
+            }
+            ResetIntent::Persistent => {
+                Err(UpdateError::PersistentNotImplemented.into())
+            }
         }
     }
 }

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -16,7 +16,6 @@ use drv_update_api::stm32h7::{
 };
 use drv_update_api::{
     ImageVersion, ResetIntent, UpdateError, UpdateStatus, UpdateTarget,
-    AUTH_MAX_SZ,
 };
 use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
 use ringbuf::*;
@@ -532,8 +531,6 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
         _: &RecvMessage,
         intent: ResetIntent,
         _target: UpdateTarget,
-        auth_len: u16,
-        _auth: LenLimit<Leased<R, [u8]>, AUTH_MAX_SZ>,
     ) -> Result<(), RequestError<UpdateError>> {
         match self.state {
             UpdateState::NoUpdate => (),
@@ -541,11 +538,6 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
                 return Err(UpdateError::UpdateInProgress.into())
             }
             UpdateState::Finished => (),
-        }
-
-        let auth_len = auth_len as usize;
-        if auth_len > 0 {
-            return Err(UpdateError::NotImplemented.into());
         }
 
         match intent {

--- a/drv/update-api/Cargo.toml
+++ b/drv/update-api/Cargo.toml
@@ -10,6 +10,8 @@ num-traits.workspace = true
 serde.workspace = true
 serde_repr.workspace = true
 zerocopy.workspace = true
+ringbuf = { path = "../../lib/ringbuf" }
+gateway-messages.workspace = true
 
 derive-idol-err.path = "../../lib/derive-idol-err"
 drv-caboose.path = "../../drv/caboose"

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -38,8 +38,6 @@ pub enum UpdateTarget {
     ImageA = 2,
     ImageB = 3,
     Bootloader = 4,
-    // For testing
-    DevNull = 0xff,
 }
 
 #[derive(
@@ -100,6 +98,10 @@ impl hubpack::SerializedSize for UpdateError {
 }
 
 /// Request component to reset and optionally modify boot image selection policy.
+/// Policies may be implemented that disallow some requests. For example,
+/// if it is known that stage0 will reject an image for being corrupted, unsigned,
+/// signed improperly, etc., a request to reset and change boot policy may be
+/// rejected.
 #[repr(u8)]
 #[derive(
     Eq,
@@ -114,13 +116,18 @@ impl hubpack::SerializedSize for UpdateError {
 )]
 pub enum ResetIntent {
     /// Just reset the component
-    Normal = 1,
-    /// The firmware image specified elsewhere in the message
-    /// should be set as the persistently preferred image.
+    Normal,
+    /// The firmware image specified in the reset_component message
+    /// will be set as the persistently preferred image.
     Persistent,
-    /// The firmware image specified elsewhere in the message
-    /// should be set as the preferred image for this reset only.
+    /// The firmware image specified in the reset_component message
+    /// will be set as the preferred image for this reset only.
     /// A transient preference overrides any persistent preference.
+    ///
+    /// Note that implementing a transient image selection for the
+    /// SP would be fairly involved but possible.
+    /// The RoT might have to effect the SP bank switch if a way cannot
+    /// be found to have the SP do it.
     Transient,
 }
 

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -95,8 +95,6 @@ pub enum UpdateError {
     ImageBoardUnknown = 24,
 
     NotImplemented = 25,
-
-    Unknown = 0xff, // XXX With Hubpack encoding, inserting a new code above this will change the deserializer's notion of Unknown.
 }
 
 impl hubpack::SerializedSize for UpdateError {

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -101,6 +101,7 @@ impl hubpack::SerializedSize for UpdateError {
     const MAX_SIZE: usize = core::mem::size_of::<UpdateError>();
 }
 
+/// Request component to reset and optionally modify boot image selection policy.
 #[repr(u8)]
 #[derive(
     Eq,
@@ -114,10 +115,15 @@ impl hubpack::SerializedSize for UpdateError {
     SerializedSize,
 )]
 pub enum ResetIntent {
+    /// Just reset the component
     Normal = 1,
+    /// The firmware image specified elsewhere in the message
+    /// should be set as the persistently preferred image.
     Persistent,
+    /// The firmware image specified elsewhere in the message
+    /// should be set as the preferred image for this reset only.
+    /// A transient preference overrides any persistent preference.
     Transient,
-    ExpensiveAndIrrevocableProdToDev = 86,
 }
 
 impl From<gateway_messages::ResetIntent> for crate::ResetIntent {

--- a/drv/update-api/src/lib.rs
+++ b/drv/update-api/src/lib.rs
@@ -88,9 +88,14 @@ pub enum UpdateError {
     ImageBoardMismatch,
     ImageBoardUnknown,
 
-    NotImplemented,
+    // Transient boot image selection with reset not implemented for component.
+    TransientNotImplemented,
+    // Persistent boot image selection with reset not implemented for component.
+    PersistentNotImplemented,
 
-    Unknown, // In cases of version skew during updates
+    // During update when there may be version skew, the RoT may produce an
+    // error that the SP doesn't know about.
+    Unknown,
 }
 
 impl hubpack::SerializedSize for UpdateError {
@@ -141,8 +146,12 @@ impl From<gateway_messages::ResetIntent> for crate::ResetIntent {
     }
 }
 
+/// This is a mapping from the control-plane/faux-mgs update parameters.
+/// As such, it expresses the product of all reset types and all firmware
+/// storage targets. Only a few of those products would apply to any component.
+/// The translation of what the control plane wants and what an
+/// embedded device should do should be handled at a higher layer.
 #[derive(Clone, Copy, SerializedSize, Serialize, Deserialize)]
-#[repr(C)]
 pub struct ResetComponentHeader {
     pub intent: ResetIntent,
     pub target: UpdateTarget,

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -132,19 +132,14 @@ Interface(
         "reset_component": (
             doc: "Just reset, or also update boot image select policy.",
             args: {
-                "intent": (
-                    type: "ResetIntent",
-                    recv: FromPrimitive("u8"),
-                ),
-                "target":  {
-                    type: "UpdateTarget",
-                    recv: FromPrimitive("u8"),
-                },
+                "intent": "ResetIntent",
+                "target": "UpdateTarget",
             },
             reply: Result (
                 ok: "()",
                 err: CLike("SprotError"),
             ),
+            encoding: Hubpack, 
         ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -129,5 +129,26 @@ Interface(
                 err: CLike("SprotError"),
             ),
         ),
+        "reset_component": (
+            doc: "Just reset, or also update boot image select policy.",
+            args: {
+                "intent": (
+                    type: "ResetIntent",
+                    recv: FromPrimitive("u8"),
+                ),
+                "target":  {
+                    type: "UpdateTarget",
+                    recv: FromPrimitive("u8"),
+                },
+                "auth_len": "u16"
+            },
+            leases : {
+                "auth": (type: "[u8]", read: true, max_len: Some(768)),
+            },
+            reply: Result (
+                ok: "()",
+                err: CLike("SprotError"),
+            ),
+        ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -140,10 +140,6 @@ Interface(
                     type: "UpdateTarget",
                     recv: FromPrimitive("u8"),
                 },
-                "auth_len": "u16"
-            },
-            leases : {
-                "auth": (type: "[u8]", read: true, max_len: Some(768)),
             },
             reply: Result (
                 ok: "()",

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -84,19 +84,14 @@ Interface(
         "reset_component": (
             doc: "Just reset, or also update boot image select policy.",
             args: {
-                "intent": (
-                    type: "ResetIntent",
-                    recv: FromPrimitive("u8"),
-                ),
-                "target":  {
-                    type: "UpdateTarget",
-                    recv: FromPrimitive("u8"),
-                },
+                "intent": "ResetIntent",
+                "target": "UpdateTarget",
             },
             reply: Result (
                 ok: "()",
                 err: CLike("UpdateError"),
             ),
+            encoding: Hubpack, 
         ),
     }
 )

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -92,10 +92,6 @@ Interface(
                     type: "UpdateTarget",
                     recv: FromPrimitive("u8"),
                 },
-                "auth_len": "u16"
-            },
-            leases : {
-                "auth": (type: "[u8]", read: true, max_len: Some(768)),
             },
             reply: Result (
                 ok: "()",

--- a/idl/update.idol
+++ b/idl/update.idol
@@ -81,5 +81,26 @@ Interface(
             ),
             idempotent: true,
         ),
+        "reset_component": (
+            doc: "Just reset, or also update boot image select policy.",
+            args: {
+                "intent": (
+                    type: "ResetIntent",
+                    recv: FromPrimitive("u8"),
+                ),
+                "target":  {
+                    type: "UpdateTarget",
+                    recv: FromPrimitive("u8"),
+                },
+                "auth_len": "u16"
+            },
+            leases : {
+                "auth": (type: "[u8]", read: true, max_len: Some(768)),
+            },
+            reply: Result (
+                ok: "()",
+                err: CLike("UpdateError"),
+            ),
+        ),
     }
 )

--- a/lib/stage0-handoff/src/lib.rs
+++ b/lib/stage0-handoff/src/lib.rs
@@ -30,7 +30,7 @@ const_assert!(DICE_RANGE.end <= UPDATE_RANGE.start);
 const_assert!(UPDATE_RANGE.end <= MEM_RANGE.end);
 /// The error returned when `HandoffData::load` fails.
 #[derive(
-    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
+    Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
 pub enum HandoffDataLoadError {
     Deserialize,

--- a/lib/stage0-handoff/src/rot_update_details.rs
+++ b/lib/stage0-handoff/src/rot_update_details.rs
@@ -19,7 +19,7 @@ unsafe impl HandoffData for RotBootState {
 ///
 /// It gets read from RAM by the `lpc55-update-server`
 #[derive(
-    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
+    Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
 pub struct RotBootState {
     pub active: RotSlot,
@@ -39,7 +39,7 @@ impl RotBootState {
 fits_in_ram!(RotBootState);
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
+    Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
 pub struct RotImageDetails {
     pub digest: [u8; 32],

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -59,6 +59,7 @@ enum Log {
     UpdatePartial { bytes_written: u32 },
     UpdateComplete,
     HostFlashSectorsErased { num_sectors: usize },
+    RotReset { err: drv_sprot_api::SprotError },
 }
 
 // This enum does not define the actual MGS protocol - it is only used in the

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -205,7 +205,7 @@ impl MgsCommon {
         // figured out for the SP.
         let target = match component {
             SpComponent::SP_ITSELF => {
-                if intent != ResetIntent::Normal || !slot.is_none() {
+                if intent != ResetIntent::Normal || slot.is_some() {
                     // A scheme for STM32 transient image selection and
                     // richer behavior for the persistent image selection
                     // will require a development of a bootloader for the

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1050,14 +1050,12 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         slot: Option<u16>,
         intent: ResetIntent,
-        auth_data: &[u8],
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(
             &self.sp_update,
             component,
             slot,
             intent,
-            auth_data,
         )
     }
 }

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1269,10 +1269,8 @@ impl UsartHandler {
             });
         }
 
-        if n_received > 0 {
-            if self.from_rx_flush_deadline.is_none() {
-                self.set_from_rx_flush_deadline();
-            }
+        if n_received > 0 && self.from_rx_flush_deadline.is_none() {
+            self.set_from_rx_flush_deadline();
         }
 
         // Re-enable USART interrupts.

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -18,7 +18,7 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
     Header, IgnitionCommand, IgnitionState, Message, MessageKind, MgsError,
-    PowerState, SpComponent, SpError, SpPort, SpRequest, SpState,
+    PowerState, ResetIntent, SpComponent, SpError, SpPort, SpRequest, SpState,
     SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
     SERIAL_CONSOLE_IDLE_TIMEOUT,
 };
@@ -1028,6 +1028,37 @@ impl SpHandler for MgsHandler {
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError> {
         self.common.get_caboose_value(key)
+    }
+
+    fn reset_component_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        match component {
+            SpComponent::ROT | SpComponent::SP_ITSELF => {}
+            _ => return Err(SpError::RequestUnsupportedForComponent),
+        }
+        self.common.reset_component_prepare(component)
+    }
+
+    fn reset_component_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+        auth_data: &[u8],
+    ) -> Result<(), SpError> {
+        self.common.reset_component_trigger(
+            &self.sp_update,
+            component,
+            slot,
+            intent,
+            auth_data,
+        )
     }
 }
 

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -591,14 +591,12 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         slot: Option<u16>,
         intent: ResetIntent,
-        auth_data: &[u8],
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(
             &self.sp_update,
             component,
             slot,
             intent,
-            auth_data,
         )
     }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -13,8 +13,9 @@ use gateway_messages::sp_impl::{
 };
 use gateway_messages::{
     ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
-    SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    IgnitionCommand, IgnitionState, MgsError, PowerState, ResetIntent,
+    SpComponent, SpError, SpPort, SpState, SpUpdatePrepare, UpdateChunk,
+    UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -568,5 +569,36 @@ impl SpHandler for MgsHandler {
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError> {
         self.common.get_caboose_value(key)
+    }
+
+    fn reset_component_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        match component {
+            SpComponent::ROT | SpComponent::SP_ITSELF => {}
+            _ => return Err(SpError::RequestUnsupportedForComponent),
+        }
+        self.common.reset_component_prepare(component)
+    }
+
+    fn reset_component_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+        auth_data: &[u8],
+    ) -> Result<(), SpError> {
+        self.common.reset_component_trigger(
+            &self.sp_update,
+            component,
+            slot,
+            intent,
+            auth_data,
+        )
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -686,14 +686,12 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         slot: Option<u16>,
         intent: ResetIntent,
-        auth_data: &[u8],
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(
             &self.sp_update,
             component,
             slot,
             intent,
-            auth_data,
         )
     }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -15,8 +15,9 @@ use gateway_messages::sp_impl::{
 };
 use gateway_messages::{
     ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, MgsError, PowerState, SpComponent, SpError,
-    SpPort, SpState, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    IgnitionCommand, IgnitionState, MgsError, PowerState, ResetIntent,
+    SpComponent, SpError, SpPort, SpState, SpUpdatePrepare, UpdateChunk,
+    UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -663,6 +664,37 @@ impl SpHandler for MgsHandler {
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError> {
         self.common.get_caboose_value(key)
+    }
+
+    fn reset_component_prepare(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        match component {
+            SpComponent::ROT | SpComponent::SP_ITSELF => {}
+            _ => return Err(SpError::RequestUnsupportedForComponent),
+        }
+        self.common.reset_component_prepare(component)
+    }
+
+    fn reset_component_trigger(
+        &mut self,
+        _sender: SocketAddrV6,
+        _port: SpPort,
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+        auth_data: &[u8],
+    ) -> Result<(), SpError> {
+        self.common.reset_component_trigger(
+            &self.sp_update,
+            component,
+            slot,
+            intent,
+            auth_data,
+        )
     }
 }
 

--- a/task/control-plane-agent/src/update/rot.rs
+++ b/task/control-plane-agent/src/update/rot.rs
@@ -71,10 +71,9 @@ impl ComponentUpdater for RotUpdate {
             }
         }
         // Can we lock the update buffer?
-        let buffer =
-            buffer.borrow(update.component, Self::BLOCK_SIZE).map_err(
-                |component| SpError::OtherComponentUpdateInProgress(component),
-            )?;
+        let buffer = buffer
+            .borrow(update.component, Self::BLOCK_SIZE)
+            .map_err(SpError::OtherComponentUpdateInProgress)?;
 
         // Which target are we updating?
         let target = match (update.component, update.slot) {

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -20,6 +20,7 @@ hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
 ringbuf = { path = "../../lib/ringbuf"  }
 static-cell = { path = "../../lib/static-cell"  }
 userlib = { path = "../../sys/userlib" }
+unwrap-lite = { path = "../../lib/unwrap-lite" }
 
 byteorder.workspace = true
 cfg-if.workspace = true

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -1229,7 +1229,8 @@ pub(crate) fn block_size(
 #[cfg(any(feature = "sprot", feature = "update"))]
 fn reset_component_args(
     stack: &[Option<u32>],
-    ) -> Result<(drv_update_api::ResetIntent, drv_update_api::UpdateTarget), Failure> {
+) -> Result<(drv_update_api::ResetIntent, drv_update_api::UpdateTarget), Failure>
+{
     if stack.len() < 2 {
         return Err(Failure::Fault(Fault::MissingParameters));
     }

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -83,6 +83,8 @@ pub enum Functions {
     FinishUpdate((), drv_update_api::UpdateError),
     #[cfg(feature = "update")]
     BlockSize((), drv_update_api::UpdateError),
+    #[cfg(feature = "update")]
+    ResetComponent((u8, usize), drv_update_api::UpdateError),
 }
 
 #[cfg(feature = "spctrl")]
@@ -389,6 +391,8 @@ pub(crate) static HIFFY_FUNCS: &[Function] = &[
     crate::common::finish_update,
     #[cfg(feature = "update")]
     crate::common::block_size,
+    #[cfg(feature = "update")]
+    crate::common::reset_component,
 ];
 
 //

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -137,6 +137,8 @@ pub enum Functions {
     FinishUpdate((), drv_update_api::UpdateError),
     #[cfg(feature = "update")]
     BlockSize((), drv_update_api::UpdateError),
+    #[cfg(feature = "update")]
+    ResetComponent((u8, usize), drv_update_api::UpdateError),
 
     #[cfg(feature = "sprot")]
     SpRotSendRecv((u32, u32), drv_spi_api::SpiError),
@@ -156,6 +158,8 @@ pub enum Functions {
     SpRotFinishUpdate((), drv_update_api::UpdateError),
     #[cfg(feature = "sprot")]
     SpRotBlockSize((), drv_update_api::UpdateError),
+    #[cfg(feature = "sprot")]
+    SpRotResetComponent((u8, usize), drv_update_api::UpdateError),
 }
 
 #[cfg(feature = "i2c")]
@@ -666,6 +670,8 @@ pub(crate) static HIFFY_FUNCS: &[Function] = &[
     crate::common::finish_update,
     #[cfg(feature = "update")]
     crate::common::block_size,
+    #[cfg(feature = "update")]
+    crate::common::reset_component,
     #[cfg(feature = "sprot")]
     crate::common::sprot_send_recv,
     #[cfg(feature = "sprot")]
@@ -682,6 +688,8 @@ pub(crate) static HIFFY_FUNCS: &[Function] = &[
     crate::common::sprot_finish_update,
     #[cfg(feature = "sprot")]
     crate::common::sprot_block_size,
+    #[cfg(feature = "sprot")]
+    crate::common::sprot_reset_component,
 ];
 
 //


### PR DESCRIPTION
This adds `ResetComponent` messages to MGS, SpRot, and Update APIs.
The function currently plumbed through is a simple reset of the RoT.
The API also provides a semantic for modifying RoT boot image selection and delivering a blob of authentication data.
The authentication blob could be used for online key revocation, debug enable, or other operations that involve RoT stage0 or hypovisor and are associated with resetting the RoT.
These forward compatible features of the messages are incorporated now because some will be needed very soon.