### PR TITLE
attest: move types in attest task IDL / API into external crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "byteorder",
  "phash",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -92,7 +92,19 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
+]
+
+[[package]]
+name = "attest-data"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
+dependencies = [
+ "hubpack",
+ "salty",
+ "serde",
+ "serde_with 3.3.0",
+ "sha3",
 ]
 
 [[package]]
@@ -576,7 +588,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -598,7 +610,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -688,13 +700,13 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/dice-util#57b4e3b4f37eea3414081a9e1bb53988c76b641f"
+source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
 dependencies = [
  "corncobs",
  "hubpack",
  "serde",
  "serde-big-array 0.5.1",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -723,7 +735,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -741,7 +753,7 @@ dependencies = [
  "stm32h7",
  "tlvc",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -775,7 +787,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -790,7 +802,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -807,7 +819,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -830,7 +842,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -840,7 +852,7 @@ dependencies = [
  "drv-fpga-api",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -856,7 +868,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -876,7 +888,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -889,7 +901,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -925,7 +937,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -934,7 +946,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -946,7 +958,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -955,7 +967,7 @@ version = "0.1.0"
 dependencies = [
  "drv-i2c-types",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -973,7 +985,7 @@ dependencies = [
  "smbus-pec",
  "task-power-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1015,7 +1027,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1033,7 +1045,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1045,7 +1057,7 @@ dependencies = [
  "drv-i2c-devices",
  "drv-oxide-vpd",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1066,7 +1078,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1080,7 +1092,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1092,7 +1104,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1109,7 +1121,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1128,7 +1140,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1145,7 +1157,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1179,7 +1191,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1203,7 +1215,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1218,7 +1230,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1229,7 +1241,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1247,7 +1259,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1264,7 +1276,7 @@ dependencies = [
  "nb 1.0.0",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1280,7 +1292,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1291,7 +1303,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1305,7 +1317,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1319,7 +1331,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1335,7 +1347,7 @@ dependencies = [
  "userlib",
  "vsc7448",
  "vsc85xx",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1344,7 +1356,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1354,7 +1366,7 @@ dependencies = [
  "drv-onewire",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1365,7 +1377,7 @@ dependencies = [
  "drv-i2c-devices",
  "ringbuf",
  "tlvc",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1415,7 +1427,7 @@ dependencies = [
  "num-traits",
  "rand_core",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1434,7 +1446,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1447,7 +1459,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1470,7 +1482,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1492,7 +1504,7 @@ dependencies = [
  "serde",
  "serde_json",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1518,7 +1530,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1545,7 +1557,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1557,7 +1569,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1575,7 +1587,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1604,7 +1616,7 @@ dependencies = [
  "tlvc",
  "unwrap-lite",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1615,7 +1627,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1627,7 +1639,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1640,7 +1652,7 @@ dependencies = [
  "num-traits",
  "stm32g0",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1668,7 +1680,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1686,7 +1698,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1697,7 +1709,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1711,7 +1723,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1722,7 +1734,7 @@ dependencies = [
  "ringbuf",
  "stm32h7",
  "vcell",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1737,7 +1749,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1766,7 +1778,7 @@ dependencies = [
  "stm32h7",
  "syn 1.0.94",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1792,7 +1804,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1817,7 +1829,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1838,7 +1850,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1855,7 +1867,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1894,7 +1906,7 @@ dependencies = [
  "stm32h7",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1909,7 +1921,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1932,7 +1944,7 @@ dependencies = [
  "task-sensor-api",
  "transceiver-messages",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1964,7 +1976,7 @@ dependencies = [
  "task-thermal-api",
  "transceiver-messages",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1980,7 +1992,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2001,7 +2013,7 @@ dependencies = [
  "stm32f4",
  "task-config",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2012,7 +2024,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2028,7 +2040,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2043,7 +2055,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2205,7 +2217,7 @@ dependencies = [
  "static_assertions",
  "strum_macros",
  "uuid",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2395,7 +2407,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-types",
  "unwrap-lite",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2441,7 +2453,7 @@ dependencies = [
  "tlvc-text",
  "toml",
  "x509-cert",
- "zerocopy",
+ "zerocopy 0.6.4",
  "zip",
 ]
 
@@ -2455,7 +2467,7 @@ dependencies = [
  "serde",
  "serde-big-array 0.5.1",
  "static_assertions",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2482,7 +2494,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
 dependencies = [
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2569,7 +2581,7 @@ dependencies = [
  "ssmarshal",
  "syn 1.0.94",
  "unwrap-lite",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2611,7 +2623,7 @@ dependencies = [
  "static_assertions",
  "unwrap-lite",
  "vcell",
- "zerocopy",
+ "zerocopy 0.6.4",
  "zeroize",
 ]
 
@@ -2669,7 +2681,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2724,7 +2736,7 @@ dependencies = [
  "static_assertions",
  "toml",
  "unwrap-lite",
- "zerocopy",
+ "zerocopy 0.6.4",
  "zeroize",
 ]
 
@@ -2753,7 +2765,7 @@ dependencies = [
  "task-jefe-api",
  "tlvc",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2798,7 +2810,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "x509-cert",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3034,7 +3046,7 @@ version = "0.1.0"
 dependencies = [
  "hubpack",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3239,9 +3251,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3591,7 +3603,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3667,7 +3679,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3905,7 +3917,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3924,7 +3936,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.29",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3946,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3980,8 +3992,8 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "attest-api",
+ "attest-data",
  "build-util",
- "crypto-common",
  "hubpack",
  "idol",
  "idol-runtime",
@@ -3991,11 +4003,10 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde_with 3.3.0",
- "sha3",
  "stage0-handoff",
  "unwrap-lite",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4010,7 +4021,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4066,7 +4077,7 @@ dependencies = [
  "task-validate-api",
  "update-buffer",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4082,7 +4093,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4108,7 +4119,7 @@ dependencies = [
  "task-jefe-api",
  "task-net-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4127,7 +4138,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4160,7 +4171,7 @@ dependencies = [
  "static-cell",
  "test-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4203,7 +4214,7 @@ dependencies = [
  "task-sensor-api",
  "tlvc",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4217,7 +4228,7 @@ dependencies = [
  "num-traits",
  "ssmarshal",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4249,7 +4260,7 @@ dependencies = [
  "ssmarshal",
  "task-jefe-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4265,7 +4276,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4293,7 +4304,7 @@ dependencies = [
  "vsc7448",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4338,7 +4349,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4358,7 +4369,7 @@ dependencies = [
  "smoltcp",
  "task-packrat-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4378,7 +4389,7 @@ dependencies = [
  "static_assertions",
  "task-packrat-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4392,7 +4403,7 @@ dependencies = [
  "num-traits",
  "oxide-barcode",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4442,7 +4453,7 @@ dependencies = [
  "task-power-api",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4459,7 +4470,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4481,7 +4492,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4499,7 +4510,7 @@ dependencies = [
  "serde",
  "task-sensor-types",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4515,7 +4526,7 @@ dependencies = [
  "ringbuf",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4528,7 +4539,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4602,7 +4613,7 @@ dependencies = [
  "task-sensor-api",
  "task-thermal-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4619,7 +4630,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4647,7 +4658,7 @@ dependencies = [
  "task-net-api",
  "task-packrat-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4669,7 +4680,7 @@ dependencies = [
  "build-util",
  "task-net-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4691,7 +4702,7 @@ dependencies = [
  "serde",
  "task-validate-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4708,7 +4719,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4728,7 +4739,7 @@ dependencies = [
  "ringbuf",
  "task-vpd-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4741,7 +4752,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4760,7 +4771,7 @@ dependencies = [
  "build-util",
  "num-traits",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4773,7 +4784,7 @@ dependencies = [
  "num-traits",
  "test-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4787,7 +4798,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4802,7 +4813,7 @@ dependencies = [
  "ssmarshal",
  "test-idol-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4818,7 +4829,7 @@ dependencies = [
  "ringbuf",
  "test-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4838,7 +4849,7 @@ dependencies = [
  "test-api",
  "test-idol-api",
  "userlib",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4965,7 +4976,7 @@ source = "git+https://github.com/oxidecomputer/tlvc#e644a21a7ca973ed31499106ea92
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4976,7 +4987,7 @@ dependencies = [
  "ron",
  "serde",
  "tlvc",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5094,7 +5105,7 @@ dependencies = [
  "ssmarshal",
  "unwrap-lite",
  "volatile-const",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5174,7 +5185,7 @@ dependencies = [
  "userlib",
  "vsc-err",
  "vsc7448-pac",
- "zerocopy",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5362,7 +5373,7 @@ dependencies = [
  "toml-task",
  "toml_edit",
  "walkdir",
- "zerocopy",
+ "zerocopy 0.6.4",
  "zip",
 ]
 
@@ -5373,7 +5384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.6.4",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.32",
 ]
 
 [[package]]
@@ -5384,7 +5405,18 @@ checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.1.0" }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }

--- a/task/attest/Cargo.toml
+++ b/task/attest/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 arrayvec.workspace = true
-crypto-common = { workspace = true }
 lib-dice = { path = "../../lib/dice" }
 hubpack = { workspace = true }
 idol-runtime = { workspace = true }
@@ -16,7 +15,7 @@ serde = { workspace = true }
 serde_with = { version = "3.3.0", default-features = false, features = ["macros"] }
 stage0-handoff = { path = "../../lib/stage0-handoff" }
 attest-api = { path = "../attest-api" }
-sha3 = { workspace = true }
+attest-data.workspace = true
 unwrap-lite = { path = "../../lib/unwrap-lite" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 zerocopy = { workspace = true }


### PR DESCRIPTION
This commit moves the types used in the attest IDL / API into a library crate in the dice-util repo. This enables consumers outside of hubris to use the API.