### PR TITLE
Add production images

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -134,6 +134,7 @@ priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
+features = ["enable"]
 task-slots = ["net"]
 notifications = ["socket"]
 

--- a/app/gimlet/rev-b-bench.toml
+++ b/app/gimlet/rev-b-bench.toml
@@ -1,0 +1,7 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "gimlet-b-bench"
+features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-b-lab.toml
+++ b/app/gimlet/rev-b-lab.toml
@@ -2,5 +2,4 @@ inherit = "rev-b.toml"
 
 [patches]
 name = "gimlet-b-lab"
-features.gimlet_seq = ["stay-in-a2"]
-features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -231,6 +231,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab and -bench images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 6

--- a/app/gimlet/rev-c-bench.toml
+++ b/app/gimlet/rev-c-bench.toml
@@ -1,0 +1,7 @@
+inherit = "rev-c.toml"
+
+[patches]
+name = "gimlet-c-bench"
+features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-c-lab.toml
+++ b/app/gimlet/rev-c-lab.toml
@@ -2,5 +2,4 @@ inherit = "rev-c.toml"
 
 [patches]
 name = "gimlet-c-lab"
-features.gimlet_seq = ["stay-in-a2"]
-features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -231,6 +231,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab and -bench images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 6

--- a/app/gimlet/rev-d-bench.toml
+++ b/app/gimlet/rev-d-bench.toml
@@ -1,0 +1,7 @@
+inherit = "rev-d.toml"
+
+[patches]
+name = "gimlet-d-bench"
+features.gimlet_seq = ["stay-in-a2"]
+features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-d-lab.toml
+++ b/app/gimlet/rev-d-lab.toml
@@ -2,5 +2,4 @@ inherit = "rev-d.toml"
 
 [patches]
 name = "gimlet-d-lab"
-features.gimlet_seq = ["stay-in-a2"]
-features.packrat = ["boot-kmdb"]
+features.udprpc = ["enable"]

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -231,6 +231,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab and -bench images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 6

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -194,7 +194,7 @@ max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
-features = ["vlan"]
+features = ["vlan", "enable"]
 notifications = ["socket"]
 
 [tasks.udpecho]

--- a/app/psc/rev-a-lab.toml
+++ b/app/psc/rev-a-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-a.toml"
+
+[patches]
+name = "psc-a-bench"
+features.udprpc = ["enable"]

--- a/app/psc/rev-a.toml
+++ b/app/psc/rev-a.toml
@@ -170,6 +170,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 5

--- a/app/psc/rev-b-lab.toml
+++ b/app/psc/rev-b-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "psc-b-bench"
+features.udprpc = ["enable"]

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -179,6 +179,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 5

--- a/app/psc/rev-c-lab.toml
+++ b/app/psc/rev-c-lab.toml
@@ -1,0 +1,5 @@
+inherit = "rev-c.toml"
+
+[patches]
+name = "psc-c-bench"
+features.udprpc = ["enable"]

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -179,6 +179,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 5

--- a/app/sidecar/rev-b-bench.toml
+++ b/app/sidecar/rev-b-bench.toml
@@ -1,0 +1,6 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "sidecar-b-bench"
+features.sequencer = ["stay-in-a2"]
+features.monorail = ["technician-port-override"]

--- a/app/sidecar/rev-b-bench.toml
+++ b/app/sidecar/rev-b-bench.toml
@@ -4,3 +4,4 @@ inherit = "rev-b.toml"
 name = "sidecar-b-bench"
 features.sequencer = ["stay-in-a2"]
 features.monorail = ["technician-port-override"]
+features.udprpc = ["enable"]

--- a/app/sidecar/rev-b-lab.toml
+++ b/app/sidecar/rev-b-lab.toml
@@ -1,5 +1,0 @@
-inherit = "rev-b.toml"
-
-[patches]
-name = "sidecar-b-lab"
-features.sequencer = ["stay-in-a2"]

--- a/app/sidecar/rev-b-lab.toml
+++ b/app/sidecar/rev-b-lab.toml
@@ -1,0 +1,6 @@
+inherit = "rev-b.toml"
+
+[patches]
+name = "sidecar-b-lab"
+features.monorail = ["technician-port-override"]
+features.udprpc = ["enable"]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -137,6 +137,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab and -bench images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 6

