### PR TITLE
Illuminate user LED on PSC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ version = "0.1.0"
 dependencies = [
  "drv-packrat-vpd-loader",
  "drv-psc-seq-api",
+ "drv-stm32xx-sys-api",
  "task-jefe-api",
  "userlib",
 ]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -7,7 +7,7 @@ stacksize = 896
 
 [kernel]
 name = "psc"
-requires = {flash = 32768, ram = 4800}
+requires = {flash = 32768, ram = 4880}
 features = ["dump"]
 
 [caboose]
@@ -73,7 +73,7 @@ name = "drv-psc-seq-server"
 priority = 4
 stacksize = 4096
 start = true
-task-slots = ["jefe", "packrat", "i2c_driver"]
+task-slots = ["jefe", "packrat", "i2c_driver", "sys"]
 
 [tasks.update_server]
 name = "stm32h7-update-server"
@@ -194,6 +194,14 @@ max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 800
+
+[tasks.user_leds]
+name = "drv-user-leds"
+features = ["stm32h7"]
+priority = 2
+max-sizes = {flash = 2048, ram = 1024}
+start = true
+task-slots = ["sys"]
 
 [tasks.power]
 name = "task-power"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -71,7 +71,7 @@ name = "drv-psc-seq-server"
 priority = 4
 stacksize = 4096
 start = true
-task-slots = ["jefe", "packrat", "i2c_driver"]
+task-slots = ["jefe", "packrat", "i2c_driver", "sys"]
 
 [tasks.update_server]
 name = "stm32h7-update-server"
@@ -203,6 +203,14 @@ max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 800
+
+[tasks.user_leds]
+name = "drv-user-leds"
+features = ["stm32h7"]
+priority = 2
+max-sizes = {flash = 2048, ram = 1024}
+start = true
+task-slots = ["sys"]
 
 [tasks.power]
 name = "task-power"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -7,7 +7,7 @@ stacksize = 896
 
 [kernel]
 name = "psc"
-requires = {flash = 32768, ram = 4800}
+requires = {flash = 32768, ram = 4880}
 features = ["dump"]
 
 [caboose]

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -71,7 +71,7 @@ name = "drv-psc-seq-server"
 priority = 4
 stacksize = 4096
 start = true
-task-slots = ["jefe", "packrat", "i2c_driver"]
+task-slots = ["jefe", "packrat", "i2c_driver", "sys"]
 
 [tasks.update_server]
 name = "stm32h7-update-server"
@@ -203,6 +203,14 @@ max-sizes = {flash = 8192, ram = 1024}
 start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 800
+
+[tasks.user_leds]
+name = "drv-user-leds"
+features = ["stm32h7"]
+priority = 2
+max-sizes = {flash = 2048, ram = 1024}
+start = true
+task-slots = ["sys"]
 
 [tasks.power]
 name = "task-power"

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -7,7 +7,7 @@ stacksize = 896
 
 [kernel]
 name = "psc"
-requires = {flash = 32768, ram = 4800}
+requires = {flash = 32768, ram = 4880}
 features = ["dump"]
 
 [caboose]

--- a/drv/psc-seq-server/Cargo.toml
+++ b/drv/psc-seq-server/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-drv-packrat-vpd-loader = { path = "../packrat-vpd-loader" }
-drv-psc-seq-api = { path = "../psc-seq-api" }
-task-jefe-api = { path = "../../task/jefe-api" }
+drv-packrat-vpd-loader.path = "../packrat-vpd-loader"
+drv-psc-seq-api.path = "../psc-seq-api"
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
+task-jefe-api.path = "../../task/jefe-api"
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/drv/psc-seq-server/src/main.rs
+++ b/drv/psc-seq-server/src/main.rs
@@ -9,15 +9,30 @@
 
 use drv_packrat_vpd_loader::{read_vpd_and_load_packrat, Packrat};
 use drv_psc_seq_api::PowerState;
+use drv_stm32xx_sys_api as sys_api;
 use task_jefe_api::Jefe;
 use userlib::*;
 
+task_slot!(SYS, sys);
 task_slot!(I2C, i2c_driver);
 task_slot!(JEFE, jefe);
 task_slot!(PACKRAT, packrat);
 
+const STATUS_LED: sys_api::PinSet = sys_api::Port::A.pin(3);
+
 #[export_name = "main"]
 fn main() -> ! {
+    let sys = sys_api::Sys::from(SYS.get_task_id());
+    // Turn off the chassis LED, in case this is a task restart (and not a
+    // full chip restart, which would leave the GPIO unconfigured).
+    sys.gpio_configure_output(
+        STATUS_LED,
+        sys_api::OutputType::PushPull,
+        sys_api::Speed::Low,
+        sys_api::Pull::None,
+    );
+    sys.gpio_reset(STATUS_LED);
+
     let jefe = Jefe::from(JEFE.get_task_id());
 
     // Populate packrat with our mac address and identity.
@@ -25,6 +40,7 @@ fn main() -> ! {
     read_vpd_and_load_packrat(&packrat, I2C.get_task_id());
 
     jefe.set_state(PowerState::A2 as u32);
+    sys.gpio_set(STATUS_LED);
 
     // We have nothing else to do, so sleep forever via waiting for a message
     // from the kernel that won't arrive.

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -68,6 +68,9 @@ cfg_if::cfg_if! {
         target_board = "gimlet-b",
         target_board = "gimlet-c",
         target_board = "gimlet-d",
+        target_board = "psc-a",
+        target_board = "psc-b",
+        target_board = "psc-c",
     ))] {
         #[derive(FromPrimitive)]
         enum Led {
@@ -405,6 +408,9 @@ cfg_if::cfg_if! {
             } else if #[cfg(any(target_board = "gimlet-b",
                                 target_board = "gimlet-c",
                                 target_board = "gimlet-d",
+                                target_board = "psc-a",
+                                target_board = "psc-b",
+                                target_board = "psc-c",
             ))] {
                 const LEDS: &[(drv_stm32xx_sys_api::PinSet, bool)] = &[
                     (drv_stm32xx_sys_api::Port::A.pin(3), false),


### PR DESCRIPTION
This works on Ian's rev B, although it doesn't work on my rev A; Ian is going to double-check the rev A layout, because it may disagree with the schematic in EDM.