### PR TITLE
Properly scope types in Ignition Idol interface

### DIFF
--- a/drv/ignition-api/src/lib.rs
+++ b/drv/ignition-api/src/lib.rs
@@ -736,7 +736,6 @@ const_assert!(
 );
 
 mod idl {
-    use super::{Counters, PortState, Request, TransceiverSelect};
     use crate as drv_ignition_api;
     use userlib::sys_send;
 

--- a/drv/ignition-server/src/main.rs
+++ b/drv/ignition-server/src/main.rs
@@ -449,8 +449,6 @@ impl idol_runtime::NotificationHandler for ServerImpl {
 }
 
 mod idl {
-    use drv_ignition_api::*;
-
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
 

--- a/idl/ignition.idol
+++ b/idl/ignition.idol
@@ -25,7 +25,7 @@ Interface(
                 "port": "u8",
             },
             reply: Result(
-                ok: "PortState",
+                ok: "drv_ignition_api::PortState",
                 err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
@@ -56,7 +56,7 @@ Interface(
                 "port": "u8",
             },
             reply: Result(
-                ok: "Counters",
+                ok: "drv_ignition_api::Counters",
                 err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),
@@ -65,7 +65,7 @@ Interface(
             args: {
                 "port": "u8",
                 "txr": (
-                    type: "TransceiverSelect",
+                    type: "drv_ignition_api::TransceiverSelect",
                     recv: FromPrimitive("u8"),
                 ),
             },
@@ -79,7 +79,7 @@ Interface(
             args: {
                 "port": "u8",
                 "txr": (
-                    type: "TransceiverSelect",
+                    type: "drv_ignition_api::TransceiverSelect",
                     recv: FromPrimitive("u8"),
                 ),
             },
@@ -103,7 +103,7 @@ Interface(
             args: {
                 "port": "u8",
                 "request": (
-                    type: "Request",
+                    type: "drv_ignition_api::Request",
                     recv: FromPrimitive("u8"),
                 )
             },
@@ -116,7 +116,7 @@ Interface(
             doc: "Return the state for the given controller ports as indicated by the ports bit vector",
             args: {},
             reply: Result(
-                ok: "[PortState; 40]",
+                ok: "[drv_ignition_api::PortState; 40]",
                 err: CLike("drv_ignition_api::IgnitionError"),
             ),
         ),


### PR DESCRIPTION
Humility needs a bit of help to distinguish between the GOFFs in `drv_ignition_api` and re-exported versions in `gateway_messages`. Being explicit helps.