### PR TITLE
stage0 should no longer enable TrustZone

### DIFF
--- a/app/gimlet-rot/stage0-c-lab.toml
+++ b/app/gimlet-rot/stage0-c-lab.toml
@@ -8,7 +8,7 @@ external-images = ["a", "b"]
 [kernel]
 name = "stage0"
 requires = {flash = 0x9000, ram = 16000}
-features = ["tz_support", "dice-self"]
+features = ["dice-self"]
 stacksize = 13000
 
 [tasks.idle]

--- a/app/gimlet-rot/stage0-c.toml
+++ b/app/gimlet-rot/stage0-c.toml
@@ -8,7 +8,7 @@ external-images = ["a", "b"]
 [kernel]
 name = "stage0"
 requires = {flash = 0x9000, ram = 16000}
-features = ["tz_support", "dice-mfg"]
+features = ["dice-mfg"]
 stacksize = 14000
 
 [tasks.idle]

--- a/app/lpc55xpresso/stage0.toml
+++ b/app/lpc55xpresso/stage0.toml
@@ -8,7 +8,7 @@ external-images = ["a", "b"]
 [kernel]
 name = "stage0"
 requires = {flash = 0x9000, ram = 16000}
-features = ["tz_support", "dice-self"]
+features = ["dice-self"]
 stacksize = 13000
 
 [tasks.idle]

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -18,8 +18,6 @@ fn main() -> Result<()> {
     build_util::expose_m_profile();
 
     let g = process_config()?;
-
-    generate_consts()?;
     generate_statics(&g)?;
 
     Ok(())
@@ -344,48 +342,6 @@ fn fmt_region(region: &RegionConfig) -> TokenStream {
             attributes: #atts,
         }
     }
-}
-
-fn generate_consts() -> Result<()> {
-    let out = build_util::out_dir();
-    let consts_path = out.join("consts.rs");
-    let mut const_file =
-        File::create(&consts_path).context("creating consts.rs file")?;
-
-    writeln!(
-        const_file,
-        "// See build.rs for an explanation of this constant"
-    )?;
-
-    // EXC_RETURN is used on ARMv8m to return from an exception. This value
-    // differs between secure and non-secure in two important ways:
-    // bit 6 = S = secure or non-secure stack used
-    // bit 0 = ES = the security domain the exception was taken to
-    // These need to be consistent! The failure mode is a secure fault
-    // otherwise
-    let exc_return_value =
-        if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
-            if secure == "0" {
-                0xFFFFFFAC_u32
-            } else {
-                0xFFFFFFED_u32
-            }
-        } else {
-            0xFFFFFFED_u32
-        };
-
-    writeln!(
-        const_file,
-        "{}",
-        quote::quote! {
-            pub const EXC_RETURN_CONST: u32 = #exc_return_value;
-        },
-    )?;
-
-    drop(const_file);
-    call_rustfmt::rustfmt(consts_path)?;
-
-    Ok(())
 }
 
 fn generate_statics(gen: &Generated) -> Result<()> {

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -259,6 +259,15 @@ const INITIAL_PSR: u32 = 1 << 24;
 #[cfg(any(armv7m, armv8m))]
 const INITIAL_FPSCR: u32 = 0;
 
+/// EXC_RETURN is used on ARMv8m to return from an exception. This value
+/// differs between secure and non-secure in two important ways:
+/// bit 6 = S = secure or non-secure stack used
+/// bit 0 = ES = the security domain the exception was taken to
+/// These need to be consistent! The failure mode is a secure fault otherwise.
+/// We currently assume that TrustZone has not been enabled (even on the parts
+/// that support it) (and that bit 6 and bit 0 can always be set).
+const EXC_RETURN_CONST: u32 = 0xFFFFFFED;
+
 // Because debuggers need to know the clock frequency to set the SWO clock
 // scaler that enables ITM, and because ITM is particularly useful when
 // debugging boot failures, this should be set as early in boot as it can
@@ -1716,6 +1725,3 @@ cfg_if::cfg_if! {
 
     }
 }
