### PR TITLE
Always calculate the firmware measurement even if there is no valid i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 target/
 itm.txt
 *.swp
-rusty-tags.vi
-cscope.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 itm.txt
 *.swp
+rusty-tags.vi
+cscope.*

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -77,7 +77,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 46300, ram = 32768}
+max-sizes = {flash = 46272, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -68,7 +68,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 46300, ram = 32768}
+max-sizes = {flash = 46272, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -11,7 +11,7 @@ fwid = true
 [kernel]
 name = "rot-carrier"
 features = ["dice-self"]
-requires = {flash = 53100, ram = 4096}
+requires = {flash = 53300, ram = 4096}
 
 [caboose]
 tasks = ["caboose_reader", "sprot"]
@@ -108,7 +108,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 46300, ram = 32768}
+max-sizes = {flash = 46272, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -11,7 +11,7 @@ fwid = true
 [kernel]
 name = "rot-carrier"
 features = ["dice-self"]
-requires = {flash = 53000, ram = 4096}
+requires = {flash = 53100, ram = 4096}
 
 [caboose]
 tasks = ["caboose_reader", "sprot"]

--- a/lib/lpc55-rot-startup/src/images.rs
+++ b/lib/lpc55-rot-startup/src/images.rs
@@ -82,7 +82,7 @@ impl Image {
         let fwid = hash.finalize().try_into().unwrap_lite();
         let programmed = Range {
             start: flash.start,
-            end: end.unwrap_or(flash.start),
+            end: end.unwrap_or(flash.end),
         };
         Image {
             flash,

--- a/lib/lpc55-rot-startup/src/images.rs
+++ b/lib/lpc55-rot-startup/src/images.rs
@@ -2,36 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use abi::{ImageHeader, ImageVectors};
+use abi::ImageHeader;
 use drv_lpc55_flash::{Flash, BYTES_PER_FLASH_PAGE};
 use sha3::{Digest, Sha3_256};
 use stage0_handoff::{ImageVersion, RotImageDetails};
 use unwrap_lite::UnwrapLite;
 
-pub fn get_image_b(flash: &mut Flash<'_>) -> Option<Image> {
-    let imageb = unsafe { &__IMAGE_B_BASE };
-
-    let img = Image {
-        flash: FLASH_B,
-        vector: imageb,
-    };
-
-    if img.validate(flash) {
+pub fn get_image_b(flash: &mut Flash) -> Option<Image> {
+    let img = Image::new(flash, FLASH_B);
+    if img.validate() {
         Some(img)
     } else {
         None
     }
 }
 
-pub fn get_image_a(flash: &mut Flash<'_>) -> Option<Image> {
-    let imagea = unsafe { &__IMAGE_A_BASE };
-
-    let img = Image {
-        flash: FLASH_A,
-        vector: imagea,
-    };
-
-    if img.validate(flash) {
+pub fn get_image_a(flash: &mut Flash) -> Option<Image> {
+    let img = Image::new(flash, FLASH_A);
+    if img.validate() {
         Some(img)
     } else {
         None
@@ -39,8 +27,6 @@ pub fn get_image_a(flash: &mut Flash<'_>) -> Option<Image> {
 }
 
 extern "C" {
-    static __IMAGE_A_BASE: abi::ImageVectors;
-    static __IMAGE_B_BASE: abi::ImageVectors;
     // __vector size is currently defined in the linker script as
     //
     // __vector_size = SIZEOF(.vector_table);
@@ -56,20 +42,83 @@ extern "C" {
 const PAGE_SIZE: u32 = BYTES_PER_FLASH_PAGE as u32;
 
 pub struct Image {
+    // The boundaries of the flash slot.
     flash: Range<u32>,
-    vector: &'static ImageVectors,
+    // The initial span of programmed flash pages.
+    programmed: Range<u32>,
+    // Measurement over the programmed pages.
+    fwid: [u8; 32],
 }
 
-pub fn image_details(img: Image, flash: &mut Flash<'_>) -> RotImageDetails {
+impl Image {
+    // Before doing any other work with a chunk of flash memory:
+    //
+    //   - Define the address boundaries.
+    //   - Determine the bounds of the initial programmed extent.
+    //   - Count the total number of fully programmed pages.
+    //   - Measure all programmed pages including those outside of the
+    //     initial programmed extent.
+    //
+    // Note: if partially programmed pages is a possibility then that could be
+    // a problem with respect to catching exfiltration attempts.
+    pub fn new(dev: &mut Flash, flash: Range<u32>) -> Image {
+        // let mut _count = 0;
+        let mut end: Option<u32> = None;
+        let mut hash = Sha3_256::new();
+        for start in flash.clone().step_by(BYTES_PER_FLASH_PAGE) {
+            if dev.is_page_range_programmed(start, PAGE_SIZE) {
+                // _count += 1;
+                let page = unsafe {
+                    core::slice::from_raw_parts(
+                        start as *const u8,
+                        BYTES_PER_FLASH_PAGE,
+                    )
+                };
+                hash.update(page);
+            } else if end.is_none() {
+                end = Some(start);
+            }
+        }
+        let fwid = hash.finalize().try_into().unwrap_lite();
+        let programmed = Range {
+            start: flash.start,
+            end: end.unwrap_or(flash.start),
+        };
+        Image {
+            flash,
+            programmed,
+            // _count,
+            fwid,
+        }
+    }
+
+    pub fn is_programmed(&self, addr: &u32) -> bool {
+        return self.programmed.contains(addr);
+    }
+
+    pub fn is_span_programmed(&self, start: u32, length: u32) -> bool {
+        if let Some(end) = start.checked_add(length) {
+            if !self.is_programmed(&start) || !self.is_programmed(&end) {
+                false
+            } else {
+                true
+            }
+        } else {
+            false
+        }
+    }
+}
+
+pub fn image_details(img: Image) -> RotImageDetails {
     RotImageDetails {
-        digest: img.get_fwid(flash),
+        digest: img.fwid,
         version: img.get_image_version(),
     }
 }
 
 impl Image {
     fn get_img_start(&self) -> u32 {
-        self.vector as *const ImageVectors as u32
+        self.flash.start
     }
 
     fn get_img_size(&self) -> Option<usize> {
@@ -86,23 +135,18 @@ impl Image {
     }
 
     /// Make sure all of the image flash is programmed
-    fn validate(&self, flash: &mut Flash<'_>) -> bool {
+    fn validate(&self) -> bool {
         let img_start = self.get_img_start();
 
         // Start by making sure we can access the page where the vectors live
-        let valid = flash.is_page_range_programmed(img_start, PAGE_SIZE);
-
-        if !valid {
+        if !self.is_span_programmed(self.flash.start, PAGE_SIZE) {
             return false;
         }
 
         let header_ptr = self.get_header();
 
         // Next validate the header location is programmed
-        let valid =
-            flash.is_page_range_programmed(header_ptr as u32, PAGE_SIZE);
-
-        if !valid {
+        if !self.is_span_programmed(header_ptr as u32, PAGE_SIZE) {
             return false;
         }
 
@@ -111,7 +155,7 @@ impl Image {
         // which we trust.
         let header = unsafe { &*header_ptr };
 
-        // Does this look correct?
+        // Does this look like a header?
         if header.magic != abi::HEADER_MAGIC {
             return false;
         }
@@ -122,30 +166,12 @@ impl Image {
             None => return false,
         };
 
-        // Last step is to make sure the entire range is programmed
-        flash.is_page_range_programmed(img_start, total_len)
-    }
-
-    pub fn get_fwid(&self, flash: &mut Flash<'_>) -> [u8; 32] {
-        let mut hash = Sha3_256::new();
-
-        for start in self.flash.clone().step_by(BYTES_PER_FLASH_PAGE) {
-            if flash.is_page_range_programmed(start, PAGE_SIZE) {
-                // SAFETY: The addresses used in this unsafe code are all
-                // generated by build.rs from data in the build environment.
-                // The safety of this code is an extension of our trust in
-                // the build.
-                let page = unsafe {
-                    core::slice::from_raw_parts(
-                        start as *const u8,
-                        BYTES_PER_FLASH_PAGE,
-                    )
-                };
-                hash.update(page);
-            }
+        // Next make sure the marked image length is programmed
+        if !self.is_span_programmed(img_start, total_len) {
+            return false;
         }
 
-        hash.finalize().try_into().unwrap_lite()
+        return true;
     }
 
     pub fn get_image_version(&self) -> ImageVersion {

--- a/lib/lpc55-rot-startup/src/lib.rs
+++ b/lib/lpc55-rot-startup/src/lib.rs
@@ -183,8 +183,8 @@ pub fn startup(
     } else {
         panic!();
     };
-    let a = img_a.map(|i| images::image_details(i, &mut flash));
-    let b = img_b.map(|i| images::image_details(i, &mut flash));
+    let a = img_a.map(|i| images::image_details(i));
+    let b = img_b.map(|i| images::image_details(i));
 
     let details = RotBootState { active, a, b };
 


### PR DESCRIPTION
…mage.

Note: The measurement is not plumbed through to the management plane at this time. It will wait for other API changes.

Also, figure out the programmed pages once while performing the slot measurement and use those results when the image is being verified.

Tweak .gitignore for tags and cscope users.