### PR TITLE
Bump hubpack and gateway-messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#76c227f97ba23a197b09d4b5fb2b11f7a7e20c34"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#caea9e57378c8d1989206c04d12cfe81f5b8aada"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",
@@ -2298,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "hubpack"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8f3c0e51b49dd73e277f8d157f7248e91b3597e3487884181b259682b715d3"
+checksum = "61a0b84aeae519f65e0ba3aa998327080993426024edbd5cc38dbaf5ec524303"
 dependencies = [
  "hubpack_derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ goblin = { version = "0.4.3", default-features = true } # goblin::Object doesn't
 heapless = { version = "0.7.16", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
-hubpack = { version = "0.1", default-features = false }
+hubpack = { version = "0.1.2", default-features = false }
 if_chain = {version = "1", default-features = false }
 indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"] }
 itertools = { version = "0.10.5", default-features = false }


### PR DESCRIPTION
This brings us up to `hubpack v0.1.2`