### PR TITLE
Fix meanwell app-meanwell.toml so that the output doesn't conflict

### DIFF
--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -1,4 +1,4 @@
-name = "gimletlet"
+name = "gimletlet-meanwell"
 target = "thumbv7em-none-eabihf"
 board = "gimletlet-2"
 chip = "../../chips/stm32h7"


### PR DESCRIPTION
If one builds with all of the available app.toml files then the outputs of app/gimletlet/app{,-meanwell}.toml get written to the same path: target/gimletlet-meanwell/dist/default/build-gimletlet-image-default.zip

This change results in app-meanwell.toml writing to: target/gimletlet-meanwell/dist/default/build-gimletlet-meanwell-image-default.zip