### PR TITLE
Fix sidecar system LED default state

### DIFF
--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -115,12 +115,9 @@ const TIMER_INTERVAL: u64 = 500;
 
 impl ServerImpl {
     fn led_init(&mut self) {
-        match self
-            .leds
-            .initialize_current()
-            .and(self.leds.update_system_led_state(true))
-        {
+        match self.leds.initialize_current() {
             Ok(_) => {
+                self.set_system_led_state(LedState::On);
                 self.leds_initialized = true;
                 ringbuf_entry!(Trace::LEDInitComplete);
             }


### PR DESCRIPTION
When I retooled the internal front-io LEDs logic I failed to change the _state_ of the system LED to `On`, so the old initialization process would turn it on directly (which lasted for for a single tick) and then the update loop would see the state was still in `Off` state and shut it off. This change just modifies the initialization process to update the state correctly and the loop will do the work of turning it on.

This resolves https://github.com/oxidecomputer/hubris/issues/1382