### PR TITLE
Expose measurement log.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,8 +537,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.0",
+ "darling_macro 0.13.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -556,14 +566,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.0",
  "quote",
  "syn 1.0.94",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3146,7 +3181,7 @@ dependencies = [
  "num-traits",
  "ron",
  "serde",
- "serde_with",
+ "serde_with 1.11.0",
 ]
 
 [[package]]
@@ -3522,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -3549,13 +3584,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3597,7 +3632,17 @@ checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
  "rustversion",
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.1",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "serde",
+ "serde_with_macros 3.3.0",
 ]
 
 [[package]]
@@ -3606,10 +3651,22 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling",
+ "darling 0.13.0",
  "proc-macro2",
  "quote",
  "syn 1.0.94",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3934,9 +3991,11 @@ dependencies = [
  "idol",
  "idol-runtime",
  "lib-dice",
+ "mutable-statics",
  "num-traits",
  "ringbuf",
  "serde",
+ "serde_with 3.3.0",
  "sha3",
  "stage0-handoff",
  "unwrap-lite",

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -142,7 +142,7 @@ extern-regions = ["sram2"]
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 13600, ram = 16384}
+max-sizes = {flash = 14800, ram = 16384}
 stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -158,7 +158,7 @@ binary_path = "../../target/gimlet-c/dist/default/final.bin"
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 13600, ram = 16384}
+max-sizes = {flash = 14800, ram = 16384}
 stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -77,7 +77,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 45792, ram = 32768}
+max-sizes = {flash = 46300, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -68,7 +68,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 45792, ram = 32768}
+max-sizes = {flash = 46300, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -137,7 +137,7 @@ task-slots = ["swd"]
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 13600, ram = 16384}
+max-sizes = {flash = 14800, ram = 16384}
 stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -204,8 +204,8 @@ binary_path = "../../target/gemini-bu/dist/final.bin"
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 13600, ram = 16384}
-stacksize = 9304
+max-sizes = {flash = 14800, ram = 16384}
+stacksize = 9952
 start = true
 extern-regions = ["dice_alias", "dice_certs"]
 

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -108,7 +108,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 45792, ram = 32768}
+max-sizes = {flash = 46300, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -385,6 +385,8 @@ pub enum AttestReq {
     CertLen(u32),
     Cert { index: u32, offset: u32, size: u32 },
     Record { algorithm: HashAlgorithm },
+    Log { offset: u32, size: u32 },
+    LogLen,
 }
 
 /// A response used for RoT updates
@@ -410,6 +412,8 @@ pub enum AttestRsp {
     CertLen(u32),
     Cert,
     Record,
+    Log,
+    LogLen(u32),
 }
 
 /// The body of a sprot response.

--- a/idl/attest.idol
+++ b/idl/attest.idol
@@ -55,5 +55,28 @@ Interface(
             ),
             encoding: Hubpack,
         ),
