### PR TITLE
kern: rework dump impl to reduce UB

### DIFF
--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -7,7 +7,7 @@ memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"
-requires = {flash = 24400, ram = 6256}
+requires = {flash = 24416, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -7,7 +7,7 @@ memory = "memory-large.toml"
 
 [kernel]
 name = "sidecar"
-requires = {flash = 24400, ram = 6256}
+requires = {flash = 24416, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -455,7 +455,9 @@ fn read_task_dump_region(
                     // at first glance since it's backwards from every other
                     // routine in the kernel -- but its shape is deliberate! We
                     // really do want to apply the SRC fault to the caller,
-                    // followed by any remaining DST fault.
+                    // followed by any remaining DST fault (by returning it from
+                    // this function, which means it'll be applied by the
+                    // generic syscall error handler).
                     //
                     // Note that if the supervisor is _really_ misbehaving, this
                     // can result in the delivery of two faults to it (the SRC

--- a/sys/kern/src/lib.rs
+++ b/sys/kern/src/lib.rs
@@ -48,3 +48,4 @@ pub mod syscalls;
 pub mod task;
 pub mod time;
 pub mod umem;
+pub mod util;

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -9,6 +9,7 @@ use zerocopy::FromBytes;
 
 use crate::err::InteractFault;
 use crate::task::Task;
+use crate::util::index2_distinct;
 use abi::{FaultInfo, FaultSource, UsageError};
 
 /// A (user, untrusted, unprivileged) slice.
@@ -313,24 +314,5 @@ pub fn safe_copy(
             src: src.err(),
             dst: dst.err(),
         }),
-    }
-}
-
-/// Utility routine for getting `&mut` to _two_ elements of a slice, at indexes
-/// `i` and `j`. `i` and `j` must be distinct, or this will panic.
-#[allow(clippy::comparison_chain)]
-fn index2_distinct<T>(
-    elements: &mut [T],
-    i: usize,
-    j: usize,
-) -> (&mut T, &mut T) {
-    if i < j {
-        let (prefix, suffix) = elements.split_at_mut(i + 1);
-        (&mut prefix[i], &mut suffix[j - (i + 1)])
-    } else if j < i {
-        let (prefix, suffix) = elements.split_at_mut(j + 1);
-        (&mut suffix[i - (j + 1)], &mut prefix[j])
-    } else {
-        panic!()
     }
 }

--- a/sys/kern/src/util.rs
+++ b/sys/kern/src/util.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Common utility functions used in various places in the kernel.
+
+/// Utility routine for getting `&mut` to _two_ elements of a slice, at indexes
+/// `i` and `j`. `i` and `j` must be distinct, or this will panic.
+#[allow(clippy::comparison_chain)]
+pub fn index2_distinct<T>(
+    elements: &mut [T],
+    i: usize,
+    j: usize,
+) -> (&mut T, &mut T) {
+    if i < j {
+        let (prefix, suffix) = elements.split_at_mut(i + 1);
+        (&mut prefix[i], &mut suffix[j - (i + 1)])
+    } else if j < i {
+        let (prefix, suffix) = elements.split_at_mut(j + 1);
+        (&mut suffix[i - (j + 1)], &mut prefix[j])
+    } else {
+        panic!()
+    }
+}


### PR DESCRIPTION
Doing a kernel dump from within the kernel is inherently hairy. We wind up needing to do a raw byte read of a Task struct, which we also need to interact with as an actual Task.

The implementation was
- Creating (using core::slice::from_raw_parts) a byte slice that aliased the &mut [Task] task table
- Then using it and the &mut concurrently

which is UB due to aliasing violations.

The code also contained an easily accessible way of crashing the kernel: send in a region such that base+size overflows. Triggering this reliably required choosing a base value within the TCB address range, because the other code path used USlice.

I've reworked the logic. The particular code that was causing the UB issue has been replaced by

- Deriving a &mut Task to the specific task we want to access, and then
- Deriving a &[u8] from it using transmute and shadowing to prevent aliasing.

(This was also the second time in the kernel I've wanted the index2_distinct function, so I've pulled it into an accessible common location.)

I've eliminated the caller-controlled kernel panic by using USlice along all code paths. This had the side effect of removing some runtime overflow checks from the generated code, slightly reducing code size. (However, the code is slightly bigger overall as a result of this change.)

I've also added a crapload of comments to try and help future readers of this subtle routine.