### PR TITLE
Fix app/lpc55xpresso/app-sprot.toml so that it compiles after SpRot changes

### DIFF
--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -183,7 +183,7 @@ task-slots = ["swd"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 44384, ram = 32768}
+max-sizes = {flash = 46272, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true
@@ -201,7 +201,7 @@ pins = [
     # HS_SPI_SCK = P1_2 = FUN6
     { pin = { port = 1, pin = 2}, alt = 6},
     # HS_SSEL1 = P1_1 = FUN5
-    { pin = { port = 1, pin = 1}, alt = 5},
+    { name = "CHIP_SELECT", pin = { port = 1, pin = 1}, alt = 5},
     # ROT_IRQ = P0_16 = FUN0
     { name = "ROT_IRQ", pin = { port = 0, pin = 16}, alt = 0, direction = "output"},
     # SP_RESET = P1_5 = FUN0 (not connected)
@@ -211,7 +211,7 @@ pins = [
 [tasks.attest]
 name = "task-attest"
 priority = 5
-max-sizes = {flash = 13600, ram = 16384}
+max-sizes = {flash = 14528, ram = 16384}
 stacksize = 9304
 start = true
 extern-regions = ["dice_alias", "dice_certs"]


### PR DESCRIPTION
This app*.toml wasn't compiling/linking. Fixed.