### PR TITLE
LPC55 raw flash driver and update support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-lpc55-flash"
+version = "0.1.0"
+dependencies = [
+ "lpc55-pac",
+]
+
+[[package]]
 name = "drv-lpc55-gpio"
 version = "0.1.0"
 dependencies = [
@@ -2560,15 +2567,17 @@ dependencies = [
  "build-util",
  "cfg-if",
  "drv-caboose",
+ "drv-lpc55-flash",
  "drv-update-api",
  "hubpack",
- "hypocalls",
  "idol",
  "idol-runtime",
+ "lpc55-pac",
  "num-traits",
  "ringbuf",
  "serde",
  "stage0-handoff",
+ "static_assertions",
  "userlib",
  "zerocopy",
 ]

--- a/app/gimlet-rot/app-b.toml
+++ b/app/gimlet-rot/app-b.toml
@@ -43,8 +43,10 @@ priority = 3
 max-sizes = {flash = 16384, ram = 4096, sram3 = 4096}
 stacksize = 2048
 start = true
-uses = ["rom", "secure_syscon", "syscon", "flash"]
+uses = ["flash_controller"]
 sections = {bootstate = "sram3"}
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
@@ -158,7 +160,3 @@ stacksize = 2048
 
 [tasks.sp_measure.config]
 binary_path = "../../target/gimlet-b/dist/default/final.bin"
-
-[extratext.rom]
-address = 0x13000000
-size = 0x20000

--- a/app/gimlet-rot/app-c.toml
+++ b/app/gimlet-rot/app-c.toml
@@ -50,8 +50,10 @@ priority = 3
 max-sizes = {flash = 16384, ram = 4096, sram3 = 4096}
 stacksize = 2048
 start = true
-uses = ["rom", "secure_syscon", "syscon", "flash"]
+uses = ["flash_controller"]
 sections = {bootstate = "sram3"}
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
@@ -149,7 +151,3 @@ stacksize = 2048
 
 [tasks.sp_measure.config]
 binary_path = "../../target/gimlet-c/dist/default/final.bin"
-
-[extratext.rom]
-address = 0x13000000
-size = 0x20000

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -48,7 +48,9 @@ priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
 start = true
-uses-secure-entry = true
+uses = ["flash_controller"]
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
@@ -129,4 +131,3 @@ start = true
 stacksize = 1000
 notifications = ["timer"]
 task-slots = ["user_leds"]
-

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -34,8 +34,10 @@ priority = 3
 max-sizes = {flash = 16384, ram = 4096, sram3 = 4096}
 stacksize = 2048
 start = true
-uses = ["rom", "secure_syscon", "syscon", "flash"]
+uses = ["flash_controller"]
 sections = {bootstate = "sram3"}
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.syscon_driver]
 name = "drv-lpc55-syscon"
@@ -189,7 +191,3 @@ stacksize = 2048
 
 [tasks.sp_measure.config]
 binary_path = "../../target/gemini-bu/dist/final.bin"
-
-[extratext.rom]
-address = 0x13000000
-size = 0x20000

--- a/chips/lpc55/chip.toml
+++ b/chips/lpc55/chip.toml
@@ -68,7 +68,12 @@ size = 0x100
 address = 0x50000000
 size = 4096
 
-[flash]
+[flash_controller]
+address = 0x40034000
+size = 0x1000
+interrupts = { irq = 0 }
+
+[secure_flash_controller]
 address = 0x50034000
 size = 0x1000
 

--- a/drv/lpc55-flash/Cargo.toml
+++ b/drv/lpc55-flash/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "drv-lpc55-flash"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lpc55-pac = { workspace = true }

