### PR TITLE
Add watchdog for QueueFull issue

### DIFF
--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -302,14 +302,10 @@ impl<E: DeviceExt> VLanState<E> {
     }
 
     pub(crate) fn check_socket_watchdog(&mut self, t: u64) -> bool {
+        const SOCKET_QUEUE_FULL_TIMEOUT_MS: u64 = 500;
         let mut changed = false;
         for socket_index in 0..SOCKET_COUNT {
             if let Some(prev_time) = self.first_queue_full[socket_index] {
-                // Reset the queue by closing + reopening it.  This will
-                // lose packets in the RX queue as well; they're collateral
-                // damage because `smoltcp` doesn't expose a way to flush
-                // just the TX side.
-                const SOCKET_QUEUE_FULL_TIMEOUT_MS: u64 = 500;
                 if t >= prev_time + SOCKET_QUEUE_FULL_TIMEOUT_MS {
                     let s = self.get_socket_mut(socket_index).unwrap_lite();
                     if !s.can_send() {

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -587,7 +587,8 @@ where
                     // lose packets in the RX queue as well; they're collateral
                     // damage because `smoltcp` doesn't expose a way to flush
                     // just the TX side.
-                    if now >= t + 500 {
+                    const SOCKET_QUEUE_FULL_TIMEOUT_MS: u64 = 500;
+                    if now >= t + SOCKET_QUEUE_FULL_TIMEOUT_MS {
                         let e = socket.endpoint();
                         socket.close();
                         socket.bind(e).unwrap();


### PR DESCRIPTION
This watchdog panics the net task if a queue remains full for > 500 ms, to work around https://github.com/smoltcp-rs/smoltcp/issues/594

Tested on a bench with a hacked `udpbroadcast` to clog the pipes, and it seems to work fine.