### PR TITLE
Allow udprpc to send `Jefe.request_reset`

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -34,7 +34,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.net]
 name = "task-net"

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -34,7 +34,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.net]
 name = "task-net"

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -34,7 +34,7 @@ spd = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.net]
 name = "task-net"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -34,7 +34,7 @@ host_sp_comms = "jefe-state-change"
 [tasks.jefe.config.allowed-callers]
 set_state = ["gimlet_seq"]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -31,7 +31,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -31,7 +31,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -31,7 +31,7 @@ net = "jefe-state-change"
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -28,7 +28,7 @@ extern-regions = [ "sram2", "sram3", "sram4" ]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -28,7 +28,7 @@ extern-regions = ["sram2", "sram3", "sram4"]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy", "control_plane_agent"]
+request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"


### PR DESCRIPTION
Prior to this PR, attempting to call `Jefe.request_reset` via `udprpc` would time out:

```
% cargo xtask humility app/gimletlet/app.toml  -- --ip fe80::0c1d:7dff:feef:9f1d%eth0 hiffy -c Jefe.request_reset
    Finished dev [optimized + debuginfo] target(s) in 0.21s
     Running `target/debug/xtask humility app/gimletlet/app.toml -- --ip 'fe80::0c1d:7dff:feef:9f1d%eth0' hiffy -c Jefe.request_reset`
humility: connecting to fe80::0c1d:7dff:feef:9f1d%eth0
humility hiffy failed: Resource temporarily unavailable (os error 11)
Error: humility failed
```

because jefe returned an access violation:

```
14 udprpc                       1   6 FAULT: reply fault: task id #0/gen0, reason AccessViolation (was: wait: reply from jefe/gen0)
```

After this PR, attempting to call `Jefe.request_reset` via `udprpc` _still_ times out from humility's point of view, but because the SP has actually reset and therefore does not respond to the request.