### PR TITLE
gimlet-hf: reduce clock speed to 33MHz.

### DIFF
--- a/drv/gimlet-hf-server/src/bsp/gimlet_bcd.rs
+++ b/drv/gimlet-hf-server/src/bsp/gimlet_bcd.rs
@@ -8,7 +8,7 @@ use drv_stm32xx_sys_api as sys_api;
 
 #[allow(dead_code)]
 pub(crate) fn init(qspi: &Qspi, sys: &sys_api::Sys) -> Config {
-    let clock = 5; // 200MHz kernel / 5 = 40MHz clock
+    let clock = 6; // 200MHz kernel / 6 = 33.333MHz clock
     qspi.configure(
         clock, 25, // 2**25 = 32MiB = 256Mib
     );


### PR DESCRIPTION
We've been having flake with the QSPI flash on Gimlet C revs, some of which has been manufacturing errors, but not all of it.

It turns out we've got at least one board (serial '43) that appears to be assembled correctly, but whose QSPI circuit doesn't work at 40 MHz. The bits wind up shifting with respect to the clock, suggesting that we've got a propagation delay or rise time issue across the translator and mux.

This change lowers the speed to 33 1/3 MHz, which is stable on all the machines we've tried so far.