### PR TITLE
Decouple `transceivers` server from Front IO readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=moar-errors#b599eaa38fe0822953520609baa8e46bd001398e"
+source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=moar-errors#3529308c020f2f04c19b2ba13f8dcc79a18fde9d"
 dependencies = [
  "bitflags 2.4.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=moar-errors#3529308c020f2f04c19b2ba13f8dcc79a18fde9d"
+source = "git+https://github.com/oxidecomputer/transceiver-control/#0a18f231372069b74b72f1756e2337186e888dc0"
 dependencies = [
  "bitflags 2.4.2",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/transceiver-control/#84e28d1263d9d07c5410fb0644469c8eb7b5fb5f"
+source = "git+https://github.com/oxidecomputer/transceiver-control/?branch=moar-errors#b599eaa38fe0822953520609baa8e46bd001398e"
 dependencies = [
  "bitflags 2.4.2",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,5 +135,5 @@ sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", def
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3.1" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3.0" }
-transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false, branch = "moar-errors"}
+transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,5 +135,5 @@ sprockets-common = { git = "https://github.com/oxidecomputer/sprockets.git", def
 sprockets-rot = { git = "https://github.com/oxidecomputer/sprockets.git", default-features = false }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3.1" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3.0" }
-transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false }
+transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false, branch = "moar-errors"}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }

--- a/drv/sidecar-front-io/src/controller.rs
+++ b/drv/sidecar-front-io/src/controller.rs
@@ -4,6 +4,7 @@
 
 use crate::{Addr, SIDECAR_IO_BITSTREAM_CHECKSUM};
 use drv_fpga_api::*;
