### PR TITLE
Add VPD identity to packets sent by udpbroadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,10 +4407,13 @@ dependencies = [
 name = "task-udpbroadcast"
 version = "0.1.0"
 dependencies = [
+ "hubpack",
  "num-traits",
  "serde",
  "ssmarshal",
+ "static_assertions",
  "task-net-api",
+ "task-packrat-api",
  "userlib",
  "zerocopy",
 ]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -51,6 +51,14 @@ task-slots = ["sys"]
 "i2c4.event" = "i2c4-irq"
 "i2c4.error" = "i2c4-irq"
 
+[tasks.packrat]
+name = "task-packrat"
+priority = 2
+max-sizes = {flash = 8192, ram = 2048}
+start = true
+# task-slots is explicitly empty: packrat should not send IPCs!
+task-slots = []
+
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
@@ -115,7 +123,7 @@ priority = 3
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 notifications = ["socket"]
 
 [tasks.udprpc]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -224,7 +224,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -224,7 +224,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -213,7 +213,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -199,7 +199,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -163,7 +163,7 @@ priority = 5
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -172,7 +172,7 @@ priority = 5
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -130,7 +130,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -129,7 +129,7 @@ priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
-task-slots = ["net"]
+task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 

--- a/task/udpbroadcast/Cargo.toml
+++ b/task/udpbroadcast/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2021"
 vlan = ["task-net-api/vlan"]
 
 [dependencies]
+hubpack = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 ssmarshal = { workspace = true }
+static_assertions = { workspace = true }
 zerocopy = { workspace = true }
 
 task-net-api = { path = "../net-api" }
+task-packrat-api = { path = "../packrat-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/udpbroadcast/src/main.rs
+++ b/task/udpbroadcast/src/main.rs
@@ -5,16 +5,59 @@
 #![no_std]
 #![no_main]
 
+use hubpack::SerializedSize;
+use serde::Serialize;
 use task_net_api::*;
+use task_packrat_api::{Packrat, VpdIdentity};
 use userlib::*;
-use zerocopy::AsBytes;
 
 task_slot!(NET, net);
+task_slot!(PACKRAT, packrat);
+
+#[derive(Debug, Clone, Copy, Serialize, SerializedSize)]
+struct BroadcastData {
+    // Version for this data structure; adding new fields to the end is okay,
+    // but changing the order, size, or meaning of existing fields should result
+    // in a version bump.
+    version: u32,
+
+    mac_address: [u8; 6],
+    image_id: [u8; 8],
+
+    // If true, we have identity from our VPD, and the following three fields
+    // are populated. If false, we have no VPD or failed to read it, and the
+    // following three fields will be all zero.
+    identity_valid: bool,
+    part_number: [u8; VpdIdentity::PART_NUMBER_LEN],
+    revision: u32,
+    serial: [u8; VpdIdentity::SERIAL_LEN],
+}
+
+impl BroadcastData {
+    const CURRENT_VERSION: u32 = 1;
+}
+
+// Ensure our serialized size doesn't change unexpectedly: if you land here
+// because compilation has failed, consider whether you need to update
+// `BroadcastData::CURRENT_VERSION`!
+//
+// Current size is 45 bytes:
+// version (4)
+// mac_address (6)
+// image_id (8)
+// identity_valid (1)
+// part_number (11)
+// revision (4)
+// serial (11)
+static_assertions::const_assert_eq!(BroadcastData::MAX_SIZE, 45);
 
 #[export_name = "main"]
 fn main() -> ! {
     let net = NET.get_task_id();
     let net = Net::from(net);
+
+    let packrat = PACKRAT.get_task_id();
+    let packrat = Packrat::from(packrat);
 
     const SOCKET: SocketName = SocketName::broadcast;
 
@@ -23,14 +66,29 @@ fn main() -> ! {
     #[cfg(feature = "vlan")]
     let mut vid_iter = VLAN_RANGE.cycle();
 
-    // We broadcast a 14-byte packet of (MAC_ADDRESS, HUBRIS_IMAGE_ID)
-    // repeatedly.  This both allows the network to discover our MAC and IP
-    // address (through normal L2/L3 mechanisms), *and* lets `humility rpc`
-    // detect valid targets.
-    let mut out = [0u8; 14];
-    let mac = net.get_mac_address();
-    out[0..6].copy_from_slice(&mac.0);
-    out[6..].copy_from_slice(kipc::read_image_id().as_bytes());
+    // Ask `net` for our mac address first; this also serves as a useful wait
+    // for `packrat` to be loaded by the sequencer if we're on a board with VPD.
+    let mac_address = net.get_mac_address().0;
+
+    // If we're on a board with no VPD or VPD reading failed, we'll construct a
+    // default (all 0) identity and set `identity_valid` to false.
+    let identity = packrat.get_identity().ok();
+    let identity_valid = identity.is_some();
+    let identity = identity.unwrap_or_default();
+
+    let data = BroadcastData {
+        version: BroadcastData::CURRENT_VERSION,
+        mac_address,
+        image_id: kipc::read_image_id().to_le_bytes(),
+        identity_valid,
+        part_number: identity.part_number,
+        revision: identity.revision,
+        serial: identity.serial,
+    };
+
+    let mut out = [0u8; BroadcastData::MAX_SIZE];
+    let n = hubpack::serialize(&mut out, &data).unwrap_lite();
+    let out = &out[..n];
 
     loop {
         let meta = UdpMetadata {


### PR DESCRIPTION
Also adds a version field to the front of the packet and a byte indicating whether the VPD is valid (useful both for VPD-less boards like gimletlet and for detecting busted VPD).

From a wireshark capture of a gimletlet's broadcasts:

```
01 00 00 00                      # version
0e 1d 7d ef 9f 1d                # mac
80 bd fe ba e3 ab 59 27          # hubris image id
00                               # identity_valid
00 00 00 00 00 00 00 00 00 00 00 # identity_valid=0, so this is all zero
00 00 00 00                      # identity_valid=0, so this is all zero
00 00 00 00 00 00 00 00 00 00 00 # identity_valid=0, so this is all zero
```

and from a snoop capture of a gimlet:

```
0100 0000                   # version
a840 2504 0281              # mac
0b4d 9df2 0ef2 0809         # hubris image id
01                          # identity_valid
39 3133 2d30 3030 3030 3139 # part 913-0000019
0600 0000                   # revision 6
4252 4d34 3232 3230 3036 36 # serial BRM42220066
```

Fixes #1216