### PR TITLE
Gimlet sequencer should check for a processor

### DIFF
--- a/drv/gimlet-seq-api/src/lib.rs
+++ b/drv/gimlet-seq-api/src/lib.rs
@@ -17,8 +17,9 @@ pub enum SeqError {
     IllegalTransition = 1,
     MuxToHostCPUFailed,
     MuxToSPFailed,
-    ClockConfigFailed,
     ReadRegsFailed,
+    CPUNotPresent,
+    UnrecognizedCPU,
 
     #[idol(server_death)]
     ServerRestarted,


### PR DESCRIPTION
This fixes #1268. On a machine with a correct CPU in SP3:

```
humility: ring buffer drv_gimlet_seq_server::__RINGBUF in gimlet_seq:
 NDX LINE      GEN    COUNT PAYLOAD
   0  167        1        1 Ice40Rails(true, true)
   1  196        1        1 Ice40PowerGoodV1P2(true)
   2  217        1        1 Ice40PowerGoodV3P3(true)
   3  259        1        1 IdentValid(false)
   4  262        1        1 ChecksumValid(false)
   5  265        1        1 Reprogram(true)
   6  279        1        1 Programming
   7  308        1        1 Programmed
   8  311        1        1 RailsOff
   9  314        1        1 Ident(0xde01)
  10  320        1        1 A2Status(0x0)
  11  343        1      446 ClockConfigWrite
  12  355        1        1 ClockConfigSuccess
  13 1131        1        1 V3P3SysA0VOut(Volts(0.171875))
  14  357        1        1 A2
  15  516        1        1 SpdDimmsFound(0x10)
  16  625        1        1 SetState(A2, A0)
  17 1131        1        1 V3P3SysA0VOut(Volts(0.091796875))
  18  629        1        1 PGStatus { b_pg: 0x0, c_pg: 0x0, nic: 0x0 }
  19  635        1        1 SMStatus { a1: 0x0, a0: 0x0 }
  20  640        1        1 PowerControl(0x0)
  21  644        1        1 InterruptFlags(0x0)
  22  672        1        2 A1Status(0x2)
  23  672        1      100 A1Status(0x3)
  24  672        1        1 A1Status(0x5)
  25  686        1        1 CPUPresent(true)
  26  698        1        1 Coretype { coretype: true, sp3r1: true, sp3r2: false }
  27  722        1       11 A0Status(0x1)
  28  722        1      163 A0Status(0x2)
  29  722        1        1 A0Status(0x4)
  30  722        1        1 A0Status(0x6)
  31  722        1        1 A0Status(0x7)
  32  735        1        1 RailsOn
  33  744        1        1 A0Power(0x7)
  34  744        1        9 A0Power(0xa)
  35  744        1        4 A0Power(0xb)
  36  744        1        1 A0Power(0xc)
  37  763        1        1 UartEnabled
  38  614        1        1 UpdateState(A0)
  39  536        1     3604 Status { ier: 0x0, ifr: 0x0, amd_status: 0x4, amd_a0: 0x4 }
```

On a machine without a CPU whatsoever:

```
humility: ring buffer drv_gimlet_seq_server::__RINGBUF in gimlet_seq:
 NDX LINE      GEN    COUNT PAYLOAD
   0  167        1        1 Ice40Rails(true, true)
   1  196        1        1 Ice40PowerGoodV1P2(true)
   2  217        1        1 Ice40PowerGoodV3P3(true)
   3  259        1        1 IdentValid(false)
   4  262        1        1 ChecksumValid(false)
   5  265        1        1 Reprogram(true)
   6  279        1        1 Programming
   7  308        1        1 Programmed
   8  311        1        1 RailsOff
   9  314        1        1 Ident(0xde01)
  10  320        1        1 A2Status(0x0)
  11  343        1      446 ClockConfigWrite
  12  355        1        1 ClockConfigSuccess
  13 1131        1        1 V3P3SysA0VOut(Volts(0.046875))
  14  357        1        1 A2
  15  473        1        1 SpdAbsent(0x0, 0x6, 0x6)
  16  516        1        1 SpdDimmsFound(0xf)
  17  625        1        1 SetState(A2, A0)
  18 1131        1        1 V3P3SysA0VOut(Volts(0.046875))
  19  629        1        1 PGStatus { b_pg: 0x0, c_pg: 0x0, nic: 0x0 }
  20  635        1        1 SMStatus { a1: 0x0, a0: 0x0 }
  21  640        1        1 PowerControl(0x0)
  22  644        1        1 InterruptFlags(0x0)
  23  672        1        1 A1Status(0x2)
  24  672        1      100 A1Status(0x3)
  25  672        1        1 A1Status(0x5)
  26  686        1        1 CPUPresent(false)
  27  384        1        1 A0Failed(CPUNotPresent)
```
