### PR TITLE
Index Renesas blackboxes by i2c address

### DIFF
--- a/drv/i2c-devices/src/adm1272.rs
+++ b/drv/i2c-devices/src/adm1272.rs
@@ -264,6 +264,10 @@ impl Adm1272 {
         let iout = pmbus_read!(self.device, adm1272::PEAK_IOUT)?;
         Ok(Amperes(iout.get(&self.load_coefficients()?.current)?.0))
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Adm1272 {

--- a/drv/i2c-devices/src/bmr491.rs
+++ b/drv/i2c-devices/src/bmr491.rs
@@ -77,6 +77,10 @@ impl Bmr491 {
         let vout = pmbus_read!(self.device, bmr491::READ_VOUT)?;
         Ok(Volts(vout.get(self.read_mode()?)?.0))
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Bmr491 {

--- a/drv/i2c-devices/src/isl68224.rs
+++ b/drv/i2c-devices/src/isl68224.rs
@@ -92,6 +92,10 @@ impl Isl68224 {
         op.set_on_off_state(OPERATION::OnOffState::On);
         pmbus_rail_write!(self.device, self.rail, OPERATION, op)
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Isl68224 {

--- a/drv/i2c-devices/src/ltc4282.rs
+++ b/drv/i2c-devices/src/ltc4282.rs
@@ -208,7 +208,7 @@ impl Ltc4282 {
     pub fn new(device: &I2cDevice, rsense: Ohms) -> Self {
         Self {
             device: *device,
-            rsense: rsense,
+            rsense,
             control: Cell::new(None),
         }
     }
@@ -246,6 +246,10 @@ impl Ltc4282 {
             Mode::Mode12V => 16.64,
             Mode::Mode24V => 33.28,
         })
+    }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
     }
 }
 

--- a/drv/i2c-devices/src/max5970.rs
+++ b/drv/i2c-devices/src/max5970.rs
@@ -236,6 +236,10 @@ impl Max5970 {
     pub fn read_reg(&self, reg: Register) -> Result<u8, ResponseCode> {
         self.device.read_reg::<u8, u8>(reg as u8)
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<ResponseCode> for Max5970 {

--- a/drv/i2c-devices/src/mwocp68.rs
+++ b/drv/i2c-devices/src/mwocp68.rs
@@ -349,6 +349,10 @@ impl Mwocp68 {
 
         Ok(val)
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Mwocp68 {

--- a/drv/i2c-devices/src/raa229618.rs
+++ b/drv/i2c-devices/src/raa229618.rs
@@ -108,6 +108,10 @@ impl Raa229618 {
             pmbus_rail_write!(self.device, self.rail, VOUT_COMMAND, vout)
         }
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Raa229618 {

--- a/drv/i2c-devices/src/tps546b24a.rs
+++ b/drv/i2c-devices/src/tps546b24a.rs
@@ -72,6 +72,10 @@ impl Tps546B24A {
             Some(mode) => mode,
         })
     }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
 }
 
 impl Validate<Error> for Tps546B24A {

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -62,8 +62,7 @@ Interface(
         "rendmp_blackbox_dump": (
             doc: "reads the RAM blackbox of a Renesas multiphase power controller to the provided lease",
             args: {
-                "dev": "Device",
-                "index": "u32",
+                "addr": "u8",
             },
             reply: Result(
                 ok: "RenesasBlackbox",


### PR DESCRIPTION
Using absolute indexes into the `CONTROLLER_CONFIG` array isn't (easily) visible outside of Hubris.

This assumes that we don't have duplicate addresses, which is true for now (good enough!)