+        "log": (
+            doc: "Get the measurement log",
+            args: {
+                "offset" : "u32",
+            },
+            leases: {
+                "dest": (type: "[u8]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: Complex("AttestError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "log_len": (
+            doc: "Get length of the serialized measurement log",
+            reply: Result(
+                ok: "u32",
+                err: Complex("AttestError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -234,6 +234,28 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
-
-     }
+        "log": (
+            doc: "Get the measurement log",
+            args: {
+                "offset" : "u32",
+            },
+            leases: {
+                "dest": (type: "[u8]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: Complex("AttestOrSprotError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "log_len": (
+            doc: "Get length of the serialized measurement log",
+            reply: Result(
+                ok: "u32",
+                err: Complex("AttestOrSprotError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
+    }
 )

--- a/task/attest-api/src/lib.rs
+++ b/task/attest-api/src/lib.rs
@@ -18,10 +18,12 @@ pub enum AttestError {
     InvalidCertIndex,
     NoCerts,
     OutOfRange,
-    MeasurementLogFull,
+    LogFull,
+    LogTooBig,
     TaskRestarted,
     BadLease,
     UnsupportedAlgorithm,
+    SerializeLog,
 }
 
 impl From<idol_runtime::ServerDeath> for AttestError {

--- a/task/attest/Cargo.toml
+++ b/task/attest/Cargo.toml
@@ -9,9 +9,11 @@ crypto-common = { workspace = true }
 lib-dice = { path = "../../lib/dice" }
 hubpack = { workspace = true }
 idol-runtime = { workspace = true }
+mutable-statics = { path = "../../lib/mutable-statics" }
 num-traits = { workspace = true }
 ringbuf = { path = "../../lib/ringbuf" }
 serde = { workspace = true }
+serde_with = { version = "3.3.0", default-features = false, features = ["macros"] }
 stage0-handoff = { path = "../../lib/stage0-handoff" }
 attest-api = { path = "../attest-api" }
 sha3 = { workspace = true }

--- a/task/attest/src/main.rs
+++ b/task/attest/src/main.rs
@@ -18,8 +18,10 @@ use crypto_common::{typenum::Unsigned, OutputSizeUser};
 use hubpack::SerializedSize;
 use idol_runtime::{ClientError, Leased, RequestError, W};
 use lib_dice::{AliasData, CertData};
+use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use sha3::Sha3_256Core;
 use stage0_handoff::{HandoffData, HandoffDataLoadError};
 use zerocopy::AsBytes;
@@ -46,6 +48,8 @@ enum Trace {
     Startup,
     Record(HashAlgorithm),
     BadLease(usize),
+    LogLen(u32),
+    Log,
     None,
 }
 
@@ -84,8 +88,9 @@ const SHA3_256_DIGEST_SIZE: usize =
 const CAPACITY: usize = 16;
 
 // Digest is a fixed length array of bytes
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct Digest<const N: usize>([u8; N]);
+#[serde_as]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, SerializedSize)]
+struct Digest<const N: usize>(#[serde_as(as = "[_; N]")] [u8; N]);
 
 impl<const N: usize> Default for Digest<N> {
     fn default() -> Self {
@@ -96,7 +101,7 @@ impl<const N: usize> Default for Digest<N> {
 type Sha3_256Digest = Digest<SHA3_256_DIGEST_SIZE>;
 
 // Measurement is an enum that can hold any of the supported hash algorithms
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, SerializedSize)]
 enum Measurement {
     Sha3_256(Sha3_256Digest),
 }
@@ -129,25 +134,24 @@ impl Default for Measurement {
     }
 }
 
-// Would have been nice to use ArrayVec but it's particularly difficult to
-// use with hubpack.
+// ArrayVec has everything we need but isn't compatible with hubpack. We only
+// need a small subset of its functionality so this saves us some flash.
+#[serde_as]
+#[derive(Serialize, SerializedSize)]
 struct Log<const N: usize> {
-    index: usize,
+    index: u32,
+    #[serde_as(as = "[_; N]")]
     measurements: [Measurement; N],
 }
 
 impl<const N: usize> Log<N> {
     fn is_full(&self) -> bool {
-        if self.index == N {
-            true
-        } else {
-            false
-        }
+        self.index as usize == N
     }
 
     fn push(&mut self, measurement: Measurement) -> bool {
         if !self.is_full() {
-            self.measurements[self.index] = measurement;
+            self.measurements[self.index as usize] = measurement;
             self.index += 1;
             true
         } else {
@@ -167,14 +171,19 @@ impl<const N: usize> Default for Log<N> {
 
 struct AttestServer {
     alias_data: Option<AliasData>,
+    buf: &'static mut [u8; Log::<CAPACITY>::MAX_SIZE],
     cert_data: Option<CertData>,
     measurements: Log<CAPACITY>,
 }
 
 impl Default for AttestServer {
     fn default() -> Self {
+        let buf = mutable_statics! {
+            static mut LOG_BUF: [u8; Log::<CAPACITY>::MAX_SIZE] = [|| 0; _];
+        };
         Self {
             alias_data: load_data_from_region(&ALIAS_DATA),
+            buf,
             cert_data: load_data_from_region(&CERT_DATA),
             measurements: Log::<CAPACITY>::default(),
         }
@@ -293,12 +302,49 @@ impl idl::InOrderAttestImpl for AttestServer {
         ringbuf_entry!(Trace::Record(algorithm));
 
         if self.measurements.is_full() {
-            return Err(AttestError::MeasurementLogFull.into());
+            return Err(AttestError::LogFull.into());
         }
 
         self.measurements.push(Measurement::new(algorithm, data)?);
 
         Ok(())
+    }
+
+    fn log(
+        &mut self,
+        _: &userlib::RecvMessage,
+        offset: u32,
+        dest: Leased<W, [u8]>,
+    ) -> Result<(), RequestError<AttestError>> {
+        ringbuf_entry!(Trace::Log);
+
+        let offset = offset as usize;
+        let log_len = hubpack::serialize(self.buf, &self.measurements)
+            .map_err(|_| AttestError::SerializeLog)?;
+
+        if log_len < offset || dest.len() > log_len - offset {
+            let err = AttestError::OutOfRange;
+            ringbuf_entry!(Trace::AttestError(err));
+            return Err(err.into());
+        }
+
+        dest.write_range(0..dest.len(), &self.buf[offset..offset + dest.len()])
+            .map_err(|_| RequestError::Fail(ClientError::WentAway))?;
+
+        Ok(())
+    }
+
+    fn log_len(
+        &mut self,
+        _: &userlib::RecvMessage,
+    ) -> Result<u32, RequestError<AttestError>> {
+        let len = hubpack::serialize(self.buf, &self.measurements)
+            .map_err(|_| AttestError::SerializeLog)?;
+        let len = u32::try_from(len).map_err(|_| AttestError::LogTooBig)?;
+
+        ringbuf_entry!(Trace::LogLen(len));
+
+        Ok(len)
     }
 }
 

--- a/task/attest/src/main.rs
+++ b/task/attest/src/main.rs
@@ -192,11 +192,7 @@ impl idl::InOrderAttestImpl for AttestServer {
         let len = self.get_cert_bytes_from_index(index)?.len();
         ringbuf_entry!(Trace::CertLen(len));
 
-        let len = u32::try_from(len).map_err(|_| {
-            <AttestError as Into<RequestError<AttestError>>>::into(
-                AttestError::CertTooBig,
-            )
-        })?;
+        let len = u32::try_from(len).map_err(|_| AttestError::CertTooBig)?;
 
         Ok(len)
     }


### PR DESCRIPTION
This PR:
- replaces use of ArrayVec for maintaining the measurement log with a custom type that can be serialized with hubpack
- adds a 'log' and 'log_len' function to the Attest IDL
- adds a 'log' and 'log_len' function to the Sprot IDL

This is sufficient to expose the measurement log through the hiffy task on either the RoT or the SP.