### PR TITLE
Store host startup options in packrat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,6 +3991,7 @@ dependencies = [
  "task-control-plane-agent-api",
  "task-host-sp-comms-api",
  "task-net-api",
+ "task-packrat-api",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,6 +4165,7 @@ name = "task-packrat-api"
 version = "0.1.0"
 dependencies = [
  "derive-idol-err",
+ "host-sp-messages",
  "idol",
  "idol-runtime",
  "num-traits",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -205,7 +205,7 @@ priority = 7
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
-task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
+task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"]
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -205,7 +205,7 @@ priority = 7
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
-task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
+task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"]
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -129,7 +129,7 @@ notifications = [
     "multitimer",
     "control-plane-agent"
 ]
-task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
+task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"]
 
 [tasks.hiffy]
 name = "task-hiffy"
@@ -165,6 +165,14 @@ uses = ["hash"]
 notifications = ["hash-irq"]
 interrupts = {"hash.irq" = "hash-irq"}
 task-slots = ["sys"]
+
+[tasks.packrat]
+name = "task-packrat"
+priority = 3
+max-sizes = {flash = 8192, ram = 2048}
+start = true
+# task-slots is explicitly empty: packrat should not send IPCs!
+task-slots = []
 
 [tasks.net]
 name = "task-net"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -113,7 +113,7 @@ priority = 8
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
-task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
+task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"]
 notifications = [
     "jefe-state-change",
      "usart-irq",

--- a/idl/packrat.idol
+++ b/idl/packrat.idol
@@ -41,6 +41,19 @@ Interface(
             ),
             idempotent: true,
         ),
+        "get_next_boot_host_startup_options": (
+            doc: "Get the value for host OS startup options we will give to the host the next time it requests them from us. This may or may not match the startup options used the most recent time the host OS boots, as the options may have changed in the meantime.",
+            reply: Simple("HostStartupOptions"),
+            idempotent: true,
+        ),
+        "set_next_boot_host_startup_options": (
+            doc: "Set the value for host OS startup options we will give to the host the next time it requests them from us.",
+            args: {
+                "startup_options": "HostStartupOptions",
+            },
+            reply: Simple("()"),
+            idempotent: true,
+        ),
     },
 )
 

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -237,7 +237,7 @@ impl idl::InOrderControlPlaneAgentImpl for ServerImpl {
         &mut self,
         _msg: &userlib::RecvMessage,
     ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
-        self.mgs_handler.startup_options()
+        self.mgs_handler.startup_options_impl()
     }
 
     fn set_startup_options(
@@ -248,7 +248,7 @@ impl idl::InOrderControlPlaneAgentImpl for ServerImpl {
         let startup_options = HostStartupOptions::from_bits(startup_options)
             .ok_or(ControlPlaneAgentError::InvalidStartupOptions)?;
 
-        self.mgs_handler.set_startup_options(startup_options)
+        self.mgs_handler.set_startup_options_impl(startup_options)
     }
 
     fn identity(

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -25,6 +25,7 @@ pub(crate) struct MgsCommon {
     reset_requested: bool,
     inventory: Inventory,
     base_mac_address: MacAddress,
+    packrat: Packrat,
 }
 
 impl MgsCommon {
@@ -33,7 +34,12 @@ impl MgsCommon {
             reset_requested: false,
             inventory: Inventory::new(),
             base_mac_address,
+            packrat: Packrat::from(PACKRAT.get_task_id()),
         }
+    }
+
+    pub(crate) fn packrat(&self) -> &Packrat {
+        &self.packrat
     }
 
     pub(crate) fn discover(
@@ -50,8 +56,7 @@ impl MgsCommon {
         // starting. If we've gotten here, we've received a packet on the
         // network, which means `net` has started and the sequencer has already
         // populated packrat with what it read from our VPD.
-        let packrat = Packrat::from(PACKRAT.get_task_id());
-        packrat.get_identity().unwrap_or_default()
+        self.packrat.get_identity().unwrap_or_default()
     }
 
     pub(crate) fn sp_state(

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -109,7 +109,7 @@ impl MgsHandler {
         Err(ControlPlaneAgentError::DataUnavailable.into())
     }
 
-    pub(crate) fn startup_options(
+    pub(crate) fn startup_options_impl(
         &self,
     ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
         // We don't have a host to give startup options; no one should be
@@ -117,7 +117,7 @@ impl MgsHandler {
         Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 
-    pub(crate) fn set_startup_options(
+    pub(crate) fn set_startup_options_impl(
         &mut self,
         _startup_options: HostStartupOptions,
     ) -> Result<(), RequestError<ControlPlaneAgentError>> {

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -129,7 +129,7 @@ impl MgsHandler {
         Err(ControlPlaneAgentError::DataUnavailable.into())
     }
 
-    pub(crate) fn startup_options(
+    pub(crate) fn startup_options_impl(
         &self,
     ) -> Result<HostStartupOptions, RequestError<ControlPlaneAgentError>> {
         // We don't have a host to give startup options; no one should be
@@ -137,7 +137,7 @@ impl MgsHandler {
         Err(ControlPlaneAgentError::InvalidStartupOptions.into())
     }
 
-    pub(crate) fn set_startup_options(
+    pub(crate) fn set_startup_options_impl(
         &mut self,
         _startup_options: HostStartupOptions,
     ) -> Result<(), RequestError<ControlPlaneAgentError>> {

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -25,6 +25,7 @@ ringbuf = { path = "../../lib/ringbuf" }
 task-control-plane-agent-api = { path = "../control-plane-agent-api" }
 task-host-sp-comms-api = { path = "../host-sp-comms-api" }
 task-net-api = { path = "../net-api" }
+task-packrat-api = { path = "../packrat-api" }
 userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]

--- a/task/packrat-api/Cargo.toml
+++ b/task/packrat-api/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 derive-idol-err.path = "../../lib/derive-idol-err"
+host-sp-messages.path = "../../lib/host-sp-messages"
 oxide-barcode.path = "../../lib/oxide-barcode"
 userlib.path = "../../sys/userlib"
 

--- a/task/packrat-api/src/lib.rs
+++ b/task/packrat-api/src/lib.rs
@@ -10,6 +10,7 @@ use derive_idol_err::IdolError;
 use userlib::*;
 use zerocopy::{AsBytes, FromBytes, LittleEndian, U16};
 
+pub use host_sp_messages::HostStartupOptions;
 pub use oxide_barcode::VpdIdentity;
 
 /// Represents a range of allocated MAC addresses, per RFD 320


### PR DESCRIPTION
This moves storage of the host startup options out of `control-plane-agent` and into `packrat`, which accomplishes two minor things:

1. They now persist even if `c-p-a` restarts
2. `host-sp-comms` makes fewer requests of `c-p-a`

It's a little tempting to remove the startup-options-related idol calls from `control-plane-agent` altogether, but I opted not to for two reasons:

1. Folks have workflows that would need a minor update, and
2. `packrat`'s setter takes an actual `HostStartupOptions`, which `hiffy` doesn't know how to accept on the command line. (`c-p-a`'s setter takes a `u64` and fails if it contains unknown bits, which seems reasonable for a hiffy interface but not so much for packrat).

One change is that the default host startup options are now specified _in packrat_ instead of in `control-plane-agent`. That doesn't seem "right" but doesn't seem too bad?