### PR TITLE
 drv/user-leds: optionally blink some LEDs at start 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "num-traits",
  "stm32f3",
  "stm32f4",
+ "task-config",
  "userlib",
  "zerocopy",
 ]

--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -37,6 +37,7 @@ start = true
 task-slots = ["sys"]
 stacksize = 256
 notifications = ["timer"]
+config = { blink_at_start = [ "Led::Zero" ] }
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/drv/user-leds/Cargo.toml
+++ b/drv/user-leds/Cargo.toml
@@ -17,6 +17,7 @@ drv-lpc55-gpio-api = { path = "../lpc55-gpio-api", optional = true }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api", optional = true }
 drv-user-leds-api.path = "../user-leds-api"
 userlib.path = "../../sys/userlib"
+task-config.path = "../../lib/task-config"
 
 [build-dependencies]
 build-util.path = "../../build/util"

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -41,6 +41,10 @@ use enum_map::EnumMap;
 use idol_runtime::RequestError;
 use userlib::*;
 
+task_config::optional_task_config! {
+    blink_at_start: &'static [Led],
+}
+
 const BLINK_INTERVAL: u64 = 500;
 
 cfg_if::cfg_if! {
@@ -187,8 +191,14 @@ fn main() -> ! {
 
     // Handle messages.
     let mut incoming = [0u8; idl::INCOMING_SIZE];
+    let mut blinking: EnumMap<Led, bool> = Default::default();
+    if let Some(config) = TASK_CONFIG {
+        for &led in config.blink_at_start {
+            blinking[led] = true;
+        }
+    }
     let mut server = ServerImpl {
-        blinking: Default::default(),
+        blinking,
         blink_state: false,
     };
     loop {

--- a/sys/kern/src/fail.rs
+++ b/sys/kern/src/fail.rs
@@ -20,7 +20,10 @@
 //!   trim off any trailing NUL bytes.
 
 #[cfg(not(feature = "nano"))]
-use core::{fmt::{Display, Write}, sync::atomic::Ordering};
+use core::{
+    fmt::{Display, Write},
+    sync::atomic::Ordering,
+};
 
 /// Flag that gets set to `true` by all failure reporting functions, giving
 /// tools a one-stop-shop for doing kernel triage.


### PR DESCRIPTION
We've been including the pong task in most basic/starter images for the
sole purpose of blinking some LEDs.

For the simplest case of a small board with a single debug LED and not a
lot of flash, this is quite wasteful (burns about a kiB). To conserve
resources on such boards, I've added a mechanism for configuring the
user-leds driver to start some LEDs blinking automatically.

Unlike with pong, the LEDs will all blink together, not in a sequence.
Such is the cost of frugality. On boards with one LED the distinction is
not material.

This imposes no size cost on existing uses of user-leds because the
configuration is evaluated at compile time, and will compile away. On
the oxcon2023 board it costs about 16 bytes to set the LED a-blinkin'.