### PR TITLE
Remove the `pull_request` trigger for the `documentation` workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,6 @@
 # * checkout PR head commit https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
 name: documentation
 on:
-  pull_request:
   push:
     branches: [master]
 


### PR DESCRIPTION
## Issue

The `documentation` workflow is triggered to run on both all pull requests and pushes to `master`. The former cannot (and should not) succeed on PRs from the public, even if the workflow is manually triggered by some with write permissions  (Oxide). This has caused checks by public PRs to fail, such as https://github.com/oxidecomputer/hubris/pull/1488 with https://github.com/oxidecomputer/hubris/actions/runs/5838750982/job/15876474521?pr=1488.

Additionally, we probably don't want to trigger the workflow on pull requests, because it'd mean the live GH pages are updated before a PR is accepted. For example: https://github.com/oxidecomputer/hubris/pull/1489/files can be seen on https://oxidecomputer.github.io/hubris/reference/.

## Fix

This PR just removes the trigger on `pull_reqeusts` while keeping the trigger on changes to the `master` branch, so the GH pages at https://oxidecomputer.github.io/hubris/reference/ should only reflect what's on `master`.

It might make sense to refine the trigger to run on changes to the `doc` directory, but this will at least resolve the issues.

## Notes

The `JamesIves/github-pages-deploy-action` action uses the builtin `GITHUB_TOKEN` by default, which cannot have write permissions to the repo (https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).