### PR TITLE
rot-carrier: Restore 'dice-mfg' feature.

### DIFF
--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [features]
 dump = ["kern/dump"]
+dice-mfg= ["lpc55-rot-startup/dice-mfg"]
 dice-self = ["lpc55-rot-startup/dice-self"]
 
 [dependencies]

--- a/lib/lpc55-rot-startup/build.rs
+++ b/lib/lpc55-rot-startup/build.rs
@@ -18,6 +18,7 @@ fn gen_memory_range(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use serde::Deserialize;
     use std::fs::File;
+    use std::io::Write;
 
     #[derive(Deserialize, Debug)]
     struct DiceMfgRegion {


### PR DESCRIPTION
Small work required to build an RoT image w/ `dice-mfg` feature.