### PR TITLE
stm32h7-startup: stop I2C timeout during debug halt

### DIFF
--- a/drv/stm32h7-startup/src/lib.rs
+++ b/drv/stm32h7-startup/src/lib.rs
@@ -132,6 +132,17 @@ pub fn system_init_custom(
             .dbgsleep_d1()
             .set_bit()
     });
+    // Halt I2C timeout clocks when the debugger halts the system.
+    p.DBGMCU.apb1lfz1.modify(|_, w| {
+        w.dbg_i2c1().set_bit();
+        w.dbg_i2c2().set_bit();
+        w.dbg_i2c3().set_bit();
+        w
+    });
+    p.DBGMCU.apb4fz1.modify(|_, w| {
+        w.dbg_i2c4().set_bit();
+        w
+    });
 
     // Set up SYSCFG selections so drivers don't have to.
     p.RCC.apb4enr.modify(|_, w| w.syscfgen().enabled());


### PR DESCRIPTION
The DBGMCU block has a facility for intercepting clocks to various peripherals during debug halt. This is nice, because otherwise the I2C transaction timeout counter keeps on counting while Humility has halted the processor.

This means that running, say, humility tasks, can cause I2C timeouts while the debugger extracts information, appearing to reproduce various I2C failures but actually just creating new and exciting ones.

So, this change turns on the debug freeze bits for the I2C controllers.