### PR TITLE
Add MGS sensor reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -572,7 +572,7 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -643,7 +643,7 @@ dependencies = [
  "abi",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -656,7 +656,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -1738,7 +1738,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "stm32h7",
- "syn",
+ "syn 1.0.94",
  "userlib",
  "zerocopy",
 ]
@@ -2069,7 +2069,7 @@ checksum = "4e40a16955681d469ab3da85aaa6b42ff656b3c67b52e1d8d3dd36afe97fd462"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -2089,7 +2089,7 @@ checksum = "a9045e2676cd5af83c3b167d917b0a5c90a4d8e266e2683d6631b235c457fc27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -2167,7 +2167,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#da51768e10dbe260cc6302bcfd2ac379e275a313"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#5e6fd0f796698d0ffd6103ac4d3b468e677edffd"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",
@@ -2175,6 +2175,7 @@ dependencies = [
  "serde_repr",
  "smoltcp",
  "static_assertions",
+ "strum_macros",
  "uuid",
  "zerocopy",
 ]
@@ -2295,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2386,7 +2387,7 @@ checksum = "0f928320aff16ee8818ef7309180f8b5897057fd79d9dcb8de3ed1ba6dcc125a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -2537,7 +2538,7 @@ dependencies = [
  "ron",
  "serde",
  "ssmarshal",
- "syn",
+ "syn 1.0.94",
  "unwrap-lite",
  "zerocopy",
 ]
@@ -2902,7 +2903,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3022,7 +3023,7 @@ checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3168,7 +3169,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
  "version_check",
 ]
 
@@ -3191,9 +3192,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3213,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3464,7 +3465,7 @@ checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3542,7 +3543,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3564,7 +3565,7 @@ checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3596,7 +3597,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3850,6 +3851,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,6 +3881,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,7 +3899,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
  "unicode-xid",
 ]
 
@@ -3930,7 +3955,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.94",
  "toml",
 ]
 
@@ -4237,7 +4262,7 @@ dependencies = [
  "serde",
  "smoltcp",
  "stm32h7",
- "syn",
+ "syn 1.0.94",
  "task-jefe-api",
  "task-net-api",
  "task-packrat-api",
@@ -4841,7 +4866,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -5273,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.94",
  "synstructure",
 ]
 
