### PR TITLE
Fix LED ordering for nucleo boards

### DIFF
--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -439,11 +439,11 @@ cfg_if::cfg_if! {
                     (drv_stm32xx_sys_api::Port::G.pin(11), true),
                 ];
             } else if #[cfg(any(target_board = "nucleo-h743zi2", target_board = "nucleo-h753zi"))] {
-                // Nucleo boards: LEDs are on PB0, PB14 and PE1.
+                // Nucleo boards: LEDs are on PB0, PE1 and PB14.
                 const LEDS: &[(drv_stm32xx_sys_api::PinSet, bool)] = &[
                     (drv_stm32xx_sys_api::Port::B.pin(0), false),
-                    (drv_stm32xx_sys_api::Port::B.pin(14), false),
                     (drv_stm32xx_sys_api::Port::E.pin(1), false),
+                    (drv_stm32xx_sys_api::Port::B.pin(14), false),
                 ];
             } else if #[cfg(target_board = "gemini-bu-1")] {
                 // Gemini bringup SP: LEDs are on PI8, PI9, PI10 and PI11.


### PR DESCRIPTION
USR LD2 is at PE1, USR LD3 is at PB14. Noticed when attempting to display an incrementing 3 bit binary number on the user leds that the order was wrong.