-
-// Constants that may change depending on configuration
-include!(concat!(env!("OUT_DIR"), "/consts.rs"));

--- a/task/ping/build.rs
+++ b/task/ping/build.rs
@@ -2,35 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::io::Write;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
-
-    generate_consts()?;
-
-    Ok(())
-}
-
-fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = build_util::out_dir();
-    let mut const_file = File::create(out.join("consts.rs")).unwrap();
-
-    // If hubris is non-secure (i.e. TZ is enabled) we need to use a
-    // different address for our bad address testing since NULL will
-    // trigger a secure fault
-    if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
-        if secure == "0" {
-            // This corresponds to USB SRAM on the LPC55
-            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")
-                .unwrap();
-        } else {
-            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
-        }
-    } else {
-        writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
-    }
-
     Ok(())
 }

--- a/task/ping/src/main.rs
+++ b/task/ping/src/main.rs
@@ -13,8 +13,12 @@ task_slot!(UART, usart_driver);
 
 #[inline(never)]
 fn nullread() {
+    // This constant should be in a region we can't access to induce a memory
+    // fault. (Note that if TZ is enabled, this will in fact induce a secure
+    // fault, and a different constant will be required.)
+    const BAD_ADDRESS: u32 = 0x0;
+
     unsafe {
-        // This constant is in a region we can't access; memory fault
         (BAD_ADDRESS as *const u8).read_volatile();
     }
 }
@@ -72,5 +76,3 @@ fn uart_send(text: &[u8]) {
 
 #[cfg(not(feature = "uart"))]
 fn uart_send(_: &[u8]) {}
-
-include!(concat!(env!("OUT_DIR"), "/consts.rs"));

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -2,37 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::io::Write;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_util::expose_m_profile();
 
     #[cfg(feature = "i2c-devices")]
     build_i2c::codegen(build_i2c::Disposition::Devices)?;
-
-    generate_consts()?;
-    Ok(())
-}
-
-fn generate_consts() -> Result<(), Box<dyn std::error::Error>> {
-    let out = build_util::out_dir();
-    let mut const_file = File::create(out.join("consts.rs")).unwrap();
-
-    // If hubris is non-secure (i.e. TZ is enabled) we need to use a
-    // different address for our bad address testing since NULL will
-    // trigger a secure fault
-    if let Ok(secure) = build_util::env_var("HUBRIS_SECURE") {
-        if secure == "0" {
-            // This corresponds to USB SRAM on the LPC55
-            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x40100000;")
-                .unwrap();
-        } else {
-            writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
-        }
-    } else {
-        writeln!(const_file, "pub const BAD_ADDRESS : u32 = 0x0;").unwrap();
-    }
 
     Ok(())
 }

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -27,6 +27,11 @@ use test_api::*;
 use userlib::*;
 use zerocopy::AsBytes;
 
+/// A constant that is known to be in a region we can't access to induce a
+/// memory fault. (Note that if TZ is enabled, this will in fact induce a
+/// secure fault, and a different constant will be required.)
+const BAD_ADDRESS: u32 = 0x0;
+
 /// Helper macro for building a list of functions with their names.
 macro_rules! test_cases {
     ($($(#[$attr:meta])* $name:path,)*) => {
@@ -1494,5 +1499,3 @@ fn main() -> ! {
         )
     }
 }
-
-include!(concat!(env!("OUT_DIR"), "/consts.rs"));


### PR DESCRIPTION
#1254 eliminates TZ support from Hubris, but because stage0 still had TZ support enabled, Hubris would fail on a secure fault on its first exception.  This disables TZ support in stage0 on those parts that support is (i.e., LPC55S69), as well as removes build apparatus that only existed to support TZ (following up on similar work done in #1255).