### PR TITLE
Add `rendmp_dma_read` Idol command

### DIFF
--- a/idl/power.idol
+++ b/idl/power.idol
@@ -60,7 +60,7 @@ Interface(
             idempotent: true,
         ),
         "rendmp_blackbox_dump": (
-            doc: "reads the RAM blackbox of a Renesas multiphase power controller to the provided lease",
+            doc: "reads the RAM blackbox of a Renesas multiphase power controller",
             args: {
                 "addr": "u8",
             },
@@ -70,6 +70,18 @@ Interface(
             ),
             idempotent: true,
             encoding: Hubpack,
+        ),
+        "rendmp_dma_read": (
+            doc: "reads a DMA register from a Renesas multiphase power controller",
+            args: {
+                "addr": "u8",
+                "reg": "u16",
+            },
+            reply: Result(
+                ok: "u32",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
         ),
     },
 )


### PR DESCRIPTION
This is a building block for https://github.com/oxidecomputer/humility/issues/374

It's a very thin API; we expect to do most of the decoding on the Humility side.

```
matt@niles ~ () $ h -tgimlet hiffy -c Power.rendmp_dma_read -aaddr=0x5a,reg=0xE905
humility: attached to 0483:374f:000C001F4D46500F20373033 via ST-Link V3
Power.rendmp_dma_read() => 0xfaa
```