### PR TITLE
Make `cargo test --workspace` work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: cargo test --verbose
-           --package host-sp-messages
-           --package lpc55-puf
-           --package multitimer
-           --package oxide-barcode
-           --package phash-gen
+      run: cargo test --verbose --workspace

--- a/app/demo-stm32f4-discovery/Cargo.toml
+++ b/app/demo-stm32f4-discovery/Cargo.toml
@@ -19,4 +19,5 @@ kern = { path = "../../sys/kern" }
 [[bin]]
 name = "demo-stm32f4-discovery"
 test = false
+doctest = false
 bench = false

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -26,4 +26,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "demo-stm32g0-nucleo"
 test = false
+doctest = false
 bench = false

--- a/app/demo-stm32h7-nucleo/Cargo.toml
+++ b/app/demo-stm32h7-nucleo/Cargo.toml
@@ -25,4 +25,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "demo-stm32h7-nucleo"
 test = false
+doctest = false
 bench = false

--- a/app/donglet/Cargo.toml
+++ b/app/donglet/Cargo.toml
@@ -24,4 +24,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "app-donglet"
 test = false
+doctest = false
 bench = false

--- a/app/gemini-bu/Cargo.toml
+++ b/app/gemini-bu/Cargo.toml
@@ -23,4 +23,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "gemini-bu"
 test = false
+doctest = false
 bench = false

--- a/app/gimletlet/Cargo.toml
+++ b/app/gimletlet/Cargo.toml
@@ -23,4 +23,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "gimletlet"
 test = false
+doctest = false
 bench = false

--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -23,4 +23,5 @@ unwrap-lite = {path = "../../lib/unwrap-lite"}
 [[bin]]
 name = "lpc55xpresso"
 test = false
+doctest = false
 bench = false

--- a/app/oxide-rot-1/Cargo.toml
+++ b/app/oxide-rot-1/Cargo.toml
@@ -24,4 +24,5 @@ unwrap-lite = { path = "../../lib/unwrap-lite" }
 [[bin]]
 name = "oxide-rot-1"
 test = false
+doctest = false
 bench = false

--- a/app/psc/Cargo.toml
+++ b/app/psc/Cargo.toml
@@ -23,4 +23,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "psc"
 test = false
+doctest = false
 bench = false

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -24,4 +24,5 @@ unwrap-lite = { path = "../../lib/unwrap-lite" }
 [[bin]]
 name = "rot-carrier"
 test = false
+doctest = false
 bench = false

--- a/app/sidecar/Cargo.toml
+++ b/app/sidecar/Cargo.toml
@@ -23,4 +23,5 @@ build-util = {path = "../../build/util"}
 [[bin]]
 name = "sidecar"
 test = false
+doctest = false
 bench = false

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -18,3 +18,8 @@ userlib = { path = "../../sys/userlib" }
 build-util = {path = "../../build/util"}
 idol.workspace = true
 serde.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -29,4 +29,5 @@ h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"
 [[bin]]
 name = "drv-auxflash-server"
 test = false
+doctest = false
 bench = false

--- a/drv/caboose-pos/Cargo.toml
+++ b/drv/caboose-pos/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 [dependencies]
 unwrap-lite.path = "../../lib/unwrap-lite"
 volatile-const.path = "../../lib/volatile-const"
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/caboose/Cargo.toml
+++ b/drv/caboose/Cargo.toml
@@ -10,3 +10,8 @@ tlvc.workspace = true
 
 derive-idol-err.path = "../../lib/derive-idol-err"
 userlib.path = "../../sys/userlib"
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/eeprom/Cargo.toml
+++ b/drv/eeprom/Cargo.toml
@@ -16,3 +16,9 @@ userlib = {path = "../../sys/userlib"}
 [build-dependencies]
 build-i2c = {path = "../../build/i2c"}
 idol = { workspace = true }
+
+[[bin]]
+name = "drv-eeprom"
+test = false
+doctest = false
+bench = false

--- a/drv/fpga-api/Cargo.toml
+++ b/drv/fpga-api/Cargo.toml
@@ -20,3 +20,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/fpga-devices/Cargo.toml
+++ b/drv/fpga-devices/Cargo.toml
@@ -21,4 +21,5 @@ drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -44,4 +44,5 @@ spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
 [[bin]]
 name = "drv-fpga-server"
 test = false
+doctest = false
 bench = false

--- a/drv/fpga-user-api/Cargo.toml
+++ b/drv/fpga-user-api/Cargo.toml
@@ -8,3 +8,8 @@ drv-fpga-api = { path = "../../drv/fpga-api" }
 num-traits = { workspace = true }
 userlib = { path = "../../sys/userlib" }
 zerocopy = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/gimlet-hf-api/Cargo.toml
