### PR TITLE
Remove CMPA and CFPA from Hubris archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,6 @@ dependencies = [
  "goblin",
  "hubtools",
  "indexmap",
- "lpc55_areas",
  "lpc55_sign",
  "memchr",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = f
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }

--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -208,14 +208,6 @@ pins = [
     { name = "SP_RESET", pin = { port = 1, pin = 5}, alt = 0, direction = "input"},
 ]
 
-[signing]
-enable-secure-boot = true
-enable-dice = true
-dice-inc-nxp-cfg = false
-dice-cust-cfg = false
-dice-inc-sec-epoch = false
-boot-error-gpio = { port = 1, pin = 1 } # BOOT0_LED
-
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -133,14 +133,6 @@ task-slots = ["jefe"]
 stacksize = 1200
 extern-regions = ["sram2"]
 
-[signing]
-enable-secure-boot = true
-enable-dice = true
-dice-inc-nxp-cfg = false
-dice-cust-cfg = false
-dice-inc-sec-epoch = false
-boot-error-gpio = { port = 1, pin = 1 } # BOOT0_LED
-
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -155,14 +155,6 @@ stacksize = 2048
 [tasks.sp_measure.config]
 binary_path = "../../target/gimlet-c/dist/default/final.bin"
 
-[signing]
-enable-secure-boot = true
-enable-dice = true
-dice-inc-nxp-cfg = false
-dice-cust-cfg = false
-dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
-
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -134,14 +134,6 @@ start = true
 stacksize = 2600
 task-slots = ["swd"]
 
-[signing]
-enable-secure-boot = true
-enable-dice = true
-dice-inc-nxp-cfg = true
-dice-cust-cfg = false
-dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 17 } # ROT_TO_IGNIT_FLT_L
-
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -201,14 +201,6 @@ stacksize = 2048
 [tasks.sp_measure.config]
 binary_path = "../../target/gemini-bu/dist/final.bin"
 
-[signing]
-enable-secure-boot = true
-enable-dice = true
-dice-inc-nxp-cfg = false
-dice-cust-cfg = false
-dice-inc-sec-epoch = false
-boot-error-gpio = { port = 0, pin = 15 } # SCT0_OUT2, red LED on carrier
-
 [signing.certs]
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -45,4 +45,3 @@ toml-task.path = "../../lib/toml-task"
 
 # For NXP signing
 lpc55_sign = { workspace = true }
-lpc55_areas = { workspace = true }

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -12,7 +12,6 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::auxflash::{build_auxflash, AuxFlash, AuxFlashData};
-use lpc55_areas::{DebugSettings, DefaultIsp, ROTKeyStatus};
 
 /// A `PatchedConfig` allows a minimal form of inheritance between TOML files
 /// Specifically, it allows you to **add features** to specific tasks; nothing
@@ -612,32 +611,6 @@ impl MpuAlignment {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RoTMfgSettings {
     pub certs: lpc55_sign::signed_image::CertConfig,
-    #[serde(default)]
-    pub enable_secure_boot: bool,
-    #[serde(default, flatten)]
-    pub dice: lpc55_sign::signed_image::DiceArgs,
-    #[serde(default)]
-    pub cmpa_settings: DebugSettings,
-    #[serde(default)]
-    pub cfpa_settings: DebugSettings,
-    #[serde(default = "ROTKeyStatus::enabled")]
-    pub rotk0: ROTKeyStatus,
-    #[serde(default = "ROTKeyStatus::invalid")]
-    pub rotk1: ROTKeyStatus,
-    #[serde(default = "ROTKeyStatus::invalid")]
-    pub rotk2: ROTKeyStatus,
-    #[serde(default = "ROTKeyStatus::invalid")]
-    pub rotk3: ROTKeyStatus,
-    #[serde(default = "DefaultIsp::auto")]
-    pub default_isp: DefaultIsp,
-    pub boot_error_gpio: RoTBootErrorPin,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RoTBootErrorPin {
-    pub port: u8,
-    pub pin: u8,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -541,27 +541,6 @@ pub fn package(
                 0, // execution address (TODO)
             )?;
 
-            let boot_pin = lpc55_areas::BootErrorPin::new(
-                signing.boot_error_gpio.port,
-                signing.boot_error_gpio.pin,
-            )
-            .ok_or_else(|| {
-                anyhow!("invalid boot error pin {:?}", signing.boot_error_gpio)
-            })?;
-            archive.set_cmpa(
-                signing.dice.clone(),
-                signing.enable_secure_boot,
-                signing.cmpa_settings,
-                signing.default_isp,
-                lpc55_areas::BootSpeed::Fro96mhz,
-                boot_pin,
-                root_certs,
-            )?;
-            archive.set_cfpa(
-                signing.cfpa_settings,
-                [signing.rotk0, signing.rotk1, signing.rotk2, signing.rotk3],
-                0,
-            )?;
             archive.overwrite()?;
         }
 


### PR DESCRIPTION
These files are unused, misleading, and potentially dangerous.  Let's not ship them in all our RoT archives.