### PR TITLE
Move transceiver LED control to the network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=led-control#99fdd8fb91f54cd9683597cc6de28933aed73f1c"
+source = "git+https://github.com/oxidecomputer/transceiver-control/#142ebb7ac603ea8541c42f53c4a5a34f1176114a"
 dependencies = [
  "bitflags 2.1.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=led-control#7570ce983bcd7eca7527f474499d92cd680b10bb"
+source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=led-control#99fdd8fb91f54cd9683597cc6de28933aed73f1c"
 dependencies = [
  "bitflags 2.1.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/transceiver-control/#ac227ce804ad966cb3412260d1d492cf0b3b1dbe"
+source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=led-control#7570ce983bcd7eca7527f474499d92cd680b10bb"
 dependencies = [
  "bitflags 2.1.0",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,5 +128,5 @@ sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", def
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false, branch = "led-control" }
+transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,5 +128,5 @@ sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", def
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false }
+transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false, branch = "led-control" }
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }

--- a/drv/sidecar-front-io/src/leds.rs
+++ b/drv/sidecar-front-io/src/leds.rs
@@ -11,13 +11,13 @@ pub struct Leds {
     /// Two PCA9956B devices, each of which control half of the LEDs
     controllers: [Pca9956B; 2],
     /// Written into the IREFALL register on the PCA9956Bs
-    /// 
+    ///
     /// From the PCA9956B datasheet, the calculus is
-    /// I = IREFALL/256 * (900mV/Rext) * 1/4. Rext (R47 & R48 on QSFP Front IO) 
+    /// I = IREFALL/256 * (900mV/Rext) * 1/4. Rext (R47 & R48 on QSFP Front IO)
     /// is a 1K, so the current value is defined as: `current` * 0.225 mA.
     current: u8,
     /// Written into the PWMx registers on the PCA9956Bs
-    /// 
+    ///
     /// The percent of time the LED is on is governed by the duty cycle
     /// calculation: `pwm`/256.
     pwm: u8,
@@ -48,7 +48,7 @@ struct LedLocation {
 }
 
 /// Summary of errors related to the LED controllers
-/// 
+///
 /// FullErrorSummary takes the errors reported by each individual PCA9956B and
 /// maps them to a by-transceiver-port representation for the masks
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -332,7 +332,7 @@ impl Leds {
     }
 
     /// Sets self.pwm to `value`
-    /// 
+    ///
     /// This will get pushed out to the controllers when the `update_led_state`
     /// function is called.
     pub fn set_pwm(&mut self, value: u8) {
@@ -340,7 +340,7 @@ impl Leds {
     }
 
     /// Helper function used by a driver to write the initial IREFALL value
-    /// 
+    ///
     /// This should be called once the controllers become available.
     pub fn initialize_current(&self) -> Result<(), Error> {
         self.update_current(self.current)
@@ -354,7 +354,7 @@ impl Leds {
     }
 
     /// Turns on the LED for each bit set in `mask`
-    /// 
+    ///
     /// For any bit set in the `mask`, sets its corresponding PWMx register
     pub fn update_led_state(&self, mask: LogicalPortMask) -> Result<(), Error> {
         let mut data_l: [u8; 16] = [0; 16];

--- a/drv/sidecar-front-io/src/leds.rs
+++ b/drv/sidecar-front-io/src/leds.rs
@@ -188,7 +188,7 @@ const LED_MAP: LedMap = LedMap([
         controller: LedController::Left,
         output: 1,
     },
-    #[cfg(not(target_board = "sidecar-b"))]
+    #[cfg(target_board = "sidecar-c")]
     // Port 16
     LedLocation {
         controller: LedController::Left,
@@ -200,7 +200,7 @@ const LED_MAP: LedMap = LedMap([
         controller: LedController::Left,
         output: 3,
     },
-    #[cfg(not(target_board = "sidecar-b"))]
+    #[cfg(target_board = "sidecar-c")]
     // Port 17
     LedLocation {
         controller: LedController::Left,
@@ -212,7 +212,7 @@ const LED_MAP: LedMap = LedMap([
         controller: LedController::Left,
         output: 5,
     },
-    #[cfg(not(target_board = "sidecar-b"))]
+    #[cfg(target_board = "sidecar-c")]
     // Port 18
     LedLocation {
         controller: LedController::Left,
@@ -224,7 +224,7 @@ const LED_MAP: LedMap = LedMap([
         controller: LedController::Left,
         output: 7,
     },
-    #[cfg(not(target_board = "sidecar-b"))]
+    #[cfg(target_board = "sidecar-c")]
     // Port 19
     LedLocation {
         controller: LedController::Left,

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -466,7 +466,7 @@ const LEFT_LOGICAL_MASK: LogicalPortMask = LogicalPortMask(0x00ff00ff);
 const RIGHT_LOGICAL_MASK: LogicalPortMask = LogicalPortMask(0xff00ff00);
 
 /// Consolidates per-module success/failure/error information.
-/// 
+///
 /// For operations which have no failure path, just success or error, make use
 /// of the `ModuleResultNoFailure` type. Since multiple modules can be accessed
 /// in parallel, we need to be able to handle a mix of the following cases on a
@@ -519,8 +519,8 @@ impl ModuleResult {
         self.error
     }
 
-    /// Combines two `ModuleResults` 
-    /// 
+    /// Combines two `ModuleResults`
+    ///
     /// Intended to be used for a sequence of `ModuleResult` yielding function
     /// calls. Building such a sequence is generally done with the following
     /// form (where `modules` is a `LogicalPortMask` of requested modules):
@@ -671,7 +671,7 @@ impl Transceivers {
 
     /// Set ResetL bits per the specified `mask`.
     ///
-    /// This directly controls the ResetL signal to the module. 
+    /// This directly controls the ResetL signal to the module.
     /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -117,7 +117,7 @@ impl LogicalPort {
     }
 }
 /// Represents a set of selected logical ports, i.e. a 32-bit bitmask
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct LogicalPortMask(pub u32);
 
 impl LogicalPortMask {

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -260,7 +260,7 @@ impl From<LogicalPortMask> for FpgaPortMasks {
     }
 }
 
-/// Port Map
+/// Logical -> physical mapping for ports
 ///
 /// Each index in this map represents the location of its transceiver port, so
 /// index 0 is for port 0, and so on. The ports numbered 0-15 left to right
@@ -268,8 +268,6 @@ impl From<LogicalPortMask> for FpgaPortMasks {
 /// ports are split up between the FPGAs based on locality, not logically and
 /// the FPGAs share code, resulting in each one reporting in terms of ports
 /// 0-15.
-///
-/// This is the logical -> physical mapping.
 struct PortMap([PortLocation; NUM_PORTS as usize]);
 
 impl core::ops::Index<LogicalPort> for PortMap {
@@ -467,12 +465,12 @@ const PORT_MAP: PortMap = PortMap([
 const LEFT_LOGICAL_MASK: LogicalPortMask = LogicalPortMask(0x00ff00ff);
 const RIGHT_LOGICAL_MASK: LogicalPortMask = LogicalPortMask(0xff00ff00);
 
-/// A type to consolidate per-module success/failure/error information. For
-/// operations which have no failure path, just success or error, make use of
-/// the `ModuleResultNoFailure` type.
-///
-/// Since multiple modules can be accessed in parallel, we need to be able to
-/// handle a mix of the following cases on a per-module basis:
+/// Consolidates per-module success/failure/error information.
+/// 
+/// For operations which have no failure path, just success or error, make use
+/// of the `ModuleResultNoFailure` type. Since multiple modules can be accessed
+/// in parallel, we need to be able to handle a mix of the following cases on a
+/// per-module basis:
 /// - The module operation succeeded
 /// - The module operation failed
 /// - The module could not be interacted with due to an FPGA communication error
@@ -490,8 +488,7 @@ impl From<ModuleResultNoFailure> for ModuleResult {
 }
 
 impl ModuleResult {
-    /// Create a new ModuleResult which enforces no overlap in the success,
-    /// failure, and error masks.
+    /// Enforces no overlap in the success, failure, and error masks.
     pub fn new(
         success: LogicalPortMask,
         failure: LogicalPortMask,
@@ -522,10 +519,11 @@ impl ModuleResult {
         self.error
     }
 
-    /// This is a helper function to combine two sets of results for when there
-    /// is a sequence of `ModuleResult` yielding function calls. Building such a
-    /// sequence is generally done with the following form (where `modules` is
-    /// a `LogicalPortMask` of requested modules):
+    /// Combines two `ModuleResults` 
+    /// 
+    /// Intended to be used for a sequence of `ModuleResult` yielding function
+    /// calls. Building such a sequence is generally done with the following
+    /// form (where `modules` is a `LogicalPortMask` of requested modules):
     ///
     /// let result = some_result_fn(modules);
     /// let next_result = result.chain(another_result_fn(result.success()))
@@ -574,8 +572,7 @@ pub struct ModuleResultNoFailure {
 }
 
 impl ModuleResultNoFailure {
-    /// Create a new ModuleResultNoFailure which enforces no overlap in the
-    /// success and error masks.
+    /// Enforces no overlap in the success and error masks.
     pub fn new(
         success: LogicalPortMask,
         error: LogicalPortMask,
@@ -610,8 +607,9 @@ impl Transceivers {
         &self.fpgas[c as usize]
     }
 
-    /// Executes a specified WriteOp (`op`) at `addr` for all ports specified by
-    /// the `mask`. The meaning of the returned `ModuleResultNoFailure`:
+    /// Executes a WriteOp (`op`) at `addr` for all ports per the `mask`.
+    ///
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     fn masked_port_op(
@@ -646,18 +644,22 @@ impl Transceivers {
         ModuleResultNoFailure::new(success, error).unwrap()
     }
 
-    /// Set power enable bits per the specified `mask`. Controls whether or not
-    /// a module's hot swap control will be turned on by the FPGA upon module
-    /// insertion. The meaning of the returned `ModuleResultNoFailure`:
+    /// Set power enable bits per the specified `mask`.
+    ///
+    /// Controls whether or not a module's hot swap control will be turned on by
+    /// the FPGA upon module insertion.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn enable_power(&self, mask: LogicalPortMask) -> ModuleResultNoFailure {
         self.masked_port_op(WriteOp::BitSet, mask, Addr::QSFP_POWER_EN0)
     }
 
-    /// Clear power enable bits per the specified `mask`. Controls whether or
-    /// not a module's hot swap control will be turned on by the FPGA upon
-    /// module insertion. The meaning of the returned `ModuleResultNoFailure`:
+    /// Clear power enable bits per the specified `mask`.
+    ///
+    /// Controls whether or not a module's hot swap control will be turned on by
+    /// the FPGA upon module insertion.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn disable_power(
@@ -667,8 +669,10 @@ impl Transceivers {
         self.masked_port_op(WriteOp::BitClear, mask, Addr::QSFP_POWER_EN0)
     }
 
-    /// Set ResetL bits per the specified `mask`. This directly controls the
-    /// ResetL signal to the module.The meaning of the returned `ModuleResultNoFailure`:
+    /// Set ResetL bits per the specified `mask`.
+    ///
+    /// This directly controls the ResetL signal to the module. 
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn deassert_reset(
@@ -678,16 +682,20 @@ impl Transceivers {
         self.masked_port_op(WriteOp::BitSet, mask, Addr::QSFP_MOD_RESETL0)
     }
 
-    /// Clear ResetL bits per the specified `mask`. This directly controls the
-    /// ResetL signal to the module. The meaning of the returned `ModuleResultNoFailure`:
+    /// Clear ResetL bits per the specified `mask`.
+    ///
+    /// This directly controls the ResetL signal to the module.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn assert_reset(&self, mask: LogicalPortMask) -> ModuleResultNoFailure {
         self.masked_port_op(WriteOp::BitClear, mask, Addr::QSFP_MOD_RESETL0)
     }
 
-    /// Set LpMode bits per the specified `mask`. This directly controls the
-    /// LpMode signal to the module. The meaning of the returned `ModuleResultNoFailure`:
+    /// Set LpMode bits per the specified `mask`.
+    ///
+    /// This directly controls the LpMode signal to the module.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn assert_lpmode(
@@ -697,8 +705,10 @@ impl Transceivers {
         self.masked_port_op(WriteOp::BitSet, mask, Addr::QSFP_MOD_LPMODE0)
     }
 
-    /// Clear LpMode bits per the specified `mask`. This directly controls the
-    /// LpMode signal to the module. The meaning of the returned `ModuleResultNoFailure`:
+    /// Clear LpMode bits per the specified `mask`.
+    ///
+    /// This directly controls the LpMode signal to the module.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     pub fn deassert_lpmode(
@@ -708,9 +718,11 @@ impl Transceivers {
         self.masked_port_op(WriteOp::BitClear, mask, Addr::QSFP_MOD_LPMODE0)
     }
 
-    /// Get the current status of all low speed signals for all ports. This is
-    /// Enable, Reset, LpMode/TxDis, Power Good, Power Good Timeout, Present,
-    /// and IRQ/RxLos. The meaning of the returned `ModuleResult`:
+    /// Get the current status of all low speed signals for all ports.
+    ///
+    /// This is Enable, Reset, LpMode/TxDis, Power Good, Power Good Timeout,
+    /// Present, and IRQ/RxLos.
+    /// The meaning of the returned `ModuleResult`:
     /// success: we were able to read from the FPGA
     /// error: an `FpgaError` occurred
     pub fn get_module_status(&self) -> (ModuleStatus, ModuleResultNoFailure) {
@@ -762,7 +774,9 @@ impl Transceivers {
         )
     }
 
-    /// Clear a fault for each port per the specified `mask`. The meaning of the
+    /// Clear a fault for each port per the specified `mask`.
+    ///
+    /// The meaning of the
     /// returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
@@ -835,10 +849,11 @@ impl Transceivers {
         self.setup_i2c_op(false, reg, num_bytes, mask)
     }
 
-    /// Initiate an I2C operation on all ports per the specified `mask`. When
-    /// `is_read` is true, the operation will be a random-read, not a pure I2C
-    /// read. The maximum value of `num_bytes` is 128. The meaning of the
-    /// returned `ModuleResultNoFailure`:
+    /// Initiate an I2C operation on all ports per the specified `mask`.
+    ///
+    /// When `is_read` is true, the operation will be a random-read, not a pure
+    /// I2C read. The maximum value of `num_bytes` is 128.
+    /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred
     fn setup_i2c_op(
@@ -900,7 +915,9 @@ impl Transceivers {
         ModuleResultNoFailure::new(success, error).unwrap()
     }
 
-    /// Read the value of the QSFP_PORTx_STATUS. This contains information on if
+    /// Read the value of the QSFP_PORTx_STATUS
+    ///
+    /// This contains information on if
     /// the I2C core is busy or if there were any errors with the transaction.
     pub fn get_i2c_status<P: Into<PortLocation>>(
         &self,
@@ -911,9 +928,10 @@ impl Transceivers {
             .read(Self::read_status_address(port_loc.port))
     }
 
-    /// Get `buf.len()` bytes of data from the I2C read buffer for a `port`. The
-    /// buffer stores data from the last I2C read transaction done and thus only
-    /// the number of bytes read will be valid in the buffer.
+    /// Get `buf.len()` bytes of data from the I2C read buffer for a `port`.
+    ///
+    /// The buffer stores data from the last I2C read transaction done and thus
+    /// only the number of bytes read will be valid in the buffer.
     pub fn get_i2c_read_buffer<P: Into<PortLocation>>(
         &self,
         port: P,
@@ -938,15 +956,16 @@ impl Transceivers {
             .read_bytes(Self::read_status_address(port_loc.port), buf)
     }
 
-    /// Write `buf.len()` bytes of data into the I2C write buffer. Upon a write
-    /// transaction happening, the number of bytes specified will be pulled from
-    /// the write buffer. Setting data in the write buffer does not require a
-    /// port be specified. This is because in the FPGA implementation, the write
-    /// buffer being written to simply pushes a copy of the data into each
-    /// individual port's write buffer. This keeps us from needing to write to
-    /// them all individually. In the event of an error during FPGA
-    /// communication, a `LogicalPortMask` representing the affected ports is
-    /// included.
+    /// Write `buf.len()` bytes of data into the I2C write buffer.
+    ///
+    /// Upon a write transaction happening, the number of bytes specified will
+    /// be pulled from the write buffer. Setting data in the write buffer does
+    /// not require a port be specified. This is because in the FPGA
+    /// implementation, the write buffer being written to simply pushes a copy
+    /// of the data into each individual port's write buffer. This keeps us from
+    /// needing to write to them all individually. In the event of an error
+    /// during FPGA communication, a `LogicalPortMask` representing the affected
+    /// ports is included.
     /// The meaning of the returned `ModuleResultNoFailure`:
     /// success: we were able to write to the FPGA
     /// error: an `FpgaError` occurred

--- a/drv/transceivers-api/src/lib.rs
+++ b/drv/transceivers-api/src/lib.rs
@@ -19,6 +19,7 @@ pub enum TransceiversError {
     InvalidNumberOfBytes,
     InvalidPowerState,
     InvalidModuleResult,
+    LedI2cError,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -72,7 +72,6 @@ ringbuf!(Trace, 16, Trace::None);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// 0-31 for port LEDs, 32 is System LED
 #[derive(Copy, Clone)]
 struct LedStates([LedState; NUM_PORTS as usize]);
 
@@ -136,8 +135,8 @@ impl ServerImpl {
         }
     }
 
-    fn get_led_state(&self) -> LedStates {
-        self.led_states
+    fn get_led_state(&self, port: LogicalPort) -> LedState {
+        self.led_states.0[port.0 as usize]
     }
 
     fn set_system_led_state(&mut self, state: LedState) {

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -24,7 +24,9 @@ use idol_runtime::{
 use ringbuf::*;
 use task_sensor_api::{NoData, Sensor, SensorError};
 use task_thermal_api::{Thermal, ThermalError, ThermalProperties};
-use transceiver_messages::{mgmt::ManagementInterface, MAX_PACKET_SIZE};
+use transceiver_messages::{
+    message::LedState, mgmt::ManagementInterface, MAX_PACKET_SIZE,
+};
 use userlib::{units::Celsius, *};
 use zerocopy::{AsBytes, FromBytes};
 
@@ -53,7 +55,7 @@ enum Trace {
     LEDEnableError(FpgaError),
     LEDReadError(Error),
     LEDUpdateError(Error),
-    ModulePresenceUpdate(u32),
+    ModulePresenceUpdate(LogicalPortMask),
     TransceiversError(TransceiversError),
     GotInterface(u8, ManagementInterface),
     UnknownInterface(u8, ManagementInterface),
@@ -70,13 +72,23 @@ ringbuf!(Trace, 16, Trace::None);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// 0-31 for port LEDs, 32 is System LED
+#[derive(Copy, Clone)]
+struct LedStates([LedState; NUM_PORTS as usize]);
+
 struct ServerImpl {
     transceivers: Transceivers,
     leds: Leds,
     net: task_net_api::Net,
-    modules_present: u32,
+    modules_present: LogicalPortMask,
+
+    /// State around LED management
     led_error: FullErrorSummary,
     leds_initialized: bool,
+    led_states: LedStates,
+    led_on: LogicalPortMask,
+    system_led_state: LedState,
+    system_led_on: bool,
 
     /// Handle to write thermal models and presence to the `thermal` task
     thermal_api: Thermal,
@@ -99,10 +111,8 @@ struct ThermalModel {
 
 /// Controls how often we poll the transceivers (in milliseconds).
 ///
-/// Polling the transceivers serves a few functions:
-/// - Transceiver presence is used to control LEDs on the front IO board
-/// - For transceivers that are present and include a thermal model, we measure
-///   their temperature and send it to the `thermal` task.
+/// For transceivers that are present and include a thermal model, we measure
+/// their temperature and send it to the `thermal` task.
 const TIMER_INTERVAL: u64 = 500;
 
 impl ServerImpl {
@@ -110,7 +120,7 @@ impl ServerImpl {
         match self
             .leds
             .initialize_current()
-            .and(self.leds.turn_on_system_led())
+            .and(self.leds.update_system_led_state(true))
         {
             Ok(_) => {
                 self.leds_initialized = true;
@@ -120,12 +130,53 @@ impl ServerImpl {
         };
     }
 
-    fn led_update(&self, presence: u32) {
-        if self.leds_initialized {
-            match self.leds.update_led_state(presence) {
-                Ok(_) => (),
-                Err(e) => ringbuf_entry!(Trace::LEDUpdateError(e)),
+    fn set_led_state(&mut self, mask: LogicalPortMask, state: LedState) {
+        for index in mask.to_indices() {
+            self.led_states.0[index.0 as usize] = state;
+        }
+    }
+
+    fn get_led_state(&self) -> LedStates {
+        self.led_states
+    }
+
+    fn set_system_led_state(&mut self, state: LedState) {
+        self.system_led_state = state;
+    }
+
+    #[allow(dead_code)]
+    fn get_system_led_state(&self) -> LedState {
+        self.system_led_state
+    }
+
+    fn update_leds(&mut self) {
+        // handle port LEDs
+        let mut next_state = LogicalPortMask(0);
+        for (i, state) in self.led_states.0.into_iter().enumerate() {
+            let i = LogicalPort(i as u8);
+            match state {
+                LedState::On => next_state.set(i),
+                LedState::Blink => {
+                    if !self.led_on.is_set(i) {
+                        next_state.set(i)
+                    }
+                }
+                LedState::Off => (),
             }
+        }
+        if let Err(e) = self.leds.update_led_state(next_state) {
+            ringbuf_entry!(Trace::LEDUpdateError(e));
+        }
+        self.led_on = next_state;
+
+        // handle system LED
+        match self.system_led_state {
+            LedState::On => self.system_led_on = true,
+            LedState::Blink => self.system_led_on = !self.system_led_on,
+            LedState::Off => self.system_led_on = false,
+        }
+        if let Err(e) = self.leds.update_system_led_state(self.system_led_on) {
+            ringbuf_entry!(Trace::LEDUpdateError(e));
         }
     }
 }
@@ -577,6 +628,76 @@ impl idl::InOrderTransceiversImpl for ServerImpl {
             Err(RequestError::from(TransceiversError::FpgaError))
         }
     }
+
+    fn set_port_led_on(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        logical_port_mask: u32,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_led_state(LogicalPortMask(logical_port_mask), LedState::On);
+        Ok(())
+    }
+
+    fn set_port_led_off(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        logical_port_mask: u32,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_led_state(LogicalPortMask(logical_port_mask), LedState::Off);
+        Ok(())
+    }
+
+    fn set_port_led_blink(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        logical_port_mask: u32,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_led_state(LogicalPortMask(logical_port_mask), LedState::Blink);
+        Ok(())
+    }
+
+    fn set_system_led_on(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_system_led_state(LedState::On);
+        Ok(())
+    }
+
+    fn set_system_led_off(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_system_led_state(LedState::Off);
+        Ok(())
+    }
+
+    fn set_system_led_blink(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.set_system_led_state(LedState::Blink);
+        Ok(())
+    }
+
+    fn set_led_current(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        value: u8,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.leds
+            .set_current(value)
+            .map_err(|_| RequestError::from(TransceiversError::LedI2cError))
+    }
+
+    fn set_led_pwm(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        value: u8,
+    ) -> Result<(), idol_runtime::RequestError<TransceiversError>> {
+        self.leds.set_pwm(value);
+        Ok(())
+    }
 }
 
 impl NotificationHandler for ServerImpl {
@@ -592,6 +713,7 @@ impl NotificationHandler for ServerImpl {
         if (bits & notifications::TIMER_MASK) != 0 {
             // Check for errors
             if self.leds_initialized {
+                self.update_leds();
                 let errors = match self.leds.error_summary() {
                     Ok(errs) => errs,
                     Err(e) => {
@@ -610,10 +732,8 @@ impl NotificationHandler for ServerImpl {
             // Query module presence and update LEDs accordingly
             let (status, _) = self.transceivers.get_module_status();
 
-            let modules_present = !status.modprsl;
+            let modules_present = LogicalPortMask(!status.modprsl);
             if modules_present != self.modules_present {
-                self.led_update(modules_present);
-
                 self.modules_present = modules_present;
                 ringbuf_entry!(Trace::ModulePresenceUpdate(modules_present));
             }
@@ -667,9 +787,13 @@ fn main() -> ! {
             transceivers,
             leds,
             net,
-            modules_present: 0,
+            modules_present: LogicalPortMask(0),
             led_error: Default::default(),
             leds_initialized: false,
+            led_states: LedStates([LedState::Off; NUM_PORTS as usize]),
+            led_on: LogicalPortMask(0),
+            system_led_state: LedState::Off,
+            system_led_on: false,
             thermal_api,
             sensor_api,
             thermal_models: [None; NUM_PORTS as usize],

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -551,7 +551,7 @@ impl ServerImpl {
                         modules: success,
                         failed_modules,
                     }),
-                    num_err_bytes + num_err_bytes,
+                    num_led_bytes + num_err_bytes,
                 )
             }
             HostRequest::SetLedState { modules, state } => {
@@ -885,12 +885,12 @@ impl ServerImpl {
         out: &mut [u8],
     ) -> (usize, ModuleResultNoFailure) {
         let mut led_state_len = 0;
-        for led in modules
+        for led_state in modules
             .to_indices()
-            .map(|m| self.get_led_state().0[m.0 as usize])
+            .map(|m| self.get_led_state(m))
         {
             let led_state_size =
-                hubpack::serialize(&mut out[led_state_len..], &led).unwrap();
+                hubpack::serialize(&mut out[led_state_len..], &led_state).unwrap();
             led_state_len += led_state_size;
         }
 

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -885,12 +885,10 @@ impl ServerImpl {
         out: &mut [u8],
     ) -> (usize, ModuleResultNoFailure) {
         let mut led_state_len = 0;
-        for led_state in modules
-            .to_indices()
-            .map(|m| self.get_led_state(m))
-        {
+        for led_state in modules.to_indices().map(|m| self.get_led_state(m)) {
             let led_state_size =
-                hubpack::serialize(&mut out[led_state_len..], &led_state).unwrap();
+                hubpack::serialize(&mut out[led_state_len..], &led_state)
+                    .unwrap();
             led_state_len += led_state_size;
         }
 

--- a/idl/transceivers.idol
+++ b/idl/transceivers.idol
@@ -138,5 +138,84 @@ Interface(
                 err: CLike("TransceiversError"),
             ),
         ),
+
+        "set_port_led_on": (
+            doc: "Turn on the LEDs for each port as set in the mask",
+            args: {
+                "logical_port_mask": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_port_led_off": (
+            doc: "Turn off the LEDs for each port as set in the mask",
+            args: {
+                "logical_port_mask": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_port_led_blink": (
+            doc: "Blink the LEDs for each port as set in the mask",
+            args: {
+                "logical_port_mask": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_system_led_on": (
+            doc: "Turn on the System LED.",
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_system_led_off": (
+            doc: "Turn off the System LED.",
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_system_led_blink": (
+            doc: "Blink the System LED.",
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_led_current": (
+            doc: "Sets the internal state which is written to the PCA9956B's IREFALL register",
+            args: {
+                "value": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
+
+        "set_led_pwm": (
+            doc: "Sets the internal state which is written to the PCA9956B's PWMx registers",
+            args: {
+                "value": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("TransceiversError"),
+            ),
+        ),
     }
 )


### PR DESCRIPTION
This change is to support the control of the transceiver port LEDs over the network (see #1167). It does not implement control of the system LED via MGS (#1332).

Summary of changes:
* Support `LedState` and `SetLedState` `transceiver-messages`
* Adds some state to the `transceiver-server` to keep track of the state of LEDs, as well as functions to determine on vs off.
* Updates the `leds` module to use stronger typing, similar to the `transceivers` module
* Adds a compile-time fix for a hardware bug on Rev B QSFP Boards which swapped LEDs for 16<->17 and 18<->19
* Add a bunch of commands to the Idol interface to adjust LED state as well as modify brightness (via current and/or PWM). These mostly to support benchtop activity and do not need to stick around.

