### PR TITLE
Add network feature to `dump-agent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#466c9e6103c06a8adb345d83c2dd6856ee56a052"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5972cd5ee06fafc4fbe88ffe5369e3d750e10ece"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,7 +1965,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -3318,7 +3318,7 @@ dependencies = [
  "pkcs8",
  "rand_core",
  "sha2",
- "signature",
+ "signature 2.0.0",
  "subtle",
  "zeroize",
 ]
@@ -3586,6 +3586,12 @@ dependencies = [
  "kern",
  "stm32h7",
 ]
+
+[[package]]
+name = "signature"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 
 [[package]]
 name = "signature"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#03e8bc34840841604fbf10eb45f352ef87552b98"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#e90393824eb2e2ed13d8fd2fb03efcb90c854f8a"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#466c9e6103c06a8adb345d83c2dd6856ee56a052"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5be443b93a15b58582c16cb3c11e9497ca79a6e7"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#47cda952e2052e1067e0d586bb125f3668864d27"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5972cd5ee06fafc4fbe88ffe5369e3d750e10ece"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#03e8bc34840841604fbf10eb45f352ef87552b98"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,8 +2344,8 @@ dependencies = [
 
 [[package]]
 name = "humpty"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#47cda952e2052e1067e0d586bb125f3668864d27"
+version = "0.1.1"
+source = "git+https://github.com/oxidecomputer/humpty#b4052d8b0c1fe555e1686b281104852d7fba5230"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#e90393824eb2e2ed13d8fd2fb03efcb90c854f8a"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5be443b93a15b58582c16cb3c11e9497ca79a6e7"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
  "nb 1.0.0",
  "salty",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.4.1",
  "sha3",
  "stage0-handoff",
  "static_assertions",
@@ -701,7 +701,7 @@ dependencies = [
  "corncobs",
  "hubpack",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.4.1",
  "zerocopy",
 ]
 
@@ -1965,7 +1965,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "signature 1.3.2",
+ "signature",
 ]
 
 [[package]]
@@ -2289,7 +2289,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.4.1",
  "serde_repr",
  "static_assertions",
  "unwrap-lite",
@@ -2345,11 +2345,11 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty#448435605eaa076a57e0b7f78837602b5dd1deef"
 dependencies = [
  "hubpack",
  "lzss",
  "serde",
+ "serde-big-array 0.5.1",
  "static_assertions",
  "zerocopy",
 ]
@@ -3317,7 +3317,7 @@ dependencies = [
  "pkcs8",
  "rand_core",
  "sha2",
- "signature 2.0.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -3479,6 +3479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,12 +3588,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
-
-[[package]]
-name = "signature"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
@@ -3661,7 +3664,7 @@ dependencies = [
  "hubpack",
  "salty",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.4.1",
 ]
 
 [[package]]
@@ -3941,6 +3944,7 @@ name = "task-dump-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "build-util",
  "cfg-if",
  "cortex-m",
  "drv-sprot-api",
@@ -3950,11 +3954,13 @@ dependencies = [
  "humpty",
  "idol",
  "idol-runtime",
+ "mutable-statics",
  "num-traits",
  "ringbuf",
  "serde",
  "static_assertions",
  "task-jefe-api",
+ "task-net-api",
  "userlib",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "udp-types" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.1" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { path = "../humpty", default-features = false }
+humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "udp-types" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false }
+humpty = { path = "../humpty", default-features = false }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -180,6 +180,7 @@ clock_divider = "DIV16"
 
 
 [config.net]
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -228,6 +228,7 @@ cs = [{port = "D", pin = 14}]
 clock_divider = "DIV32"
 
 [config.net]
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -1282,14 +1282,14 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -1257,6 +1257,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -41,7 +41,7 @@ name = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16"]
 start = true
@@ -309,12 +309,14 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 6
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
 extern-regions = ["sram2", "sram3", "sram4"]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.sbrmi]
 name = "drv-sbrmi"
@@ -1283,6 +1285,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.sprot]
 # ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -310,10 +310,10 @@ task-slots = ["sys"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
-stacksize = 1200
+stacksize = 2400
 extern-regions = ["sram2", "sram3", "sram4"]
 notifications = ["socket"]
 features = ["net", "vlan"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -1310,7 +1310,7 @@ rx = { packets = 3, bytes = 2048 }
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for MGS traffic?
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -1303,14 +1303,14 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -41,7 +41,7 @@ name = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16"]
 start = true

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -1278,6 +1278,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -309,7 +309,7 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
+priority = 6
 max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -310,11 +310,13 @@ task-slots = ["sys"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
+task-slots = ["sprot", "jefe", "net"]
 stacksize = 1200
 extern-regions = ["sram2", "sram3", "sram4"]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.sbrmi]
 name = "drv-sbrmi"
@@ -1304,6 +1306,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for MGS traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.sprot]
 # ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -1285,6 +1285,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -41,7 +41,7 @@ name = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16"]
 start = true
@@ -309,12 +309,14 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 6
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
 extern-regions = ["sram2", "sram3", "sram4"]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.sbrmi]
 name = "drv-sbrmi"
@@ -1311,6 +1313,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.sprot]
 # ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -1310,14 +1310,14 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -310,7 +310,7 @@ task-slots = ["sys"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 6
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -380,6 +380,7 @@ cs = [{port = "E", pin = 11}]
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.broadcast]
 kind = "udp"

--- a/app/gimletlet/app-dc2024.toml
+++ b/app/gimletlet/app-dc2024.toml
@@ -405,7 +405,7 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -94,6 +94,7 @@ mux = "port_i"
 cs = [{port = "I", pin = 0}]
 
 [config.net]
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -10,6 +10,7 @@ version = 0
 [kernel]
 name = "gimletlet"
 requires = {flash = 32768, ram = 8192}
+features = ["dump"]
 
 [caboose]
 tasks = ["control_plane_agent", "caboose_reader"]
@@ -20,11 +21,12 @@ default = true
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 8192, ram = 2048}
+max-sizes = {flash = 16384, ram = 2048}
 start = true
-features = ["itm"]
+features = ["itm", "dump"]
 stacksize = 1536
 notifications = ["fault", "timer"]
+extern-regions = ["sram2", "sram3", "sram4"]
 
 [tasks.jefe.config.on-state-change]
 host_sp_comms = "jefe-state-change"
@@ -76,6 +78,17 @@ priority = 5
 max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
+
+[tasks.dump_agent]
+name = "task-dump-agent"
+priority = 5
+max-sizes = {flash = 16384, ram = 4096 }
+start = true
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 1200
+extern-regions = ["sram2", "sram3", "sram4"]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.gimlet_seq]
 name = "drv-mock-gimlet-seq-server"
@@ -386,6 +399,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for MGS traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.sprot]
 # TODO: This config is inert. Need to implement STM32 build.rs like the LPC55 has.

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -81,7 +81,7 @@ task-slots = ["sys"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
+priority = 6
 max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -174,7 +174,7 @@ name = "task-net"
 stacksize = 6040
 priority = 3
 features = ["h753", "vlan", "gimletlet-nic", "use-spi-core", "spi4"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi4"]
 start = true

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -371,6 +371,7 @@ cs = [{port = "E", pin = 11}]
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.broadcast]
 kind = "udp"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -396,14 +396,14 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for MGS traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -82,10 +82,10 @@ task-slots = ["sys"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
-stacksize = 1200
+stacksize = 2400
 extern-regions = ["sram2", "sram3", "sram4"]
 notifications = ["socket"]
 features = ["net", "vlan"]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -476,13 +476,13 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -451,6 +451,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -108,7 +108,7 @@ name = "task-net"
 stacksize = 6040
 priority = 4
 features = ["mgmt", "h753", "psc", "vlan", "vpd-mac", "use-spi-core", "spi2"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
 start = true
@@ -231,12 +231,14 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 4
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 5
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
-extern-regions = ["sram2", "sram3", "sram4"]
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
+extern-regions = [ "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.idle]
 name = "task-idle"
@@ -477,3 +479,10 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -232,7 +232,7 @@ task-slots = ["i2c_driver", "sensor"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -452,13 +452,13 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -241,7 +241,7 @@ task-slots = ["i2c_driver", "sensor"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -427,6 +427,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -106,7 +106,7 @@ name = "task-net"
 stacksize = 6040
 priority = 4
 features = ["mgmt", "h753", "psc", "vlan", "vpd-mac", "use-spi-core", "spi2"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
 start = true
@@ -240,12 +240,14 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 4
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 5
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
-extern-regions = ["sram2", "sram3", "sram4"]
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
+extern-regions = [ "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.idle]
 name = "task-idle"
@@ -453,3 +455,10 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -241,7 +241,7 @@ task-slots = ["i2c_driver", "sensor"]
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -429,6 +429,7 @@ clock_divider = "DIV256"
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -454,13 +454,13 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -106,7 +106,7 @@ name = "task-net"
 stacksize = 6040
 priority = 4
 features = ["mgmt", "h753", "psc", "vlan", "vpd-mac", "use-spi-core", "spi2"]
-max-sizes = {flash = 131072, ram = 32768, sram1 = 16384}
+max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
 start = true
@@ -240,12 +240,14 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 4
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 5
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
-extern-regions = ["sram2", "sram3", "sram4"]
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
+extern-regions = [ "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.idle]
 name = "task-idle"
@@ -456,3 +458,9 @@ port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -1068,21 +1068,21 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 
 [config.net.sockets.transceivers]
 kind = "udp"
 owner = {name = "transceivers", notification = "socket"}
-port = 11112 # TODO do we have a documented port for transceiver traffic?
+port = 11112
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -308,7 +308,7 @@ stacksize = 800
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 6
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -1043,6 +1043,7 @@ cs = [{port = "J", pin = 6}] # SPI_SP_TO_FPGA_CS_USER_L
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -307,12 +307,14 @@ stacksize = 800
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 6
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
 extern-regions = [ "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.idle]
 name = "task-idle"
@@ -1069,6 +1071,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.net.sockets.transceivers]
 kind = "udp"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -307,7 +307,7 @@ stacksize = 800
 [tasks.dump_agent]
 name = "task-dump-agent"
 priority = 6
-max-sizes = {flash = 16384, ram = 4096 }
+max-sizes = {flash = 16384, ram = 8192 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
 stacksize = 2400

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -1042,6 +1042,7 @@ cs = [{port = "J", pin = 6}] # SPI_SP_TO_FPGA_CS_USER_L
 
 [config.net]
 vlan = { start = 0x301, count = 2 }
+# UDP ports in sockets below are assigned in oxidecomputer/oana
 
 [config.net.sockets.echo]
 kind = "udp"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -1067,21 +1067,21 @@ rx = { packets = 3, bytes = 1024 }
 [config.net.sockets.control_plane_agent]
 kind = "udp"
 owner = {name = "control_plane_agent", notification = "socket"}
-port = 11111 # TODO do we have a documented port for MGS traffic?
+port = 11111
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 
 [config.net.sockets.dump_agent]
 kind = "udp"
 owner = {name = "dump_agent", notification = "socket"}
-port = 11113 # TODO do we have a documented port for dump_agent traffic?
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 
 [config.net.sockets.transceivers]
 kind = "udp"
 owner = {name = "transceivers", notification = "socket"}
-port = 11112 # TODO do we have a documented port for transceiver traffic?
+port = 11112
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
 

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -306,12 +306,14 @@ stacksize = 800
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+priority = 6
+max-sizes = {flash = 16384, ram = 4096 }
 start = true
-task-slots = ["sprot", "jefe"]
-stacksize = 1200
-extern-regions = ["sram2", "sram3", "sram4"]
+task-slots = ["sprot", "jefe", "net"]
+stacksize = 2400
+extern-regions = [ "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+features = ["net", "vlan"]
 
 [tasks.idle]
 name = "task-idle"
@@ -1068,6 +1070,13 @@ owner = {name = "control_plane_agent", notification = "socket"}
 port = 11111 # TODO do we have a documented port for MGS traffic?
 tx = { packets = 3, bytes = 2048 }
 rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113 # TODO do we have a documented port for dump_agent traffic?
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
 
 [config.net.sockets.transceivers]
 kind = "udp"

--- a/build/net/src/lib.rs
+++ b/build/net/src/lib.rs
@@ -122,5 +122,27 @@ pub fn generate_socket_enum(
         writeln!(out, "    {} = {},", name, i)?;
     }
     writeln!(out, "}}")?;
+
+    writeln!(
+        out,
+        "#[allow(unused)]\
+        pub const SOCKET_TX_SIZE: [usize; {}] = [",
+        config.sockets.len(),
+    )?;
+    for c in config.sockets.values() {
+        writeln!(out, "{},", c.tx.bytes)?;
+    }
+    writeln!(out, "];")?;
+    writeln!(
+        out,
+        "#[allow(unused)]\
+        pub const SOCKET_RX_SIZE: [usize; {}] = [",
+        config.sockets.len(),
+    )?;
+    for c in config.sockets.values() {
+        writeln!(out, "{},", c.rx.bytes)?;
+    }
+    writeln!(out, "];")?;
+
     Ok(())
 }

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -7,7 +7,6 @@ use crate::{
     update::rot::RotUpdate, update::sp::SpUpdate, update::ComponentUpdater,
     usize_max, vlan_id_from_sp_port, Log, MgsMessage, SYS,
 };
-use core::convert::Infallible;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 use drv_gimlet_seq_api::Sequencer;

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -321,7 +321,7 @@ impl SpHandler for MgsHandler {
         action: ComponentAction,
     ) -> Result<(), SpError> {
         match (component, action) {
-            (SpComponent::SYSTEM_LED, ComponentAction::Led(action)) => {
+            (SpComponent::SYSTEM_LED, ComponentAction::Led(_action)) => {
                 // TODO: implement this
                 Err(SpError::RequestUnsupportedForComponent)
             }

--- a/task/dump-agent-api/src/lib.rs
+++ b/task/dump-agent-api/src/lib.rs
@@ -59,6 +59,42 @@ impl From<DumperError> for DumpAgentError {
     }
 }
 
+impl From<DumpAgentError> for humpty::udp::Error {
+    fn from(d: DumpAgentError) -> Self {
+        use humpty::udp::Error;
+        match d {
+            DumpAgentError::DumpAgentUnsupported => Error::DumpAgentUnsupported,
+            DumpAgentError::InvalidArea => Error::InvalidArea,
+            DumpAgentError::BadOffset => Error::BadOffset,
+            DumpAgentError::UnalignedOffset => Error::UnalignedOffset,
+            DumpAgentError::UnalignedSegmentAddress => {
+                Error::UnalignedSegmentAddress
+            }
+            DumpAgentError::UnalignedSegmentLength => {
+                Error::UnalignedSegmentLength
+            }
+            DumpAgentError::DumpFailed => Error::DumpFailed,
+            DumpAgentError::NotSupported => Error::NotSupported,
+            DumpAgentError::DumpPresent => Error::DumpPresent,
+            DumpAgentError::UnclaimedDumpArea => Error::UnclaimedDumpArea,
+            DumpAgentError::CannotClaimDumpArea => Error::CannotClaimDumpArea,
+            DumpAgentError::DumpAreaInUse => Error::DumpAreaInUse,
+            DumpAgentError::BadSegmentAdd => Error::BadSegmentAdd,
+            DumpAgentError::ServerRestarted => Error::ServerRestarted,
+            DumpAgentError::BadDumpResponse => Error::BadDumpResponse,
+            DumpAgentError::DumpMessageFailed => Error::DumpMessageFailed,
+            DumpAgentError::DumpFailedSetup => Error::DumpFailedSetup,
+            DumpAgentError::DumpFailedRead => Error::DumpFailedRead,
+            DumpAgentError::DumpFailedWrite => Error::DumpFailedWrite,
+            DumpAgentError::DumpFailedControl => Error::DumpFailedControl,
+            DumpAgentError::DumpFailedUnknown => Error::DumpFailedUnknown,
+            DumpAgentError::DumpFailedUnknownError => {
+                Error::DumpFailedUnknownError
+            }
+        }
+    }
+}
+
 pub const DUMP_READ_SIZE: usize = 256;
 
 //

--- a/task/dump-agent/Cargo.toml
+++ b/task/dump-agent/Cargo.toml
@@ -7,30 +7,41 @@ edition = "2021"
 target = "thumbv7em-none-eabihf"
 
 [dependencies]
-cfg-if = { workspace = true }
-cortex-m = { workspace = true }
-idol-runtime = { workspace = true }
-num-traits = { workspace = true }
-zerocopy = { workspace = true }
-hubpack = { workspace = true }
-serde = { workspace = true }
-humpty = { workspace = true }
-ringbuf = { path = "../../lib/ringbuf"  }
-dump-agent-api = { path = "../dump-agent-api" }
+cfg-if.workspace = true
+cortex-m.workspace = true
+hubpack.workspace = true
+humpty.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+static_assertions.workspace = true
+zerocopy.workspace = true
+
+drv-sprot-api.path = "../../drv/sprot-api"
+dump-agent-api.path = "../dump-agent-api"
+dumper-api.path = "../dumper-api"
+mutable-statics.path = "../../lib/mutable-statics"
+ringbuf.path = "../../lib/ringbuf"
+task-jefe-api.path = "../../task/jefe-api"
+task-net-api = { path = "../../task/net-api", optional = true }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
-static_assertions = { workspace = true }
-drv-sprot-api = { path = "../../drv/sprot-api" }
-task-jefe-api = { path = "../../task/jefe-api" }
-dumper-api = { path = "../dumper-api" }
 
 [features]
 # Disable the SP-ROT communication, e.g. to run dump-agent on a Gimletlet
 no-rot = []
 
+# Runs a network service to dump remotely
+net = ["task-net-api"]
+
+# Configures the net task with VLANs enabled
+vlan = ["task-net-api?/vlan"]
+
 [build-dependencies]
-anyhow = { workspace = true }
-cfg-if = { workspace = true }
-idol = { workspace = true }
+anyhow.workspace = true
+cfg-if.workspace = true
+idol.workspace = true
+
+build-util.path = "../../build/util"
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/dump-agent/build.rs
+++ b/task/dump-agent/build.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_util::build_notifications()?;
     idol::server::build_server_support(
         "../../idl/dump-agent.idol",
         "server_stub.rs",

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -233,7 +233,7 @@ fn main() -> ! {
 
     #[cfg(feature = "net")]
     {
-        let (rx_data_buf, tx_data_buf) = claim_statics();
+        let (rx_data_buf, tx_data_buf) = udp::claim_statics();
         let mut server = ServerImpl {
             jefe: Jefe::from(JEFE.get_task_id()),
             net: task_net_api::Net::from(NET.get_task_id()),
@@ -260,30 +260,6 @@ fn main() -> ! {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-use hubpack::SerializedSize;
-
-// We are sending a (Header, Result<Response, Error>) to the host
-const MAX_UDP_TX_SIZE: usize = <(
-    humpty::udp::Header,
-    Result<humpty::udp::Response, humpty::udp::Error>,
-)>::MAX_SIZE;
-
-// We are receiving a (Header, Request) from the host
-const MAX_UDP_RX_SIZE: usize =
-    <(humpty::udp::Header, humpty::udp::Request)>::MAX_SIZE;
-
-/// Grabs references to the static descriptor/buffer receive rings. Can only be
-/// called once.
-pub fn claim_statics() -> (
-    &'static mut [u8; MAX_UDP_RX_SIZE],
-    &'static mut [u8; MAX_UDP_TX_SIZE],
-) {
-    mutable_statics::mutable_statics! {
-        static mut TX_BUF: [u8; MAX_UDP_RX_SIZE] = [|| 0u8; _];
-        static mut RX_BUF: [u8; MAX_UDP_TX_SIZE] = [|| 0u8; _];
-    }
-}
 
 mod idl {
     use super::*;

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -285,24 +285,32 @@ fn main() -> ! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const MAX_UDP_MESSAGE_SIZE: usize = 1024;
+use hubpack::SerializedSize;
+
+// We are sending a (Header, Result<Response, Error>) to the host
+const MAX_UDP_TX_SIZE: usize = <(
+    humpty::udp::Header,
+    Result<humpty::udp::Response, humpty::udp::Error>,
+)>::MAX_SIZE;
+
+// We are receiving a (Header, Request) from the host
+const MAX_UDP_RX_SIZE: usize =
+    <(humpty::udp::Header, humpty::udp::Request)>::MAX_SIZE;
 
 /// Grabs references to the static descriptor/buffer receive rings. Can only be
 /// called once.
 pub fn claim_statics() -> (
-    &'static mut [u8; MAX_UDP_MESSAGE_SIZE],
-    &'static mut [u8; MAX_UDP_MESSAGE_SIZE],
+    &'static mut [u8; MAX_UDP_TX_SIZE],
+    &'static mut [u8; MAX_UDP_RX_SIZE],
 ) {
-    const S: usize = MAX_UDP_MESSAGE_SIZE;
     mutable_statics::mutable_statics! {
-        static mut TX_BUF: [u8; S] = [|| 0u8; _];
-        static mut RX_BUF: [u8; S] = [|| 0u8; _];
+        static mut TX_BUF: [u8; MAX_UDP_TX_SIZE] = [|| 0u8; _];
+        static mut RX_BUF: [u8; MAX_UDP_RX_SIZE] = [|| 0u8; _];
     }
 }
 
 mod idl {
     use super::*;
-
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
 

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -17,9 +17,6 @@ use userlib::*;
 #[cfg(feature = "net")]
 mod udp;
 
-#[cfg(feature = "net")]
-task_slot!(NET, net);
-
 //
 // Our DUMP_READ_SIZE must be an even power of 2 -- and practically speaking
 // cannot be more than 1K
@@ -233,6 +230,7 @@ fn main() -> ! {
 
     #[cfg(feature = "net")]
     {
+        task_slot!(NET, net);
         let (rx_data_buf, tx_data_buf) = udp::claim_statics();
         let mut server = ServerImpl {
             jefe: Jefe::from(JEFE.get_task_id()),

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -311,6 +311,7 @@ pub fn claim_statics() -> (
 
 mod idl {
     use super::*;
+
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
 

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -233,7 +233,7 @@ fn main() -> ! {
 
     #[cfg(feature = "net")]
     {
-        let (tx_data_buf, rx_data_buf) = claim_statics();
+        let (rx_data_buf, tx_data_buf) = claim_statics();
         let mut server = ServerImpl {
             jefe: Jefe::from(JEFE.get_task_id()),
             net: task_net_api::Net::from(NET.get_task_id()),
@@ -241,8 +241,8 @@ fn main() -> ! {
 
         loop {
             server.check_net(
-                tx_data_buf.as_mut_slice(),
                 rx_data_buf.as_mut_slice(),
+                tx_data_buf.as_mut_slice(),
             );
             idol_runtime::dispatch_n(&mut buffer, &mut server);
         }
@@ -276,12 +276,12 @@ const MAX_UDP_RX_SIZE: usize =
 /// Grabs references to the static descriptor/buffer receive rings. Can only be
 /// called once.
 pub fn claim_statics() -> (
-    &'static mut [u8; MAX_UDP_TX_SIZE],
     &'static mut [u8; MAX_UDP_RX_SIZE],
+    &'static mut [u8; MAX_UDP_TX_SIZE],
 ) {
     mutable_statics::mutable_statics! {
-        static mut TX_BUF: [u8; MAX_UDP_TX_SIZE] = [|| 0u8; _];
-        static mut RX_BUF: [u8; MAX_UDP_RX_SIZE] = [|| 0u8; _];
+        static mut TX_BUF: [u8; MAX_UDP_RX_SIZE] = [|| 0u8; _];
+        static mut RX_BUF: [u8; MAX_UDP_TX_SIZE] = [|| 0u8; _];
     }
 }
 

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -27,8 +27,12 @@ const MAX_UDP_TX_SIZE: usize = humpty::udp::ResponseMessage::MAX_SIZE;
 const MAX_UDP_RX_SIZE: usize = humpty::udp::RequestMessage::MAX_SIZE;
 
 // Check against packet sizes in the TOML file
-static_assertions::const_assert!(MAX_UDP_TX_SIZE <= 1024);
-static_assertions::const_assert!(MAX_UDP_RX_SIZE <= 1024);
+static_assertions::const_assert!(
+    MAX_UDP_TX_SIZE <= SOCKET_TX_SIZE[SocketName::dump_agent as usize]
+);
+static_assertions::const_assert!(
+    MAX_UDP_RX_SIZE <= SOCKET_RX_SIZE[SocketName::dump_agent as usize]
+);
 
 // The response message is a tuple (Header, Result<Response, Error>)
 static_assertions::const_assert_eq!(

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -100,6 +100,7 @@ impl ServerImpl {
         // If the header is < our min version, then we can't deserialize at all,
         // so return an error immediately.
         if header.version < humpty::udp::version::MIN {
+            ringbuf_entry!(Trace::WrongVersion(header.version));
             return Err(humpty::udp::Error::VersionMismatch);
         }
 
@@ -123,11 +124,13 @@ impl ServerImpl {
                 }
             },
             Err(e) => {
-                ringbuf_entry!(Trace::DeserializeError(e));
-                // This message is from a newer version
+                // This message is from a newer version, so it makes sense that
+                // we failed to deserialize it.
                 if header.version > humpty::udp::version::CURRENT {
+                    ringbuf_entry!(Trace::WrongVersion(header.version));
                     return Err(humpty::udp::Error::VersionMismatch);
                 } else {
+                    ringbuf_entry!(Trace::DeserializeError(e));
                     return Err(humpty::udp::Error::DeserializeError);
                 }
             }

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -122,7 +122,10 @@ impl ServerImpl {
         // so return an error immediately.
         if header.version < humpty::udp::version::MIN {
             ringbuf_entry!(Trace::WrongVersion(header.version));
-            return Err(humpty::udp::Error::VersionMismatch);
+            return Err(humpty::udp::Error::VersionMismatch {
+                ours: humpty::udp::version::CURRENT,
+                theirs: header.version,
+            });
         }
 
         use humpty::udp::{Request, Response};
@@ -149,7 +152,10 @@ impl ServerImpl {
                 // we failed to deserialize it.
                 if header.version > humpty::udp::version::CURRENT {
                     ringbuf_entry!(Trace::WrongVersion(header.version));
-                    return Err(humpty::udp::Error::VersionMismatch);
+                    return Err(humpty::udp::Error::VersionMismatch {
+                        ours: humpty::udp::version::CURRENT,
+                        theirs: header.version,
+                    });
                 } else {
                     ringbuf_entry!(Trace::DeserializeError(e));
                     return Err(humpty::udp::Error::DeserializeError);

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -30,6 +30,19 @@ const MAX_UDP_RX_SIZE: usize = humpty::udp::RequestMessage::MAX_SIZE;
 static_assertions::const_assert!(MAX_UDP_TX_SIZE <= 1024);
 static_assertions::const_assert!(MAX_UDP_RX_SIZE <= 1024);
 
+// The response message is a tuple (Header, Result<Response, Error>)
+static_assertions::const_assert_eq!(
+    humpty::udp::ResponseMessage::MAX_SIZE,
+    humpty::udp::Header::MAX_SIZE
+        + <Result<humpty::udp::Response, humpty::udp::Error>>::MAX_SIZE
+);
+
+// The request message is a tuple (Header, Request)
+static_assertions::const_assert_eq!(
+    humpty::udp::RequestMessage::MAX_SIZE,
+    humpty::udp::Header::MAX_SIZE + humpty::udp::Request::MAX_SIZE
+);
+
 /// Grabs references to the static descriptor/buffer receive rings. Can only be
 /// called once.
 pub fn claim_statics() -> (

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -146,9 +146,6 @@ impl ServerImpl {
                 Request::ReadDump { index, offset } => {
                     self.read_dump(index, offset).map(Response::ReadDump)?
                 }
-                Request::GetDumpArea { index } => {
-                    self.dump_area(index).map(Response::GetDumpArea)?
-                }
                 Request::InitializeDump => {
                     self.initialize().map(|()| Response::InitializeDump)?
                 }

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+static_assertions::const_assert_eq!(
+    DUMP_READ_SIZE,
+    humpty::udp::DUMP_READ_SIZE
+);
+
+use crate::{ServerImpl, DUMP_READ_SIZE};
+use ringbuf::*;
+use task_net_api::*;
+
+#[derive(Copy, Clone, PartialEq)]
+enum Trace {
+    None,
+    DeserializeError(hubpack::Error),
+    DeserializeHeaderError(hubpack::Error),
+    SendError(SendError),
+    WrongVersion(u8),
+}
+
+ringbuf!(Trace, 16, Trace::None);
+
+impl ServerImpl {
+    pub fn check_net(
+        &mut self,
+        rx_data_buf: &mut [u8],
+        tx_data_buf: &mut [u8],
+    ) {
+        match self.net.recv_packet(
+            SocketName::dump_agent,
+            LargePayloadBehavior::Discard,
+            rx_data_buf,
+        ) {
+            Ok(meta) => self.handle_packet(meta, rx_data_buf, tx_data_buf),
+            Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
+                // Our incoming queue is empty or `net` restarted. Wait for more
+                // packets in dispatch_n, back in the main loop.
+            }
+            Err(RecvError::NotYours | RecvError::Other) => panic!(),
+        }
+    }
+
+    fn handle_packet(
+        &mut self,
+        mut meta: UdpMetadata,
+        rx_data_buf: &[u8],
+        tx_data_buf: &mut [u8],
+    ) {
+        let out_len =
+            match hubpack::deserialize(&rx_data_buf[0..meta.size as usize]) {
+                Ok((header, msg)) => {
+                    let r = self.handle_message(header, msg);
+                    let reply = (header, r);
+                    Some(hubpack::serialize(tx_data_buf, &reply).unwrap())
+                }
+                Err(e) => {
+                    // We couldn't deserialize the header; give up
+                    ringbuf_entry!(Trace::DeserializeHeaderError(e));
+                    None
+                }
+            };
+
+        if let Some(out_len) = out_len {
+            meta.size = out_len as u32;
+            if let Err(e) = self.net.send_packet(
+                SocketName::dump_agent,
+                meta,
+                &tx_data_buf[..meta.size as usize],
+            ) {
+                // We'll drop packets if the outgoing queue is full;
+                // the host is responsible for retrying.
+                //
+                // Other errors are unexpected and panic.
+                //
+                // This includes ServerRestarted, because the server should only
+                // restart if the watchdog times out, and the watchdog should
+                // not be timing out, because we're literally replying to a
+                // packet here.
+                ringbuf_entry!(Trace::SendError(e));
+                match e {
+                    SendError::QueueFull => (),
+                    SendError::Other
+                    | SendError::ServerRestarted
+                    | SendError::NotYours
+                    | SendError::InvalidVLan => panic!(),
+                }
+            }
+        }
+    }
+
+    /// Handles a single message
+    fn handle_message(
+        &mut self,
+        header: humpty::udp::Header,
+        data: &[u8],
+    ) -> Result<humpty::udp::Response, humpty::udp::Error> {
+        use humpty::udp::{Request, Response};
+        let r = match hubpack::deserialize::<Request>(data) {
+            Ok((msg, _data)) => match msg {
+                Request::ReadDump { index, offset } => {
+                    self.read_dump(index, offset).map(Response::ReadDump)?
+                }
+                Request::GetDumpArea { index } => {
+                    self.dump_area(index).map(Response::GetDumpArea)?
+                }
+                Request::InitializeDump => {
+                    self.initialize().map(|()| Response::InitializeDump)?
+                }
+                Request::AddDumpSegment { address, length } => self
+                    .add_dump_segment(address, length)
+                    .map(|()| Response::AddDumpSegment)?,
+                Request::TakeDump => {
+                    self.take_dump().map(|()| Response::TakeDump)?
+                }
+            },
+            Err(e) => {
+                ringbuf_entry!(Trace::DeserializeError(e));
+                return Err(humpty::udp::Error::DeserializeError);
+                // TODO: reply something?
+            }
+        };
+        Ok(r)
+    }
+}

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -93,7 +93,7 @@ impl ServerImpl {
     /// Handles a single message
     fn handle_message(
         &mut self,
-        header: humpty::udp::Header,
+        _header: humpty::udp::Header,
         data: &[u8],
     ) -> Result<humpty::udp::Response, humpty::udp::Error> {
         use humpty::udp::{Request, Response};

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -108,20 +108,15 @@ impl ServerImpl {
                 meta,
                 &tx_data_buf[..meta.size as usize],
             ) {
-                // We'll drop packets if the outgoing queue is full;
-                // the host is responsible for retrying.
+                // We'll drop packets if the outgoing queue is full or the
+                // server has died; the host is responsible for retrying
+                // (which isn't implemented yet in Humility).
                 //
                 // Other errors are unexpected and panic.
-                //
-                // This includes ServerRestarted, because the server should only
-                // restart if the watchdog times out, and the watchdog should
-                // not be timing out, because we're literally replying to a
-                // packet here.
                 ringbuf_entry!(Trace::SendError(e));
                 match e {
-                    SendError::QueueFull => (),
+                    SendError::QueueFull | SendError::ServerRestarted => (),
                     SendError::Other
-                    | SendError::ServerRestarted
                     | SendError::NotYours
                     | SendError::InvalidVLan => panic!(),
                 }


### PR DESCRIPTION
This is part of the https://github.com/oxidecomputer/hubris/issues/1217 saga, which begins with https://github.com/oxidecomputer/humpty/pull/4/files and also requires a Humility PR.

This Hubris PR adds an optional `net` feature to `dump-agent`.  When the feature is enabled, `dump-agent` listens on a UDP socket for messages which encode dump commands, using API types from `humpty` (see PR above).  These messages are a thin layer above the existing hiffy API.

Most of the code changes are in the `udp` module; changes in `ServerImpl` are mostly to make more functions callable from either hiffy or the `udp` module.