+use userlib::UnwrapLite;
 
 pub struct FrontIOController {
     fpga: Fpga,
@@ -90,6 +91,6 @@ impl FrontIOController {
     /// Returns the expected (short) checksum, which simply a prefix of the full
     /// SHA3-256 hash of the bitstream.
     pub fn short_checksum() -> [u8; 4] {
-        SIDECAR_IO_BITSTREAM_CHECKSUM[..4].try_into().unwrap()
+        SIDECAR_IO_BITSTREAM_CHECKSUM[..4].try_into().unwrap_lite()
     }
 }

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -6,6 +6,7 @@ use crate::{Addr, Reg};
 use drv_fpga_api::{FpgaError, FpgaUserDesign, WriteOp};
 use drv_transceivers_api::{ModuleStatus, TransceiversError, NUM_PORTS};
 use transceiver_messages::ModuleId;
+use userlib::FromPrimitive;
 use zerocopy::{byteorder, AsBytes, FromBytes, Unaligned, U16};
 
 // The transceiver modules are split across two FPGAs on the QSFP Front IO
@@ -24,7 +25,7 @@ pub enum FpgaController {
 }
 
 /// Physical port location
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct PortLocation {
     pub controller: FpgaController,
     pub port: PhysicalPort,
@@ -37,7 +38,7 @@ impl From<LogicalPort> for PortLocation {
 }
 
 /// Physical port location within a particular FPGA, as a 0-15 index
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct PhysicalPort(pub u8);
 impl PhysicalPort {
     pub fn as_mask(&self) -> PhysicalPortMask {
@@ -46,6 +47,20 @@ impl PhysicalPort {
 
     pub fn get(&self) -> u8 {
         self.0
+    }
+
+    pub fn to_logical_port(
+        &self,
+        fpga: FpgaController,
+    ) -> Result<LogicalPort, TransceiversError> {
+        let loc = PortLocation {
+            controller: fpga,
+            port: *self,
+        };
+        match PORT_MAP.into_iter().position(|&l| l == loc) {
+            Some(p) => Ok(LogicalPort(p as u8)),
+            None => Err(TransceiversError::InvalidPhysicalToLogicalMap),
+        }
     }
 }
 
@@ -479,11 +494,26 @@ pub struct ModuleResult {
     success: LogicalPortMask,
     failure: LogicalPortMask,
     error: LogicalPortMask,
+    failure_types: LogicalPortFailureTypes,
+}
+
+/// This is a slimmed down version of ModuleResult for use in the ringbuf
+#[derive(Copy, Clone, PartialEq)]
+pub struct ModuleResultSlim {
+    success: LogicalPortMask,
+    failure: LogicalPortMask,
+    error: LogicalPortMask,
 }
 
 impl From<ModuleResultNoFailure> for ModuleResult {
     fn from(r: ModuleResultNoFailure) -> Self {
-        ModuleResult::new(r.success(), LogicalPortMask(0), r.error()).unwrap()
+        ModuleResult::new(
+            r.success(),
+            LogicalPortMask(0),
+            r.error(),
+            LogicalPortFailureTypes::default(),
+        )
+        .unwrap()
     }
 }
 
@@ -493,6 +523,7 @@ impl ModuleResult {
         success: LogicalPortMask,
         failure: LogicalPortMask,
         error: LogicalPortMask,
+        failure_types: LogicalPortFailureTypes,
     ) -> Result<Self, TransceiversError> {
         if !(success & failure).is_empty()
             || !(success & error).is_empty()
@@ -504,6 +535,7 @@ impl ModuleResult {
             success,
             failure,
             error,
+            failure_types,
         })
     }
 
@@ -517,6 +549,10 @@ impl ModuleResult {
 
     pub fn error(&self) -> LogicalPortMask {
         self.error
+    }
+
+    pub fn failure_types(&self) -> LogicalPortFailureTypes {
+        self.failure_types
     }
 
     /// Combines two `ModuleResults`
@@ -555,7 +591,29 @@ impl ModuleResult {
         // has subsequently occurred.
         let failure = (self.failure() | next.failure()) & !self.error();
 
-        Self::new(success, failure, error).unwrap()
+        // merge the failure types observed, prefering newer failure types
+        // should both results have a failure at the same port.
+        let mut combined_failures = LogicalPortFailureTypes::default();
+        for p in failure.to_indices() {
+            if next.failure().is_set(p) {
+                combined_failures.0[p.0 as usize] =
+                    next.failure_types().0[p.0 as usize];
+            } else if self.failure().is_set(p) {
+                combined_failures.0[p.0 as usize] =
+                    self.failure_types().0[p.0 as usize];
+            }
+        }
+
+        Self::new(success, failure, error, combined_failures).unwrap()
+    }
+
+    /// Helper to provide a nice way to get a ModuleResultSlim from this result
+    pub fn to_slim(&self) -> ModuleResultSlim {
+        ModuleResultSlim {
+            success: self.success(),
+            failure: self.failure(),
+            error: self.error(),
+        }
     }
 }
 
@@ -589,6 +647,49 @@ impl ModuleResultNoFailure {
 
     pub fn error(&self) -> LogicalPortMask {
         self.error
+    }
+}
+
+/// A type to provide more ergonomic access to the FPGA generated type
+pub type FpgaI2CFailure = Reg::QSFP::PORT0_STATUS::Encoded;
+
+/// A type to consolidate per-module failure types.
+///
+/// Currently the only types of operations that can be considered failures are
+/// those that involve the FPGA doing I2C. Thus, that is the only supported type
+/// right now.
+#[derive(Copy, Clone, PartialEq)]
+pub struct LogicalPortFailureTypes(pub [FpgaI2CFailure; NUM_PORTS as usize]);
+
+impl Default for LogicalPortFailureTypes {
+    fn default() -> Self {
+        Self([FpgaI2CFailure::NoError; NUM_PORTS as usize])
+    }
+}
+
+impl core::ops::Index<LogicalPort> for LogicalPortFailureTypes {
+    type Output = FpgaI2CFailure;
+
+    fn index(&self, i: LogicalPort) -> &Self::Output {
+        &self.0[i.0 as usize]
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct PortI2CStatus {
+    pub done: bool,
+    pub error: FpgaI2CFailure,
+}
+
+impl PortI2CStatus {
+    pub fn new(status: u8) -> Self {
+        Self {
+            done: (status & Reg::QSFP::PORT0_STATUS::BUSY) == 0,
+            error: FpgaI2CFailure::from_u8(
+                status & Reg::QSFP::PORT0_STATUS::ERROR,
+            )
+            .unwrap(),
+        }
     }
 }
 
@@ -1089,30 +1190,31 @@ impl Transceivers {
         let mut physical_failure = FpgaPortMasks::default();
         let mut physical_error = FpgaPortMasks::default();
         let phys_mask: FpgaPortMasks = mask.into();
+        let mut failure_types = LogicalPortFailureTypes::default();
 
         #[derive(AsBytes, Default, FromBytes)]
         #[repr(C)]
-        struct StatusAndErr {
+        struct BusyAndPortStatus {
             busy: u16,
-            err: [u8; 8],
+            status: [u8; 8],
         }
         for fpga_index in phys_mask.iter_fpgas() {
             let fpga = self.fpga(fpga_index);
             // This loop should break immediately, because I2C is fast
-            let status = loop {
-                // Two bytes of BUSY, followed by 8 bytes of error status
-                let status = match fpga.read(Addr::QSFP_I2C_BUSY0) {
+            let status_all = loop {
+                // Two bytes of BUSY, followed by 816bytes of port status
+                let status_all = match fpga.read(Addr::QSFP_I2C_BUSY0) {
                     Ok(data) => data,
                     // If there is an FPGA communication error, mark that as an
                     // error on all of that FPGA's ports
                     Err(_) => {
                         *physical_error.get_mut(fpga_index) =
                             PhysicalPortMask(0xffff);
-                        StatusAndErr::default()
+                        BusyAndPortStatus::default()
                     }
                 };
-                if status.busy == 0 {
-                    break status;
+                if status_all.busy == 0 {
+                    break status_all;
                 }
                 userlib::hl::sleep_for(1);
             };
@@ -1123,25 +1225,30 @@ impl Transceivers {
                 FpgaController::Right => phys_mask.right,
             };
             for port in (0..16).map(PhysicalPort) {
+                // skip ports we didn't interact with
                 if !phys_mask.is_set(port) {
                     continue;
                 }
-                // Each error byte packs together two ports
-                let err = status.err[port.0 as usize / 2]
-                    >> ((port.0 as usize % 2) * 4);
 
-                // For now, check for the presence of an error, but don't bother
-                // reporting the details.
-                let has_err = (err & 0b1000) != 0;
-                if has_err {
+                // cast status byte into a type
+                let failure = FpgaI2CFailure::from_u8(
+                    status_all.status[port.0 as usize]
+                        & Reg::QSFP::PORT0_STATUS::ERROR,
+                )
+                .unwrap();
+                // if a failure occurred, mark it and record the failure type
+                if failure != FpgaI2CFailure::NoError {
                     physical_failure.get_mut(fpga_index).set(port);
+                    let logical_port =
+                        port.to_logical_port(fpga_index).unwrap();
+                    failure_types.0[logical_port.0 as usize] = failure;
                 }
             }
         }
         let error = mask & LogicalPortMask::from(physical_error);
         let failure = mask & LogicalPortMask::from(physical_failure);
         let success = mask & !(error | failure);
-        ModuleResult::new(success, failure, error).unwrap()
+        ModuleResult::new(success, failure, error, failure_types).unwrap()
     }
 }
 

--- a/drv/transceivers-api/src/lib.rs
+++ b/drv/transceivers-api/src/lib.rs
@@ -22,6 +22,7 @@ pub enum TransceiversError {
     InvalidPowerState,
     InvalidModuleResult,
     LedI2cError,
+    InvalidPhysicalToLogicalMap,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -25,7 +25,7 @@ use task_thermal_api::{Thermal, ThermalError, ThermalProperties};
 use transceiver_messages::{
     message::LedState, mgmt::ManagementInterface, MAX_PACKET_SIZE,
 };
-use userlib::{units::Celsius, *};
+use userlib::{FromPrimitive, sys_get_timer, task_slot, units::Celsius};
 use zerocopy::{AsBytes, FromBytes};
 
 mod udp; // UDP API is implemented in a separate file

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -25,7 +25,7 @@ use task_thermal_api::{Thermal, ThermalError, ThermalProperties};
 use transceiver_messages::{
     message::LedState, mgmt::ManagementInterface, MAX_PACKET_SIZE,
 };
-use userlib::{FromPrimitive, sys_get_timer, task_slot, units::Celsius};
+use userlib::{sys_get_timer, task_slot, units::Celsius, FromPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
 mod udp; // UDP API is implemented in a separate file

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -670,15 +670,22 @@ fn main() -> ! {
                         // the server itself has no knowledge of the sequencer.
                         if server.check_front_io_status {
                             let ready = seq.front_io_board_ready();
-            
+
                             match ready {
                                 Ok(true) => {
-                                    ringbuf_entry!(Trace::FrontIOBoardReady(true));
+                                    ringbuf_entry!(Trace::FrontIOBoardReady(
+                                        true
+                                    ));
                                     server.check_front_io_status = false;
                                     ringbuf_entry!(Trace::LEDInit);
-                                    match server.transceivers.enable_led_controllers() {
+                                    match server
+                                        .transceivers
+                                        .enable_led_controllers()
+                                    {
                                         Ok(_) => server.led_init(),
-                                        Err(e) => ringbuf_entry!(Trace::LEDEnableError(e)),
+                                        Err(e) => ringbuf_entry!(
+                                            Trace::LEDEnableError(e)
+                                        ),
                                     };
                                 }
                                 Err(SeqError::NoFrontIOBoard) => {
@@ -688,7 +695,9 @@ fn main() -> ! {
                                     server.check_front_io_status = false;
                                 }
                                 _ => {
-                                    ringbuf_entry!(Trace::FrontIOBoardReady(false));
+                                    ringbuf_entry!(Trace::FrontIOBoardReady(
+                                        false
+                                    ));
                                 }
                             }
                         }

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -665,8 +665,6 @@ fn main() -> ! {
             for t in multitimer.iter_fired() {
                 match t {
                     Timers::I2C => {
-                        server.handle_i2c_loop();
-
                         // Handle the Front IO status checking as part of this
                         // loop because the frequency is what we had before and
                         // the server itself has no knowledge of the sequencer.
@@ -694,6 +692,8 @@ fn main() -> ! {
                                 }
                             }
                         }
+
+                        server.handle_i2c_loop();
                     }
                     Timers::SPI => {
                         server.handle_spi_loop();

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -307,7 +307,7 @@ impl ServerImpl {
                 let mask = LogicalPortMask::from(modules);
                 let (data_len, result) = if self
                     .front_io_board_present
-                    .unwrap_or_default()
+                    .unwrap_or(false)
                 {
                     self.get_status(mask, out)
                 } else {
@@ -337,7 +337,7 @@ impl ServerImpl {
                 let mask = LogicalPortMask::from(modules);
                 let (data_len, result) = if self
                     .front_io_board_present
-                    .unwrap_or_default()
+                    .unwrap_or(false)
                 {
                     self.get_extended_status(mask, out)
                 } else {
@@ -387,7 +387,7 @@ impl ServerImpl {
                 }
 
                 let (data_len, result) =
-                    if self.front_io_board_present.unwrap_or_default() {
+                    if self.front_io_board_present.unwrap_or(false) {
                         let r = self.read(read, mask & !self.disabled, out);
                         let len = r.success().count() * read.len() as usize;
                         (len, r)
@@ -436,8 +436,7 @@ impl ServerImpl {
                 }
 
                 let mask = LogicalPortMask::from(modules);
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.write(write, mask & !self.disabled, data)
                 } else {
                     ModuleResult::new(
@@ -469,8 +468,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::AssertReset(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.assert_reset(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -494,8 +492,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::DeassertReset(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.deassert_reset(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -519,8 +516,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::AssertLpMode(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.assert_lpmode(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -544,8 +540,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::DeassertLpMode(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.deassert_lpmode(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -569,8 +564,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::EnablePower(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.enable_power(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -594,8 +588,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::DisablePower(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.disable_power(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -645,8 +638,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::ClearPowerFault(modules));
                 let mask = LogicalPortMask::from(modules) & !self.disabled;
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.transceivers.clear_power_fault(mask)
                 } else {
                     ModuleResultNoFailure::new(LogicalPortMask(0), mask)
@@ -671,7 +663,7 @@ impl ServerImpl {
                 let mask = LogicalPortMask::from(modules);
                 let (data_len, result) = if self
                     .front_io_board_present
-                    .unwrap_or_default()
+                    .unwrap_or(false)
                 {
                     self.get_led_state_response(mask, out)
                 } else {
@@ -700,8 +692,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::SetLedState(modules, state));
                 let mask = LogicalPortMask::from(modules);
 
-                let result = if self.front_io_board_present.unwrap_or_default()
-                {
+                let result = if self.front_io_board_present.unwrap_or(false) {
                     self.set_led_state(mask, state);
                     ModuleResultNoFailure::new(mask, LogicalPortMask(0))
                         .unwrap()


### PR DESCRIPTION
Currently the `transceivers` server will loop and await the Front IO board to be ready before entering is service loop. This means that in the case where the Front IO board is not present (or ready), `transceivers` server cannot handle any incoming requests, making the host software that is sending those requests unhappy. This change addresses that.

This is intended to address #1562 