### PR TITLE
Implement MGS LED control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#cf6bf75986289892eccd562231afea197539a30b"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#76c227f97ba23a197b09d4b5fb2b11f7a7e20c34"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -3888,6 +3888,7 @@ dependencies = [
  "drv-sprot-api",
  "drv-stm32h7-usart",
  "drv-update-api",
+ "drv-user-leds-api",
  "gateway-messages",
  "heapless",
  "host-sp-messages",

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -259,6 +259,7 @@ task-slots = [
     "sprot",
     "i2c_driver",
     "packrat",
+    "user_leds",
 ]
 features = [
     "gimlet",

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -259,6 +259,7 @@ task-slots = [
     "sprot",
     "i2c_driver",
     "packrat",
+    "user_leds",
 ]
 features = [
     "gimlet",

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -259,6 +259,7 @@ task-slots = [
     "sprot",
     "i2c_driver",
     "packrat",
+    "user_leds",
 ]
 features = [
     "gimlet",

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -221,6 +221,7 @@ task-slots = [
     "sensor",
     "sprot",
     "packrat",
+    "user_leds",
 ]
 features = ["gimlet", "usart1-gimletlet", "vlan", "baud_rate_3M"]
 notifications = ["usart-irq", "socket", "timer"]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -132,6 +132,7 @@ task-slots = [
     "sensor",
     "sprot",
     "packrat",
+    "user_leds",
 ]
 features = ["psc", "vlan"]
 notifications = ["usart-irq", "socket", "timer"]

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -141,6 +141,7 @@ task-slots = [
     "sensor",
     "sprot",
     "packrat",
+    "user_leds",
 ]
 features = ["psc", "vlan"]
 notifications = ["usart-irq", "socket", "timer"]

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -141,6 +141,7 @@ task-slots = [
     "sensor",
     "sprot",
     "packrat",
+    "user_leds",
 ]
 features = ["psc", "vlan"]
 notifications = ["usart-irq", "socket", "timer"]

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -20,6 +20,7 @@ drv-gimlet-hf-api = { path = "../../drv/gimlet-hf-api", optional = true }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api", optional = true }
 drv-ignition-api = { path = "../../drv/ignition-api", optional = true }
 drv-monorail-api = { path = "../../drv/monorail-api", optional = true }
+drv-user-leds-api = { path = "../../drv/user-leds-api", optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-sprot-api = { path = "../../drv/sprot-api" }
 drv-stm32h7-usart = { path = "../../drv/stm32h7-usart", features = ["h753"], optional = true }
@@ -41,9 +42,9 @@ build-util = { path = "../../build/util" }
 idol = { workspace = true }
 
 [features]
-gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart"]
+gimlet = ["drv-gimlet-hf-api", "drv-gimlet-seq-api", "drv-stm32h7-usart", "drv-user-leds-api"]
 sidecar = ["drv-sidecar-seq-api", "drv-monorail-api", "drv-ignition-api"]
-psc = []
+psc = ["drv-user-leds-api"]
 
 vlan = ["task-net-api/vlan"]
 

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -304,6 +304,15 @@ mod devices_with_static_validation {
             // to MGS messages anyway!
             presence: DevicePresence::Present,
         },
+        #[cfg(any(feature = "gimlet", feature = "psc"))]
+        DeviceDescription {
+            component: SpComponent::SYSTEM_LED,
+            device: SpComponent::SYSTEM_LED.const_as_str(),
+            description: "System attention LED",
+            capabilities: DeviceCapabilities::IS_LED,
+            // The LED is soldered to the board
+            presence: DevicePresence::Present,
+        },
     ];
 
     pub(super) static OUR_DEVICES: &[DeviceDescription<'static>] =

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -38,6 +38,7 @@ impl MgsCommon {
         }
     }
 
+    #[allow(dead_code)] // This function is only used by Gimlet right now
     pub(crate) fn packrat(&self) -> &Packrat {
         &self.packrat
     }

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -598,6 +598,9 @@ impl SpHandler for MgsHandler {
                 match action {
                     LedComponentAction::TurnOn => self.user_leds.led_on(0),
                     LedComponentAction::TurnOff => self.user_leds.led_off(0),
+                    LedComponentAction::Blink => {
+                        return Err(SpError::RequestUnsupportedForComponent)
+                    }
                 }
                 .unwrap();
                 Ok(())

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -285,6 +285,9 @@ impl SpHandler for MgsHandler {
                 match action {
                     LedComponentAction::TurnOn => self.user_leds.led_on(0),
                     LedComponentAction::TurnOff => self.user_leds.led_off(0),
+                    LedComponentAction::Blink => {
+                        return Err(SpError::RequestUnsupportedForComponent)
+                    }
                 }
                 .unwrap();
                 Ok(())

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -8,14 +8,15 @@ use crate::{
     mgs_common::MgsCommon, update::rot::RotUpdate, update::sp::SpUpdate,
     update::ComponentUpdater, Log, MgsMessage,
 };
+use drv_user_leds_api::UserLeds;
 use gateway_messages::sp_impl::{
     BoundsChecked, DeviceDescription, SocketAddrV6, SpHandler,
 };
 use gateway_messages::{
-    ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, MgsError, PowerState, SlotId, SpComponent,
-    SpError, SpPort, SpState, SpUpdatePrepare, SwitchDuration, UpdateChunk,
-    UpdateId, UpdateStatus,
+    ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
+    DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
+    SlotId, SpComponent, SpError, SpPort, SpState, SpUpdatePrepare,
+    SwitchDuration, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -27,6 +28,8 @@ use userlib::sys_get_timer;
 // How big does our shared update buffer need to be? Has to be able to handle SP
 // update blocks for now, no other updateable components.
 const UPDATE_BUFFER_SIZE: usize = SpUpdate::BLOCK_SIZE;
+
+userlib::task_slot!(USER_LEDS, user_leds);
 
 // Create type aliases that include our `UpdateBuffer` size (i.e., the size of
 // the largest update chunk of all the components we update).
@@ -45,6 +48,7 @@ pub(crate) struct MgsHandler {
     common: MgsCommon,
     sp_update: SpUpdate,
     rot_update: RotUpdate,
+    user_leds: UserLeds,
 }
 
 impl MgsHandler {
@@ -55,6 +59,7 @@ impl MgsHandler {
             common: MgsCommon::claim_static_resources(base_mac_address),
             sp_update: SpUpdate::new(),
             rot_update: RotUpdate::new(),
+            user_leds: UserLeds::from(USER_LEDS.get_task_id()),
         }
     }
 
@@ -261,6 +266,28 @@ impl SpHandler for MgsHandler {
         match update.component {
             SpComponent::ROT | SpComponent::STAGE0 => {
                 self.rot_update.prepare(&UPDATE_MEMORY, update)
+            }
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_action(
+        &mut self,
+        _sender: SocketAddrV6,
+        component: SpComponent,
+        action: ComponentAction,
+    ) -> Result<(), SpError> {
+        match (component, action) {
+            (SpComponent::SYSTEM_LED, ComponentAction::Led(action)) => {
+                use gateway_messages::LedComponentAction;
+                // Setting the LED should be infallible, because we know that
+                // this board supports LED 0 as the system LED.
+                match action {
+                    LedComponentAction::TurnOn => self.user_leds.led_on(0),
+                    LedComponentAction::TurnOff => self.user_leds.led_off(0),
+                }
+                .unwrap();
+                Ok(())
             }
             _ => Err(SpError::RequestUnsupportedForComponent),
         }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -14,10 +14,10 @@ use gateway_messages::sp_impl::{
     BoundsChecked, DeviceDescription, SocketAddrV6, SpHandler,
 };
 use gateway_messages::{
-    ignition, ComponentDetails, ComponentUpdatePrepare, DiscoverResponse,
-    IgnitionCommand, IgnitionState, MgsError, PowerState, SlotId, SpComponent,
-    SpError, SpPort, SpState, SpUpdatePrepare, SwitchDuration, UpdateChunk,
-    UpdateId, UpdateStatus,
+    ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
+    DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
+    SlotId, SpComponent, SpError, SpPort, SpState, SpUpdatePrepare,
+    SwitchDuration, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -310,6 +310,21 @@ impl SpHandler for MgsHandler {
         match update.component {
             SpComponent::ROT | SpComponent::STAGE0 => {
                 self.rot_update.prepare(&UPDATE_MEMORY, update)
+            }
+            _ => Err(SpError::RequestUnsupportedForComponent),
+        }
+    }
+
+    fn component_action(
+        &mut self,
+        _sender: SocketAddrV6,
+        component: SpComponent,
+        action: ComponentAction,
+    ) -> Result<(), SpError> {
+        match (component, action) {
+            (SpComponent::SYSTEM_LED, ComponentAction::Led(action)) => {
+                // TODO: implement this
+                Err(SpError::RequestUnsupportedForComponent)
             }
             _ => Err(SpError::RequestUnsupportedForComponent),
         }


### PR DESCRIPTION
This should be merged after https://github.com/oxidecomputer/management-gateway-service/pull/76

It plumbs system LED control through `control-plane-agent`.