@@ -5294,7 +5319,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
  "synstructure",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#f953c022458b5f13a234df32c1ce52060e2f8e3d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#6b0afefb7f232caba837f38b3e87c426e99ed561"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#534dfaa393f025b42aa430c013f8a5de1b9d1372"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#f953c022458b5f13a234df32c1ce52060e2f8e3d"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#5e6fd0f796698d0ffd6103ac4d3b468e677edffd"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#534dfaa393f025b42aa430c013f8a5de1b9d1372"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sensor-reading#6b0afefb7f232caba837f38b3e87c426e99ed561"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#1c71aa8101ca3d786f6f8972ff15616154190561"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch="sensor-reading" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, version = "0.4.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch="sensor-reading" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, version = "0.4.1" }

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -76,7 +76,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44320, ram = 32768}
+max-sizes = {flash = 44384, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -76,7 +76,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44200, ram = 32768}
+max-sizes = {flash = 44320, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -67,7 +67,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44320, ram = 32768}
+max-sizes = {flash = 44384, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -67,7 +67,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44200, ram = 32768}
+max-sizes = {flash = 44320, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -107,7 +107,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44320, ram = 32768}
+max-sizes = {flash = 44384, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -107,7 +107,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44200, ram = 32768}
+max-sizes = {flash = 44320, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -21,7 +21,7 @@ use enum_map::Enum;
 use idol_runtime::{NotificationHandler, RequestError};
 use multitimer::{Multitimer, Repeat};
 use ringbuf::*;
-use task_sensor_api::{NoData, Sensor, SensorError};
+use task_sensor_api::{NoData, Sensor, SensorApiError};
 use task_thermal_api::{Thermal, ThermalError, ThermalProperties};
 use transceiver_messages::{
     message::LedState, mgmt::ManagementInterface, MAX_PACKET_SIZE,
@@ -62,7 +62,7 @@ enum Trace {
     RemovedDisabledModuleThermalModel(usize),
     TemperatureReadError(usize, Reg::QSFP::PORT0_STATUS::Encoded),
     TemperatureReadUnexpectedError(usize, FpgaError),
-    SensorError(usize, SensorError),
+    SensorError(usize, SensorApiError),
     ThermalError(usize, ThermalError),
     GetInterfaceError(usize, Reg::QSFP::PORT0_STATUS::Encoded),
     GetInterfaceUnexpectedError(usize, FpgaError),

--- a/idl/sensor.idol
+++ b/idl/sensor.idol
@@ -29,6 +29,48 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
+        "get_raw_reading": (
+            description: "returns the most recent reading (data or error) and its timestamp",
+            args: {
+                "id": (
+                    type: "SensorId",
+                )
+            },
+            reply: Result(
+                ok: "(Result<f32, NoData>, u64)",
+                err: CLike("SensorApiError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
+        "get_last_data": (
+            description: "returns the most recent data reading and its timestamp",
+            args: {
+                "id": (
+                    type: "SensorId",
+                )
+            },
+            reply: Result(
+                ok: "(f32, u64)",
+                err: CLike("SensorApiError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
+        "get_last_nodata": (
+            description: "returns the most recent error recorded and its timestamp",
+            args: {
+                "id": (
+                    type: "SensorId",
+                )
+            },
+            reply: Result(
+                ok: "(NoData, u64)",
+                err: CLike("SensorApiError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
         "post": (
             args: {
                 "id": (
@@ -40,7 +82,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SensorError"),
+                err: CLike("SensorApiError"),
             ),
             idempotent: true,
         ),
@@ -58,7 +100,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SensorError"),
+                err: CLike("SensorApiError"),
             ),
             idempotent: true,
         ),
@@ -71,8 +113,9 @@ Interface(
             },
             reply: Result(
                 ok: "u32",
-                err: CLike("SensorError"),
+                err: CLike("SensorApiError"),
             ),
+            idempotent: true,
         ),
     },
 )

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -437,8 +437,6 @@ impl From<SensorErrorConvert> for MeasurementError {
             SensorError::DeviceUnavailable => Self::DeviceUnavailable,
             SensorError::DeviceTimeout => Self::DeviceTimeout,
             SensorError::DeviceOff => Self::DeviceOff,
-
-            SensorError::ServerDied => panic!(),
         }
     }
 }

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -10,8 +10,8 @@ use drv_sprot_api::{
 };
 use drv_stm32h7_update_api::Update;
 use gateway_messages::{
-    DiscoverResponse, PowerState, RotError, RotSlotId, RotStateV2, SpComponent,
-    SpError, SpPort, SpStateV2,
+    DiscoverResponse, PowerState, RotError, RotSlotId, RotStateV2,
+    SensorRequest, SensorResponse, SpComponent, SpError, SpPort, SpStateV2,
 };
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use static_assertions::const_assert;
@@ -319,6 +319,13 @@ impl MgsCommon {
             // Other components might also be served someday.
             _ => return Err(SpError::RequestUnsupportedForComponent),
         }
+    }
+
+    pub(crate) fn read_sensor(
+        &mut self,
+        req: SensorRequest,
+    ) -> Result<SensorResponse, SpError> {
+        todo!()
     }
 }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1068,6 +1068,10 @@ impl SpHandler for MgsHandler {
     ) -> Result<SensorResponse, SpError> {
         self.common.read_sensor(req)
     }
+
+    fn current_time(&mut self) -> Result<u64, SpError> {
+        self.common.current_time()
+    }
 }
 
 struct UsartHandler {

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -18,9 +18,9 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
     DiscoverResponse, Header, IgnitionCommand, IgnitionState, Message,
-    MessageKind, MgsError, PowerState, SpComponent, SpError, SpPort, SpRequest,
-    SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
-    SERIAL_CONSOLE_IDLE_TIMEOUT,
+    MessageKind, MgsError, PowerState, SensorRequest, SensorResponse,
+    SpComponent, SpError, SpPort, SpRequest, SpStateV2, SpUpdatePrepare,
+    UpdateChunk, UpdateId, UpdateStatus, SERIAL_CONSOLE_IDLE_TIMEOUT,
 };
 use heapless::{Deque, Vec};
 use host_sp_messages::HostStartupOptions;
@@ -1060,6 +1060,13 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(component)
+    }
+
+    fn read_sensor(
+        &mut self,
+        req: SensorRequest,
+    ) -> Result<SensorResponse, SpError> {
+        self.common.read_sensor(req)
     }
 }
 

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -13,8 +13,8 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
-    SpComponent, SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk,
-    UpdateId, UpdateStatus,
+    SensorRequest, SensorResponse, SpComponent, SpError, SpPort, SpStateV2,
+    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -596,5 +596,12 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(component)
+    }
+
+    fn read_sensor(
+        &mut self,
+        req: SensorRequest,
+    ) -> Result<SensorResponse, SpError> {
+        self.common.read_sensor(req)
     }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -604,4 +604,8 @@ impl SpHandler for MgsHandler {
     ) -> Result<SensorResponse, SpError> {
         self.common.read_sensor(req)
     }
