### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -37,6 +37,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/devboards')
     uses: ./.github/workflows/release.yml
     with:
-      board-set: psc
+      board-set: devboards
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         name: "${{ inputs.board-set }} release"
-        draft: true
         fail_on_unmatched_files: true
         files: |
           ${{ steps.grab.outputs.download-path }}/*.zip


### PR DESCRIPTION
The release tagging seems to be working as expected, drop the draft option. Also fix typo for building devboard releases.