### PR TITLE
Remove duplicate task_slot! definition

### DIFF
--- a/sys/userlib/src/macros.rs
+++ b/sys/userlib/src/macros.rs
@@ -69,26 +69,10 @@ cfg_if::cfg_if! {
 
 #[macro_export]
 macro_rules! task_slot {
-    ($var:ident, $task_name:ident) => {
+    ($vis:vis $var:ident, $task_name:ident) => {
         $crate::macros::paste::paste! {
             #[used]
-            static $var: $crate::task_slot::TaskSlot =
-                $crate::task_slot::TaskSlot::UNBOUND;
-
-            #[used]
-            #[link_section = ".task_slot_table"]
-            static [< _TASK_SLOT_TABLE_ $var >]: $crate::task_slot::TaskSlotTableEntry<
-                { $crate::macros::bstringify::bstringify!($task_name).len() },
-            > = $crate::task_slot::TaskSlotTableEntry::for_task_slot(
-                $crate::macros::bstringify::bstringify!($task_name),
-                &$var,
-            );
-        }
-    };
-    (pub $var:ident, $task_name:ident) => {
-        $crate::macros::paste::paste! {
-            #[used]
-            pub static $var: $crate::task_slot::TaskSlot =
+            $vis static $var: $crate::task_slot::TaskSlot =
                 $crate::task_slot::TaskSlot::UNBOUND;
 
             #[used]


### PR DESCRIPTION
The `:vis` syntax type lets us remove some copypasta introduced in #1357.