+
+    fn current_time(&mut self) -> Result<u64, SpError> {
+        self.common.current_time()
+    }
 }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -16,8 +16,8 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentAction, ComponentDetails, ComponentUpdatePrepare,
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
-    SpComponent, SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk,
-    UpdateId, UpdateStatus,
+    SensorRequest, SensorResponse, SpComponent, SpError, SpPort, SpStateV2,
+    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -705,6 +705,13 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
     ) -> Result<(), SpError> {
         self.common.reset_component_trigger(component)
+    }
+
+    fn read_sensor(
+        &mut self,
+        req: SensorRequest,
+    ) -> Result<SensorResponse, SpError> {
+        self.common.read_sensor(req)
     }
 }
 

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -713,6 +713,10 @@ impl SpHandler for MgsHandler {
     ) -> Result<SensorResponse, SpError> {
         self.common.read_sensor(req)
     }
+
+    fn current_time(&mut self) -> Result<u64, SpError> {
+        self.common.current_time()
+    }
 }
 
 // Helper function for `.map_err()`; we can't use `?` because we can't implement

--- a/task/sensor-polling/src/main.rs
+++ b/task/sensor-polling/src/main.rs
@@ -9,7 +9,7 @@
 
 use drv_i2c_devices::mwocp68::{Error as Mwocp68Error, Mwocp68};
 use ringbuf::*;
-use task_sensor_api::{Sensor, SensorError, SensorId};
+use task_sensor_api::{Sensor, SensorApiError, SensorId};
 use userlib::*;
 
 task_slot!(I2C, i2c_driver);
@@ -113,8 +113,8 @@ enum Trace {
     Start,
     SpeedReadFailed(SensorId, Error),
     TemperatureReadFailed(SensorId, Error),
-    SpeedPostFailed(SensorId, SensorError),
-    TemperaturePostFailed(SensorId, SensorError),
+    SpeedPostFailed(SensorId, SensorApiError),
+    TemperaturePostFailed(SensorId, SensorApiError),
 }
 ringbuf!(Trace, 32, Trace::None);
 

--- a/task/sensor/src/main.rs
+++ b/task/sensor/src/main.rs
@@ -26,23 +26,22 @@ enum LastReading {
 }
 
 /// Zero-cost array wrapper that can be indexed with a `SensorId`
-struct SensorArray<T: 'static, const N: usize>(&'static mut [T; N]);
-impl<T: 'static, const N: usize> core::ops::Index<SensorId>
-    for SensorArray<T, N>
-{
+struct SensorArray<T: 'static>(&'static mut [T; NUM_SENSORS]);
+impl<T: 'static> core::ops::Index<SensorId> for SensorArray<T> {
     type Output = T;
+    #[inline(always)]
     fn index(&self, idx: SensorId) -> &Self::Output {
         &self.0[idx.0 as usize]
     }
 }
-impl<T: 'static, const N: usize> core::ops::IndexMut<SensorId>
-    for SensorArray<T, N>
-{
+impl<T: 'static> core::ops::IndexMut<SensorId> for SensorArray<T> {
+    #[inline(always)]
     fn index_mut(&mut self, idx: SensorId) -> &mut Self::Output {
         &mut self.0[idx.0 as usize]
     }
 }
-impl<T: 'static, const N: usize> SensorArray<T, N> {
+impl<T: 'static> SensorArray<T> {
+    #[inline(always)]
     fn get(&self, idx: SensorId) -> Option<&T> {
         self.0.get(idx.0 as usize)
     }
