### PR TITLE
sidecar: fix comment about fan rotor ordering

### DIFF
--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -453,7 +453,7 @@ address = 0b0100_011
 device = "max31790"
 name = "East"
 description = "Fan 0/1 controller"
-sensors = { speed = 4, names = [ "NE_fan1", "SE_fan1", "ENE_fan0", "ESE_fan0" ] }
+sensors = { speed = 4, names = [ "SE_fan1", "NE_fan1", "ESE_fan0", "ENE_fan0" ] }
 refdes = "U66"
 
 [[config.i2c.devices]]
@@ -604,7 +604,7 @@ address = 0b0100_000
 device = "max31790"
 name = "West"
 description = "Fan 2/3 controller"
-sensors = { speed = 4, names = [ "WNW_fan3", "WSW_fan3", "NW_fan2", "SW_fan2", ] }
+sensors = { speed = 4, names = [ "WSW_fan3", "WNW_fan3", "SW_fan2", "NW_fan2" ] }
 refdes = "U78"
 
 [[config.i2c.devices]]

--- a/task/thermal/src/bsp/sidecar_bc.rs
+++ b/task/thermal/src/bsp/sidecar_bc.rs
@@ -87,14 +87,14 @@ impl Bsp {
         // controller and fan index:
         //
         // System Index    Controller     Fan           MAX31790 Fan (Datasheet)
-        //     0            East           ENE           2 (3)
-        //     1            East           ESE           3 (4)
-        //     2            East           NE            0 (1)
-        //     3            East           SE            1 (2)
-        //     4            West           NW            2 (3)
-        //     5            West           SW            3 (4)
-        //     6            West           WNW           0 (1)
-        //     7            West           WSW           1 (2)
+        //     0            East           ESE           2 (3)
+        //     1            East           ENE           3 (4)
+        //     2            East           SE            0 (1)
+        //     3            East           NE            1 (2)
+        //     4            West           SW            2 (3)
+        //     5            West           NW            3 (4)
+        //     6            West           WSW           0 (1)
+        //     7            West           WNW           1 (2)
         //
 
         // The supplied `fan` is the System Index. From that we can map to a fan


### PR DESCRIPTION
In a [previous comment](https://github.com/oxidecomputer/hubris/pull/1400#discussion_r1223337891) I stated:
>The drawing we got from SD notes an inlet vs outlet fan. In our system the inlet fan is more "north" and connects to pwm0/tach0, while the outlet fan is more "south" and connects to pwm1/tach1.

This is incorrect, for whatever reason my brain that day was thinking that the inlet fan was more towards the back (aka North) while the outlet fan was towards the front (aka South). This is backwards as we draw air from front to back, not back to front, which means that the inlet fan is _actually_ South while the outlet fan is North. This commit cleans up that error.

There aren't any other system impacts beyond fixing up the comment and fan naming.