### PR TITLE
Build system cleanups as followup to #1254

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/hubtools#c07c7664996d4d0f8fe70ae7f457131d920e2390"
+source = "git+https://github.com/oxidecomputer/hubtools#46e06955cb316a4297761f3c78c6f4f15c5209c1"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#2940a0f7fbae7b7cfb48ad6d3206ee754f9237d6"
+source = "git+https://github.com/oxidecomputer/lpc55_support#2a636db8dc8336a6d5fb4d3ee7285adf9814c308"
 dependencies = [
  "bitfield 0.14.0",
  "packed_struct",
@@ -2630,10 +2630,9 @@ dependencies = [
 [[package]]
 name = "lpc55_sign"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#2940a0f7fbae7b7cfb48ad6d3206ee754f9237d6"
+source = "git+https://github.com/oxidecomputer/lpc55_support#2a636db8dc8336a6d5fb4d3ee7285adf9814c308"
 dependencies = [
  "byteorder",
- "colored",
  "crc-any",
  "env_logger",
  "hex",

--- a/build/task-link.x
+++ b/build/task-link.x
@@ -15,8 +15,6 @@ SECTIONS
     __etext = .;
   } > FLASH =0xdededede
 
-  INCLUDE trustzone.x
-
   /* ### .rodata */
   .rodata : ALIGN(4)
   {

--- a/build/task-rlink.x
+++ b/build/task-rlink.x
@@ -13,8 +13,6 @@ SECTIONS
     __etext = .;
   }
 
-  INCLUDE trustzone.x
-
   /* ### .rodata */
   .rodata : ALIGN(4)
   {

--- a/build/task-tlink.x
+++ b/build/task-tlink.x
@@ -17,9 +17,6 @@ SECTIONS
     __etext = .;
   } > FLASH =0xdededede
 
-
-  INCLUDE trustzone.x
-
   /* ### .rodata */
   .rodata : ALIGN(4)
   {

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -79,7 +79,6 @@ pub fn run(
                 &allocs.tasks,
                 &entry_points,
                 &toml.image_names[0],
-                &None,
             )?;
             let kconfig = ron::ser::to_string(&kconfig)?;
 

--- a/lib/toml-task/src/lib.rs
+++ b/lib/toml-task/src/lib.rs
@@ -20,8 +20,6 @@ pub struct Task<T = ordered_toml::Value> {
     pub priority: u8,
     pub stacksize: Option<u32>,
     #[serde(default)]
-    pub uses_secure_entry: bool,
-    #[serde(default)]
     pub start: bool,
 
     #[serde(default)]

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![feature(cmse_nonsecure_entry)]
 #![feature(naked_functions)]
 #![feature(array_methods)]
 #![no_main]


### PR DESCRIPTION
- Bumps hubtools to a version that accepts the new or old magic numbers in images, in preparation for the magic number change.
- Improves diagnostics of hubtool errors by adding context messages in the build system
- Removes currently-untested trustzone related config stuff in the TOML and collapses it down to the "not trustzone" case.