### PR TITLE
attest: Add function to record a measurement observed by the platform.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,8 +3879,10 @@ name = "task-attest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "attest-api",
  "build-util",
+ "crypto-common",
  "hubpack",
  "idol",
  "idol-runtime",
@@ -3882,6 +3890,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "serde",
+ "sha3",
  "stage0-handoff",
  "unwrap-lite",
  "userlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ path = "sys/abi"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
+arrayvec = { version = "0.7.4", default-features = false }
 atty = { version = "0.2", default-features = false }
 bitfield = { version = "0.13", default-features = false }
 bitflags = { version = "1.2.1", default-features = false }
@@ -46,6 +47,7 @@ cortex-m = { version = "0.7", default-features = false, features = ["inline-asm"
 cortex-m-rt = { version = "0.6.12", default-features = false }
 cortex-m-semihosting = { version = "0.5.0", default-features = false }
 crc = { version = "3.0.0", default-features = false }
+crypto-common = { version = "0.1.6", default-features = false }
 ctrlc = { version = "3.1.5", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["from", "into"] }
 digest = { version = "0.10", default-features = false }

--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -211,8 +211,8 @@ pins = [
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 12512, ram = 16384}
-stacksize = 9000
+max-sizes = {flash = 13600, ram = 16384}
+stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -141,8 +141,8 @@ extern-regions = ["sram2"]
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 12256, ram = 16384}
-stacksize = 9000
+max-sizes = {flash = 13600, ram = 16384}
+stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -158,8 +158,8 @@ binary_path = "../../target/gimlet-c/dist/default/final.bin"
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 12512, ram = 16384}
-stacksize = 9000
+max-sizes = {flash = 13600, ram = 16384}
+stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -137,8 +137,8 @@ task-slots = ["swd"]
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 12256, ram = 16384}
-stacksize = 9000
+max-sizes = {flash = 13600, ram = 16384}
+stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -204,8 +204,8 @@ binary_path = "../../target/gemini-bu/dist/final.bin"
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 12256, ram = 16384}
-stacksize = 9000
+max-sizes = {flash = 13600, ram = 16384}
+stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/idl/attest.idol
+++ b/idl/attest.idol
@@ -40,6 +40,20 @@ Interface(
             ),
             encoding: Hubpack,
             idempotent: true,
-        )
+        ),
+        "record": (
+            doc: "Record a measurment",
+            args: {
+                "algorithm": "HashAlgorithm",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: Complex("AttestError"),
+            ),
+            encoding: Hubpack,
+        ),
     }
 )

--- a/task/attest-api/src/lib.rs
+++ b/task/attest-api/src/lib.rs
@@ -18,6 +18,23 @@ pub enum AttestError {
     InvalidCertIndex,
     NoCerts,
     OutOfRange,
+    MeasurementLogFull,
+    TaskRestarted,
+    BadLease,
+    UnsupportedAlgorithm,
+}
+
+impl From<idol_runtime::ServerDeath> for AttestError {
+    fn from(_: idol_runtime::ServerDeath) -> Self {
+        AttestError::TaskRestarted
+    }
+}
+
+#[derive(
+    Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
+)]
+pub enum HashAlgorithm {
+    Sha3_256,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/task/attest/Cargo.toml
+++ b/task/attest/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+arrayvec.workspace = true
+crypto-common = { workspace = true }
 lib-dice = { path = "../../lib/dice" }
 hubpack = { workspace = true }
 idol-runtime = { workspace = true }
@@ -12,6 +14,7 @@ ringbuf = { path = "../../lib/ringbuf" }
 serde = { workspace = true }
 stage0-handoff = { path = "../../lib/stage0-handoff" }
 attest-api = { path = "../attest-api" }
+sha3 = { workspace = true }
 unwrap-lite = { path = "../../lib/unwrap-lite" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 zerocopy = { workspace = true }


### PR DESCRIPTION
This function is *not* idempotent: if the 'record' function is called with the same parameters repeatedly the measurement log will eventually fill up resulting in an error. The measurement log is just an array of measurements (aka [u8; 32]) that is managed in an ArrayVec. The 'record' function takes an enum parameter identifying the hash algorithm and a lease holding the digest. We pass the digest as a lease partially because humility / hiffy can't pass arbitrary arrays as parameters, but also because it's possible that in the future we'll need to support digests with varying lengths.