### PR TITLE
Update `dice-mfg-msgs` to get rfd 303 platform id string format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/dice-util#0a5cc84577d38bfda1d86b242f35de4b9887fec1"
+source = "git+https://github.com/oxidecomputer/dice-util#ff5bde9363f9e3294068b6838f2de3651d9aeadb"
 dependencies = [
  "corncobs",
  "hubpack",


### PR DESCRIPTION
All changes are internal to the type & all of the work happens on the mfg side of the message exchange.

This PR is a replacement for #1360 and resolves #1305 