### PR TITLE
Reply with MessageKind::Error when reporting an error

### DIFF
--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -181,7 +181,7 @@ impl ServerImpl {
         } else if request[0] > version::inner::CURRENT {
             let header_size = hubpack::serialize(
                 tx_data_buf,
-                &Header::new(header.message_id, header.message_kind),
+                &Header::new(header.message_id, MessageKind::Error),
             )
             .unwrap();
             let message_size = hubpack::serialize(


### PR DESCRIPTION
Otherwise, we copy `MessageKind::HostToSp` from the header, which makes the host mad.