### PR TITLE
Single-task dumping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5bbb47df7f68b3b0f9996a2e5eebda9f88b23e73"
+source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5d1191286b7a8de218f9469a8485eb87472b4db4"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#391699a1b04b92bfa0aee9c6945c1aa57913c585"
+source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5bbb47df7f68b3b0f9996a2e5eebda9f88b23e73"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/humpty#b4052d8b0c1fe555e1686b281104852d7fba5230"
+source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5a89634ee21463b3b0a3b56af82d9ebbe15dc2ef"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5d1191286b7a8de218f9469a8485eb87472b4db4"
+source = "git+https://github.com/oxidecomputer/humpty#cbfa0ad343f9b6f085aecac706cadb7cde03581c"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,8 +2344,8 @@ dependencies = [
 
 [[package]]
 name = "humpty"
-version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#5a89634ee21463b3b0a3b56af82d9ebbe15dc2ef"
+version = "0.1.2"
+source = "git+https://github.com/oxidecomputer/humpty?branch=single-task-dump#391699a1b04b92bfa0aee9c6945c1aa57913c585"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "single-task-dump", version = "0.1.1" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "single-task-dump", version = "0.1.2" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "single-task-dump", version = "0.1.2" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.2" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
-humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.1" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, branch = "single-task-dump", version = "0.1.1" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -140,7 +140,7 @@ uses = ["rng"]
 name = "task-dump-agent"
 features = ["no-rot"]
 priority = 4
-max-sizes = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["jefe"]
 stacksize = 1200

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -190,7 +190,7 @@ uses = ["rng"]
 name = "task-dump-agent"
 features = ["no-rot"]
 priority = 4
-max-sizes = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["jefe"]
 stacksize = 1200

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -134,7 +134,7 @@ task-slots = ["user_leds"]
 name = "task-dump-agent"
 features = ["no-rot"]
 priority = 5
-max-sizes = {flash = 8192, ram = 2048 }
+max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["jefe"]
 stacksize = 1200

--- a/app/lpc55xpresso/src/main.rs
+++ b/app/lpc55xpresso/src/main.rs
@@ -6,7 +6,6 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use lpc55_pac as device;
 
 // When we're secure we don't have access to read the CMPA/NMPA where the
 // official setting is stored, emulate what the clock driver does instead
@@ -42,7 +41,7 @@ fn get_clock_speed() -> (u32, u8) {
 
 #[entry]
 fn main() -> ! {
-    let (cycles_per_ms, div) = get_clock_speed();
+    let (cycles_per_ms, _div) = get_clock_speed();
 
     unsafe { kern::startup::start_kernel(cycles_per_ms * 1_000) }
 }

--- a/idl/dump-agent.idol
+++ b/idl/dump-agent.idol
@@ -50,5 +50,38 @@ Interface(
                 err: CLike("DumpAgentError"),
             ),
         ),
+        "dump_task": (
+            doc: "Dump a single task, without the external dumper",
+            args: {
+                "task_index": "u32",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("DumpAgentError"),
+            ),
+        ),
+        "dump_task_region": (
+            doc: "Dump a region from single task, without the external dumper",
+            args: {
+                "task_index": "u32",
+                "start": "u32",
+                "length": "u32",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("DumpAgentError"),
+            ),
+        ),
+        "reinitialize_dump_from": (
+            description: "reinitializes the dump memory starting at the given area",
+            args: {
+                "index": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DumpAgentError"),
+            ),
+            encoding: Hubpack,
+        ),
     },
 )

--- a/idl/jefe.idol
+++ b/idl/jefe.idol
@@ -59,5 +59,40 @@ Interface(
             ),
             encoding: Hubpack,
         ),
