### PR TITLE
Adds missing TPS546b24As on the front-io i2c bus

### DIFF
--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -786,6 +786,36 @@ description = "Front IO LED driver (right)"
 removable = true
 refdes = "U6"
 
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_011
+device = "tps546b24a"
+description = "Front IO V3P3_SYS_A2 rail"
+removable = true
+power = {rails = ["V3P3_SYS_A2"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U7"
+
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_001
+device = "tps546b24a"
+description = "Front IO V3P3_QSFP0_A0 rail"
+removable = true
+power = {rails = ["V3P3_QSFP0_A0"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U15"
+
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_010
+device = "tps546b24a"
+description = "Front IO V3P3_QSFP1_A0 rail"
+removable = true
+power = {rails = ["V3P3_QSFP1_A0"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U18"
+
 [[config.sensor.devices]]
 name = "xcvr0"
 device = "qsfp"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -785,6 +785,36 @@ description = "Front IO LED driver (right)"
 removable = true
 refdes = "U6"
 
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_011
+device = "tps546b24a"
+description = "Front IO V3P3_SYS_A2 rail"
+removable = true
+power = {rails = ["V3P3_SYS_A2"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U7"
+
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_001
+device = "tps546b24a"
+description = "Front IO V3P3_QSFP0_A0 rail"
+removable = true
+power = {rails = ["V3P3_QSFP0_A0"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U15"
+
+[[config.i2c.devices]]
+bus = "front_io"
+address = 0b0011_010
+device = "tps546b24a"
+description = "Front IO V3P3_QSFP1_A0 rail"
+removable = true
+power = {rails = ["V3P3_QSFP1_A0"] }
+sensors = { temperature = 1, voltage = 1, current = 1 }
+refdes = "U18"
+
 [[config.sensor.devices]]
 name = "xcvr0"
 device = "qsfp"


### PR DESCRIPTION
This adds the following missing devices to the manifest:
* U7: `V3P3_SYS_A2` (TPS546B24A)
* U15: `V3P3_QSFP0_A0` (TPS546B24A)
* U18: `V3P3_QSFP1_A0` (TPS546B24A)

As with other front-io devices, these are marked with `removable = true` since a Sidecar mainboard does not require a front-io board to be connected to operate.

Both QSFP rails have 3 phases (each a unique device). The devices in the manifest act as the I2C controller with the remaining two devices being targets.

All other devices of importance on the front-io board have been accounted for already: 
* I2C: FRUID, GPIO Expander, Left/Right LED Controllers
* SPI: FPGA(s)
* Sensors: Transceiver's thermals

The FPGAs proxy communications to the transceivers and the technician port PHY, so they do not exist in the manifest.

Fixes #1381