### PR TITLE
Fix build badge

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,6 +1,6 @@
 # Hubris
 
-[![build](https://github.com/oxidecomputer/hubris/workflows/build/badge.svg)](https://github.com/oxidecomputer/hubris/actions?query=workflow%3Abuild)
+![dist](https://github.com/oxidecomputer/hubris/actions/workflows/dist.yml/badge.svg)
 
 Hubris is a microcontroller operating environment designed for deeply-embedded
 systems with reliability requirements. Its design was initially proposed in


### PR DESCRIPTION
This was pointing at an old workflow that no longer exists. 

Shout-out to https://news.ycombinator.com/item?id=38032561 for raising this issue.