### PR TITLE
lpc55_romapi: fix validate_programmed

### DIFF
--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -8,7 +8,7 @@ image-names = ["a", "b"]
 [kernel]
 name = "lpc55xpresso"
 features = ["dump", "dice-self"]
-requires = {flash = 53888, ram = 4096}
+requires = {flash = 54016, ram = 4096}
 
 [tasks.jefe]
 name = "task-jefe"


### PR DESCRIPTION
ROMAPI's flash_erase_verify only indicates that at least one page in
the range is programmed.  validate_programmed needs to call that on
each individual flash page to ensure that all of them are programmed.

Fixes #1432
