### PR TITLE
Dice optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,30 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dice"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "dice-mfg-msgs",
- "hkdf",
- "hmac",
- "hubpack",
- "lib-lpc55-usart",
- "lpc55-pac",
- "nb 1.0.0",
- "salty",
- "serde",
- "serde-big-array 0.4.1",
- "sha3",
- "stage0-handoff",
- "static_assertions",
- "unwrap-lite",
- "vcell",
- "zerocopy",
- "zeroize",
-]
-
-[[package]]
 name = "dice-mfg-msgs"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/dice-util#a78bfa3e7152f8464e2910ed71d0e5aded40023e"
@@ -2515,6 +2491,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lib-dice"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dice-mfg-msgs",
+ "hkdf",
+ "hmac",
+ "hubpack",
+ "lib-lpc55-usart",
+ "lpc55-pac",
+ "nb 1.0.0",
+ "salty",
+ "serde",
+ "serde-big-array 0.4.1",
+ "sha3",
+ "stage0-handoff",
+ "static_assertions",
+ "unwrap-lite",
+ "vcell",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
 name = "lib-lpc55-usart"
 version = "0.1.0"
 dependencies = [
@@ -2602,9 +2602,9 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
- "dice",
  "digest",
  "hubpack",
+ "lib-dice",
  "lib-lpc55-usart",
  "lpc55-pac",
  "lpc55-puf",

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dice"
+name = "lib-dice"
 version = "0.1.0"
 edition = "2021"
 

--- a/lib/lpc55-rot-startup/Cargo.toml
+++ b/lib/lpc55-rot-startup/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-dice-mfg = ["dice_crate", "lpc55-puf", "salty", "static_assertions",  "lib-lpc55-usart"]
-dice-self = ["dice_crate", "lpc55-puf", "salty"]
+dice-mfg = ["lib-dice", "lpc55-puf", "salty", "static_assertions",  "lib-lpc55-usart"]
+dice-self = ["lib-dice", "lpc55-puf", "salty"]
 
 [dependencies]
 cfg-if = { workspace = true }
@@ -25,18 +25,11 @@ zeroize = { workspace = true }
 abi = { path = "../../sys/abi" }
 armv8-m-mpu = { path = "../armv8-m-mpu" }
 lpc55-puf = { path = "../lpc55-puf", optional = true }
+lib-dice = { path = "../dice", optional = true }
 lib-lpc55-usart = { path = "../lpc55-usart", optional = true }
 lpc55_romapi = { path = "../lpc55-romapi" }
 stage0-handoff = { path = "../stage0-handoff"}
 unwrap-lite = { path = "../unwrap-lite" }
-
-# features & deps can't have the same name, using this method from:
-# https://github.com/RustCrypto/RSA/pull/41/files
-[dependencies.dice_crate]
-package = "dice"
-path = "../dice"
-default-features = false
-optional = true
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/lib/lpc55-rot-startup/Cargo.toml
+++ b/lib/lpc55-rot-startup/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-dice-mfg = ["lpc55-puf", "salty", "static_assertions",  "lib-lpc55-usart"]
-dice-self = ["lpc55-puf", "salty"]
+dice-mfg = ["dice_crate", "lpc55-puf", "salty", "static_assertions",  "lib-lpc55-usart"]
+dice-self = ["dice_crate", "lpc55-puf", "salty"]
 
 [dependencies]
 cfg-if = { workspace = true }
@@ -36,7 +36,7 @@ unwrap-lite = { path = "../unwrap-lite" }
 package = "dice"
 path = "../dice"
 default-features = false
-optional = false
+optional = true
 
 [build-dependencies]
 build-util = { path = "../../build/util" }

--- a/lib/lpc55-rot-startup/src/dice.rs
+++ b/lib/lpc55-rot-startup/src/dice.rs
@@ -4,7 +4,7 @@
 
 use crate::Handoff;
 use core::mem;
-use dice_crate::{
+use lib_dice::{
     AliasCertBuilder, AliasData, AliasOkm, Cdi, CdiL1, CertData,
     CertSerialNumber, DeviceIdCertBuilder, DeviceIdOkm, IntermediateCert,
     PersistIdCert, PlatformId, RngData, RngSeed, SeedBuf, SpMeasureCertBuilder,
@@ -52,7 +52,7 @@ fn gen_mfg_artifacts(peripherals: &Peripherals) -> MfgResult {
 #[cfg(feature = "dice-self")]
 fn gen_mfg_artifacts_self(peripherals: &Peripherals) -> MfgResult {
     use core::ops::{Deref, DerefMut};
-    use dice_crate::{DiceMfg, PersistIdSeed, SelfMfg};
+    use lib_dice::{DiceMfg, PersistIdSeed, SelfMfg};
     use zeroize::Zeroizing;
 
     let puf = Puf::new(&peripherals.PUF);

--- a/lib/lpc55-rot-startup/src/dice_mfg_usart.rs
+++ b/lib/lpc55-rot-startup/src/dice_mfg_usart.rs
@@ -4,11 +4,11 @@
 
 use crate::dice::{MfgResult, KEYCODE_LEN, KEY_INDEX, SEED_LEN};
 use core::ops::{Deref, DerefMut};
-use dice_crate::{
+use hubpack::SerializedSize;
+use lib_dice::{
     CertSerialNumber, DiceMfg, IntermediateCert, PersistIdCert, PersistIdSeed,
     PlatformId, SeedBuf, SerialMfg,
 };
-use hubpack::SerializedSize;
 use lib_lpc55_usart::Usart;
 use lpc55_pac::Peripherals;
 use lpc55_puf::Puf;


### PR DESCRIPTION
I ran across this while trying to cause the `attest` task from #1378 to behave badly as described in: 
https://github.com/oxidecomputer/hubris/pull/1378#discussion_r1220440263. While disabling the dice features in `lib-lpc55-rot-startup` I noticed that the dependency on the `dice` crate remained. This was caused by `lib-lpc55-rot-startup` not listing the dependency as optional & enabled by the dice features.

This PR includes additional cleanup renaming the dice library from `dice` to `lib-dice` to align with project conventions & prevent conflicts with feature names.