### PR TITLE
Fix 10G watchdog checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "cfg-if",
  "drv-monorail-api",
  "drv-sidecar-front-io",
+ "drv-sidecar-mainboard-controller",
  "drv-sidecar-seq-api",
  "drv-spi-api",
  "drv-stm32h7-spi-server-core",

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 drv-monorail-api = { path = "../../drv/monorail-api"  }
+drv-sidecar-mainboard-controller = { path = "../../drv/sidecar-mainboard-controller"  }
 drv-sidecar-front-io = { path = "../../drv/sidecar-front-io", features = ["phy_smi"], optional = true }
 drv-sidecar-seq-api = { path = "../../drv/sidecar-seq-api", optional = true }
 drv-spi-api = { path = "../../drv/spi-api" }

--- a/task/monorail-server/src/bsp/sidecar_bc.rs
+++ b/task/monorail-server/src/bsp/sidecar_bc.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use drv_sidecar_front_io::phy_smi::PhySmi;
+use drv_sidecar_mainboard_controller::Reg;
 use drv_sidecar_seq_api::{SeqError, Sequencer, TofinoSeqState};
 use ringbuf::*;
 use userlib::{hl::sleep_for, task_slot};
@@ -479,7 +480,8 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             Ok(TofinoSeqState::A0) => {
                 match self.seq.tofino_pcie_hotplug_status() {
                     Ok(pcie_hotplug_status) => {
-                        let host_reset = pcie_hotplug_status & 1;
+                        let host_reset = pcie_hotplug_status
+                            & Reg::PCIE_HOTPLUG_STATUS::HOST_RESET;
                         host_reset == 0
                     }
                     Err(e) => {


### PR DESCRIPTION
To avoid spurious calls to `Monorail.reinit`, the 10G link watchdog checks whether the PCIE host reset bit is set.

Unfortunately, this bit changed from bit 0 to bit 1 in #1454; this broke the VSC7448 side of the watchdog, resulting in the link staying down if `dendrite` restarted on the Scrimlet.

This PR switches to using the bit's canonical definition in our register file, which is less likely to be wrong.