### PR TITLE
Add Idol APIs for PMBus operations

### DIFF
--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -552,9 +552,11 @@ impl I2cDevice {
     }
 
     ///
-    /// Like `write_read_reg`, but instead of returning a value, reads as many
-    /// bytes as the device will send into a specified slice, returning the
-    /// number of bytes read.
+    /// Performs a write followed by an SMBus block read (in which the first
+    /// byte returned from the device contains the total number of bytes to
+    /// read) into the specified buffer, returning the total number of bytes
+    /// read.  Note that the byte count is only returned from the function; it
+    /// is *not* present as the payload's first byte.
     ///
     /// The write and read are not performed as a single I2C transaction (that
     /// is, it is not a repeated start) -- but the effect is the same in that
@@ -562,7 +564,7 @@ impl I2cDevice {
     /// (assuring that the write can modify device state that the subsequent
     /// read can assume).
     ///
-    pub fn write_read_reg_into<R: AsBytes>(
+    pub fn write_read_block<R: AsBytes>(
         &self,
         reg: R,
         buffer: &[u8],
@@ -572,7 +574,7 @@ impl I2cDevice {
 
         let (code, _) = sys_send(
             self.task,
-            Op::WriteRead as u16,
+            Op::WriteReadBlock as u16,
             &Marshal::marshal(&(
                 self.address,
                 self.controller,

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -32,6 +32,21 @@ use userlib::*;
 #[derive(FromPrimitive, Eq, PartialEq)]
 pub enum Op {
     WriteRead = 1,
+
+    /// In a `WriteReadBlock` operation, only the **final read** is an SMBus
+    /// block operation.
+    ///
+    /// All writes and all other read operations are normal (non-block)
+    /// operations.
+    ///
+    /// We don't need a special way to perform block writes, because they can be
+    /// constructed by the caller without cooperation from the driver.
+    /// Specifically, the caller can construct the array `[reg, size, data[0],
+    /// data[1], ...]` and pass it to a normal `WriteRead` operation.
+    ///
+    /// If we encounter a device which requires multiple block reads in a row
+    /// without interruption, this logic would not work, but that would be a
+    /// very strange device indeed.
     WriteReadBlock = 2,
     SelectedMuxSegment = 3,
 }

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -319,10 +319,10 @@ fn main() -> ! {
                         |pos| wbuf.read_at(pos),
                         // Only the final read operation in a WriteReadBlock is
                         // a block read; everything else is a normal read.
-                        if op == Op::WriteRead || i != lease_count - 2 {
-                            ReadLength::Fixed(rinfo.len)
-                        } else {
+                        if op == Op::WriteReadBlock && i == lease_count - 2 {
                             ReadLength::Variable
+                        } else {
+                            ReadLength::Fixed(rinfo.len)
                         },
                         |pos, byte| {
                             if pos + 1 > nread {

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -317,7 +317,9 @@ fn main() -> ! {
                         addr,
                         winfo.len,
                         |pos| wbuf.read_at(pos),
-                        if op == Op::WriteRead {
+                        // Only the final read operation in a WriteReadBlock is
+                        // a block read; everything else is a normal read.
+                        if op == Op::WriteRead || i != lease_count - 2 {
                             ReadLength::Fixed(rinfo.len)
                         } else {
                             ReadLength::Variable

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -18,6 +18,34 @@ Interface(
             ),
             idempotent: true,
         ),
+        "raw_pmbus_read": (
+            doc: "performs a raw pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "size": "u8",
+            },
+            reply: Result(
+                ok: "RawPmbusData",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_write": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "data": "RawPmbusData",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
         "read_mode": (
             doc: "reads the VOUT_MODE value for the given device",
             encoding: Hubpack,

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -109,6 +109,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
             },
             reply: Result(
@@ -122,6 +123,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
             },
             reply: Result(
@@ -135,6 +137,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
             },
             reply: Result(
@@ -148,6 +151,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
             },
             reply: Result(
@@ -161,6 +165,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
             },
             reply: Result(
@@ -174,6 +179,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
                 "data": "u8",
             },
@@ -188,6 +194,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
                 "data": "u16",
             },
@@ -202,6 +209,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
                 "data": "u32",
             },
@@ -216,6 +224,7 @@ Interface(
             encoding: Hubpack,
             args: {
                 "index": "u32",
+                "has_rail": "bool",
                 "op": "u8",
                 "data": "RawPmbusBlock",
             },

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -18,34 +18,6 @@ Interface(
             ),
             idempotent: true,
         ),
-        "raw_pmbus_read": (
-            doc: "performs a raw pmbus read operation",
-            encoding: Hubpack,
-            args: {
-                "index": "u32",
-                "op": "u8",
-                "size": "u8",
-            },
-            reply: Result(
-                ok: "RawPmbusData",
-                err: CLike("ResponseCode"),
-            ),
-            idempotent: true,
-        ),
-        "raw_pmbus_write": (
-            doc: "performs a raw pmbus write operation",
-            encoding: Hubpack,
-            args: {
-                "index": "u32",
-                "op": "u8",
-                "data": "RawPmbusData",
-            },
-            reply: Result(
-                ok: "()",
-                err: CLike("ResponseCode"),
-            ),
-            idempotent: true,
-        ),
         "read_mode": (
             doc: "reads the VOUT_MODE value for the given device",
             encoding: Hubpack,
@@ -122,6 +94,133 @@ Interface(
             },
             reply: Result(
                 ok: "u32",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+
+        // Low-level read/write APIs
+        //
+        // In all of these APIs, `index` is the index of the rail within
+        // CONTROLLER_CONFIG.  This must be determined by parsing the ELF data,
+        // as it's not necessarily the same as the order in the app.toml
+        "raw_pmbus_read_byte": (
+            doc: "performs a raw pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+            },
+            reply: Result(
+                ok: "u8",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_read_word": (
+            doc: "performs a raw pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+            },
+            reply: Result(
+                ok: "u16",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_read_word32": (
+            doc: "performs a raw pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+            },
+            reply: Result(
+                ok: "u32",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_read_block": (
+            doc: "performs a raw pmbus read operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+            },
+            reply: Result(
+                ok: "RawPmbusBlock",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_set": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_write_byte": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "data": "u8",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_write_word": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "data": "u16",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_write_word32": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "data": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
+        "raw_pmbus_write_block": (
+            doc: "performs a raw pmbus write operation",
+            encoding: Hubpack,
+            args: {
+                "index": "u32",
+                "op": "u8",
+                "data": "RawPmbusBlock",
+            },
+            reply: Result(
+                ok: "()",
                 err: CLike("ResponseCode"),
             ),
             idempotent: true,

--- a/idl/power.idol
+++ b/idl/power.idol
@@ -98,6 +98,19 @@ Interface(
             ),
             idempotent: true,
         ),
+        "rendmp_dma_write": (
+            doc: "reads a DMA register from a Renesas multiphase power controller",
+            args: {
+                "addr": "u8",
+                "reg": "u16",
+                "data": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ResponseCode"),
+            ),
+            idempotent: true,
+        ),
 
         // Low-level read/write APIs
         //

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -97,6 +97,14 @@ pub enum PmbusValue {
     Block { data: [u8; MAX_BLOCK_LEN], len: u8 },
 }
 
+#[derive(
+    Copy, Clone, Debug, Default, Deserialize, Serialize, SerializedSize,
+)]
+pub struct RawPmbusData {
+    pub data: [u8; MAX_BLOCK_LEN],
+    pub len: u8,
+}
+
 impl From<pmbus::units::Celsius> for PmbusValue {
     fn from(value: pmbus::units::Celsius) -> Self {
         Self::Celsius(value.0)

--- a/task/power-api/src/lib.rs
+++ b/task/power-api/src/lib.rs
@@ -98,11 +98,21 @@ pub enum PmbusValue {
 }
 
 #[derive(
-    Copy, Clone, Debug, Default, Deserialize, Serialize, SerializedSize,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    SerializedSize,
+    AsBytes,
+    FromBytes,
 )]
-pub struct RawPmbusData {
-    pub data: [u8; MAX_BLOCK_LEN],
+#[repr(C)]
+pub struct RawPmbusBlock {
+    // When performing a PMBus block read, the length is the first byte
     pub len: u8,
+    pub data: [u8; MAX_BLOCK_LEN],
 }
 
 impl From<pmbus::units::Celsius> for PmbusValue {

--- a/task/power/src/bsp/gimlet_bcd.rs
+++ b/task/power/src/bsp/gimlet_bcd.rs
@@ -7,7 +7,9 @@ use crate::{
     PowerState,
 };
 
-pub(crate) const CONTROLLER_CONFIG: [PowerControllerConfig; 37] = [
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 37;
+pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
+    CONTROLLER_CONFIG_LEN] = [
     rail_controller!(IBC, bmr491, v12_sys_a2, A2),
     rail_controller!(Core, raa229618, vdd_vcore, A0),
     rail_controller!(Core, raa229618, vddcr_soc, A0),

--- a/task/power/src/bsp/gimletlet_2.rs
+++ b/task/power/src/bsp/gimletlet_2.rs
@@ -7,7 +7,9 @@ use crate::{
     DeviceType, Ohms, PowerControllerConfig, PowerState,
 };
 
-pub(crate) const CONTROLLER_CONFIG: [PowerControllerConfig; 1] = [
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 1;
+pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
+    CONTROLLER_CONFIG_LEN] = [
     // The DC2024 has 10 3mΩ current sense resistors in parallel (5 on each
     // channel), given a total current sense resistance of 300µΩ
     ltc4282_controller!(HotSwapQSFP, v12_out_100a, A2, Ohms(0.003 / 10.0)),

--- a/task/power/src/bsp/psc_abc.rs
+++ b/task/power/src/bsp/psc_abc.rs
@@ -7,7 +7,9 @@ use crate::{
     DeviceType, PowerControllerConfig, PowerState,
 };
 
-pub(crate) const CONTROLLER_CONFIG: [PowerControllerConfig; 12] = [
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 12;
+pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
+    CONTROLLER_CONFIG_LEN] = [
     mwocp68_controller!(PowerShelf, v54_psu0, A2),
     mwocp68_controller!(PowerShelf, v12_psu0, A2),
     mwocp68_controller!(PowerShelf, v54_psu1, A2),

--- a/task/power/src/bsp/sidecar_bc.rs
+++ b/task/power/src/bsp/sidecar_bc.rs
@@ -7,7 +7,9 @@ use crate::{
     DeviceType, Ohms, PowerControllerConfig, PowerState,
 };
 
-pub(crate) const CONTROLLER_CONFIG: [PowerControllerConfig; 16] = [
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 1;
+pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
+    CONTROLLER_CONFIG_LEN] = [
     rail_controller!(IBC, bmr491, v12p0_sys, A2),
     adm1272_controller!(Fan, v54_fan0, A2, Ohms(0.001)),
     adm1272_controller!(Fan, v54_fan1, A2, Ohms(0.001)),

--- a/task/power/src/bsp/sidecar_bc.rs
+++ b/task/power/src/bsp/sidecar_bc.rs
@@ -7,7 +7,7 @@ use crate::{
     DeviceType, Ohms, PowerControllerConfig, PowerState,
 };
 
-pub(crate) const CONTROLLER_CONFIG_LEN: usize = 1;
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 16;
 pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
     CONTROLLER_CONFIG_LEN] = [
     rail_controller!(IBC, bmr491, v12p0_sys, A2),

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -426,7 +426,7 @@ fn main() -> ! {
 struct ServerImpl {
     i2c_task: TaskId,
     sensor: sensor_api::Sensor,
-    devices: &'static mut [Device; bsp::CONTROLLER_CONFIG.len()],
+    devices: &'static mut [Device; bsp::CONTROLLER_CONFIG_LEN],
 }
 
 impl ServerImpl {
@@ -978,10 +978,10 @@ impl idl::InOrderPowerImpl for ServerImpl {
 /// This function can only be called once, and will panic otherwise!
 fn claim_devices(
     i2c_task: TaskId,
-) -> &'static mut [Device; bsp::CONTROLLER_CONFIG.len()] {
+) -> &'static mut [Device; bsp::CONTROLLER_CONFIG_LEN] {
     let mut iter = bsp::CONTROLLER_CONFIG.iter();
     let dev = mutable_statics::mutable_statics!(
-        static mut DEVICES: [Device; bsp::CONTROLLER_CONFIG.len()] =
+        static mut DEVICES: [Device; bsp::CONTROLLER_CONFIG_LEN] =
             [|| iter.next().unwrap().get_device(i2c_task); _];
     );
     dev


### PR DESCRIPTION
These are building blocks that allow us to
- Run `humility pmbus` over the network (https://github.com/oxidecomputer/humility/pull/382)
- Switch to fixed-PWM mode for debugging (pending implementation in Humility)