### PR TITLE
dice-mfg: allow querying secure boot key slot status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,13 +661,13 @@ dependencies = [
 
 [[package]]
 name = "dice-mfg-msgs"
-version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/dice-util#a78bfa3e7152f8464e2910ed71d0e5aded40023e"
+version = "0.2.1"
+source = "git+https://github.com/oxidecomputer/dice-util#57b4e3b4f37eea3414081a9e1bb53988c76b641f"
 dependencies = [
  "corncobs",
  "hubpack",
  "serde",
- "serde-big-array 0.4.1",
+ "serde-big-array 0.5.1",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
-dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false }
+dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -9,7 +9,7 @@ version = 0
 
 [kernel]
 name = "oxide-rot-1"
-requires = {flash = 59840, ram = 2696}
+requires = {flash = 60544, ram = 2696}
 features = ["dice-mfg"]
 
 [caboose]


### PR DESCRIPTION
Tested by modifying lpc55expresso to use dice-mfg, flashing to lpc55xpresso w/ secure boot enabled, and running `dice-mfg get-key-slot-status` (from https://github.com/oxidecomputer/dice-util/pull/88) which reported all slots enabled as expected.

Depends on https://github.com/oxidecomputer/dice-util/pull/88 so CI will fail until that is merged.