### PR TITLE
Use `write_read_reg` in Renesas blackbox functions

### DIFF
--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -703,10 +703,11 @@ impl idl::InOrderPowerImpl for ServerImpl {
         }
 
         // Step 2a - Write to DMA Address Register
-        dev.write(&[CommandCode::DMAADDR as u8, addr_reg, 0x00])?;
-
         // Step 2b - Read DMA Data Register
-        let mut r: u32 = dev.read_reg(CommandCode::DMAFIX as u8)?;
+        let mut r: u32 = dev.write_read_reg(
+            CommandCode::DMAFIX as u8,
+            &[CommandCode::DMAADDR as u8, addr_reg, 0x00],
+        )?;
         ringbuf_entry!(Trace::GotAddr(r));
 
         // "Divide this value by 4 to determine the starting address of the
@@ -720,16 +721,21 @@ impl idl::InOrderPowerImpl for ServerImpl {
         }
 
         // Step 3a - Write to DMA Address Register
-        dev.write(&[CommandCode::DMAADDR as u8, r as u8, (r >> 8) as u8])?;
-
         // Step 3b - Read Black Box Data
         let buf = match &mut out {
             RenesasBlackbox::Gen2(buf) => buf.as_mut_slice(),
             RenesasBlackbox::Gen2p5(buf) => buf.as_mut_slice(),
         };
         for b in buf {
-            let r: u32 = dev.read_reg(CommandCode::DMASEQ as u8)?;
-            *b = r.swap_bytes();
+            // Note that we're using DMAFIX and specifying the address for each
+            // byte.  This is less efficient, but means that no one can mess
+            // with us by modifying the DMA address mid-loop.
+            let v: u32 = dev.write_read_reg(
+                CommandCode::DMAFIX as u8,
+                &[CommandCode::DMAADDR as u8, r as u8, (r >> 8) as u8],
+            )?;
+            r += 1; // We do the address incrementing ourselves
+            *b = v.swap_bytes();
         }
 
         Ok(out)
@@ -752,8 +758,10 @@ impl idl::InOrderPowerImpl for ServerImpl {
             .i2c_device();
 
         use pmbus::commands::isl68224::CommandCode;
-        dev.write(&[CommandCode::DMAADDR as u8, reg as u8, (reg >> 8) as u8])?;
-        let out: u32 = dev.read_reg(CommandCode::DMAFIX as u8)?;
+        let out: u32 = dev.write_read_reg(
+            CommandCode::DMAFIX as u8,
+            &[CommandCode::DMAADDR as u8, reg as u8, (reg >> 8) as u8],
+        )?;
         Ok(out)
     }
 }


### PR DESCRIPTION
This prevents us from being interrupted; it's very unlikely to matter, but might as well do this right.