### PR TITLE
Always use dispatch_n for LED blinking

### DIFF
--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -190,11 +190,7 @@ fn main() -> ! {
         blink_state: false,
     };
     loop {
-        if server.blinking.values().any(|b| *b) {
-            idol_runtime::dispatch_n(&mut incoming, &mut server);
-        } else {
-            idol_runtime::dispatch(&mut incoming, &mut server);
-        }
+        idol_runtime::dispatch_n(&mut incoming, &mut server);
     }
 }
 


### PR DESCRIPTION
This prevents a timer interrupt from being queued up and not delivered until the next time blinking is enabled, which would cause a double-blink.

(harmless, but might as well do it right)