### PR TITLE
Extract final.bin/elf from the archive in the build system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools#3aa711b26fc179c130986bf41c13445a984e8adb"
+source = "git+https://github.com/oxidecomputer/hubtools#c07c7664996d4d0f8fe70ae7f457131d920e2390"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -458,10 +458,9 @@ pub fn package(
             kentry,
             0xFF,
         )?;
-        raw_image.write_all(&cfg.img_dir(image_name), "final")?;
 
         write_gdb_script(&cfg, image_name)?;
-        let archive_name = build_archive(&cfg, image_name)?;
+        let archive_name = build_archive(&cfg, image_name, raw_image)?;
 
         // Post-build modifications: populate a default caboose if requested
         if let Some(caboose) = &cfg.toml.caboose {
@@ -534,6 +533,14 @@ pub fn package(
                 [signing.rotk0, signing.rotk1, signing.rotk2, signing.rotk3],
             )?;
             archive.overwrite()?;
+        }
+
+        // Unzip the signed + caboose'd images into our build directory
+        let archive = hubtools::RawHubrisArchive::load(&archive_name)?;
+        for ext in ["elf", "bin"] {
+            let name = format!("final.{}", ext);
+            let file_data = archive.extract_file(&format!("img/{name}"))?;
+            std::fs::write(cfg.img_file(&name, image_name), file_data)?;
         }
     }
     Ok(allocated)
@@ -679,7 +686,11 @@ fn write_gdb_script(cfg: &PackageConfig, image_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<PathBuf> {
+fn build_archive(
+    cfg: &PackageConfig,
+    image_name: &str,
+    raw_image: hubtools::RawHubrisImage,
+) -> Result<PathBuf> {
     // Bundle everything up into an archive.
     let archive_path =
         cfg.img_file(format!("build-{}.zip", cfg.toml.name), image_name);
@@ -727,11 +738,8 @@ fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<PathBuf> {
     archive.copy(cfg.img_file("kernel", image_name), elf_dir.join("kernel"))?;
 
     let img_dir = PathBuf::from("img");
-
-    for ext in ["elf", "bin"] {
-        let name = format!("final.{}", ext);
-        archive.copy(cfg.img_file(&name, image_name), img_dir.join(&name))?;
-    }
+    archive.binary(img_dir.join("final.elf"), raw_image.to_elf()?)?;
+    archive.binary(img_dir.join("final.bin"), raw_image.to_binary()?)?;
 
     //
     // To allow for the image to be flashed based only on the archive (e.g.,
@@ -2437,6 +2445,18 @@ impl Archive {
         self.inner
             .start_file(zip_path.as_ref().to_slash().unwrap(), self.opts)?;
         self.inner.write_all(contents.as_ref().as_bytes())?;
+        Ok(())
+    }
+
+    /// Creates a binary file in the archive at `zip_path` with `contents`.
+    fn binary(
+        &mut self,
+        zip_path: impl AsRef<Path>,
+        contents: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.inner
+            .start_file(zip_path.as_ref().to_slash().unwrap(), self.opts)?;
+        self.inner.write_all(contents.as_ref())?;
         Ok(())
     }
 


### PR DESCRIPTION
This ensures that the `final.{bin,elf}` in the build directory are cabooséd and signed.