+        "dump_task": (
+            description: "dumps the specified task",
+            args: {
+                "task_index": "u32",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("DumpAgentError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "dump_task_region": (
+            description: "dumps a subregion of the specified task",
+            args: {
+                "task_index": "u32",
+                "address": "u32",
+                "length": "u32",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("DumpAgentError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "reinitialize_dump_from": (
+            description: "reinitializes the dump memory starting at the given area",
+            args: {
+                "index": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DumpAgentError"),
+            ),
+            encoding: Hubpack,
+        ),
     },
 )

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -246,6 +246,33 @@ impl idl::InOrderDumpAgentImpl for ServerImpl {
     ) -> Result<[u8; DUMP_READ_SIZE], RequestError<DumpAgentError>> {
         self.read_dump(index, offset).map_err(|e| e.into())
     }
+
+    fn dump_task(
+        &mut self,
+        _msg: &RecvMessage,
+        task_index: u32,
+    ) -> Result<u8, RequestError<DumpAgentError>> {
+        self.dump_task(task_index).map_err(|e| e.into())
+    }
+
+    fn dump_task_region(
+        &mut self,
+        _msg: &RecvMessage,
+        task_index: u32,
+        start: u32,
+        length: u32,
+    ) -> Result<u8, RequestError<DumpAgentError>> {
+        self.dump_task_region(task_index, start, length)
+            .map_err(|e| e.into())
+    }
+
+    fn reinitialize_dump_from(
+        &mut self,
+        _msg: &RecvMessage,
+        index: u8,
+    ) -> Result<(), RequestError<DumpAgentError>> {
+        self.reinitialize_dump_from(index).map_err(|e| e.into())
+    }
 }
 
 #[export_name = "main"]

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -173,7 +173,9 @@ impl ServerImpl {
                     //
                     if val == 0 {
                         Ok(())
-                    } else if let Some(err) = DumperError::from_u32(val) {
+                    } else if let Some(err) =
+                        dumper_api::DumperError::from_u32(val)
+                    {
                         Err(DumpAgentError::from(err).into())
                     } else {
                         Err(DumpAgentError::DumpFailedUnknownError.into())

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -74,7 +74,7 @@ impl ServerImpl {
         }
 
         humpty::add_dump_segment_header(
-            area.address,
+            area.region.address,
             addr,
             length,
             |addr, buf, _| unsafe { humpty::from_mem(addr, buf) },
@@ -97,13 +97,13 @@ impl ServerImpl {
         let area = self.dump_area(index)?;
 
         let written = unsafe {
-            let header = area.address as *mut DumpAreaHeader;
+            let header = area.region.address as *mut DumpAreaHeader;
             core::ptr::read_volatile(header).written
         };
 
         if written > offset {
             let to_read = written - offset;
-            let base = area.address as *const u8;
+            let base = area.region.address as *const u8;
             let base = unsafe { base.add(offset as usize) };
 
             for i in 0..usize::min(to_read as usize, DUMP_READ_SIZE) {
@@ -154,7 +154,7 @@ impl ServerImpl {
 
         match sprot.send_recv(
             drv_sprot_api::MsgType::DumpReq,
-            &area.address.to_le_bytes(),
+            &area.region.address.to_le_bytes(),
             &mut buf,
         ) {
             Err(_) => Err(DumpAgentError::DumpMessageFailed.into()),

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -116,6 +116,29 @@ impl ServerImpl {
         }
     }
 
+    fn dump_task(&mut self, task_index: u32) -> Result<u8, DumpAgentError> {
+        let out = self.jefe.dump_task(task_index)?;
+        Ok(out)
+    }
+
+    fn dump_task_region(
+        &mut self,
+        task_index: u32,
+        start: u32,
+        length: u32,
+    ) -> Result<u8, DumpAgentError> {
+        let out = self.jefe.dump_task_region(task_index, start, length)?;
+        Ok(out)
+    }
+
+    fn reinitialize_dump_from(
+        &mut self,
+        index: u8,
+    ) -> Result<(), DumpAgentError> {
+        self.jefe.reinitialize_dump_from(index)?;
+        Ok(())
+    }
+
     #[cfg(not(feature = "no-rot"))]
     fn take_dump(&mut self) -> Result<(), DumpAgentError> {
         use dumper_api::DumperError;

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -171,6 +171,19 @@ impl ServerImpl {
                 Request::TakeDump => {
                     self.take_dump().map(|()| Response::TakeDump)?
                 }
+                Request::DumpTask { task_index } => {
+                    self.dump_task(task_index).map(Response::DumpTask)?
+                }
+                Request::DumpTaskRegion {
+                    task_index,
+                    start,
+                    length,
+                } => self
+                    .dump_task_region(task_index, start, length)
+                    .map(Response::DumpTaskRegion)?,
+                Request::ReinitializeDumpFrom { index } => self
+                    .reinitialize_dump_from(index)
+                    .map(|()| Response::ReinitializeDumpFrom)?,
             },
             Err(e) => {
                 // This message is from a newer version, so it makes sense that

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -22,7 +22,6 @@ enum Trace {
     DeserializeHeaderError(hubpack::Error),
     SendError(SendError),
     WrongVersion(u8),
-    Hi(u8, usize),
 }
 
 ringbuf!(Trace, 16, Trace::None);
@@ -100,7 +99,6 @@ impl ServerImpl {
         rx_data_buf: &[u8],
         tx_data_buf: &mut [u8],
     ) {
-        ringbuf_entry!(Trace::Hi(rx_data_buf[0], rx_data_buf.len()));
         let out_len =
             match hubpack::deserialize(&rx_data_buf[0..meta.size as usize]) {
                 Ok((mut header, msg)) => {

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -121,7 +121,7 @@ fn output_dump_areas(out: &mut std::fs::File) -> Result<()> {
 
     write!(
         out,
-        "pub(crate) const DUMP_AREAS: [humpty::DumpArea; {}] = [",
+        "pub(crate) const DUMP_AREAS: [humpty::DumpAreaRegion; {}] = [",
         dump_regions.len(),
     )?;
 
@@ -133,10 +133,9 @@ fn output_dump_areas(out: &mut std::fs::File) -> Result<()> {
             out,
             r##"
     // {name} dump area
-    humpty::DumpArea {{
+    humpty::DumpAreaRegion {{
         address: {address:#x},
         length: {length:#x},
-        contents: humpty::DumpContents::Available,
     }},"##
         )?;
     }

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<()> {
     .unwrap();
 
     build_util::expose_m_profile();
+    build_util::expose_target_board();
     build_util::build_notifications()?;
 
     let out_dir = build_util::out_dir();

--- a/task/jefe/src/dump.rs
+++ b/task/jefe/src/dump.rs
@@ -288,9 +288,9 @@ pub fn reinitialize_dump_from(
     base: u32,
     index: u8,
 ) -> Result<(), DumpAgentError> {
+    let area = get_dump_area(base, index)?;
     humpty::release_dump_areas_from(
-        base,
-        index,
+        area.address,
         |addr, buf, _| unsafe { humpty::from_mem(addr, buf) },
         |addr, buf| unsafe { humpty::to_mem(addr, buf) },
     )

--- a/task/jefe/src/dump.rs
+++ b/task/jefe/src/dump.rs
@@ -9,6 +9,19 @@ use ringbuf::*;
 use task_jefe_api::DumpAgentError;
 use userlib::*;
 
+#[cfg(all(
+    armv8m,
+    not(any(
+        target_board = "lpcxpresso55s69",
+        target_board = "rot-carrier-1",
+        target_board = "rot-carrier-2",
+    ))
+))]
+compile_error!(
+    "Cannot enable `dump` feature on LPC55, \
+     except on specially designated boards"
+);
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 enum Trace {
     None,

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -243,7 +243,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
                 if task_index == 0 {
                     // Can't dump the supervisor
                     return Err(DumpAgentError::NotSupported.into());
-                } else if task_index as usize > self.task_states.len() {
+                } else if task_index as usize >= self.task_states.len() {
                     // Can't dump a non-existent task
                     return Err(DumpAgentError::BadOffset.into());
                 }
@@ -259,7 +259,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
             ) -> Result<u8, RequestError<DumpAgentError>> {
                 if task_index == 0 {
                     return Err(DumpAgentError::NotSupported.into());
-                } else if task_index as usize > self.task_states.len() {
+                } else if task_index as usize >= self.task_states.len() {
                     return Err(DumpAgentError::BadOffset.into());
                 }
                 dump::dump_task_region(

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -250,6 +250,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
                 dump::dump_task(self.dump_areas, task_index as usize)
                     .map_err(|e| e.into())
             }
+
             fn dump_task_region(
                 &mut self,
                 _msg: &userlib::RecvMessage,
@@ -266,6 +267,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
                     self.dump_areas, task_index as usize, address, length
                 ).map_err(|e| e.into())
             }
+
             fn reinitialize_dump_from(
                 &mut self,
                 _msg: &userlib::RecvMessage,
@@ -304,6 +306,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
             ) -> Result<u8, RequestError<DumpAgentError>> {
                 Err(DumpAgentError::DumpAgentUnsupported.into())
             }
+
             fn dump_task_region(
                 &mut self,
                 _msg: &userlib::RecvMessage,
@@ -313,6 +316,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
             ) -> Result<u8, RequestError<DumpAgentError>> {
                 Err(DumpAgentError::DumpAgentUnsupported.into())
             }
+
             fn reinitialize_dump_from(
                 &mut self,
                 _msg: &userlib::RecvMessage,

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -278,7 +278,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
             fn get_dump_area(
                 &mut self,
                 _msg: &userlib::RecvMessage,
-                _index: u32,
+                _index: u8,
             ) -> Result<DumpArea, RequestError<DumpAgentError>> {
                 Err(DumpAgentError::DumpAgentUnsupported.into())
             }
@@ -299,8 +299,8 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
             fn dump_task(
                 &mut self,
-                _task_index: u32,
                 _msg: &userlib::RecvMessage,
+                _task_index: u32,
             ) -> Result<u8, RequestError<DumpAgentError>> {
                 Err(DumpAgentError::DumpAgentUnsupported.into())
             }


### PR DESCRIPTION
This PR implements single-task dumping in Hubris, mediated by the supervisor task.  It includes three new APIs:

- Dump a single task
- Dump a subregion of memory from a single task
- Reinitialize dump areas starting at a particular index

(see https://github.com/oxidecomputer/humpty/pull/5 for the associated UDP types)

Single-task dumping is between the supervisor and the kernel, and doesn't require the RoT!

Most of this PR is plumbing of various kinds:

- UDP messages to `dump-agent` → Idol messages to Jefe
- Idol messages to `dump-agent` -> Idol messages to Jefe
- Idol messages to Jefe → actual work being done 

Within `jefe::dump`, `dump_task` splits into four functions:

- Setup (`dump_task_setup`)
- Run (`dump_task_run`)
- `dump_task`, which now uses the above
- The new `dump_task_region`

To be very clear – even though it may go without saying – tasks talking to `jefe` through these APIs **should not be able to crash the supervisor**.

The most suspicion is directed towards `dump_task_region`, because it specifies an arbitrary address + length.  To make sure the region is legal, `jefe` checks this region against the kernel's report of valid dump regions for the task (`kipc::get_task_dump_region`) and bails out early if it's invalid.