### PR TITLE
Set production host startup options

### DIFF
--- a/app/gimlet/rev-b-lab.toml
+++ b/app/gimlet/rev-b-lab.toml
@@ -3,3 +3,4 @@ inherit = "rev-b.toml"
 [patches]
 name = "gimlet-b-lab"
 features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]

--- a/app/gimlet/rev-c-lab.toml
+++ b/app/gimlet/rev-c-lab.toml
@@ -3,3 +3,4 @@ inherit = "rev-c.toml"
 [patches]
 name = "gimlet-c-lab"
 features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]

--- a/app/gimlet/rev-d-lab.toml
+++ b/app/gimlet/rev-d-lab.toml
@@ -3,3 +3,4 @@ inherit = "rev-d.toml"
 [patches]
 name = "gimlet-d-lab"
 features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]

--- a/task/packrat/Cargo.toml
+++ b/task/packrat/Cargo.toml
@@ -25,6 +25,7 @@ build-util = { path = "../../build/util" }
 
 [features]
 gimlet = ["drv-gimlet-seq-api"]
+boot-kmdb = []
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/packrat/src/gimlet.rs
+++ b/task/packrat/src/gimlet.rs
@@ -23,10 +23,13 @@ pub(crate) struct GimletData {
 }
 
 fn default_host_startup_options() -> HostStartupOptions {
-    // XXX For now, we want to default to these options.
-    HostStartupOptions::STARTUP_KMDB
-        | HostStartupOptions::STARTUP_PROM
-        | HostStartupOptions::STARTUP_VERBOSE
+    if cfg!(feature = "boot-kmdb") {
+        HostStartupOptions::STARTUP_KMDB
+            | HostStartupOptions::STARTUP_PROM
+            | HostStartupOptions::STARTUP_VERBOSE
+    } else {
+        HostStartupOptions::empty()
+    }
 }
 
 impl GimletData {


### PR DESCRIPTION
This change set the default gimlet startup options to none, and adds a
new packrat task feature that is set in lab builds that sets the
default to be more verbose and boot with the kernel debugger loaded.

Fixes #1148 
