### PR TITLE
Enable RoT debug when the beacon is set

### DIFF
--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -9,7 +9,7 @@ version = 0
 
 [kernel]
 name = "oxide-rot-1"
-requires = {flash = 60544, ram = 2696}
+requires = {flash = 60644, ram = 2696}
 features = ["dice-mfg"]
 
 [caboose]


### PR DESCRIPTION
The beacon register can only be set during debug authentication. If this register is set, enable debugging.