--- a/app/sidecar/rev-c-bench.toml
+++ b/app/sidecar/rev-c-bench.toml
@@ -1,0 +1,7 @@
+inherit = "rev-c.toml"
+
+[patches]
+name = "sidecar-c-bench"
+features.sequencer = ["stay-in-a2"]
+features.monorail = ["technician-port-override"]
+features.udprpc = ["enable"]

--- a/app/sidecar/rev-c-lab.toml
+++ b/app/sidecar/rev-c-lab.toml
@@ -1,5 +1,0 @@
-inherit = "rev-c.toml"
-
-[patches]
-name = "sidecar-c-lab"
-features.sequencer = ["stay-in-a2"]

--- a/app/sidecar/rev-c-lab.toml
+++ b/app/sidecar/rev-c-lab.toml
@@ -1,0 +1,6 @@
+inherit = "rev-c.toml"
+
+[patches]
+name = "sidecar-c-lab"
+features.monorail = ["technician-port-override"]
+features.udprpc = ["enable"]

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -136,6 +136,8 @@ task-slots = ["net", "packrat"]
 features = ["vlan"]
 notifications = ["socket"]
 
+# NOTE: udprpc is diabled here (because the `enable` feature is inactive);
+# we enable it in the -lab and -bench images
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 6

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -15,6 +15,12 @@ num-traits.workspace = true
 serde.workspace = true
 zerocopy.workspace = true
 
+[features]
+# Allow the technician port to talk to every SP, instead of just upstream to the
+# Scrimlet.  This is the default in -lab and -bench builds, but is not allowed
+# in production.
+technician-port-override = []
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -15,12 +15,6 @@ num-traits.workspace = true
 serde.workspace = true
 zerocopy.workspace = true
 
-[features]
-# Allow the technician port to talk to every SP, instead of just upstream to the
-# Scrimlet.  This is the default in -lab and -bench builds, but is not allowed
-# in production.
-technician-port-override = []
-
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -41,6 +41,11 @@ spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
 spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
 spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
 
+# When this feature is enabled, the technician ports can talk to every SP,
+# instead of just upstream to the Scrimlet.  This feature is enabled in -lab and
+# -bench builds, but is not allowed in production.
+technician-port-override = []
+
 [build-dependencies]
 build-util = {path = "../../build/util"}
 idol = { workspace = true }

--- a/task/monorail-server/src/bsp/sidecar_bc.rs
+++ b/task/monorail-server/src/bsp/sidecar_bc.rs
@@ -215,7 +215,12 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         self.phy_vsc8562_init()?;
 
         self.vsc7448.configure_ports_from_map(&PORT_MAP)?;
+
+        #[cfg(not(feature = "technician-port-override"))]
+        self.vsc7448.configure_vlan_strict()?;
+        #[cfg(feature = "technician-port-override")]
         self.vsc7448.configure_vlan_semistrict()?;
+
         self.vsc7448_postconfig()?;
 
         Ok(())

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -13,6 +13,11 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 build-util = { path = "../../build/util" }
 
 [features]
+# The Hubris build system only allows us to add features when doing inheritance
+# of TOML files.  In addition, we want the base `app.toml` to be our production
+# image.  Given these constraints, `udprpc` is disabled unless the `enable`
+# feature is set.
+enable = []
 vlan = ["task-net-api/vlan"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,


### PR DESCRIPTION
This PR disables features that we don't want in production images.

It splits images into three flavors with different `udprpc`, technician port (TP), and power-on behavior:

| Name | `udprpc` | TP can talk to any SP | A0 on boot |
|-|-|-|-|
| `rev-c.toml` | Disabled | No | Yes |
| `rev-c-lab.toml` | Enabled | Yes | Yes |
| `rev-c-bench.toml` | Enabled | Yes | No |

This is deliberately opened as a draft PR, because it will dramatically change system behavior:

- `pilot sp list` and `faux-mgs` will only work from the switch zone (because SPs will no longer talk to the TP)
- ⚠️ If the Scrimlet's switch zone fails to automatically come up and connect to the management network, we have **very limited** access to the system
  - The second Sidecar + Scrimlet can be used in a pinch, as long as we only update them one at a time
- Most `humility` subcommands will no longer work remotely; any command that executes code on the target will fail.  The only commands that will work are memory reads, e.g. `humility ringbuf/tasks/readvar`