### PR TITLE
Document and tidy Gimlet PowerStates

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -588,7 +588,6 @@ impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
                 }
 
                 (PowerState::A2, _)
-                | (PowerState::A2PlusMono, _)
                 | (PowerState::A2PlusFans, _)
                 | (PowerState::A1, _) => {
                     //

--- a/drv/gimlet-state/src/lib.rs
+++ b/drv/gimlet-state/src/lib.rs
@@ -13,12 +13,25 @@ use zerocopy::AsBytes;
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, Eq, AsBytes)]
 #[repr(u8)]
 pub enum PowerState {
+    /// Initial A2 state where the SP and most associated circuitry is powered.
     A2 = 1,
-    A2PlusMono = 2,
+    /// A2 substate where we've turned on the fan hotplug controller.
     A2PlusFans = 3,
+    /// Intermediate A1 state on the way toward A0. This corresponds to the
+    /// system-wide notion of A1 and currently has no substates.
     A1 = 4,
+    /// Initial A0 state: the system-wide A0 domain is on, but we have not
+    /// turned on any of the subdomains within A0 (below).
     A0 = 5,
+    /// A0 with the NIC hotplug controller enabled. This is the state we expect
+    /// to be in most of the time.
     A0PlusHP = 6,
+
+    /// A thermal trip event has occurred in A0. This state is terminal and
+    /// requires an explicit transition back to A2.
     A0Thermtrip = 7,
+
+    /// We have detected a host reset in A0. This state is terminal and requires
+    /// an explicit transition back to A2.
     A0Reset = 8,
 }

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -433,9 +433,7 @@ impl MgsHandler {
             .get_state()
             .map_err(|e| SpError::PowerStateError(e as u32))?
         {
-            DrvPowerState::A2
-            | DrvPowerState::A2PlusMono
-            | DrvPowerState::A2PlusFans => PowerState::A2,
+            DrvPowerState::A2 | DrvPowerState::A2PlusFans => PowerState::A2,
             DrvPowerState::A1 => PowerState::A1,
             DrvPowerState::A0
             | DrvPowerState::A0PlusHP

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -281,9 +281,7 @@ impl ServerImpl {
                 | PowerState::A0Reset => continue,
 
                 // If we're already in A2 somehow, we're done.
-                PowerState::A2
-                | PowerState::A2PlusMono
-                | PowerState::A2PlusFans => {
+                PowerState::A2 | PowerState::A2PlusFans => {
                     if reboot {
                         // Somehow we're already in A2 when the host wanted to
                         // reboot; set our reboot timer.
@@ -313,9 +311,7 @@ impl ServerImpl {
         // If we're rebooting and jefe has notified us that we're now in A2,
         // move to A0. Otherwise, ignore this notification.
         match state {
-            PowerState::A2
-            | PowerState::A2PlusMono
-            | PowerState::A2PlusFans => {
+            PowerState::A2 | PowerState::A2PlusFans => {
                 // Were we waiting for a transition to A2? If so, start our
                 // timer for going back to A0.
                 if self.reboot_state == Some(RebootState::WaitingForA2) {

--- a/task/net/src/bsp/gimlet_bcd.rs
+++ b/task/net/src/bsp/gimlet_bcd.rs
@@ -63,7 +63,6 @@ impl crate::bsp_support::Bsp for BspImpl {
             // have to be added explicitly here.
             match PowerState::from_u32(jefe.get_state()) {
                 Some(PowerState::A2)
-                | Some(PowerState::A2PlusMono)
                 | Some(PowerState::A2PlusFans)
                 | Some(PowerState::A1)
                 | Some(PowerState::A0)

--- a/task/power/src/bsp/gimlet_bcd.rs
+++ b/task/power/src/bsp/gimlet_bcd.rs
@@ -65,7 +65,6 @@ pub(crate) fn get_state() -> PowerState {
         | seq_api::PowerState::A0Reset => PowerState::A0,
         seq_api::PowerState::A1
         | seq_api::PowerState::A2
-        | seq_api::PowerState::A2PlusMono
         | seq_api::PowerState::A2PlusFans => PowerState::A2,
     }
 }

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -93,7 +93,6 @@ fn main() -> ! {
         // have to be added explicitly here.
         match PowerState::from_u32(jefe.get_state()) {
             Some(PowerState::A2)
-            | Some(PowerState::A2PlusMono)
             | Some(PowerState::A2PlusFans)
             | Some(PowerState::A1)
             | Some(PowerState::A0)

--- a/task/thermal/src/bsp/gimlet_bcd.rs
+++ b/task/thermal/src/bsp/gimlet_bcd.rs
@@ -137,7 +137,6 @@ impl Bsp {
                 out
             }
             PowerState::A2
-            | PowerState::A2PlusMono
             | PowerState::A2PlusFans
             | PowerState::A0Thermtrip => PowerBitmask::A2,
         }


### PR DESCRIPTION
The main goal of this change was to have some comments on the enum variants, but while attempting to reverse engineer the comments, I noticed that A2PlusMono is unused and removed it rather than documenting it.