### PR TITLE
Sidecar: avoid Monorail restart if Tofino PCIe link not up

### DIFF
--- a/drv/sidecar-mainboard-controller/src/tofino2.rs
+++ b/drv/sidecar-mainboard-controller/src/tofino2.rs
@@ -448,6 +448,7 @@ pub enum DirectBarSegment {
 pub enum TofinoBar0Registers {
     Scratchpad = 0x0,
     FreeRunningCounter = 0x10,
+    PcieDevInfo = 0x180,
     SoftwareReset = (0x80000 | 0x0),
     ResetOptions = (0x80000 | 0x4),
     PciePhyLaneControl0 = (0x80000 | 0x38),

--- a/drv/sidecar-seq-server/src/front_io.rs
+++ b/drv/sidecar-seq-server/src/front_io.rs
@@ -4,7 +4,8 @@
 
 use crate::*;
 use drv_i2c_devices::{at24csw080::At24Csw080, Validate};
-use drv_sidecar_front_io::{controller::FrontIOController, phy_smi::PhySmi};
+use drv_sidecar_front_io::controller::FrontIOController;
+use drv_sidecar_front_io::phy_smi::PhySmi;
 
 #[allow(dead_code)]
 pub(crate) struct FrontIOBoard {

--- a/idl/sidecar-seq.idol
+++ b/idl/sidecar-seq.idol
@@ -129,13 +129,16 @@ Interface(
                 err: CLike("SeqError"),
             ),
         ),
+        "tofino_pcie_link_up": (
+            doc: "Return whether or not the Tofino PCIe link is up",
+            reply: Simple("bool"),
+            idempotent: true,
+        ),
 
         "is_clock_config_loaded": (
             args: {},
-            reply: Result(
-                ok: "bool",
-                err: CLike("SeqError"),
-            ),
+            reply: Simple("bool"),
+            idempotent: true,
         ),
 
         "load_clock_config": (

--- a/idl/sidecar-seq.idol
+++ b/idl/sidecar-seq.idol
@@ -168,7 +168,7 @@ Interface(
                 err: CLike("SeqError"),
             ),
         ),
-        "set_front_io_phy_osc_good": (
+        "set_front_io_phy_osc_state": (
             args: {
                 "good": "bool",
             },

--- a/task/monorail-server/src/bsp/sidecar_bc.rs
+++ b/task/monorail-server/src/bsp/sidecar_bc.rs
@@ -232,7 +232,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             // oscillator is good any future resets of the PHY do not require a
             // full power cycle of the front IO board.
             self.seq
-                .set_front_io_phy_osc_good(osc_good)
+                .set_front_io_phy_osc_state(osc_good)
                 .map_err(|e| VscError::ProxyError(e.into()))?;
 
             if !osc_good {

--- a/task/monorail-server/src/bsp/sidecar_bc.rs
+++ b/task/monorail-server/src/bsp/sidecar_bc.rs
@@ -3,8 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use drv_sidecar_front_io::phy_smi::PhySmi;
-use drv_sidecar_mainboard_controller::Reg;
-use drv_sidecar_seq_api::{SeqError, Sequencer, TofinoSeqState};
+use drv_sidecar_seq_api::Sequencer;
 use ringbuf::*;
 use userlib::{hl::sleep_for, task_slot};
 use vsc7448::{
@@ -29,7 +28,6 @@ enum Trace {
         after: Speed,
     },
     FrontIoPhyOscillatorBad,
-    SeqError(SeqError),
     AnegCheckFailed(VscError),
     Restarted10GAneg,
     Reinit,
@@ -144,7 +142,7 @@ pub use map::PORT_MAP;
 pub fn preinit() {
     // Wait for the sequencer to turn on the clock
     let seq = Sequencer::from(SEQ.get_task_id());
-    while !seq.is_clock_config_loaded().unwrap_or(false) {
+    while !seq.is_clock_config_loaded() {
         sleep_for(10);
     }
 }
@@ -473,37 +471,12 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             }
         }
 
-        // The 10G link should only be up if we're in A0 and the host isn't
-        // trying to hold us in reset; we won't retrigger autonegotiation /
-        // system reset if that's not the case.
-        let check_10g_link = match self.seq.tofino_seq_state() {
-            Ok(TofinoSeqState::A0) => {
-                match self.seq.tofino_pcie_hotplug_status() {
-                    Ok(pcie_hotplug_status) => {
-                        let host_reset = pcie_hotplug_status
-                            & Reg::PCIE_HOTPLUG_STATUS::HOST_RESET;
-                        host_reset == 0
-                    }
-                    Err(e) => {
-                        // If the sequencer failed to talk to us, then fail safe (i.e.
-                        // in favor of checking the 10G link).
-                        ringbuf_entry!(Trace::SeqError(e));
-                        true
-                    }
-                }
-            }
-            Ok(_) => false,
-            Err(e) => {
-                // If the sequencer failed to talk to us, then fail safe (i.e.
-                // in favor of checking the 10G link).
-                ringbuf_entry!(Trace::SeqError(e));
-                true
-            }
-        };
-
         // Workaround for the link-stuck issue discussed in
-        // https://github.com/oxidecomputer/bf_sde/issues/5
-        if check_10g_link {
+        // https://github.com/oxidecomputer/bf_sde/issues/5. This should only
+        // run if the Tofino PCIe link is up otherwise the Tofino port is almost
+        // certainly down and the condition we are trying to avoid here does not
+        // matter.
+        if self.seq.tofino_pcie_link_up() {
             if self.vsc7448.check_10gbase_kr_aneg(0)? {
                 ringbuf_entry!(Trace::Restarted10GAneg);
             }

--- a/task/net/src/bsp/sidecar_bc.rs
+++ b/task/net/src/bsp/sidecar_bc.rs
@@ -62,7 +62,7 @@ impl bsp_support::Bsp for BspImpl {
     fn preinit() {
         // Wait for the sequencer to turn on the clock
         let seq = Sequencer::from(SEQ.get_task_id());
-        while !seq.is_clock_config_loaded().unwrap_or(false) {
+        while !seq.is_clock_config_loaded() {
             sleep_for(10);
         }
     }


### PR DESCRIPTION
Monorail monitors the 10G link with Tofino and periodically restarts the task if this link is not up. This in turn causes the technician port PHY to flap which is disruptive while working with `pilot racktest`.

In order to reduce spurious restarts the PCIe link with Tofino is monitored and restarts are only performed if the link is up, assuming the 10G port is down otherwise. In addition logging in the sequencer task is improved, making the events more accurate and cutting down on noise.

The following ringbuf snippets are shown when a chassis is freshly booted and the PCIe link with a Gimlet is not (yet) up:
```
humility: ring buffer drv_sidecar_seq_server::__RINGBUF in sequencer:
 NDX LINE      GEN    COUNT PAYLOAD
   0  802        1        1 FpgaInit
   1  810        1        1 LoadingFpgaBitstream
   2  855        1        1 MainboardControllerId(0x1de5bae)
   3  869        1        1 MainboardControllerChecksum(0x8e40be86)
   4  901        1        1 MainboardControllerVersion(0xe6)
   5  902        1        1 MainboardControllerSha(0xfebfa15a)
   6  903        1        1 FpgaInitComplete
   7   27        1        1 LoadingClockConfiguration
   8  928        1        1 ClockConfigurationComplete
   9  219        1        1 FrontIOBoardPowerEnable(true)
  10  933        1        1 FrontIOBoardPresent
  11   80        1        1 LoadingFrontIOControllerBitstream { fpga_id: 0x0 }
  12   92        1        1 FrontIOControllerIdent { fpga_id: 0x0, ident: 0x1deaa55 }
  13   99        1        1 FrontIOControllerChecksum { fpga_id: 0x0, checksum: [ 0x5, 0x9a, 0xa, 0x59 ], expected: [ 0x5, 0x9a, 0xa, 0x59 ] }
  14   80        1        1 LoadingFrontIOControllerBitstream { fpga_id: 0x1 }
  15   92        1        1 FrontIOControllerIdent { fpga_id: 0x1, ident: 0x1deaa55 }
  16   99        1        1 FrontIOControllerChecksum { fpga_id: 0x1, checksum: [ 0x5, 0x9a, 0xa, 0x59 ], expected: [ 0x5, 0x9a, 0xa, 0x59 ] }
  17  336        1        1 TofinoSequencerTick(Disabled, A2 { error: None })
  18  145        1        1 FanModuleLedUpdate(Zero, On)
  19  145        1        1 FanModuleLedUpdate(One, On)
  20  145        1        1 FanModuleLedUpdate(Two, On)
  21  145        1        1 FanModuleLedUpdate(Three, On)
  22  336        1        3 TofinoSequencerTick(Disabled, A2 { error: None })
  23  299        1        1 FrontIOBoardPhyPowerEnable(true)
  24  336        1        1 TofinoSequencerTick(Disabled, A2 { error: None })
  25  521        1        1 FrontIOBoardPhyOscGood
  26  336        1      116 TofinoSequencerTick(Disabled, A2 { error: None })
```
```
humility: ring buffer task_monorail_server::bsp::__RINGBUF in monorail:
 NDX LINE      GEN    COUNT PAYLOAD
   0  173        1        1 Reinit
   1  433        1        1 FrontIoSpeedChange { port: 0x2d, before: Speed1G, after: Speed100M }
```
As shown, 116 sequencer ticks have elapsed and Monorail has not restarted itself, which is expected to happen every ~25 ticks/seconds.

After attaching a Gimlet:
```
humility: ring buffer drv_sidecar_seq_server::__RINGBUF in sequencer:
 NDX LINE      GEN    COUNT PAYLOAD
  17  336        1        1 TofinoSequencerTick(Disabled, A2 { error: None })
  18  145        1        1 FanModuleLedUpdate(Zero, On)
  19  145        1        1 FanModuleLedUpdate(One, On)
  20  145        1        1 FanModuleLedUpdate(Two, On)
  21  145        1        1 FanModuleLedUpdate(Three, On)
  22  336        1        3 TofinoSequencerTick(Disabled, A2 { error: None })
  23  299        1        1 FrontIOBoardPhyPowerEnable(true)
  24  336        1        1 TofinoSequencerTick(Disabled, A2 { error: None })
  25  521        1        1 FrontIOBoardPhyOscGood
  26  336        1      137 TofinoSequencerTick(Disabled, A2 { error: None })
  27  374        1        1 ClearingTofinoSequencerFault(None)
  28  339        1        1 TofinoSequencerPolicyUpdate(LatchOffOnFault)
  29  336        1        1 TofinoSequencerTick(LatchOffOnFault, A2 { error: None })
  30   80        1        1 TofinoPowerUp
  31   51        1        1 SetVddCoreVout(Volts(0.79))
   0  105        2        1 TofinoVidAck
   1  122        2        1 TofinoBar0RegisterValue(SoftwareReset, 0xf3fc0f0)
   2  152        2        1 TofinoBar0RegisterValue(ResetOptions, 0x70000a8)
   3  165        2        1 TofinoEepromIdCode(0x220134)
   4  191        2        1 TofinoBar0RegisterValue(PciePhyLaneControl0, 0xc000c)
   5  191        2        1 TofinoBar0RegisterValue(PciePhyLaneControl1, 0xc000c)
   6  217        2        1 TofinoCfgRegisterValue(KGen, 0xe20f03)
   7  236        2        1 TofinoBar0RegisterValue(SoftwareReset, 0xf3fc000)
   8   61        2        1 SetPCIePresent
   9  336        2        1 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: false })
  10  336        2       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  11  279        2        1 FrontIOBoardPhyPowerEnable(false)
  12  299        2        1 FrontIOBoardPhyPowerEnable(true)
  13  336        2       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  14  279        2        1 FrontIOBoardPhyPowerEnable(false)
  15  299        2        1 FrontIOBoardPhyPowerEnable(true)
  16  336        2        7 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
```
```
humility: ring buffer task_monorail_server::bsp::__RINGBUF in monorail:
 NDX LINE      GEN    COUNT PAYLOAD
   0  173        1        1 Reinit
   1  433        1        1 FrontIoSpeedChange { port: 0x2d, before: Speed1G, after: Speed100M }
   2  481        1       41 Restarted10GAneg
   3  173        1        1 Reinit
   4  481        1        4 Restarted10GAneg
   5  433        1        1 FrontIoSpeedChange { port: 0x2d, before: Speed1G, after: Speed100M }
   6  481        1       36 Restarted10GAneg
   7  173        1        1 Reinit
   8  481        1        4 Restarted10GAneg
   9  433        1        1 FrontIoSpeedChange { port: 0x2d, before: Speed1G, after: Speed100M }
  10  481        1       36 Restarted10GAneg
  11  173        1        1 Reinit
  12  481        1        4 Restarted10GAneg
  13  433        1        1 FrontIoSpeedChange { port: 0x2d, before: Speed1G, after: Speed100M }
  14  481        1       34 Restarted10GAneg
```
Monorail now monitors the 10G link and restarts itself every ~25 ticks/seconds.

And after disconnecting the PCIe link 228 ticks/seconds pass without Monorail restarting itself, only to resume this behavior when the PCIe link comes back up:
```
humility: ring buffer drv_sidecar_seq_server::__RINGBUF in sequencer:
 NDX LINE      GEN    COUNT PAYLOAD
  30   61        2        1 ClearPCIePresent
  31  338        2      133 TofinoSequencerTick(Disabled, A2 { error: None })
   0  372        3        1 ClearingTofinoSequencerFault(None)
   1  337        3        1 TofinoSequencerPolicyUpdate(LatchOffOnFault)
   2  338        3        1 TofinoSequencerTick(LatchOffOnFault, A2 { error: None })
   3   82        3        1 TofinoPowerUp
   4   51        3        1 SetVddCoreVout(Volts(0.79))
   5  107        3        1 TofinoVidAck
   6  124        3        1 TofinoBar0RegisterValue(SoftwareReset, 0xf3fc0f0)
   7  154        3        1 TofinoBar0RegisterValue(ResetOptions, 0x70000a8)
   8  167        3        1 TofinoEepromIdCode(0x220134)
   9  193        3        1 TofinoBar0RegisterValue(PciePhyLaneControl0, 0xc000c)
  10  193        3        1 TofinoBar0RegisterValue(PciePhyLaneControl1, 0xc000c)
  11  219        3        1 TofinoCfgRegisterValue(KGen, 0xe20f03)
  12  238        3        1 TofinoBar0RegisterValue(SoftwareReset, 0xf3fc000)
  13   61        3        1 SetPCIePresent
  14  338        3        1 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: false })
  15  338        3       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  16  277        3        1 FrontIOBoardPhyPowerEnable(false)
  17  297        3        1 FrontIOBoardPhyPowerEnable(true)
  18  338        3       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  19  277        3        1 FrontIOBoardPhyPowerEnable(false)
  20  297        3        1 FrontIOBoardPhyPowerEnable(true)
  21  338        3       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  22  277        3        1 FrontIOBoardPhyPowerEnable(false)
  23  297        3        1 FrontIOBoardPhyPowerEnable(true)
  24  338        3       14 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  25  338        3      228 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: false })
  26  338        3       24 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
  27  277        3        1 FrontIOBoardPhyPowerEnable(false)
  28  297        3        1 FrontIOBoardPhyPowerEnable(true)
  29  338        3        7 TofinoSequencerTick(LatchOffOnFault, A0 { pcie_link: true })
```