### PR TITLE
Bump lpc55-update-server stack size up by 512

### DIFF
--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -50,7 +50,7 @@ start = true
 name = "lpc55-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096, usbsram = 4096}
-stacksize = 2048
+stacksize = 2560
 start = true
 sections = {bootstate = "usbsram"}
 uses = ["flash_controller", "hash_crypt"]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -47,7 +47,7 @@ start = true
 name = "lpc55-update-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096, usbsram = 4096}
-stacksize = 2048
+stacksize = 2560
 start = true
 sections = {bootstate = "usbsram"}
 uses = ["flash_controller", "hash_crypt"]


### PR DESCRIPTION
Our stack margin prior to this PR was 24 bytes; after this PR, we _usually_ see a stackmargin of 536 bytes (i.e., 24+512), but after running sufficiently-many requests for state from MGS, we see it drop to 432 bytes. Cliff suggests this is from getting an interrupt at an inopportune time. This explains what we were seeing in #1374: if we received such an interrupt while the update was running, it would trigger a SO of `update_server`, explaining the "no update started" error we saw.

Fixes #1374.