### PR TITLE
Improve QueueFull watchdog

### DIFF
--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -320,10 +320,10 @@ impl<E: DeviceExt> VLanState<E> {
             if self.queue_watchdog[socket_index]
                 == QueueWatchdog::QueueFullTimeout
             {
-                // Reset the queue by closing + reopening it.  This
-                // will lose packets in the RX queue as well;
-                // they're collateral damage because `smoltcp`
-                // doesn't expose a way to flush just the TX side.
+                // Reset the queue by closing + reopening it.  This will lose
+                // packets in the RX queue as well; they're collateral damage
+                // because `smoltcp` doesn't expose a way to flush just the TX
+                // side.
                 let s = self.get_socket_mut(socket_index).unwrap_lite();
                 let e = s.endpoint();
                 s.close();

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -285,8 +285,8 @@ enum QueueWatchdog {
     /// Data is flowing through the queue
     Nominal,
 
-    /// We have seen a `QueueFull` error, and no packets have successfully enter
-    /// the queue since then
+    /// We have seen a `QueueFull` error, and no packets have successfully
+    /// entered the queue since then
     QueueFullAt(u64),
 
     /// We have seen two `QueueFull` errors separated by some timeout without
@@ -607,8 +607,9 @@ where
             Err(udp::SendError::BufferFull) => {
                 const SOCKET_QUEUE_FULL_TIMEOUT_MS: u64 = 500;
 
-                // Record the QueueFull error, adjusting the later timestamp in
-                // the tuple to be our current time.
+                // Record a new QueueFull error if the socket had been working
+                // until now, or roll over into QueueFullTimeout if we've
+                // exceeded our timeout delay.
                 let now = userlib::sys_get_timer().now;
                 match vlan.queue_watchdog[socket_index] {
                     QueueWatchdog::Nominal => {

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -329,6 +329,9 @@ impl<E: DeviceExt> VLanState<E> {
                 s.close();
                 s.bind(e).unwrap_lite();
                 changed = true;
+
+                // Reset the watchdog, so it doesn't fire right away
+                self.queue_watchdog[socket_index] = QueueWatchdog::Nominal;
             }
         }
         changed


### PR DESCRIPTION
Using `can_send` is too optimistic; it will return `true` if there's room in the buffer but a max-length packet won't actually fit.  This results in a storm of `QueueFull` if

a) The host isn't replying
b) There's room in the buffer, **but**
c) The next packet is larger than available space

This PR switches to the single source of truth for socket happiness: did we get a `QueueFull`?