+++ b/drv/gimlet-hf-api/Cargo.toml
@@ -17,3 +17,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -27,3 +27,9 @@ host_access = []
 hash = []
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743", "drv-stm32h7-qspi/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]
+
+[[bin]]
+name = "drv-gimlet-hf-server"
+test = false
+doctest = false
+bench = false

--- a/drv/gimlet-seq-api/Cargo.toml
+++ b/drv/gimlet-seq-api/Cargo.toml
@@ -14,3 +14,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -43,3 +43,9 @@ sha2 = { workspace = true }
 [features]
 h753 = ["drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]
 stay-in-a2 = []
+
+[[bin]]
+name = "drv-gimlet-seq-server"
+test = false
+doctest = false
+bench = false

--- a/drv/gimlet-state/Cargo.toml
+++ b/drv/gimlet-state/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 userlib = { path = "../../sys/userlib" }
 zerocopy = { workspace = true }
 num-traits = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/hash-api/Cargo.toml
+++ b/drv/hash-api/Cargo.toml
@@ -13,3 +13,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -13,4 +13,5 @@ userlib.path = "../../sys/userlib"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/i2c-devices/Cargo.toml
+++ b/drv/i2c-devices/Cargo.toml
@@ -22,4 +22,5 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/ice40-spi-program/Cargo.toml
+++ b/drv/ice40-spi-program/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 drv-spi-api = { path = "../spi-api" }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/ignition-api/Cargo.toml
+++ b/drv/ignition-api/Cargo.toml
@@ -22,3 +22,8 @@ userlib = { path = "../../sys/userlib" }
 build-fpga-regmap = { path = "../../build/fpga-regmap" }
 build-util = { path = "../../build/util" }
 idol = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/ignition-server/Cargo.toml
+++ b/drv/ignition-server/Cargo.toml
@@ -29,4 +29,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-ignition-server"
 test = false
+doctest = false
 bench = false

--- a/drv/ksz8463/Cargo.toml
+++ b/drv/ksz8463/Cargo.toml
@@ -14,4 +14,5 @@ userlib = {path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/local-vpd/Cargo.toml
+++ b/drv/local-vpd/Cargo.toml
@@ -13,3 +13,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 build-i2c = {path = "../../build/i2c" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-flash/Cargo.toml
+++ b/drv/lpc55-flash/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [dependencies]
 lpc55-pac = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-gpio-api/Cargo.toml
+++ b/drv/lpc55-gpio-api/Cargo.toml
@@ -15,3 +15,8 @@ userlib = { path = "../../sys/userlib" }
 [build-dependencies]
 build-util = { path = "../../build/util" }
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-gpio/Cargo.toml
+++ b/drv/lpc55-gpio/Cargo.toml
@@ -21,4 +21,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-lpc55-gpio"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-i2c/Cargo.toml
+++ b/drv/lpc55-i2c/Cargo.toml
@@ -17,4 +17,5 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [[bin]]
 name = "drv-lpc55-i2c"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-iocon-gen/src/lib.rs
+++ b/drv/lpc55-iocon-gen/src/lib.rs
@@ -16,9 +16,11 @@ use quote::{format_ident, quote};
 ///
 /// This proc macro generates the following function
 ///
-///        fn set_iocon(pin : Pin, alt : AltFn, mode : Mode,
-///                     slew : Slew, invert : Invert, digimode : Digimode,
-///                     od : Opendrain)
+/// ```ignore
+/// fn set_iocon(pin: Pin, alt: AltFn, mode: Mode,
+///              slew: Slew, invert: Invert, digimode: Digimode,
+///              od : Opendrain)
+/// ```
 ///
 /// Which ends up being a gigantic switch function to call the right port and
 /// pin function.

--- a/drv/lpc55-rng/Cargo.toml
+++ b/drv/lpc55-rng/Cargo.toml
@@ -24,4 +24,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-lpc55-rng"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-sha256/Cargo.toml
+++ b/drv/lpc55-sha256/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 [dependencies]
 userlib.path = "../../sys/userlib"
 lpc55-pac.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-spi-server/Cargo.toml
+++ b/drv/lpc55-spi-server/Cargo.toml
@@ -27,4 +27,5 @@ spi0 = []
 [[bin]]
 name = "drv-lpc55-spi-server"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-spi/Cargo.toml
+++ b/drv/lpc55-spi/Cargo.toml
@@ -10,3 +10,8 @@ zerocopy = { workspace = true }
 
 drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
 userlib = { path = "../../sys/userlib" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -43,4 +43,5 @@ spi0 = []
 [[bin]]
 name = "drv-lpc55-sprot-server"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-swd/Cargo.toml
+++ b/drv/lpc55-swd/Cargo.toml
@@ -31,4 +31,5 @@ serde = { workspace = true }
 [[bin]]
 name = "drv-lpc55-swd"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-syscon-api/Cargo.toml
+++ b/drv/lpc55-syscon-api/Cargo.toml
@@ -17,4 +17,5 @@ idol = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-syscon/Cargo.toml
+++ b/drv/lpc55-syscon/Cargo.toml
@@ -22,4 +22,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-lpc55-syscon"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-update-api/Cargo.toml
+++ b/drv/lpc55-update-api/Cargo.toml
@@ -21,3 +21,8 @@ userlib.path = "../../sys/userlib/"
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/lpc55-update-server/Cargo.toml
+++ b/drv/lpc55-update-server/Cargo.toml
@@ -35,4 +35,5 @@ idol = { workspace = true }
 [[bin]]
 name = "lpc55-update-server"
 test = false
+doctest = false
 bench = false

--- a/drv/lpc55-usart/Cargo.toml
+++ b/drv/lpc55-usart/Cargo.toml
@@ -25,4 +25,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "drv-lpc55-usart"
 test = false
+doctest = false
 bench = false

--- a/drv/meanwell-api/Cargo.toml
+++ b/drv/meanwell-api/Cargo.toml
@@ -14,6 +14,7 @@ zerocopy = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/meanwell/Cargo.toml
+++ b/drv/meanwell/Cargo.toml
@@ -28,4 +28,5 @@ panic-messages = ["userlib/panic-messages"]
 [[bin]]
 name = "drv-meanwell"
 test = false
+doctest = false
 bench = false

--- a/drv/mock-gimlet-hf-server/Cargo.toml
+++ b/drv/mock-gimlet-hf-server/Cargo.toml
@@ -24,3 +24,9 @@ host_access = []
 hash = []
 h743 = []
 h753 = []
+
+[[bin]]
+name = "drv-mock-gimlet-hf-server"
+test = false
+doctest = false
+bench = false

--- a/drv/mock-gimlet-seq-server/Cargo.toml
+++ b/drv/mock-gimlet-seq-server/Cargo.toml
@@ -15,3 +15,9 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol = { workspace = true }
+
+[[bin]]
+name = "drv-mock-gimlet-seq-server"
+test = false
+doctest = false
+bench = false

--- a/drv/monorail-api/Cargo.toml
+++ b/drv/monorail-api/Cargo.toml
@@ -19,6 +19,7 @@ zerocopy.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/onewire-devices/Cargo.toml
+++ b/drv/onewire-devices/Cargo.toml
@@ -14,4 +14,5 @@ zerocopy = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/onewire/Cargo.toml
+++ b/drv/onewire/Cargo.toml
@@ -13,4 +13,5 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/oxide-vpd/Cargo.toml
+++ b/drv/oxide-vpd/Cargo.toml
@@ -10,3 +10,8 @@ zerocopy = { workspace = true }
 drv-i2c-api = { path = "../../drv/i2c-api" }
 drv-i2c-devices = { path = "../../drv/i2c-devices" }
 ringbuf = { path = "../../lib/ringbuf" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/packrat-vpd-loader/Cargo.toml
+++ b/drv/packrat-vpd-loader/Cargo.toml
@@ -9,3 +9,8 @@ oxide-barcode.path = "../../lib/oxide-barcode"
 ringbuf.path = "../../lib/ringbuf"
 task-packrat-api.path = "../../task/packrat-api"
 userlib.path = "../../sys/userlib"
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/psc-seq-api/Cargo.toml
+++ b/drv/psc-seq-api/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 num-traits.workspace = true
 
 userlib.path = "../../sys/userlib"
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/psc-seq-server/Cargo.toml
+++ b/drv/psc-seq-server/Cargo.toml
@@ -15,4 +15,5 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [[bin]]
 name = "drv-psc-seq-server"
 test = false
+doctest = false
 bench = false

--- a/drv/qspi-api/Cargo.toml
+++ b/drv/qspi-api/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/rng-api/Cargo.toml
+++ b/drv/rng-api/Cargo.toml
@@ -24,4 +24,5 @@ idol.workspace = true
 [lib]
 name = "drv_rng_api"
 test = false
+doctest = false
 bench = false

--- a/drv/sbrmi-api/Cargo.toml
+++ b/drv/sbrmi-api/Cargo.toml
@@ -16,6 +16,7 @@ zerocopy = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/sbrmi/Cargo.toml
+++ b/drv/sbrmi/Cargo.toml
@@ -30,4 +30,5 @@ panic-messages = ["userlib/panic-messages"]
 [[bin]]
 name = "drv-sbrmi"
 test = false
+doctest = false
 bench = false

--- a/drv/sidecar-front-io/Cargo.toml
+++ b/drv/sidecar-front-io/Cargo.toml
@@ -30,3 +30,8 @@ leds = []
 build-fpga-regmap = { path = "../../build/fpga-regmap" }
 build-util = { path = "../../build/util" }
 gnarle = { path = "../../lib/gnarle", features=["std"] }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/sidecar-mainboard-controller/Cargo.toml
+++ b/drv/sidecar-mainboard-controller/Cargo.toml
@@ -27,3 +27,8 @@ gnarle = { path = "../../lib/gnarle", features=["std"] }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
+++ b/drv/sidecar-mainboard-i2c-emulator/Cargo.toml
@@ -13,4 +13,5 @@ userlib = { path = "../../sys/userlib" }
 [[bin]]
 name = "drv-sidecar-mainboard-i2c-emulator"
 test = false
+doctest = false
 bench = false

--- a/drv/sidecar-seq-api/Cargo.toml
+++ b/drv/sidecar-seq-api/Cargo.toml
@@ -18,3 +18,8 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/sidecar-seq-server/Cargo.toml
+++ b/drv/sidecar-seq-server/Cargo.toml
@@ -38,4 +38,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-sidecar-seq-server"
 test = false
+doctest = false
 bench = false

--- a/drv/sp-ctrl-api/Cargo.toml
+++ b/drv/sp-ctrl-api/Cargo.toml
@@ -15,6 +15,7 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/spi-api/Cargo.toml
+++ b/drv/spi-api/Cargo.toml
@@ -18,6 +18,7 @@ userlib.path = "../../sys/userlib"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/sprot-api/Cargo.toml
+++ b/drv/sprot-api/Cargo.toml
@@ -34,3 +34,7 @@ idol = { workspace = true }
 [features]
 sink_test = []
 
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32fx-rcc/Cargo.toml
+++ b/drv/stm32fx-rcc/Cargo.toml
@@ -20,4 +20,5 @@ f4 = ["stm32f4/stm32f407"]
 [[bin]]
 name = "drv-stm32fx-rcc"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32fx-usart/Cargo.toml
+++ b/drv/stm32fx-usart/Cargo.toml
@@ -19,4 +19,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "drv-stm32fx-usart"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32g0-usart/Cargo.toml
+++ b/drv/stm32g0-usart/Cargo.toml
@@ -27,4 +27,5 @@ semihosting = ["userlib/log-semihosting"]
 [[bin]]
 name = "drv-stm32g0-usart"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-dbgmcu/Cargo.toml
+++ b/drv/stm32h7-dbgmcu/Cargo.toml
@@ -9,3 +9,8 @@ stm32h7 = { workspace = true }
 [features]
 h743 = ["stm32h7/stm32h743"]
 h753 = ["stm32h7/stm32h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-eth/Cargo.toml
+++ b/drv/stm32h7-eth/Cargo.toml
@@ -22,4 +22,5 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-hash-server/Cargo.toml
+++ b/drv/stm32h7-hash-server/Cargo.toml
@@ -22,3 +22,9 @@ idol = { workspace = true }
 
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-hash/h753"]
+
+[[bin]]
+name = "drv-stm32h7-hash-server"
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-hash/Cargo.toml
+++ b/drv/stm32h7-hash/Cargo.toml
@@ -13,3 +13,8 @@ userlib = { path = "../../sys/userlib" }
 
 [features]
 h753 = ["stm32h7/stm32h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-qspi/Cargo.toml
+++ b/drv/stm32h7-qspi/Cargo.toml
@@ -14,3 +14,8 @@ userlib = { path = "../../sys/userlib" }
 [features]
 h743 = ["stm32h7/stm32h743"]
 h753 = ["stm32h7/stm32h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-rng/Cargo.toml
+++ b/drv/stm32h7-rng/Cargo.toml
@@ -25,4 +25,5 @@ h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
 [[bin]]
 name = "drv-stm32h7-rng"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -46,3 +46,8 @@ spi5 = []
 spi6 = []
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-spi/h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -35,4 +35,5 @@ h753 = ["drv-stm32h7-spi-server-core/h753", "drv-stm32xx-sys-api/h753"]
 [[bin]]
 name = "drv-stm32h7-spi-server"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-spi/Cargo.toml
+++ b/drv/stm32h7-spi/Cargo.toml
@@ -15,3 +15,8 @@ ringbuf = { path = "../../lib/ringbuf" }
 h743 = ["stm32h7/stm32h743"]
 h753 = ["stm32h7/stm32h753"]
 h7b3 = ["stm32h7/stm32h7b3"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -45,4 +45,5 @@ spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
 [[bin]]
 name = "drv-stm32h7-sprot-server"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-startup/Cargo.toml
+++ b/drv/stm32h7-startup/Cargo.toml
@@ -11,3 +11,8 @@ stm32h7 = { workspace = true }
 [features]
 h743 = ["stm32h7/stm32h743"]
 h753 = ["stm32h7/stm32h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-update-api/Cargo.toml
+++ b/drv/stm32h7-update-api/Cargo.toml
@@ -22,4 +22,5 @@ idol.workspace = true
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-update-server/Cargo.toml
+++ b/drv/stm32h7-update-server/Cargo.toml
@@ -26,4 +26,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "stm32h7-update-server"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32h7-usart/Cargo.toml
+++ b/drv/stm32h7-usart/Cargo.toml
@@ -12,3 +12,8 @@ userlib = { path = "../../sys/userlib" }
 [features]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32xx-gpio-common/Cargo.toml
+++ b/drv/stm32xx-gpio-common/Cargo.toml
@@ -80,3 +80,8 @@ has-port-gpiok = []
 # simpler STM32 implementations missing this feature the top 8 values are
 # reserved.)
 has-af8-thru-af15 = []
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/stm32xx-i2c-server/Cargo.toml
+++ b/drv/stm32xx-i2c-server/Cargo.toml
@@ -36,4 +36,5 @@ itm = []
 [[bin]]
 name = "drv-stm32xx-i2c-server"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32xx-i2c/Cargo.toml
+++ b/drv/stm32xx-i2c/Cargo.toml
@@ -26,4 +26,5 @@ amd_erratum_1394 = []
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -32,4 +32,5 @@ g0b1 = ["family-stm32g0", "drv-stm32xx-gpio-common/model-stm32g0b1"]
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -37,4 +37,5 @@ g0b1 = ["family-stm32g0", "stm32g0/stm32g0b1", "drv-stm32xx-sys-api/g0b1", "drv-
 [[bin]]
 name = "drv-stm32xx-sys"
 test = false
+doctest = false
 bench = false

--- a/drv/stm32xx-uid/Cargo.toml
+++ b/drv/stm32xx-uid/Cargo.toml
@@ -14,4 +14,5 @@ family-stm32h7 = []
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/transceivers-api/Cargo.toml
+++ b/drv/transceivers-api/Cargo.toml
@@ -17,3 +17,8 @@ userlib = { path = "../../sys/userlib" }
 [build-dependencies]
 idol = { workspace = true }
 build-i2c = { path = "../../build/i2c" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/drv/transceivers-server/Cargo.toml
+++ b/drv/transceivers-server/Cargo.toml
@@ -44,4 +44,5 @@ idol = { workspace = true }
 [[bin]]
 name = "drv-transceivers-server"
 test = false
+doctest = false
 bench = false

--- a/drv/update-api/Cargo.toml
+++ b/drv/update-api/Cargo.toml
@@ -20,4 +20,5 @@ userlib.path = "../../sys/userlib"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/user-leds-api/Cargo.toml
+++ b/drv/user-leds-api/Cargo.toml
@@ -14,6 +14,7 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -33,4 +33,5 @@ panic-messages = ["userlib/panic-messages"]
 [[bin]]
 name = "drv-user-leds"
 test = false
+doctest = false
 bench = false

--- a/drv/vsc-err/Cargo.toml
+++ b/drv/vsc-err/Cargo.toml
@@ -11,4 +11,5 @@ idol-runtime = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/vsc7448/Cargo.toml
+++ b/drv/vsc7448/Cargo.toml
@@ -22,4 +22,5 @@ build-util.path = "../../build/util"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/drv/vsc85xx/Cargo.toml
+++ b/drv/vsc85xx/Cargo.toml
@@ -15,4 +15,5 @@ vsc-err = { path = "../vsc-err" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/lib/armv6m-atomic-hack/Cargo.toml
+++ b/lib/armv6m-atomic-hack/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/armv8-m-mpu/Cargo.toml
+++ b/lib/armv8-m-mpu/Cargo.toml
@@ -6,3 +6,8 @@ description = "ARMv8-m MPU config helpers"
 
 [dependencies]
 cortex-m = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -25,3 +25,8 @@ vcell.workspace = true
 
 [dev-dependencies]
 chrono = { workspace = true }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/fixedmap/Cargo.toml
+++ b/lib/fixedmap/Cargo.toml
@@ -2,7 +2,3 @@
 name = "fixedmap"
 version = "0.1.0"
 edition = "2021"
-
-[lib]
-test = false
-bench = false

--- a/lib/lpc55-puf/Cargo.toml
+++ b/lib/lpc55-puf/Cargo.toml
@@ -8,3 +8,8 @@ lpc55-pac = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 unwrap-lite = { path = "../unwrap-lite" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/lpc55-romapi/Cargo.toml
+++ b/lib/lpc55-romapi/Cargo.toml
@@ -17,4 +17,5 @@ cfg-if = { workspace = true }
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/lib/lpc55-rot-startup/Cargo.toml
+++ b/lib/lpc55-rot-startup/Cargo.toml
@@ -38,4 +38,5 @@ toml = { workspace = true }
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/lib/lpc55-usart/Cargo.toml
+++ b/lib/lpc55-usart/Cargo.toml
@@ -9,3 +9,8 @@ lpc55-pac = { workspace = true }
 nb = { workspace = true }
 
 unwrap-lite = { path = "../../lib/unwrap-lite" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/ringbuf/Cargo.toml
+++ b/lib/ringbuf/Cargo.toml
@@ -10,3 +10,8 @@ disabled = []
 
 [dependencies]
 static-cell = { path = "../static-cell" }
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/lib/static-cell/Cargo.toml
+++ b/lib/static-cell/Cargo.toml
@@ -11,4 +11,5 @@ build-util = { path = "../../build/util" }
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/lib/task-config/src/lib.rs
+++ b/lib/task-config/src/lib.rs
@@ -96,7 +96,7 @@ fn config_to_token(
 /// from the Hubris task config.
 ///
 /// For example, the following definition could live in a task's `main.rs`:
-/// ```rust
+/// ```ignore
 /// task_config::task_config! {
 ///     count: usize,
 ///     leds: &'static [(drv_stm32xx_sys_api::PinSet, bool)],
@@ -117,7 +117,7 @@ fn config_to_token(
 /// ```
 ///
 /// This would generate the following Rust code:
-/// ```rust
+/// ```ignore
 /// struct TaskConfig {
 ///     count: usize,
 ///     leds: &'static [(drv_stm32xx_sys_api::PinSet, bool)],

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -9,7 +9,3 @@ bitflags = { workspace = true }
 byteorder = { workspace = true }
 serde = { workspace = true }
 phash = { path = "../../lib/phash" }
-
-[lib]
-test = false
-bench = false

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -37,4 +37,5 @@ dump = []
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/sys/num-tasks/Cargo.toml
+++ b/sys/num-tasks/Cargo.toml
@@ -11,4 +11,5 @@ task-enum = []
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -48,4 +48,5 @@ build-util = { path = "../../build/util" }
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/task/attest-api/Cargo.toml
+++ b/task/attest-api/Cargo.toml
@@ -19,4 +19,5 @@ serde = { workspace = true }
 
 [lib]
 test = false
+doctest = false
 bench = false

--- a/task/attest/Cargo.toml
+++ b/task/attest/Cargo.toml
@@ -29,4 +29,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "task-attest"
 test = false
+doctest = false
 bench = false

--- a/task/caboose-reader/Cargo.toml
+++ b/task/caboose-reader/Cargo.toml
@@ -18,3 +18,9 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [build-dependencies]
 build-util = { path = "../../build/util" }
 idol = { workspace = true }
+
+[[bin]]
+name = "task-caboose-reader"
+test = false
+doctest = false
+bench = false

--- a/task/control-plane-agent-api/Cargo.toml
+++ b/task/control-plane-agent-api/Cargo.toml
@@ -19,6 +19,7 @@ userlib.path = "../../sys/userlib"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/control-plane-agent/Cargo.toml
+++ b/task/control-plane-agent/Cargo.toml
@@ -56,3 +56,9 @@ usart1 = []
 usart1-gimletlet = []
 baud_rate_3M = []
 auxflash = ["drv-auxflash-api"]
+
+[[bin]]
+name = "task-control-plane-agent"
+test = false
+doctest = false
+bench = false

--- a/task/dump-agent-api/Cargo.toml
+++ b/task/dump-agent-api/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/dump-agent/Cargo.toml
+++ b/task/dump-agent/Cargo.toml
@@ -48,4 +48,5 @@ build-util.path = "../../build/util"
 [[bin]]
 name = "task-dump-agent"
 test = false
+doctest = false
 bench = false

--- a/task/dumper-api/Cargo.toml
+++ b/task/dumper-api/Cargo.toml
@@ -18,6 +18,7 @@ serde.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/dumper/Cargo.toml
+++ b/task/dumper/Cargo.toml
@@ -26,4 +26,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "task-dumper"
 test = false
+doctest = false
 bench = false

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -60,4 +60,5 @@ spctrl = ["drv-sp-ctrl-api"]
 [[bin]]
 name = "task-hiffy"
 test = false
+doctest = false
 bench = false

--- a/task/host-sp-comms-api/Cargo.toml
+++ b/task/host-sp-comms-api/Cargo.toml
@@ -17,6 +17,7 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -57,4 +57,5 @@ gimlet = ["pmbus", "tlvc", "drv-i2c-api", "drv-i2c-devices", "drv-spi-api", "ksz
 [[bin]]
 name = "task-host-sp-comms"
 test = false
+doctest = false
 bench = false

--- a/task/jefe-api/Cargo.toml
+++ b/task/jefe-api/Cargo.toml
@@ -22,4 +22,5 @@ idol = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -40,4 +40,5 @@ dump = []
 [[bin]]
 name = "task-jefe"
 test = false
+doctest = false
 bench = false

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -45,3 +45,9 @@ spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
 [build-dependencies]
 build-util = {path = "../../build/util"}
 idol = { workspace = true }
+
+[[bin]]
+name = "task-monorail-server"
+test = false
+doctest = false
+bench = false

--- a/task/net-api/Cargo.toml
+++ b/task/net-api/Cargo.toml
@@ -32,4 +32,5 @@ idol = { workspace = true }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -74,4 +74,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "task-net"
 test = false
+doctest = false
 bench = false

--- a/task/packrat-api/Cargo.toml
+++ b/task/packrat-api/Cargo.toml
@@ -17,6 +17,7 @@ zerocopy.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/packrat/Cargo.toml
+++ b/task/packrat/Cargo.toml
@@ -32,4 +32,5 @@ boot-kmdb = []
 [[bin]]
 name = "task-packrat"
 test = false
+doctest = false
 bench = false

--- a/task/ping/Cargo.toml
+++ b/task/ping/Cargo.toml
@@ -17,4 +17,5 @@ uart = []
 [[bin]]
 name = "task-ping"
 test = false
+doctest = false
 bench = false

--- a/task/pong/Cargo.toml
+++ b/task/pong/Cargo.toml
@@ -18,4 +18,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "task-pong"
 test = false
+doctest = false
 bench = false

--- a/task/power-api/Cargo.toml
+++ b/task/power-api/Cargo.toml
@@ -18,3 +18,8 @@ userlib.path = "../../sys/userlib"
 
 [build-dependencies]
 idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false

--- a/task/power/Cargo.toml
+++ b/task/power/Cargo.toml
@@ -50,4 +50,5 @@ h7b3 = ["build-i2c/h7b3"]
 [[bin]]
 name = "task-power"
 test = false
+doctest = false
 bench = false

--- a/task/sensor-api/Cargo.toml
+++ b/task/sensor-api/Cargo.toml
@@ -18,6 +18,7 @@ userlib.path = "../../sys/userlib"
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/sensor-polling/Cargo.toml
+++ b/task/sensor-polling/Cargo.toml
@@ -23,4 +23,5 @@ build-i2c = { path = "../../build/i2c" }
 [[bin]]
 name = "task-sensor-polling"
 test = false
+doctest = false
 bench = false

--- a/task/sensor/Cargo.toml
+++ b/task/sensor/Cargo.toml
@@ -41,4 +41,5 @@ h7b3 = ["task-sensor-api/h7b3"]
 [[bin]]
 name = "task-sensor"
 test = false
+doctest = false
 bench = false

--- a/task/sp_measure/Cargo.toml
+++ b/task/sp_measure/Cargo.toml
@@ -24,4 +24,5 @@ build-util = { path = "../../build/util" }
 [[bin]]
 name = "task-sp-measure"
 test = false
+doctest = false
 bench = false

--- a/task/spd/Cargo.toml
+++ b/task/spd/Cargo.toml
@@ -37,4 +37,5 @@ itm = [ "userlib/log-itm" ]
 [[bin]]
 name = "task-spd"
 test = false
+doctest = false
 bench = false

--- a/task/template/Cargo.toml
+++ b/task/template/Cargo.toml
@@ -11,4 +11,5 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [[bin]]
 name = "task-template"
 test = false
+doctest = false
 bench = false

--- a/task/thermal-api/Cargo.toml
+++ b/task/thermal-api/Cargo.toml
@@ -23,4 +23,5 @@ idol.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/task/thermal/Cargo.toml
+++ b/task/thermal/Cargo.toml
@@ -47,4 +47,5 @@ semihosting = [ "userlib/log-semihosting" ]
 [[bin]]
 name = "task-thermal"
 test = false
+doctest = false
 bench = false

--- a/task/uartecho/Cargo.toml
+++ b/task/uartecho/Cargo.toml
@@ -31,4 +31,5 @@ baud_rate_3M = []
 [[bin]]
 name = "task-uartecho"
 test = false
+doctest = false
 bench = false

--- a/task/udpbroadcast/Cargo.toml
+++ b/task/udpbroadcast/Cargo.toml
@@ -23,4 +23,5 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [[bin]]
 name = "task-udpbroadcast"
 test = false
+doctest = false
 bench = false

--- a/task/udpecho/Cargo.toml
+++ b/task/udpecho/Cargo.toml
@@ -22,4 +22,5 @@ vlan = ["task-net-api/vlan"]
 [[bin]]
 name = "task-udpecho"
 test = false
+doctest = false
 bench = false

--- a/task/udprpc/Cargo.toml
+++ b/task/udprpc/Cargo.toml
@@ -20,4 +20,5 @@ vlan = ["task-net-api/vlan"]
 [[bin]]
 name = "task-udprpc"
 test = false
+doctest = false
 bench = false

--- a/task/validate-api/Cargo.toml
+++ b/task/validate-api/Cargo.toml
@@ -19,6 +19,7 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/validate/Cargo.toml
+++ b/task/validate/Cargo.toml
@@ -42,4 +42,5 @@ g031 = ["build-i2c/g031", "ringbuf/disabled"]
 [[bin]]
 name = "task-validate"
 test = false
+doctest = false
 bench = false

--- a/task/vpd-api/Cargo.toml
+++ b/task/vpd-api/Cargo.toml
@@ -16,6 +16,7 @@ zerocopy.workspace = true
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/task/vpd/Cargo.toml
+++ b/task/vpd/Cargo.toml
@@ -38,4 +38,5 @@ tmp117-eeprom = []
 [[bin]]
 name = "task-vpd"
 test = false
+doctest = false
 bench = false

--- a/test/test-api/Cargo.toml
+++ b/test/test-api/Cargo.toml
@@ -14,4 +14,5 @@ build-util = { path = "../../build/util" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -23,4 +23,5 @@ semihosting = [ "userlib/log-semihosting", "cortex-m-semihosting"]
 [[bin]]
 name = "test-assist"
 test = false
+doctest = false
 bench = false

--- a/test/test-idol-api/Cargo.toml
+++ b/test/test-idol-api/Cargo.toml
@@ -17,6 +17,7 @@ userlib = { path = "../../sys/userlib" }
 # since test builds don't work for cross compilation.
 [lib]
 test = false
+doctest = false
 bench = false
 
 [build-dependencies]

--- a/test/test-idol-server/Cargo.toml
+++ b/test/test-idol-server/Cargo.toml
@@ -22,4 +22,5 @@ idol = { workspace = true }
 [[bin]]
 name = "test-idol-server"
 test = false
+doctest = false
 bench = false

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -25,4 +25,5 @@ semihosting = ["cortex-m-semihosting", "userlib/log-semihosting"]
 [[bin]]
 name = "test-runner"
 test = false
+doctest = false
 bench = false

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -32,4 +32,5 @@ fru-id-eeprom = ["i2c-devices"]
 [[bin]]
 name = "test-suite"
 test = false
+doctest = false
 bench = false

--- a/test/tests-gemini-bu-rot/Cargo.toml
+++ b/test/tests-gemini-bu-rot/Cargo.toml
@@ -20,5 +20,5 @@ kern = { path = "../../sys/kern" }
 name = "tests-lpc55"
 path = "../../app/lpc55xpresso/src/main.rs"
 test = false
+doctest = false
 bench = false
-

--- a/test/tests-gemini-bu/Cargo.toml
+++ b/test/tests-gemini-bu/Cargo.toml
@@ -23,4 +23,5 @@ build-util = { path = "../../build/util" }
 name = "tests-gemini-bu"
 path = "../../app/gemini-bu/src/main.rs"
 test = false
+doctest = false
 bench = false

--- a/test/tests-gimletlet/Cargo.toml
+++ b/test/tests-gimletlet/Cargo.toml
@@ -23,4 +23,5 @@ build-util = { path = "../../build/util" }
 name = "tests-gimletlet"
 path = "../../app/gimletlet/src/main.rs"
 test = false
+doctest = false
 bench = false

--- a/test/tests-lpc55xpresso/Cargo.toml
+++ b/test/tests-lpc55xpresso/Cargo.toml
@@ -19,5 +19,5 @@ kern = { path = "../../sys/kern" }
 [[bin]]
 name = "tests-lpc55xpresso"
 test = false
+doctest = false
 bench = false
-

--- a/test/tests-psc/Cargo.toml
+++ b/test/tests-psc/Cargo.toml
@@ -8,4 +8,5 @@ version = "0.1.0"
 name = "tests-psc"
 path = "../../app/psc/src/main.rs"
 test = false
+doctest = false
 bench = false

--- a/test/tests-stm32g0/Cargo.toml
+++ b/test/tests-stm32g0/Cargo.toml
@@ -23,4 +23,5 @@ build-util = { path = "../../build/util" }
 name = "tests-stm32g0"
 path = "../../app/demo-stm32g0-nucleo/src/main.rs"
 test = false
+doctest = false
 bench = false

--- a/test/tests-stm32h7/Cargo.toml
+++ b/test/tests-stm32h7/Cargo.toml
@@ -24,4 +24,5 @@ build-util = { path = "../../build/util" }
 name = "tests-stm32h7"
 path = "../../app/demo-stm32h7-nucleo/src/main.rs"
 test = false
+doctest = false
 bench = false


### PR DESCRIPTION
This PR adds the standard stanza of
```toml
[lib] # or [[bin]]
test = false
doctest = false
bench = false
```
to _everything_ that can't compile on the host.

This lets us run `cargo test --workspace` in CI, instead of hand-specifying packages.