### PR TITLE
Add name for `tests` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: tests
 
 on:
   push:
@@ -11,9 +11,8 @@ env:
 
 jobs:
   build:
-
+    name: tests
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Run tests


### PR DESCRIPTION
For some reason, you need a secondary `name` for this check to show up as a branch protection option.

(I also decapitalized "Tests" to match our other CI workflows)