### PR TITLE
Remove switch-default-image MGS handler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#a8638b2a54b697f55a69032629049a6ea291a698"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=remove-switch-default-image#316a34ec627f3bdfe3adcc023baa3bd076f99748"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=remove-switch-default-image#316a34ec627f3bdfe3adcc023baa3bd076f99748"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#3be94e878b291806b3bd83d62edc8f130d0ed0bc"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,9 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+#gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+# TODO revert back to main before merging
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "remove-switch-default-image" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.2" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
-#gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
-# TODO revert back to main before merging
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "remove-switch-default-image" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.2" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -15,8 +15,8 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
-    SlotId, SpComponent, SpError, SpPort, SpState, SpUpdatePrepare,
-    SwitchDuration, UpdateChunk, UpdateId, UpdateStatus,
+    SpComponent, SpError, SpPort, SpState, SpUpdatePrepare, UpdateChunk,
+    UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -523,10 +523,8 @@ impl SpHandler for MgsHandler {
             component
         }));
 
-        // For now, we don't have any components with active slots.
-        match component {
-            _ => Err(SpError::RequestUnsupportedForComponent),
-        }
+        self.common
+            .component_get_active_slot(&self.sp_update, component)
     }
 
     fn component_set_active_slot(
@@ -543,10 +541,12 @@ impl SpHandler for MgsHandler {
             persist,
         }));
 
-        // For now, we don't have any components with active slots.
-        match component {
-            _ => Err(SpError::RequestUnsupportedForComponent),
-        }
+        self.common.component_set_active_slot(
+            &self.sp_update,
+            component,
+            slot,
+            persist,
+        )
     }
 
     fn component_clear_status(
@@ -662,22 +662,6 @@ impl SpHandler for MgsHandler {
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError> {
         self.common.get_caboose_value(key)
-    }
-
-    fn switch_default_image(
-        &mut self,
-        _sender: SocketAddrV6,
-        _port: SpPort,
-        component: SpComponent,
-        slot: SlotId,
-        duration: SwitchDuration,
-    ) -> Result<(), SpError> {
-        self.common.switch_default_image(
-            &self.sp_update,
-            component,
-            slot,
-            duration,
-        )
     }
 
     fn reset_component_prepare(


### PR DESCRIPTION
We can use the existing "component active slot" messages the same way host flash does.

Depends on https://github.com/oxidecomputer/management-gateway-service/pull/86.