### PR TITLE
kern: add new RESTART_ME syscall, use in net

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -75,7 +75,7 @@ uses = ["eth", "eth_dma", "tim16"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}
-task-slots = ["sys"]
+task-slots = ["sys", "jefe"]
 
 [tasks.user_leds]
 name = "drv-user-leds"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -83,7 +83,7 @@ uses = ["eth", "eth_dma", "tim16"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}
-task-slots = ["sys"]
+task-slots = ["sys", "jefe"]
 
 [tasks.user_leds]
 name = "drv-user-leds"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -58,7 +58,7 @@ sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi2"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
-task-slots = ["sys", "user_leds"]
+task-slots = ["sys", "user_leds", "jefe"]
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -179,7 +179,7 @@ max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi4"]
 start = true
-task-slots = ["sys"]
+task-slots = ["sys", "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 
 [tasks.net.interrupts]

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -72,7 +72,7 @@ sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi3"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
-task-slots = ["sys", "packrat", { seq = "sequencer" }]
+task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -72,7 +72,7 @@ sections = {eth_bulk = "sram1"}
 uses = ["eth", "eth_dma", "tim16", "spi3"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
-task-slots = ["sys", "packrat", { seq = "sequencer" }]
+task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 
 [tasks.net.interrupts]
 "eth.irq" = "eth-irq"

--- a/idl/jefe.idol
+++ b/idl/jefe.idol
@@ -94,5 +94,17 @@ Interface(
             ),
             encoding: Hubpack,
         ),
+
+        // Note: this is the "raw" API; there is a nice wrapper in the client
+        // crate.
+        "restart_me_raw": (
+            description: "restarts the caller without recording a fault",
+            args: {},
+            // Note: this will not actually return, but Idol can't currently
+            // describe a noreturn IPC, so, we have a placeholder:
+            reply: Simple("()"),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
     },
 )

--- a/task/jefe-api/src/lib.rs
+++ b/task/jefe-api/src/lib.rs
@@ -34,4 +34,13 @@ pub enum DumpAreaError {
     AlreadyInUse,
 }
 
+impl Jefe {
+    /// Asks the supervisor to restart the current task without recording a
+    /// fault.
+    pub fn restart_me(&self) -> ! {
+        self.restart_me_raw();
+        unreachable!()
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -207,6 +207,19 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
         Ok(())
     }
 
+    fn restart_me_raw(
+        &mut self,
+        msg: &userlib::RecvMessage,
+    ) -> Result<(), RequestError<Infallible>> {
+        kipc::restart_task(msg.sender.index(), true);
+
+        // Note: the returned value here won't go anywhere because we just
+        // unblocked the caller. So this is doing a small amount of unnecessary
+        // work. This is a compromise because Idol can't easily describe an IPC
+        // that won't return at this time.
+        Ok(())
+    }
+
     cfg_if::cfg_if! {
         if #[cfg(feature = "dump")] {
             fn get_dump_area(

--- a/task/net/src/bsp/gimlet_bcd.rs
+++ b/task/net/src/bsp/gimlet_bcd.rs
@@ -17,10 +17,8 @@ use task_jefe_api::Jefe;
 use task_net_api::{
     ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
 };
-use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
+use userlib::{sys_recv_closed, FromPrimitive, TaskId};
 use vsc7448_pac::types::PhyRegisterAddress;
-
-task_slot!(JEFE, jefe);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -56,7 +54,7 @@ impl crate::bsp_support::Bsp for BspImpl {
     fn preinit() {
         // Wait for the sequencer to turn on the clock. This requires that Jefe
         // state change notifications are routed to our notification bit 3.
-        let jefe = Jefe::from(JEFE.get_task_id());
+        let jefe = Jefe::from(crate::JEFE.get_task_id());
 
         loop {
             // This laborious list is intended to ensure that new power states

--- a/task/net/src/bsp/psc_a.rs
+++ b/task/net/src/bsp/psc_a.rs
@@ -17,10 +17,8 @@ use task_jefe_api::Jefe;
 use task_net_api::{
     ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
 };
-use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
+use userlib::{sys_recv_closed, FromPrimitive, TaskId};
 use vsc7448_pac::types::PhyRegisterAddress;
-
-task_slot!(JEFE, jefe);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -55,7 +53,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn preinit() {
         // Wait for the sequencer to turn read our VPD.
-        let jefe = Jefe::from(JEFE.get_task_id());
+        let jefe = Jefe::from(crate::JEFE.get_task_id());
 
         loop {
             // This laborious list is intended to ensure that new power states

--- a/task/net/src/bsp/psc_bc.rs
+++ b/task/net/src/bsp/psc_bc.rs
@@ -17,10 +17,8 @@ use task_jefe_api::Jefe;
 use task_net_api::{
     ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
 };
-use userlib::{sys_recv_closed, task_slot, FromPrimitive, TaskId};
+use userlib::{sys_recv_closed, FromPrimitive, TaskId};
 use vsc7448_pac::types::PhyRegisterAddress;
-
-task_slot!(JEFE, jefe);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -60,7 +58,7 @@ impl bsp_support::Bsp for BspImpl {
 
     fn preinit() {
         // Wait for the sequencer to turn read our VPD.
-        let jefe = Jefe::from(JEFE.get_task_id());
+        let jefe = Jefe::from(crate::JEFE.get_task_id());
 
         loop {
             // This laborious list is intended to ensure that new power states


### PR DESCRIPTION
We've talked for a while (...roughly three years afaict) about having a mechanism for a task to restart itself without indicating a fault. This became relevant recently when we started recording crash dumps -- restarting from a fault is now significantly more expensive than before. This has caused problems in `net`, which (to work around an STM32H7 Ethernet hardware bug) will restart itself under certain circumstances to reinitialize everything. On Gimlet the full dump process currently takes 66 ms, and that'll get longer as the task grows more state.

This adds a "clean restart" syscall that asks for a restart without suggesting that a fault happened. See the `doc` entry for more semantics.