### PR TITLE
Replace explicit wrapping `if` with modular arith

### DIFF
--- a/drv/stm32h7-eth/src/ring.rs
+++ b/drv/stm32h7-eth/src/ring.rs
@@ -652,11 +652,8 @@ impl RxRing {
             Self::set_descriptor(d, buffer);
 
             // Bump index forward.
-            self.next.set(if self.next.get() + 1 == self.storage.len() {
-                0
-            } else {
-                self.next.get() + 1
-            });
+            self.next.set((self.next.get() + 1) % self.storage.len());
+
             any_dropped = true;
         }
     }
@@ -722,11 +719,7 @@ impl RxRing {
         // potentially in use, and we must not access either.
 
         // Bump index forward.
-        self.next.set(if self.next.get() + 1 == self.storage.len() {
-            0
-        } else {
-            self.next.get() + 1
-        });
+        self.next.set((self.next.get() + 1) % self.storage.len());
 
         retval
     }


### PR DESCRIPTION
The stm32h7 ethernet driver uses a code sequence bult from explicit tests against the size of the ring to wrap around to the beginning, for both Tx and Rx rings.

I had asked about this sequence when I first joined, and Cliff said it was due to lack of an integer modulus operator and the compiler generating very poor code generation if the `%` operator was used:

https://matrix.to/#/!uMMSVUNAgMdoTtyJPR:oxide.computer/$JY-kOZprRrGzFFG6KoVRQ_a7RB9KFbWR6GQuKFW_azk?via=oxide.computer&via=unix.house

I noticed this again when working on the ring tail pointer fixes and decided to take a look at the generated code; perhaps it had changed?  I think perhaps it has (though have little basis for comparison against older compilers).

The generated code has become a `udiv` followed by an `mls`, which was discussed elsewhere:
https://matrix.to/#/!jxnlDLnJsVaIRstnrt:oxide.computer/$li8Y-dTHnOVSdzi9z1n0tBqU-4xq9OXGLCahueefYXw?via=oxide.computer&via=unix.house

That same discussion indicated some concern for the size of generated code on M0, but given that this driver is only used with an M7 chip (the driver is specific to the stm32h7), this seems inapplicable here.