@@ -55,15 +54,15 @@ struct ServerImpl {
     //
     // The compiler is smart enough to present `None` with an invalid
     // `LastReading` variant tag, so we don't need to store presence separately.
-    last_reading: SensorArray<Option<LastReading>, NUM_SENSORS>,
+    last_reading: SensorArray<Option<LastReading>>,
 
-    data_value: SensorArray<f32, NUM_SENSORS>,
-    data_time: SensorArray<u64, NUM_SENSORS>,
+    data_value: SensorArray<f32>,
+    data_time: SensorArray<u64>,
 
-    err_value: SensorArray<NoData, NUM_SENSORS>,
-    err_time: SensorArray<u64, NUM_SENSORS>,
+    err_value: SensorArray<NoData>,
+    err_time: SensorArray<u64>,
 
-    nerrors: SensorArray<u32, NUM_SENSORS>,
+    nerrors: SensorArray<u32>,
     deadline: u64,
 }
 
@@ -207,6 +206,7 @@ impl idl::InOrderSensorImpl for ServerImpl {
 }
 
 impl ServerImpl {
+    #[inline(always)]
     fn last_reading(
         &self,
         id: SensorId,

--- a/task/sensor/src/main.rs
+++ b/task/sensor/src/main.rs
@@ -25,6 +25,29 @@ enum LastReading {
     Error,
 }
 
+/// Zero-cost array wrapper that can be indexed with a `SensorId`
+struct SensorArray<T: 'static, const N: usize>(&'static mut [T; N]);
+impl<T: 'static, const N: usize> core::ops::Index<SensorId>
+    for SensorArray<T, N>
+{
+    type Output = T;
+    fn index(&self, idx: SensorId) -> &Self::Output {
+        &self.0[idx.0 as usize]
+    }
+}
+impl<T: 'static, const N: usize> core::ops::IndexMut<SensorId>
+    for SensorArray<T, N>
+{
+    fn index_mut(&mut self, idx: SensorId) -> &mut Self::Output {
+        &mut self.0[idx.0 as usize]
+    }
+}
+impl<T: 'static, const N: usize> SensorArray<T, N> {
+    fn get(&self, idx: SensorId) -> Option<&T> {
+        self.0.get(idx.0 as usize)
+    }
+}
+
 struct ServerImpl {
     // We're using structure-of-arrays packing here because otherwise padding
     // eats up a considerable amount of RAM; for example, Sidecar goes from 2868
@@ -32,15 +55,15 @@ struct ServerImpl {
     //
     // The compiler is smart enough to present `None` with an invalid
     // `LastReading` variant tag, so we don't need to store presence separately.
-    last_reading: &'static mut [Option<LastReading>; NUM_SENSORS],
+    last_reading: SensorArray<Option<LastReading>, NUM_SENSORS>,
 
-    data_value: &'static mut [f32; NUM_SENSORS],
-    data_time: &'static mut [u64; NUM_SENSORS],
+    data_value: SensorArray<f32, NUM_SENSORS>,
+    data_time: SensorArray<u64, NUM_SENSORS>,
 
-    err_value: &'static mut [NoData; NUM_SENSORS],
-    err_time: &'static mut [u64; NUM_SENSORS],
+    err_value: SensorArray<NoData, NUM_SENSORS>,
+    err_time: SensorArray<u64, NUM_SENSORS>,
 
-    nerrors: &'static mut [u32; NUM_SENSORS],
+    nerrors: SensorArray<u32, NUM_SENSORS>,
     deadline: u64,
 }
 
@@ -73,20 +96,14 @@ impl idl::InOrderSensorImpl for ServerImpl {
         _: &RecvMessage,
         id: SensorId,
     ) -> Result<(Result<f32, NoData>, u64), RequestError<SensorApiError>> {
-        let index = id.0 as usize;
-
-        if index < NUM_SENSORS {
-            match self.last_reading[index] {
-                Some(LastReading::Data | LastReading::DataOnly) => {
-                    Ok((Ok(self.data_value[index]), self.data_time[index]))
-                }
-                Some(LastReading::Error | LastReading::ErrorOnly) => {
-                    Ok((Err(self.err_value[index]), self.err_time[index]))
-                }
-                None => Err(SensorApiError::NoReading.into()),
+        match self.last_reading(id)? {
+            Some(LastReading::Data | LastReading::DataOnly) => {
+                Ok((Ok(self.data_value[id]), self.data_time[id]))
             }
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
+            Some(LastReading::Error | LastReading::ErrorOnly) => {
+                Ok((Err(self.err_value[id]), self.err_time[id]))
+            }
+            None => Err(SensorApiError::NoReading.into()),
         }
     }
 
@@ -95,21 +112,13 @@ impl idl::InOrderSensorImpl for ServerImpl {
         _: &RecvMessage,
         id: SensorId,
     ) -> Result<(f32, u64), RequestError<SensorApiError>> {
-        let index = id.0 as usize;
-
-        if index < NUM_SENSORS {
-            match self.last_reading[index] {
-                None | Some(LastReading::ErrorOnly) => {
-                    Err(SensorApiError::NoReading.into())
-                }
-                Some(
-                    LastReading::Data
-                    | LastReading::DataOnly
-                    | LastReading::Error,
-                ) => Ok((self.data_value[index], self.data_time[index])),
+        match self.last_reading(id)? {
+            None | Some(LastReading::ErrorOnly) => {
+                Err(SensorApiError::NoReading.into())
             }
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
+            Some(
+                LastReading::Data | LastReading::DataOnly | LastReading::Error,
+            ) => Ok((self.data_value[id], self.data_time[id])),
         }
     }
 
@@ -118,21 +127,13 @@ impl idl::InOrderSensorImpl for ServerImpl {
         _: &RecvMessage,
         id: SensorId,
     ) -> Result<(NoData, u64), RequestError<SensorApiError>> {
-        let index = id.0 as usize;
-
-        if index < NUM_SENSORS {
-            match self.last_reading[index] {
-                None | Some(LastReading::DataOnly) => {
-                    Err(SensorApiError::NoReading.into())
-                }
-                Some(
-                    LastReading::Data
-                    | LastReading::Error
-                    | LastReading::ErrorOnly,
-                ) => Ok((self.err_value[index], self.err_time[index])),
+        match self.last_reading(id)? {
+            None | Some(LastReading::DataOnly) => {
+                Err(SensorApiError::NoReading.into())
             }
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
+            Some(
+                LastReading::Data | LastReading::Error | LastReading::ErrorOnly,
+            ) => Ok((self.err_value[id], self.err_time[id])),
         }
     }
 
@@ -143,23 +144,17 @@ impl idl::InOrderSensorImpl for ServerImpl {
         value: f32,
         timestamp: u64,
     ) -> Result<(), RequestError<SensorApiError>> {
-        let index = id.0 as usize;
+        let r = match self.last_reading(id)? {
+            None | Some(LastReading::DataOnly) => LastReading::DataOnly,
+            Some(
+                LastReading::Data | LastReading::Error | LastReading::ErrorOnly,
+            ) => LastReading::Data,
+        };
 
-        if index < NUM_SENSORS {
-            self.last_reading[index] = Some(match self.last_reading[index] {
-                None | Some(LastReading::DataOnly) => LastReading::DataOnly,
-                Some(
-                    LastReading::Data
-                    | LastReading::Error
-                    | LastReading::ErrorOnly,
-                ) => LastReading::Data,
-            });
-            self.data_value[index] = value;
-            self.data_time[index] = timestamp;
-            Ok(())
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
-        }
+        self.last_reading[id] = Some(r);
+        self.data_value[id] = value;
+        self.data_time[id] = timestamp;
+        Ok(())
     }
 
     fn nodata(
@@ -169,40 +164,34 @@ impl idl::InOrderSensorImpl for ServerImpl {
         nodata: NoData,
         timestamp: u64,
     ) -> Result<(), RequestError<SensorApiError>> {
-        let index = id.0 as usize;
+        let r = match self.last_reading(id)? {
+            None | Some(LastReading::ErrorOnly) => LastReading::ErrorOnly,
+            Some(
+                LastReading::Data | LastReading::DataOnly | LastReading::Error,
+            ) => LastReading::Error,
+        };
 
-        if index < NUM_SENSORS {
-            self.last_reading[index] = Some(match self.last_reading[index] {
-                None | Some(LastReading::ErrorOnly) => LastReading::ErrorOnly,
-                Some(
-                    LastReading::Data
-                    | LastReading::DataOnly
-                    | LastReading::Error,
-                ) => LastReading::Error,
-            });
-            self.err_value[index] = nodata;
-            self.err_time[index] = timestamp;
+        self.last_reading[id] = Some(r);
+        self.err_value[id] = nodata;
+        self.err_time[id] = timestamp;
 
-            //
-            // We pack per-`NoData` counters into a u32.
-            //
-            let (nbits, shift) = nodata.counter_encoding::<u32>();
-            let mask = (1 << nbits) - 1;
-            let bitmask = mask << shift;
-            let incr = 1 << shift;
+        //
+        // We pack per-`NoData` counters into a u32.
+        //
+        let (nbits, shift) = nodata.counter_encoding::<u32>();
+        let mask = (1 << nbits) - 1;
+        let bitmask = mask << shift;
+        let incr = 1 << shift;
 
-            //
-            // Perform a saturating increment by checking our current value
-            // against our bitmask: if we have unset bits, we can safely add.
-            //
-            if self.nerrors[index] & bitmask != bitmask {
-                self.nerrors[index] += incr;
-            }
-
-            Ok(())
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
+        //
+        // Perform a saturating increment by checking our current value
+        // against our bitmask: if we have unset bits, we can safely add.
+        //
+        if self.nerrors[id] & bitmask != bitmask {
+            self.nerrors[id] += incr;
         }
+
+        Ok(())
     }
 
     fn get_nerrors(
@@ -210,13 +199,22 @@ impl idl::InOrderSensorImpl for ServerImpl {
         _: &RecvMessage,
         id: SensorId,
     ) -> Result<u32, RequestError<SensorApiError>> {
-        let index = id.0 as usize;
+        self.nerrors
+            .get(id)
+            .cloned()
+            .ok_or(SensorApiError::InvalidSensor.into())
+    }
+}
 
-        if index < NUM_SENSORS {
-            Ok(self.nerrors[index])
-        } else {
-            Err(SensorApiError::InvalidSensor.into())
-        }
+impl ServerImpl {
+    fn last_reading(
+        &self,
+        id: SensorId,
+    ) -> Result<Option<LastReading>, SensorApiError> {
+        self.last_reading
+            .get(id)
+            .cloned()
+            .ok_or(SensorApiError::InvalidSensor)
     }
 }
 
@@ -250,12 +248,12 @@ fn main() -> ! {
     };
 
     let mut server = ServerImpl {
-        last_reading,
-        data_value,
-        data_time,
-        err_value,
-        err_time,
-        nerrors,
+        last_reading: SensorArray(last_reading),
+        data_value: SensorArray(data_value),
+        data_time: SensorArray(data_time),
+        err_value: SensorArray(err_value),
+        err_time: SensorArray(err_time),
+        nerrors: SensorArray(nerrors),
         deadline,
     };
 

--- a/task/sensor/src/main.rs
+++ b/task/sensor/src/main.rs
@@ -64,7 +64,7 @@ impl idl::InOrderSensorImpl for ServerImpl {
             .map_err(|e| e.map_runtime(SensorError::from))
             .and_then(|(value, timestamp)| match value {
                 Ok(value) => Ok(Reading { value, timestamp }),
-                Err(e) => Err(<SensorError as From<_>>::from(e).into()),
+                Err(e) => Err(SensorError::from(e).into()),
             })
     }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -37,7 +37,7 @@ use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::max31790::I2cWatchdog;
 use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
-use task_sensor_api::{Sensor as SensorApi, SensorError, SensorId};
+use task_sensor_api::{Sensor as SensorApi, SensorApiError, SensorId};
 use task_thermal_api::{
     SensorReadError, ThermalAutoState, ThermalError, ThermalMode,
     ThermalProperties,
@@ -68,7 +68,7 @@ enum Trace {
     FanReadFailed(SensorId, ResponseCode),
     MiscReadFailed(SensorId, SensorReadError),
     SensorReadFailed(SensorId, SensorReadError),
-    PostFailed(SensorId, SensorError),
+    PostFailed(SensorId, SensorApiError),
     ControlPwm(u8),
     PowerModeChanged(PowerBitmask),
     PowerDownFailed(SeqError),


### PR DESCRIPTION
This PR bumps MGS and implements the new `SensorRead` message.

It also ends up making the `Sensor` API more flexible:

- We now distinguish between device errors (`NoData`) and API errors (the new `enum SensorApiError`).  The existing existing `SensorError` type remains the union of both types, but we can use `SensorApiError` for almost all `Sensor` API return values
- Add a new `Sensor.get_raw_reading` function, which maintains the distinction between device and API errors in its return type.  This 
- All `Sensor` functions are idempotent, so we can remove the `ServerDeath` variant
- Added new APIs to get the last data or error reading, including the timestamp
- Extend the `LastReading` type so that we know if we've _ever_ seen a data or error value; this allows us to correctly return `NoReading` for the new `get_last_data` / `get_last_nodata` APIs