### PR TITLE
Add feature to mimic locking

### DIFF
--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [features]
 dump = ["kern/dump"]
 dice-self = ["lpc55-rot-startup/dice-self"]
+locked = ["lpc55-rot-startup/locked"]
 
 [dependencies]
 cortex-m = { workspace = true }

--- a/app/oxide-rot-1/Cargo.toml
+++ b/app/oxide-rot-1/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dump = ["kern/dump"]
 dice-mfg= ["lpc55-rot-startup/dice-mfg"]
 dice-self = ["lpc55-rot-startup/dice-self"]
+locked = ["lpc55-rot-startup/locked"]
 
 [dependencies]
 cortex-m = { workspace = true }

--- a/app/rot-carrier/Cargo.toml
+++ b/app/rot-carrier/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dump = ["kern/dump"]
 dice-mfg= ["lpc55-rot-startup/dice-mfg"]
 dice-self = ["lpc55-rot-startup/dice-self"]
+locked = ["lpc55-rot-startup/locked"]
 
 [dependencies]
 cortex-m = {version = "0.7"}

--- a/lib/lpc55-rot-startup/Cargo.toml
+++ b/lib/lpc55-rot-startup/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 dice-mfg = ["lib-dice", "lpc55-puf", "salty", "static_assertions",  "lib-lpc55-usart"]
 dice-self = ["lib-dice", "lpc55-puf", "salty"]
+locked = []
 
 [dependencies]
 cfg-if = { workspace = true }


### PR DESCRIPTION
Locking via CMPA is permanent and can't be undone. We can at least mimic part of the behavior by setting the flash lock registers.