### PR TITLE
Fully specify `IgnitionError` type in Idol API

### DIFF
--- a/drv/ignition-api/src/lib.rs
+++ b/drv/ignition-api/src/lib.rs
@@ -713,9 +713,8 @@ const_assert!(
 );
 
 mod idl {
-    use super::{
-        Counters, IgnitionError, PortState, Request, TransceiverSelect,
-    };
+    use super::{Counters, PortState, Request, TransceiverSelect};
+    use crate as drv_ignition_api;
     use userlib::sys_send;
 
     include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/idl/ignition.idol
+++ b/idl/ignition.idol
@@ -8,7 +8,7 @@ Interface(
             args: {},
             reply: Result(
                 ok: "u8",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "presence_summary": (
@@ -16,7 +16,7 @@ Interface(
             args: {},
             reply: Result(
                 ok: "u64",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "port_state": (
@@ -26,7 +26,7 @@ Interface(
             },
             reply: Result(
                 ok: "PortState",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "counters": (
@@ -36,7 +36,7 @@ Interface(
             },
             reply: Result(
                 ok: "Counters",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "transceiver_events": (
@@ -50,7 +50,7 @@ Interface(
             },
             reply: Result(
                 ok: "u8",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "clear_transceiver_events": (
@@ -64,7 +64,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
          "link_events": (
@@ -74,7 +74,7 @@ Interface(
             },
             reply: Result(
                 ok: "[u8; 3]",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "send_request": (
@@ -88,7 +88,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "all_port_state": (
@@ -96,7 +96,7 @@ Interface(
             args: {},
             reply: Result(
                 ok: "[PortState; 40]",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
         "all_link_events": (
@@ -104,7 +104,7 @@ Interface(
             args: {},
             reply: Result(
                 ok: "[[u8; 3]; 40]",
-                err: CLike("IgnitionError"),
+                err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
     }


### PR DESCRIPTION
Fixes this issue:
```
matt@lurch ~ (sidecar-sp) $ h hiffy -c Ignition.send_request -aport=34,request=SystemPowerReset
humility: attached to 0483:374e:0028001E4741500720383733 via ST-Link V3
humility hiffy failed: IgnitionError matches more than one enum: drv_ignition_api::IgnitionError as GOFF 0x0000331d (object 23), gateway_messages::sp_to_mgs::ignition::IgnitionError as GOFF 0x0000b8e8 (object 23)
```