--- a/drv/lpc55-flash/src/lib.rs
+++ b/drv/lpc55-flash/src/lib.rs
@@ -1,0 +1,389 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A raw driver for the LPC55 flash controller without using the ROM.
+//!
+//! This driver is written in a very generic form that doesn't assume any
+//! particular execution model. You can use it to implement busy waiting, or
+//! an interrupt driven driver, etc.
+//!
+//! See the [`Flash`] type for more details.
+
+#![no_std]
+
+use core::ops::RangeInclusive;
+
+/// Number of bytes per flash word.
+pub const BYTES_PER_FLASH_WORD: usize = 16;
+
+/// Number of bytes per flash page.
+pub const BYTES_PER_FLASH_PAGE: usize = 512;
+
+/// Flash driver handle. Wraps a pointer to the flash register set and provides
+/// encapsulated operations.
+///
+/// # Procedure for writing to flash
+///
+/// 1. Use `start_erase_region` to begin an erase of your desired region. Use
+///    `poll_erase_or_program_result` to discover when it's done. (Note: you can
+///    use `start_blank_check` to skip this step if there's a chance the flash
+///    is already erased.)
+/// 2. Call `start_write_row` with each 16 byte chunk of the first page you're
+///    writing, 32 times, for rows 0-31. Each time, use `poll_write_result` to
+///    check that it's done.
+/// 3. Call `start_program` with the index of any word in the target flash page
+///    to begin the programming process. (See the next section on word numbers
+///    for explanation.) Use `poll_erase_or_program_result` to learn when it's
+///    done.
+/// 4. Repeat steps 2 and 3 for each page in the region you want to write.
+///
+/// # Flash addressing and word numbers
+///
+/// While the flash is directly addressable by the processor at byte
+/// granularity, most of the flash controller operations work in terms of a
+/// _word number._ Internal flash words are 16 bytes (128 bits) in length; the
+/// word number is the index of a word within the flash, starting at 0.
+///
+/// The flash controller thinks entirely in word numbers, _including on
+/// operations that deal in pages._ For example, to erase a range of pages, you
+/// give the hardware a range of word numbers, _not_ page numbers, and it erases
+/// the sequence of contiguous pages that contain the start and end word
+/// numbers. In the interest of not introducing additional, confusable, types of
+/// addresses, this API preserves this and deals only in word numbers.
+///
+/// Should you need to convert a direct-addressed flash location (byte address)
+/// to a word number, the procedure is:
+///
+/// - Divide by 16 (or right-shift by 4).
+/// - Mask all but the bottom 18 bits.
+///
+/// Note: The `start_write_row` operation does not use _absolute_ flash word
+/// numbers, but uses equivalent indices within a 512-byte internal page
+/// register.
+pub struct Flash<'a> {
+    reg: &'a lpc55_pac::flash::RegisterBlock,
+}
+
+impl<'a> Flash<'a> {
+    /// Wraps a pointer to the flash controller registers in a `Flash` driver
+    /// instance.
+    pub fn new(reg: &'a lpc55_pac::flash::RegisterBlock) -> Self {
+        Self { reg }
+    }
+
+    /// Copies 16 bytes of data into one of the rows of the flash controller's
+    /// internal page register.
+    ///
+    /// The page register is 512 bytes long and consists of 32 rows of 16 bytes
+    /// each. Data must be accumulated into the page register before being
+    /// programmed.
+    ///
+    /// The `row_in_page` passed to this routine specifies one of the 32 rows.
+    /// This means it operates a lot like a flash word number, but in the
+    /// separate "address space" of the page register.
+    ///
+    /// This routine only starts the operation; use `poll_write_result` to learn
+    /// when it has completed. Since writes are just latching values into
+    /// registers, they tend to be very fast, and it may not be useful to use
+    /// interrupts to wait for completion here.
+    pub fn start_write_row(&mut self, row_in_page: u32, values: &[u8; 16]) {
+        self.clear_status_flags();
+        self.set_single_word_number(row_in_page);
+        for (register, chunk) in self.reg.dataw.iter().zip(values.chunks(4)) {
+            let value = u32::from_ne_bytes(chunk.try_into().unwrap());
+            register.write(|w| unsafe { w.bits(value) });
+        }
+        self.issue_cmd(FlashCmd::Write);
+    }
+
+    /// Checks the completion status for the values expected after a
+    /// `start_write_row` operation. `true` means the write has finished.
+    /// `false` means it has not.
+    pub fn poll_write_result(&mut self) -> bool {
+        self.read_completion_status().is_some()
+    }
+
+    /// Begins an erase of all flash words in `word_range`.
+    ///
+    /// The start and end values of `word_range` are _word numbers._ See the
+    /// discussion of word numbers on the [`Flash`] type.
+    ///
+    /// This routine only starts the operation; use
+    /// `poll_erase_or_program_result` to learn when it has completed and
+    /// whether it succeeded.
+    pub fn start_erase_range(&mut self, word_range: RangeInclusive<u32>) {
+        self.clear_status_flags();
+        self.set_word_range(word_range);
+        self.issue_cmd(FlashCmd::EraseRange);
+    }
+
+    /// Begins programming the data loaded in the page register (by previous
+    /// write operations) into the flash page containing `word_number`.
+    ///
+    /// See the discussion of word numbers on the [`Flash`] type.
+    ///
+    /// This routine only starts the operation; use
+    /// `poll_erase_or_program_result` to learn when it has completed and
+    /// whether it succeeded.
+    pub fn start_program(&mut self, word_number: u32) {
+        self.clear_status_flags();
+        self.set_single_word_number(word_number);
+        self.issue_cmd(FlashCmd::Program);
+    }
+
+    /// Checks the completion status for the values expected after a
+    /// `start_erase_range` or `start_program` operation.
+    ///
+    /// `None` means the operation has not yet completed.
+    ///
+    /// `Some(Ok(())` means the operation completed without issue.
+    ///
+    /// `Some(Err(FlashTimeout))` means the operation did not complete because
+    /// the internal flash state machine didn't finish within the time allotted.
+    /// This is the only way these operations are able to fail according to the
+    /// user manual. It's not at all clear what to _do_ in this situation since
+    /// the internal state machine is essentially opaque -- but you can assume
+    /// that your program or erase did not succeed.
+    pub fn poll_erase_or_program_result(
+        &mut self,
+    ) -> Option<Result<(), FlashTimeout>> {
+        let s = self.read_completion_status()?;
+        // Erase and program operations only define the behavior of the FAIL
+        // bit, which indicates that the flash internal state machine didn't
+        // finish within a generous timeout.
+        Some(if s.fail { Err(FlashTimeout) } else { Ok(()) })
+    }
+
+    /// Begins a blank-check operation on the range of flash pages containing
+    /// the start and end of `word_range`, inclusive.
+    ///
+    /// `word_range` is given in terms of _word numbers._ See the discussion of
+    /// word numbers on the [`Flash`] type.
+    ///
+    /// This routine only starts the operation; use `poll_blank_check_result` to
+    /// learn when it has completed and whether it succeeded.
+    pub fn start_blank_check(&mut self, word_range: RangeInclusive<u32>) {
+        self.clear_status_flags();
+        self.set_word_range(word_range);
+        self.issue_cmd(FlashCmd::BlankCheck);
+    }
+
+    /// Checks the completion status for the values expected after a
+    /// `start_blank_check` operation.
+    ///
+    /// `None` means the operation is still underway.
+    ///
+    /// `Some(state)` means the operation has completed and the pages were found
+    /// to be in the given `state`.
+    pub fn poll_blank_check_result(&mut self) -> Option<ProgramState> {
+        let s = self.read_completion_status()?;
+        // The result is in the FAIL bit. FAIL being set means the page is
+        // _not_ blank (i.e. the blank check operation "failed" to find a
+        // blank page). In this case, DATAW0 contains a word number within the
+        // first non-blank page that was found.
+        Some(if s.fail {
+            let word_number = self.reg.dataw[0].read().bits();
+            ProgramState::NotBlank { word_number }
+        } else {
+            ProgramState::Blank
+        })
+    }
+
+    /// Begins a read operation on the flash word indexed by `word_index`. This
+    /// is the "indirect" method of reading flash -- the direct method is to
+    /// read from the address space where flash is mapped. This method can be
+    /// useful if you control the flash peripheral and need access to random
+    /// areas of flash but don't want to extend your memory map to include them.
+    ///
+    /// `word_index` is given in terms of _word numbers._ See the discussion of
+    /// word numbers on the [`Flash`] type.
+    ///
+    /// This routine only starts the operation; use `poll_read_result` to learn
+    /// when it has completed and whether it succeeded.
+    pub fn start_read(&mut self, word_index: u32) {
+        self.clear_status_flags();
+        self.set_single_word_number(word_index);
+        // Read commands use DATAW0 to select unusual read modes, like bypassing
+        // ECC. Here we just want a normal read of normal flash, so the proper
+        // value is zero.
+        self.reg.dataw[0].write(|w| unsafe { w.bits(0) });
+        self.issue_cmd(FlashCmd::ReadSingleWord);
+    }
+
+    /// Checks the completion status for the values expected after a
+    /// `start_read` operation.
+    ///
+    /// `None` means the operation is still underway.
+    ///
+    /// `Some(Ok(data))` means the operation has completed successfully, and the
+    /// word was found to contain `data`.
+    ///
+    /// `Some(Err(e))` means the operation completed in failure.
+    ///
+    /// On success, the word is returned as an array of `u32`s in ascending
+    /// address order. To turn this into the bytes you'd read at the direct bus
+    /// interface, convert each `u32` to little-endian bytes (or reinterpret it
+    /// in place using `zerocopy::AsBytes`).
+    pub fn poll_read_result(&mut self) -> Option<Result<[u32; 4], ReadError>> {
+        let s = self.read_completion_status()?;
+        // The manual's definition of the status bits for READ_SINGLE_WORD is a
+        // bit vague -- they clearly don't expect us to be using this. This
+        // driver makes the following decisions:
+        //
+        // 1. An ECC error means that the read was successfully issued but found
+        //    bad data. So, we treat it as superceding the other, vaguer, error
+        //    bits.
+        // 2. Next, the ERR bit (which indicates an illegal operation) is
+        //    prioritized, to try to give feedback on that case.
+        // 3. Finally, if only the FAIL bit is set, we return the vague Fail
+        //    code.
+        // 4. If _none_ of those bits is set, we have a success.
+        if s.ecc_err {
+            Some(Err(ReadError::Ecc))
+        } else if s.err {
+            Some(Err(ReadError::IllegalOperation))
+        } else if s.fail {
+            Some(Err(ReadError::Fail))
+        } else {
+            // Success!
+            Some(Ok([
+                self.reg.dataw[0].read().bits(),
+                self.reg.dataw[1].read().bits(),
+                self.reg.dataw[2].read().bits(),
+                self.reg.dataw[3].read().bits(),
+            ]))
+        }
+    }
+
+    /// Turns on all interrupt sources in the flash controller (FAIL, ERR, ECC,
+    /// and DONE). This will cause an interrupt to pend in the NVIC when the
+    /// corresponding bit in the status register is set. This does _not_ enable
+    /// the interrupt in the NVIC, so to actually receive an IRQ, you will need
+    /// to also do that.
+    pub fn enable_interrupt_sources(&mut self) {
+        self.reg.int_set_enable.write(|w| {
+            w.fail().set_bit();
+            w.err().set_bit();
+            w.ecc_err().set_bit();
+            w.done().set_bit();
+            w
+        });
+    }
+
+    /// Turns off all interrupt sources in the flash controller (FAIL, ERR, ECC,
+    /// and DONE). This does _not_ clear any event that's pended in the NVIC
+    /// already, so you may still get an interrupt after doing this if you don't
+    /// clear pending.
+    pub fn disable_interrupt_sources(&mut self) {
+        self.reg.int_clr_enable.write(|w| {
+            w.fail().set_bit();
+            w.err().set_bit();
+            w.ecc_err().set_bit();
+            w.done().set_bit();
+            w
+        });
+    }
+
+    // API below this point is internal, but is exposed in case someone needs to
+    // do something weird, like attack the flash controller. The routines are
+    // deliberately documented less than the "official" API above.
+
+    pub fn issue_cmd(&mut self, cmd: FlashCmd) {
+        self.reg.cmd.write(|w| unsafe { w.cmd().bits(cmd as u32) });
+    }
+
+    pub fn set_single_word_number(&mut self, word_number: u32) {
+        // Technically, the write to STOPA this will incur is unnecessary.
+        // However, this avoids potentially undefined behavior if
+        // set_single_word_number is used before a command that actually takes a
+        // range. I'm being paranoid, and the cost is low.
+        self.set_word_range(word_number..=word_number);
+    }
+
+    pub fn set_word_range(&mut self, range: RangeInclusive<u32>) {
+        self.reg
+            .starta
+            .write(|w| unsafe { w.starta().bits(*range.start()) });
+        // The code example in the user manual treats the STOPA word number for
+        // flash erase as _exclusive_ -- the code example is wrong. The
+        // documentation for the commands that take ranges correctly describes
+        // it as being inclusive. Otherwise how would you erase the last sector?
+        self.reg
+            .stopa
+            .write(|w| unsafe { w.stopa().bits(*range.end()) });
+    }
+
+    pub fn read_completion_status(&mut self) -> Option<Status> {
+        let s = self.reg.int_status.read();
+        if s.done().bit() {
+            Some(Status {
+                ecc_err: s.ecc_err().bit(),
+                err: s.err().bit(),
+                fail: s.fail().bit(),
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn clear_status_flags(&mut self) {
+        self.reg.int_clr_status.write(|w| {
+            w.done().set_bit();
+            w.ecc_err().set_bit();
+            w.err().set_bit();
+            w.fail().set_bit();
+            w
+        });
+    }
+}
+
+/// Raw status bits from the flash controller.
+///
+/// This type is exposed in case you want to do something weird with the raw
+/// flash controller operations; the higher-level APIs do not use it directly.
+///
+/// Note: this type is only constructed when we find the `DONE` bit set, so the
+/// `DONE` bit is not included here.
+pub struct Status {
+    pub ecc_err: bool,
+    pub err: bool,
+    pub fail: bool,
+}
+
+/// Observed state of a region after a blank check command.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ProgramState {
+    Blank,
+    NotBlank { word_number: u32 },
+}
+
+/// Error produced if the erase or program commands don't terminate as expected
+/// by the flash controller. (The timeout is internal and set by hardware.)
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct FlashTimeout;
+
+/// Internal enumeration of commands understood by the flash controller. This
+/// enumeration includes only the variants we use.
+///
+/// See UM11126 rev2.4 table 171.
+#[derive(Copy, Clone, Debug)]
+pub enum FlashCmd {
+    ReadSingleWord = 3,
+    EraseRange = 4,
+    BlankCheck = 5,
+    Write = 8,
+    Program = 12,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ReadError {
+    /// The flash controller rejected the read as illegal, likely because the
+    /// word number was out of range.
+    IllegalOperation,
+    /// The read failed because of an ECC error.
+    Ecc,
+    /// The read failed due to unspecified other reasons (represents the `FAIL`
+    /// bit in the controller).
+    Fail,
+}

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 abi.path = "../../sys/abi"
 drv-caboose.path = "../../drv/caboose"
 drv-update-api.path = "../update-api/"
-hypocalls.path = "../../lib/hypocalls"
 ringbuf.path = "../../lib/ringbuf"
 stage0-handoff.path = "../../lib/stage0-handoff"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+drv-lpc55-flash.path = "../lpc55-flash"
 
 cfg-if = { workspace = true }
 hubpack = { workspace = true }
@@ -18,6 +18,8 @@ idol-runtime = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 zerocopy = { workspace = true }
+lpc55-pac.workspace = true
+static_assertions.workspace = true
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/drv/lpc55-update-server/build.rs
+++ b/drv/lpc55-update-server/build.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
+    build_util::build_notifications()?;
 
     idol::server::build_server_support(
         "../../idl/update.idol",

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -12,8 +12,8 @@
 use core::convert::Infallible;
 use core::mem::MaybeUninit;
 use drv_caboose::CabooseError;
+use drv_lpc55_flash::{BYTES_PER_FLASH_PAGE, BYTES_PER_FLASH_WORD};
 use drv_update_api::{UpdateError, UpdateStatus, UpdateTarget};
-use hypocalls::*;
 use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
 use stage0_handoff::{HandoffData, ImageVersion, RotBootState};
 use userlib::*;
@@ -28,19 +28,12 @@ extern "C" {
     static __IMAGE_B_END: [u32; 0];
     static __IMAGE_STAGE0_END: [u32; 0];
 
+    static __this_image: [u32; 0];
 }
 
 #[used]
 #[link_section = ".bootstate"]
 static BOOTSTATE: MaybeUninit<[u8; 0x1000]> = MaybeUninit::uninit();
-
-cfg_if::cfg_if! {
-    if #[cfg(any(target_board = "lpcxpresso55s69", target_board = "gimlet-c"))]{
-        declare_tz_table!();
-    } else {
-        declare_not_tz_table!();
-    }
-}
 
 enum UpdateState {
     NoUpdate,
@@ -59,7 +52,7 @@ struct ServerImpl {
 const MAGIC_OFFSET: usize = 0x130;
 const RESET_VECTOR_OFFSET: usize = 4;
 
-const BLOCK_SIZE_BYTES: usize = FLASH_PAGE_SIZE;
+const BLOCK_SIZE_BYTES: usize = BYTES_PER_FLASH_PAGE;
 
 const MAX_LEASE: usize = 1024;
 const HEADER_BLOCK: usize = 0;
@@ -246,15 +239,20 @@ fn validate_header_block(
         return Ok(());
     }
 
+    // This part aliases flash in two positions that differ in bit 28. To allow
+    // for either position to be used in new images, we clear bit 28 in all of
+    // the numbers used for comparison below, by ANDing them with this mask:
+    const ADDRMASK: u32 = !(1 << 28);
+
     let reset_vector = u32::from_le_bytes(
         block[RESET_VECTOR_OFFSET..][..4].try_into().unwrap_lite(),
-    );
-    let a_base = unsafe { &__IMAGE_A_BASE } as *const u32 as u32;
-    let b_base = unsafe { &__IMAGE_B_BASE } as *const u32 as u32;
-    let stage0_base = unsafe { &__IMAGE_STAGE0_BASE } as *const u32 as u32;
-    let a_end = unsafe { &__IMAGE_A_END } as *const u32 as u32;
-    let b_end = unsafe { &__IMAGE_B_END } as *const u32 as u32;
-    let stage0_end = unsafe { &__IMAGE_STAGE0_END } as *const u32 as u32;
+    ) & ADDRMASK;
+    let a_base = unsafe { __IMAGE_A_BASE.as_ptr() } as u32 & ADDRMASK;
+    let b_base = unsafe { __IMAGE_B_BASE.as_ptr() } as u32 & ADDRMASK;
+    let stage0_base = unsafe { __IMAGE_STAGE0_BASE.as_ptr() } as u32 & ADDRMASK;
+    let a_end = unsafe { __IMAGE_A_END.as_ptr() } as u32 & ADDRMASK;
+    let b_end = unsafe { __IMAGE_B_END.as_ptr() } as u32 & ADDRMASK;
+    let stage0_end = unsafe { __IMAGE_STAGE0_END.as_ptr() } as u32 & ADDRMASK;
 
     // Ensure the image is destined for the right target
     let valid = match target {
@@ -279,29 +277,141 @@ fn validate_header_block(
     Ok(())
 }
 
+/// Performs an erase-write sequence to a single page within a given target
+/// image.
 fn do_block_write(
     img: UpdateTarget,
     block_num: usize,
     flash_page: &mut [u8; BLOCK_SIZE_BYTES],
 ) -> Result<(), UpdateError> {
-    let result = unsafe {
-        // The write_to_flash API takes raw pointers due to TrustZone
-        // ABI requirements which makes this function unsafe.
-        tz_table!().write_to_flash(
-            img,
-            block_num as u32,
-            flash_page.as_mut_ptr(),
-        )
+    // The update.idol definition uses usize; our hardware uses u32; convert
+    // here so we don't have to cast everywhere.
+    let page_num = block_num as u32;
+
+    let flash = unsafe { &*lpc55_pac::FLASH::ptr() };
+    let mut flash = drv_lpc55_flash::Flash::new(flash);
+
+    // Can only update opposite image
+    if same_image(img) {
+        return Err(UpdateError::RunningImage);
+    }
+
+    let write_addr = match target_addr(img, page_num) {
+        Some(addr) => addr,
+        None => return Err(UpdateError::OutOfBounds),
     };
 
-    match result {
-        HypoStatus::Success => Ok(()),
-        HypoStatus::OutOfBounds => Err(UpdateError::OutOfBounds),
-        HypoStatus::RunningImage => Err(UpdateError::RunningImage),
-        // Should probably encode the LPC55 flash status into the update
-        // error for good measure but that takes effort...
-        HypoStatus::FlashError(_) => Err(UpdateError::FlashError),
+    // Step one: erase the page.
+
+    // write_addr is a byte address; page_num is a page index; but the actual
+    // erase machinery operates in terms of flash words. A flash word is 16
+    // bytes in length. So, we need to convert.
+    //
+    // Note that the range used here is _inclusive._
+    //
+    // We wind up needing this in u32 form a lot, so let's cast once and reuse.
+    const WORDSZ: u32 = BYTES_PER_FLASH_WORD as u32;
+    static_assertions::const_assert_eq!(
+        BLOCK_SIZE_BYTES % BYTES_PER_FLASH_WORD,
+        0
+    );
+
+    flash.start_erase_range(
+        write_addr / WORDSZ
+            ..=(write_addr + BLOCK_SIZE_BYTES as u32 - 1) / WORDSZ,
+    );
+    wait_for_erase_or_program(&mut flash)?;
+
+    // Transfer each 16-byte flash word (page row) into the write registers in
+    // the flash controller.
+    for (i, row) in flash_page.chunks_exact(BYTES_PER_FLASH_WORD).enumerate() {
+        // TODO: this will be unnecessary if array_chunks stabilizes
+        let row: &[u8; BYTES_PER_FLASH_WORD] = row.try_into().unwrap_lite();
+
+        flash.start_write_row(i as u32, row);
+        while !flash.poll_write_result() {
+            // spin - supposed to be very quick in hardware.
+        }
     }
+
+    // Now, program the whole page into non-volatile storage. This again uses
+    // page indices, requiring a divide-by-16.
+    flash.start_program(write_addr / WORDSZ);
+    wait_for_erase_or_program(&mut flash)?;
+
+    Ok(())
+}
+
+/// Utility function that does an interrupt-driven poll and sleep while the
+/// flash controller finishes a write or erase.
+fn wait_for_erase_or_program(
+    flash: &mut drv_lpc55_flash::Flash,
+) -> Result<(), UpdateError> {
+    loop {
+        if let Some(result) = flash.poll_erase_or_program_result() {
+            return result.map_err(|_| UpdateError::FlashError);
+        }
+
+        flash.enable_interrupt_sources();
+        sys_irq_control(notifications::FLASH_IRQ_MASK, true);
+        // RECV from the kernel cannot produce an error, so ignore it.
+        let _ = sys_recv_closed(
+            &mut [],
+            notifications::FLASH_IRQ_MASK,
+            TaskId::KERNEL,
+        );
+        flash.disable_interrupt_sources();
+    }
+}
+
+fn same_image(which: UpdateTarget) -> bool {
+    get_base(which) == unsafe { __this_image.as_ptr() } as u32
+}
+
+/// Returns the byte address of the first byte of the given flash target slot,
+/// or panics if you're holding it wrong.
+fn get_base(which: UpdateTarget) -> u32 {
+    (match which {
+        UpdateTarget::ImageA => unsafe { __IMAGE_A_BASE.as_ptr() },
+        UpdateTarget::ImageB => unsafe { __IMAGE_B_BASE.as_ptr() },
+        UpdateTarget::Bootloader => unsafe { __IMAGE_STAGE0_BASE.as_ptr() },
+        _ => unreachable!(),
+    }) as u32
+}
+
+fn get_end(which: UpdateTarget) -> u32 {
+    (match which {
+        UpdateTarget::ImageA => unsafe { __IMAGE_A_END.as_ptr() },
+        UpdateTarget::ImageB => unsafe { __IMAGE_B_END.as_ptr() },
+        UpdateTarget::Bootloader => unsafe { __IMAGE_STAGE0_END.as_ptr() },
+        _ => unreachable!(),
+    }) as u32
+}
+
+/// Computes the byte address of the first byte in a particular (slot, page)
+/// combination.
+///
+/// `image_target` designates the flash slot and must be `ImageA`, `ImageB`, or
+/// `Bootloader`, despite containing many other variants. All other choices will
+/// panic. (TODO: fix this when time permits.)
+///
+/// `page_num` designates a flash page (called a block elsewhere in this file, a
+/// 512B unit) within the flash slot. If the page is out range for the target
+/// slot, returns `None`.
+fn target_addr(image_target: UpdateTarget, page_num: u32) -> Option<u32> {
+    let base = get_base(image_target);
+
+    // This is safely calculating addr = base + page_num * PAGE_SIZE
+    let addr = page_num
+        .checked_mul(BLOCK_SIZE_BYTES as u32)?
+        .checked_add(base)?;
+
+    // check addr + PAGE_SIZE <= end
+    if addr.checked_add(BLOCK_SIZE_BYTES as u32)? > get_end(image_target) {
+        return None;
+    }
+
+    Some(addr)
 }
 
 #[export_name = "main"]
@@ -319,6 +429,7 @@ fn main() -> ! {
 }
 
 include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
 mod idl {
     use super::{
         CabooseError, ImageVersion, UpdateError, UpdateStatus, UpdateTarget,


### PR DESCRIPTION
Previously we've been calling through the LPC55's ROM to write/erase flash. In build configurations where Trustzone was enabled, this meant indirecting through the hypovisor into the secure-world to perform the flash writes.

This mostly worked fine but had some structural issues:

- The actual code to interact with flash was spread over four crates and a closed-source ROM, so answering basic questions like "does this function called write actually erase?" was surprisingly involved.

- Adding new entry points to flash (e.g. for erase-check or verify) required modifying ~4 crates.

- Getting the ROM working from within a Hubris task (for the non-hypovisor case) consumed all of the task's MPU slots to map: SYSCON, the secure alias of SYSCON, the flash controller, the ROM itself, program RAM, program flash, and handoff memory in USBSRAM. This meant adding a new mapping for something like caboose of CFPA access was impossible.

I got here during the Verified Boot Debacle because of my need to rewrite CFPA in-system, map the transient boot select RAM into the task, and finish the "Read Caboose" TODO -- all of which were not possible given the jammed MPU configuration.

However, I also happened to have written most of a direct ROM-free driver for the LPC55 flash controller during my RFD374 stage0 work. So, I ported it over, and have rewritten the lpc55-update-server to use it.

You're probably wondering: this seems to strip out all hypocall code, how can this work on Trustzone configurations? Well, I have sort-of-good news for you, in two parts:

1. We only have one trustzone configuration, which is the LPC55xpresso board, because the attempt to add trustzone to the Gimlet C rev was silently undone by a typo. (Our configuration system could do a better job noticing this, but it's not immediately obvious how to pull it off.)

2. Even in trustzone, we never actually limited nonsecure access to the flash controller -- defeating the point of trustzone, but also enabling this driver to work without further changes.

Besides freeing up MPU regions and cutting the ROM out of the picture, which I consider to be good things, there are a couple of unintended benefits of this change:

1. Driving the flash controller directly requires less code than calling the ROM (seriously), and shrinks the update server by 300 bytes.

2. Flash writes and erases are now interrupt-driven. The ROM appears to have used busy-waits the way we were calling it (since it had no ability to configure or respond to interrupts, running in unprivileged mode).

I've also renamed the peripheral in chips.toml from "flash" to "flash_controller," since program text is also called "flash" and I felt like it was potentially confusing.