### PR TITLE
doc(interrupts): fix variable name in code sample

### DIFF
--- a/doc/interrupts.adoc
+++ b/doc/interrupts.adoc
@@ -114,7 +114,7 @@ loop {
         TaskId::KERNEL,
     ).unwrap();
 
-    if result.operation & MY_INTERRUPTS != 0 {
+    if result.operation & MY_INTERRUPT != 0 {
         do_interrupt_stuff();
         // Unmask that interrupt so it can fire again.
         sys_irq_control(MY_INTERRUPT, true);


### PR DESCRIPTION
Just a one-line doc fix.