### PR TITLE
Drop compilation triple

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -22,39 +22,32 @@ jobs:
           - build: sidecar-b
             app_name: sidecar-b
             app_toml: app/sidecar/rev-b.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-b-lab
             app_name: sidecar-b-lab
             app_toml: app/sidecar/rev-b-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-b-dev
             app_name: sidecar-b-dev
             app_toml: app/sidecar/rev-b-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-c
             app_name: sidecar-c
             app_toml: app/sidecar/rev-c.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-c-lab
             app_name: sidecar-c-lab
             app_toml: app/sidecar/rev-c-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: sidecar-c-dev
             app_name: sidecar-c-dev
             app_toml: app/sidecar/rev-c-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
     uses: ./.github/workflows/build-one.yml
     with:
       build: ${{ matrix.build }}
       app_name: ${{ matrix.app_name }}
       app_toml: ${{ matrix.app_toml }}
-      target: ${{ matrix.target }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
 
@@ -68,29 +61,24 @@ jobs:
           - build: psc-b
             app_name: psc-b
             app_toml: app/psc/rev-b.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: psc-b-dev
             app_name: psc-b-dev
             app_toml: app/psc/rev-b-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: psc-c
             app_name: psc-c
             app_toml: app/psc/rev-c.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: psc-c-dev
             app_name: psc-c-dev
             app_toml: app/psc/rev-c-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
     uses: ./.github/workflows/build-one.yml
     with:
       build: ${{ matrix.build }}
       app_name: ${{ matrix.app_name }}
       app_toml: ${{ matrix.app_toml }}
-      target: ${{ matrix.target }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
 
@@ -104,19 +92,16 @@ jobs:
           - build: oxide-rot-1
             app_name: oxide-rot-1
             app_toml: app/oxide-rot-1/app.toml
-            target: thumbv8m.main-none-eabihf
             image: "a, b"
           - build: oxide-rot-1-dev
             app_name: oxide-rot-1-dev
             app_toml: app/oxide-rot-1/app-dev.toml
-            target: thumbv8m.main-none-eabihf
             image: "a, b"
     uses: ./.github/workflows/build-one.yml
     with:
       build: ${{ matrix.build }}
       app_name: ${{ matrix.app_name }}
       app_toml: ${{ matrix.app_toml }}
-      target: ${{ matrix.target }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
 
@@ -130,69 +115,56 @@ jobs:
           - build: gimlet-b
             app_name: gimlet-b
             app_toml: app/gimlet/rev-b.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-b-lab
             app_name: gimlet-b-lab
             app_toml: app/gimlet/rev-b-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-b-dev
             app_name: gimlet-b-dev
             app_toml: app/gimlet/rev-b-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-c
             app_name: gimlet-c
             app_toml: app/gimlet/rev-c.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-c-lab
             app_name: gimlet-c-lab
             app_toml: app/gimlet/rev-c-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-c-dev
             app_name: gimlet-c-dev
             app_toml: app/gimlet/rev-c-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-d
             app_name: gimlet-d
             app_toml: app/gimlet/rev-d.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-d-lab
             app_name: gimlet-d-lab
             app_toml: app/gimlet/rev-d-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-d-dev
             app_name: gimlet-d-dev
             app_toml: app/gimlet/rev-d-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-e
             app_name: gimlet-e
             app_toml: app/gimlet/rev-e.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-e-lab
             app_name: gimlet-e-lab
             app_toml: app/gimlet/rev-e-lab.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gimlet-e-dev
             app_name: gimlet-e-dev
             app_toml: app/gimlet/rev-e-dev.toml
-            target: thumbv7em-none-eabihf
             image: default
     uses: ./.github/workflows/build-one.yml
     with:
       build: ${{ matrix.build }}
       app_name: ${{ matrix.app_name }}
       app_toml: ${{ matrix.app_toml }}
-      target: ${{ matrix.target }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
 
@@ -206,59 +178,48 @@ jobs:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
             app_toml: app/demo-stm32g0-nucleo/app-g070.toml
-            target: thumbv6m-none-eabi
             image: default
           - build: stm32f3
             app_name: demo-stm32f3-discovery
             app_toml: app/demo-stm32f4-discovery/app-f3.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: stm32f4
             app_name: demo-stm32f4-discovery
             app_toml: app/demo-stm32f4-discovery/app.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: lpc55
             app_name: lpc55xpresso
             app_toml: app/lpc55xpresso/app.toml
-            target: thumbv8m.main-none-eabihf
             image: "a, b"
           - build: stm32h743
             app_name: demo-stm32h743-nucleo
             app_toml: app/demo-stm32h7-nucleo/app-h743.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: stm32h753
             app_name: demo-stm32h753-nucleo
             app_toml: app/demo-stm32h7-nucleo/app-h753.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: gemini
             app_name: gemini-bu
             app_toml: app/gemini-bu/app.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: rot-carrier
             app_name: rot-carrier
             app_toml: app/rot-carrier/app.toml
-            target: thumbv8m.main-none-eabihf
             image: "a, b"
           - build: gimletlet
             app_name: gimletlet
             app_toml: app/gimletlet/app.toml
-            target: thumbv7em-none-eabihf
             image: default
           - build: donglet-g031
             app_name: donglet-g031
             app_toml: app/donglet/app-g031.toml
-            target: thumbv6m-none-eabi
             image: default
     uses: ./.github/workflows/build-one.yml
     with:
       build: ${{ matrix.build }}
       app_name: ${{ matrix.app_name }}
       app_toml: ${{ matrix.app_toml }}
-      target: ${{ matrix.target }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
  

--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -14,10 +14,6 @@ on:
         description: "TOML file name (must be app directory)"
         required: true
         type: string
-      target:
-        description: "Compilation target triplet"
-        required: true
-        type: string
       image:
         description: "Comma separated string of image names to build"
         required: true


### PR DESCRIPTION
One upon a time we needed to manually specify the compilation triple. This is no longer true.