### PR TITLE
Multi region packing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "byteorder",
  "phash",
  "serde",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -73,9 +73,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.10"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
@@ -92,18 +92,18 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
 name = "attest-data"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
+source = "git+https://github.com/oxidecomputer/dice-util#51fb528143d802b7a83127ffd5e4cbe50dd49638"
 dependencies = [
  "hubpack",
  "salty",
  "serde",
- "serde_with 3.3.0",
+ "serde_with 3.5.1",
  "sha3",
 ]
 
@@ -150,12 +150,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitfield"
@@ -357,11 +351,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -432,9 +425,9 @@ checksum = "f9236877021b66ad90f833d8a73a7acb702b985b64c5986682d9f1f1a184f0fb"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield 0.13.2",
@@ -504,15 +497,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
-]
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-utils"
@@ -545,12 +532,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core 0.13.0",
- "darling_macro 0.13.0",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
 ]
 
 [[package]]
@@ -565,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -593,11 +580,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core 0.13.0",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.94",
 ]
@@ -700,7 +687,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
+source = "git+https://github.com/oxidecomputer/dice-util#51fb528143d802b7a83127ffd5e4cbe50dd49638"
 dependencies = [
  "corncobs",
  "hubpack",
@@ -735,7 +722,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -753,7 +740,7 @@ dependencies = [
  "stm32h7",
  "tlvc",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -787,7 +774,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -802,7 +789,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -819,7 +806,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -842,7 +829,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -852,7 +839,7 @@ dependencies = [
  "drv-fpga-api",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -868,7 +855,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -888,7 +875,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -901,7 +888,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -937,7 +924,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -946,7 +933,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -958,7 +945,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -967,7 +954,7 @@ version = "0.1.0"
 dependencies = [
  "drv-i2c-types",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -985,7 +972,7 @@ dependencies = [
  "smbus-pec",
  "task-power-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1027,7 +1014,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1045,7 +1032,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1057,7 +1044,7 @@ dependencies = [
  "drv-i2c-devices",
  "drv-oxide-vpd",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1078,7 +1065,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1092,7 +1079,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1104,7 +1091,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1121,7 +1108,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1140,7 +1127,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1157,7 +1144,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1191,7 +1178,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1215,7 +1202,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1230,7 +1217,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1241,7 +1228,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1259,7 +1246,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1273,10 +1260,10 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "lib-lpc55-usart",
  "lpc55-pac",
- "nb 1.0.0",
+ "nb 1.1.0",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1292,7 +1279,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1303,7 +1290,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1317,7 +1304,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1331,7 +1318,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1347,7 +1334,7 @@ dependencies = [
  "userlib",
  "vsc7448",
  "vsc85xx",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1356,7 +1343,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1366,7 +1353,7 @@ dependencies = [
  "drv-onewire",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1377,7 +1364,7 @@ dependencies = [
  "drv-i2c-devices",
  "ringbuf",
  "tlvc",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1427,7 +1414,7 @@ dependencies = [
  "num-traits",
  "rand_core",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1446,7 +1433,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1459,7 +1446,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1482,7 +1469,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1504,7 +1491,7 @@ dependencies = [
  "serde",
  "serde_json",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1530,7 +1517,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1557,7 +1544,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1569,7 +1556,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1587,7 +1574,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1616,7 +1603,7 @@ dependencies = [
  "tlvc",
  "unwrap-lite",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1627,7 +1614,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1639,7 +1626,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1652,7 +1639,7 @@ dependencies = [
  "num-traits",
  "stm32g0",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1680,7 +1667,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1698,7 +1685,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1709,7 +1696,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1723,7 +1710,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1734,7 +1721,7 @@ dependencies = [
  "ringbuf",
  "stm32h7",
  "vcell",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1749,7 +1736,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1778,7 +1765,7 @@ dependencies = [
  "stm32h7",
  "syn 1.0.94",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1804,7 +1791,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1829,7 +1816,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1850,7 +1837,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1867,7 +1854,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1906,7 +1893,7 @@ dependencies = [
  "stm32h7",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1921,7 +1908,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1944,7 +1931,7 @@ dependencies = [
  "task-sensor-api",
  "transceiver-messages",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1976,7 +1963,7 @@ dependencies = [
  "task-thermal-api",
  "transceiver-messages",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1992,7 +1979,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2013,7 +2000,7 @@ dependencies = [
  "stm32f4",
  "task-config",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2024,7 +2011,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2040,7 +2027,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2055,7 +2042,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2075,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embedded-crc-macros"
@@ -2087,9 +2074,9 @@ checksum = "4f1c75747a43b086df1a87fb2a889590bc0725e0abf54bba6d0c4bf7bd9e762c"
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -2114,22 +2101,22 @@ dependencies = [
 
 [[package]]
 name = "enum-map"
-version = "2.4.1"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a56d54c8dd9b3ad34752ed197a4eb2a6601bc010808eb097a04a58ae4c43e1"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.10.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9045e2676cd5af83c3b167d917b0a5c90a4d8e266e2683d6631b235c457fc27"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2207,7 +2194,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#7f0bdd583be56510780cee5b008361d9eed86d9d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#fe874caf3c7549de64ce73c53ce4687578904156"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",
@@ -2217,7 +2204,7 @@ dependencies = [
  "static_assertions",
  "strum_macros",
  "uuid",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2331,15 +2318,15 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
  "serde",
- "spin 0.9.4",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2382,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -2416,7 +2403,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-types",
  "unwrap-lite",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2462,7 +2449,7 @@ dependencies = [
  "tlvc-text",
  "toml",
  "x509-cert",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
  "zip",
 ]
 
@@ -2476,7 +2463,7 @@ dependencies = [
  "serde",
  "serde-big-array 0.5.1",
  "static_assertions",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2503,7 +2490,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
 dependencies = [
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2590,7 +2577,7 @@ dependencies = [
  "ssmarshal",
  "syn 1.0.94",
  "unwrap-lite",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2623,7 +2610,7 @@ dependencies = [
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
- "nb 1.0.0",
+ "nb 1.1.0",
  "salty",
  "serde",
  "serde-big-array 0.4.1",
@@ -2632,7 +2619,7 @@ dependencies = [
  "static_assertions",
  "unwrap-lite",
  "vcell",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
  "zeroize",
 ]
 
@@ -2642,7 +2629,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal",
  "lpc55-pac",
- "nb 1.0.0",
+ "nb 1.1.0",
  "unwrap-lite",
 ]
 
@@ -2666,9 +2653,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -2690,7 +2677,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2736,7 +2723,7 @@ dependencies = [
  "lpc55-pac",
  "lpc55-puf",
  "lpc55_romapi",
- "nb 1.0.0",
+ "nb 1.1.0",
  "ron",
  "salty",
  "serde",
@@ -2745,7 +2732,7 @@ dependencies = [
  "static_assertions",
  "toml",
  "unwrap-lite",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
  "zeroize",
 ]
 
@@ -2774,7 +2761,7 @@ dependencies = [
  "task-jefe-api",
  "tlvc",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2819,7 +2806,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "x509-cert",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2890,14 +2877,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nix"
@@ -2914,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -2944,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -2964,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -2974,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2985,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3055,7 +3042,7 @@ version = "0.1.0"
 dependencies = [
  "hubpack",
  "serde",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -3096,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-slash"
@@ -3192,8 +3179,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pmbus"
-version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/pmbus#735a70bbc90707a963ec1731c8a0fa427a013f21"
+version = "0.1.2"
+source = "git+https://github.com/oxidecomputer/pmbus#c7e916cdfd75091c1b06d8348ad9e03fcb295cb2"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -3202,14 +3189,14 @@ dependencies = [
  "num-traits",
  "ron",
  "serde",
- "serde_with 1.11.0",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
 name = "postcard"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8863e251332eb18520388099b8b0acc4810ed6e602e3b6f674e8a46ba20e15c"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "heapless",
  "postcard-cobs",
@@ -3254,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3380,27 +3367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "ron"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,7 +3428,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.13",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -3481,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -3513,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -3558,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "semver-parser"
@@ -3628,13 +3594,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.8"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3648,32 +3614,31 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
- "rustversion",
  "serde",
- "serde_with_macros 1.5.1",
+ "serde_with_macros 1.5.2",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.3.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
  "serde",
- "serde_with_macros 3.3.0",
+ "serde_with_macros 3.5.1",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling 0.13.0",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.94",
@@ -3681,9 +3646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.3.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -3780,9 +3745,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -3926,7 +3891,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -3937,9 +3902,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum_macros"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3977,18 +3942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.94",
- "unicode-xid",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,12 +3965,12 @@ dependencies = [
  "ringbuf",
  "salty",
  "serde",
- "serde_with 3.3.0",
+ "serde_with 3.5.1",
  "sha3",
  "stage0-handoff",
  "unwrap-lite",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4032,7 +3985,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4088,7 +4041,7 @@ dependencies = [
  "task-validate-api",
  "update-buffer",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4104,7 +4057,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4130,7 +4083,7 @@ dependencies = [
  "task-jefe-api",
  "task-net-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4149,7 +4102,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4195,7 +4148,7 @@ dependencies = [
  "static-cell",
  "test-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4238,7 +4191,7 @@ dependencies = [
  "task-sensor-api",
  "tlvc",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4252,7 +4205,7 @@ dependencies = [
  "num-traits",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4284,7 +4237,7 @@ dependencies = [
  "ssmarshal",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4300,7 +4253,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4328,7 +4281,7 @@ dependencies = [
  "vsc7448",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4373,7 +4326,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4393,7 +4346,7 @@ dependencies = [
  "smoltcp",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4413,7 +4366,7 @@ dependencies = [
  "static_assertions",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4427,7 +4380,7 @@ dependencies = [
  "num-traits",
  "oxide-barcode",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4477,7 +4430,7 @@ dependencies = [
  "task-power-api",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4494,7 +4447,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4517,7 +4470,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4535,7 +4488,7 @@ dependencies = [
  "serde",
  "task-sensor-types",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4551,7 +4504,7 @@ dependencies = [
  "ringbuf",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4564,7 +4517,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4638,7 +4591,7 @@ dependencies = [
  "task-sensor-api",
  "task-thermal-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4655,7 +4608,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4683,7 +4636,7 @@ dependencies = [
  "task-net-api",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4705,7 +4658,7 @@ dependencies = [
  "build-util",
  "task-net-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4727,7 +4680,7 @@ dependencies = [
  "serde",
  "task-validate-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4744,7 +4697,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4764,7 +4717,7 @@ dependencies = [
  "ringbuf",
  "task-vpd-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4777,7 +4730,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4796,7 +4749,7 @@ dependencies = [
  "build-util",
  "num-traits",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4809,7 +4762,7 @@ dependencies = [
  "num-traits",
  "test-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4823,7 +4776,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4838,7 +4791,7 @@ dependencies = [
  "ssmarshal",
  "test-idol-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4854,7 +4807,7 @@ dependencies = [
  "ringbuf",
  "test-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4874,7 +4827,7 @@ dependencies = [
  "test-api",
  "test-idol-api",
  "userlib",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -5001,7 +4954,7 @@ source = "git+https://github.com/oxidecomputer/tlvc#e644a21a7ca973ed31499106ea92
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -5012,7 +4965,7 @@ dependencies = [
  "ron",
  "serde",
  "tlvc",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -5071,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/transceiver-control/#84e28d1263d9d07c5410fb0644469c8eb7b5fb5f"
+source = "git+https://github.com/oxidecomputer/transceiver-control/#f7311cc31a74fb32fa481030a634996d39cf43ad"
 dependencies = [
  "bitflags 2.4.1",
  "hubpack",
@@ -5110,7 +5063,7 @@ version = "0.1.0"
 name = "update-buffer"
 version = "0.1.0"
 dependencies = [
- "spin 0.9.4",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -5130,14 +5083,14 @@ dependencies = [
  "ssmarshal",
  "unwrap-lite",
  "volatile-const",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "vcell"
@@ -5163,9 +5116,9 @@ version = "0.1.0"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]
@@ -5210,7 +5163,7 @@ dependencies = [
  "userlib",
  "vsc-err",
  "vsc7448-pac",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -5398,18 +5351,18 @@ dependencies = [
  "toml-task",
  "toml_edit",
  "walkdir",
- "zerocopy 0.6.4",
+ "zerocopy 0.6.6",
  "zip",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.6.4",
+ "zerocopy-derive 0.6.6",
 ]
 
 [[package]]
@@ -5424,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5455,14 +5408,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.94",
- "synstructure",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "byteorder",
  "phash",
  "serde",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -73,9 +73,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
  "critical-section",
 ]
@@ -92,18 +92,18 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
 name = "attest-data"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dice-util#51fb528143d802b7a83127ffd5e4cbe50dd49638"
+source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
 dependencies = [
  "hubpack",
  "salty",
  "serde",
- "serde_with 3.5.1",
+ "serde_with 3.3.0",
  "sha3",
 ]
 
@@ -150,6 +150,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitfield"
@@ -351,10 +357,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -425,9 +432,9 @@ checksum = "f9236877021b66ad90f833d8a73a7acb702b985b64c5986682d9f1f1a184f0fb"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.7"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield 0.13.2",
@@ -497,9 +504,15 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m",
+ "riscv",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -532,12 +545,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
+ "darling_core 0.13.0",
+ "darling_macro 0.13.0",
 ]
 
 [[package]]
@@ -552,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
 dependencies = [
  "fnv",
  "ident_case",
@@ -580,11 +593,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core 0.13.4",
+ "darling_core 0.13.0",
  "quote",
  "syn 1.0.94",
 ]
@@ -687,7 +700,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/dice-util#51fb528143d802b7a83127ffd5e4cbe50dd49638"
+source = "git+https://github.com/oxidecomputer/dice-util#785ee6db783ecaafd741fcf59e21f2432e27c5ef"
 dependencies = [
  "corncobs",
  "hubpack",
@@ -722,7 +735,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -740,7 +753,7 @@ dependencies = [
  "stm32h7",
  "tlvc",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -774,7 +787,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -789,7 +802,7 @@ dependencies = [
  "sha3",
  "tlvc",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -806,7 +819,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -829,7 +842,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -839,7 +852,7 @@ dependencies = [
  "drv-fpga-api",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -855,7 +868,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -875,7 +888,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -888,7 +901,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -924,7 +937,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -933,7 +946,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -945,7 +958,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -954,7 +967,7 @@ version = "0.1.0"
 dependencies = [
  "drv-i2c-types",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -972,7 +985,7 @@ dependencies = [
  "smbus-pec",
  "task-power-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1014,7 +1027,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1032,7 +1045,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1044,7 +1057,7 @@ dependencies = [
  "drv-i2c-devices",
  "drv-oxide-vpd",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1065,7 +1078,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1079,7 +1092,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1091,7 +1104,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1108,7 +1121,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1127,7 +1140,7 @@ dependencies = [
  "lpc55-pac",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1144,7 +1157,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1178,7 +1191,7 @@ dependencies = [
  "static_assertions",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1202,7 +1215,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1217,7 +1230,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1228,7 +1241,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1246,7 +1259,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1260,10 +1273,10 @@ dependencies = [
  "drv-lpc55-syscon-api",
  "lib-lpc55-usart",
  "lpc55-pac",
- "nb 1.1.0",
+ "nb 1.0.0",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1279,7 +1292,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1290,7 +1303,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1304,7 +1317,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1318,7 +1331,7 @@ dependencies = [
  "num-traits",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1334,7 +1347,7 @@ dependencies = [
  "userlib",
  "vsc7448",
  "vsc85xx",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1343,7 +1356,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1353,7 +1366,7 @@ dependencies = [
  "drv-onewire",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1364,7 +1377,7 @@ dependencies = [
  "drv-i2c-devices",
  "ringbuf",
  "tlvc",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1414,7 +1427,7 @@ dependencies = [
  "num-traits",
  "rand_core",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1433,7 +1446,7 @@ dependencies = [
  "num-traits",
  "ringbuf",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1446,7 +1459,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1469,7 +1482,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1491,7 +1504,7 @@ dependencies = [
  "serde",
  "serde_json",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1517,7 +1530,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1544,7 +1557,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1556,7 +1569,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1574,7 +1587,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1603,7 +1616,7 @@ dependencies = [
  "tlvc",
  "unwrap-lite",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1614,7 +1627,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1626,7 +1639,7 @@ dependencies = [
  "stm32f3",
  "stm32f4",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1639,7 +1652,7 @@ dependencies = [
  "num-traits",
  "stm32g0",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1667,7 +1680,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1685,7 +1698,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1696,7 +1709,7 @@ dependencies = [
  "stm32h7",
  "userlib",
  "vcell",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1710,7 +1723,7 @@ dependencies = [
  "num-traits",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1721,7 +1734,7 @@ dependencies = [
  "ringbuf",
  "stm32h7",
  "vcell",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1736,7 +1749,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1765,7 +1778,7 @@ dependencies = [
  "stm32h7",
  "syn 1.0.94",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1791,7 +1804,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1816,7 +1829,7 @@ dependencies = [
  "serde",
  "stage0-handoff",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1837,7 +1850,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1854,7 +1867,7 @@ dependencies = [
  "stm32g0",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1893,7 +1906,7 @@ dependencies = [
  "stm32h7",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1908,7 +1921,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1931,7 +1944,7 @@ dependencies = [
  "task-sensor-api",
  "transceiver-messages",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1963,7 +1976,7 @@ dependencies = [
  "task-thermal-api",
  "transceiver-messages",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -1979,7 +1992,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2000,7 +2013,7 @@ dependencies = [
  "stm32f4",
  "task-config",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2011,7 +2024,7 @@ dependencies = [
  "idol",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2027,7 +2040,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2042,7 +2055,7 @@ dependencies = [
  "num-traits",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2062,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "embedded-crc-macros"
@@ -2074,9 +2087,9 @@ checksum = "4f1c75747a43b086df1a87fb2a889590bc0725e0abf54bba6d0c4bf7bd9e762c"
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -2101,22 +2114,22 @@ dependencies = [
 
 [[package]]
 name = "enum-map"
-version = "2.7.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+checksum = "f5a56d54c8dd9b3ad34752ed197a4eb2a6601bc010808eb097a04a58ae4c43e1"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.17.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+checksum = "a9045e2676cd5af83c3b167d917b0a5c90a4d8e266e2683d6631b235c457fc27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -2194,7 +2207,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#fe874caf3c7549de64ce73c53ce4687578904156"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#7f0bdd583be56510780cee5b008361d9eed86d9d"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack",
@@ -2204,7 +2217,7 @@ dependencies = [
  "static_assertions",
  "strum_macros",
  "uuid",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2318,15 +2331,15 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.4",
  "stable_deref_trait",
 ]
 
@@ -2369,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
  "hmac",
 ]
@@ -2403,7 +2416,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-types",
  "unwrap-lite",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2449,7 +2462,7 @@ dependencies = [
  "tlvc-text",
  "toml",
  "x509-cert",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
  "zip",
 ]
 
@@ -2463,7 +2476,7 @@ dependencies = [
  "serde",
  "serde-big-array 0.5.1",
  "static_assertions",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2490,7 +2503,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
 dependencies = [
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2577,7 +2590,7 @@ dependencies = [
  "ssmarshal",
  "syn 1.0.94",
  "unwrap-lite",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2610,7 +2623,7 @@ dependencies = [
  "hubpack",
  "lib-lpc55-usart",
  "lpc55-pac",
- "nb 1.1.0",
+ "nb 1.0.0",
  "salty",
  "serde",
  "serde-big-array 0.4.1",
@@ -2619,7 +2632,7 @@ dependencies = [
  "static_assertions",
  "unwrap-lite",
  "vcell",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
  "zeroize",
 ]
 
@@ -2629,7 +2642,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal",
  "lpc55-pac",
- "nb 1.1.0",
+ "nb 1.0.0",
  "unwrap-lite",
 ]
 
@@ -2653,9 +2666,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -2677,7 +2690,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2723,7 +2736,7 @@ dependencies = [
  "lpc55-pac",
  "lpc55-puf",
  "lpc55_romapi",
- "nb 1.1.0",
+ "nb 1.0.0",
  "ron",
  "salty",
  "serde",
@@ -2732,7 +2745,7 @@ dependencies = [
  "static_assertions",
  "toml",
  "unwrap-lite",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
  "zeroize",
 ]
 
@@ -2761,7 +2774,7 @@ dependencies = [
  "task-jefe-api",
  "tlvc",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2806,7 +2819,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "x509-cert",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -2877,14 +2890,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.1.0",
+ "nb 1.0.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "nix"
@@ -2901,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -2931,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
 ]
@@ -2951,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -2961,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2972,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3042,7 +3055,7 @@ version = "0.1.0"
 dependencies = [
  "hubpack",
  "serde",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3083,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "path-slash"
@@ -3179,8 +3192,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pmbus"
-version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/pmbus#c7e916cdfd75091c1b06d8348ad9e03fcb295cb2"
+version = "0.1.1"
+source = "git+https://github.com/oxidecomputer/pmbus#735a70bbc90707a963ec1731c8a0fa427a013f21"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -3189,14 +3202,14 @@ dependencies = [
  "num-traits",
  "ron",
  "serde",
- "serde_with 1.14.0",
+ "serde_with 1.11.0",
 ]
 
 [[package]]
 name = "postcard"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+checksum = "c8863e251332eb18520388099b8b0acc4810ed6e602e3b6f674e8a46ba20e15c"
 dependencies = [
  "heapless",
  "postcard-cobs",
@@ -3241,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -3367,6 +3380,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3462,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.21",
+ "semver 1.0.13",
 ]
 
 [[package]]
@@ -3447,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -3479,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
@@ -3524,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "semver-parser"
@@ -3594,13 +3628,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.17"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -3614,31 +3648,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
+ "rustversion",
  "serde",
- "serde_with_macros 1.5.2",
+ "serde_with_macros 1.5.1",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.5.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
  "serde",
- "serde_with_macros 3.5.1",
+ "serde_with_macros 3.3.0",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling 0.13.4",
+ "darling 0.13.0",
  "proc-macro2",
  "quote",
  "syn 1.0.94",
@@ -3646,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.5.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -3745,9 +3780,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -3891,7 +3926,7 @@ dependencies = [
  "serde",
  "stm32h7",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3902,9 +3937,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3942,6 +3977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.94",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,12 +4012,12 @@ dependencies = [
  "ringbuf",
  "salty",
  "serde",
- "serde_with 3.5.1",
+ "serde_with 3.3.0",
  "sha3",
  "stage0-handoff",
  "unwrap-lite",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -3985,7 +4032,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4041,7 +4088,7 @@ dependencies = [
  "task-validate-api",
  "update-buffer",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4057,7 +4104,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4083,7 +4130,7 @@ dependencies = [
  "task-jefe-api",
  "task-net-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4102,7 +4149,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4148,7 +4195,7 @@ dependencies = [
  "static-cell",
  "test-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4191,7 +4238,7 @@ dependencies = [
  "task-sensor-api",
  "tlvc",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4205,7 +4252,7 @@ dependencies = [
  "num-traits",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4237,7 +4284,7 @@ dependencies = [
  "ssmarshal",
  "task-jefe-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4253,7 +4300,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4281,7 +4328,7 @@ dependencies = [
  "vsc7448",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4326,7 +4373,7 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4346,7 +4393,7 @@ dependencies = [
  "smoltcp",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4366,7 +4413,7 @@ dependencies = [
  "static_assertions",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4380,7 +4427,7 @@ dependencies = [
  "num-traits",
  "oxide-barcode",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4430,7 +4477,7 @@ dependencies = [
  "task-power-api",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4447,7 +4494,7 @@ dependencies = [
  "static_assertions",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4470,7 +4517,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4488,7 +4535,7 @@ dependencies = [
  "serde",
  "task-sensor-types",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4504,7 +4551,7 @@ dependencies = [
  "ringbuf",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4517,7 +4564,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4591,7 +4638,7 @@ dependencies = [
  "task-sensor-api",
  "task-thermal-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4608,7 +4655,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4636,7 +4683,7 @@ dependencies = [
  "task-net-api",
  "task-packrat-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4658,7 +4705,7 @@ dependencies = [
  "build-util",
  "task-net-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4680,7 +4727,7 @@ dependencies = [
  "serde",
  "task-validate-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4697,7 +4744,7 @@ dependencies = [
  "serde",
  "task-sensor-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4717,7 +4764,7 @@ dependencies = [
  "ringbuf",
  "task-vpd-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4730,7 +4777,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4749,7 +4796,7 @@ dependencies = [
  "build-util",
  "num-traits",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4762,7 +4809,7 @@ dependencies = [
  "num-traits",
  "test-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4776,7 +4823,7 @@ dependencies = [
  "serde",
  "ssmarshal",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4791,7 +4838,7 @@ dependencies = [
  "ssmarshal",
  "test-idol-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4807,7 +4854,7 @@ dependencies = [
  "ringbuf",
  "test-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4827,7 +4874,7 @@ dependencies = [
  "test-api",
  "test-idol-api",
  "userlib",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4954,7 +5001,7 @@ source = "git+https://github.com/oxidecomputer/tlvc#e644a21a7ca973ed31499106ea92
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4965,7 +5012,7 @@ dependencies = [
  "ron",
  "serde",
  "tlvc",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5024,7 +5071,7 @@ dependencies = [
 [[package]]
 name = "transceiver-messages"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/transceiver-control/#f7311cc31a74fb32fa481030a634996d39cf43ad"
+source = "git+https://github.com/oxidecomputer/transceiver-control/#84e28d1263d9d07c5410fb0644469c8eb7b5fb5f"
 dependencies = [
  "bitflags 2.4.1",
  "hubpack",
@@ -5063,7 +5110,7 @@ version = "0.1.0"
 name = "update-buffer"
 version = "0.1.0"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -5083,14 +5130,14 @@ dependencies = [
  "ssmarshal",
  "unwrap-lite",
  "volatile-const",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 
 [[package]]
 name = "vcell"
@@ -5116,9 +5163,9 @@ version = "0.1.0"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
 ]
@@ -5163,7 +5210,7 @@ dependencies = [
  "userlib",
  "vsc-err",
  "vsc7448-pac",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5351,18 +5398,18 @@ dependencies = [
  "toml-task",
  "toml_edit",
  "walkdir",
- "zerocopy 0.6.6",
+ "zerocopy 0.6.4",
  "zip",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.6.6",
+ "zerocopy-derive 0.6.4",
 ]
 
 [[package]]
@@ -5377,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5408,13 +5455,14 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 1.0.94",
+ "synstructure",
 ]
 
 [[package]]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 24600, ram = 6256}
+requires = {flash = 24960, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 24960, ram = 6256}
+requires = {flash = 25120, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 25120, ram = 6256}
+requires = {flash = 25184, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/build/kconfig/src/lib.rs
+++ b/build/kconfig/src/lib.rs
@@ -51,7 +51,7 @@ pub struct TaskConfig {
     ///
     /// The name is the "output" assignment that generated this region,
     /// typically (but not necessarily!) either `"ram"` or `"flash"`.
-    pub owned_regions: BTreeMap<String, RegionConfig>,
+    pub owned_regions: BTreeMap<String, MultiRegionConfig>,
 
     /// Names of regions (in the app-level `shared_regions`) that this task
     /// needs access to.
@@ -113,6 +113,24 @@ pub struct RegionConfig {
     /// for this; it must meet them. (For example, on ARMv7-M, it must be a
     /// power of two greater than 16.)
     pub size: u32,
+    /// Flags describing what can be done with this region.
+    pub attributes: RegionAttributes,
+}
+
+/// Description of one memory span containing multiple adjacent regions
+///
+/// This is equivalent to [`RegionConfig`], but represents a single memory span
+/// that should be configured as multiple regions in the MPU.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MultiRegionConfig {
+    /// Address of start of region. The platform likely has alignment
+    /// requirements for this; it must meet them. (For example, on ARMv7-M, it
+    /// must be naturally aligned for the size.)
+    pub base: u32,
+    /// Size of region, in bytes for each chunk. The platform likely has
+    /// alignment requirements for this; it must meet them. (For example, on
+    /// ARMv7-M, it must be a power of two greater than 16.)
+    pub sizes: Vec<u32>,
     /// Flags describing what can be done with this region.
     pub attributes: RegionAttributes,
 }

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -72,7 +72,7 @@ pub fn run(
             let mut entry_points: std::collections::HashMap<_, _> = allocs
                 .tasks
                 .iter()
-                .map(|(k, v)| (k.clone(), v["flash"][0].start))
+                .map(|(k, v)| (k.clone(), v["flash"].start()))
                 .collect();
 
             // add a dummy caboose point

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -5,7 +5,6 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
-use indexmap::IndexMap;
 
 use crate::config::Config;
 
@@ -49,8 +48,10 @@ pub fn run(
 
         let build_config = if name == "kernel" {
             // Build dummy allocations for each task
-            let fake_sizes: IndexMap<_, _> =
-                [("flash", 64), ("ram", 64)].into_iter().collect();
+            let fake_sizes = crate::dist::TaskRequest {
+                memory: [("flash", 64), ("ram", 64)].into_iter().collect(),
+                spare_regions: 0,
+            };
             let task_sizes = toml
                 .tasks
                 .keys()
@@ -71,7 +72,7 @@ pub fn run(
             let mut entry_points: std::collections::HashMap<_, _> = allocs
                 .tasks
                 .iter()
-                .map(|(k, v)| (k.clone(), v["flash"].start))
+                .map(|(k, v)| (k.clone(), v["flash"][0].start))
                 .collect();
 
             // add a dummy caboose point

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -572,6 +572,23 @@ impl MpuAlignment {
                         break;
                     }
                 }
+                // Split the initial (largest) region into as many smaller
+                // regions as we can fit.  This doesn't change total size, but
+                // can make alignment more flexible, since smaller regions have
+                // less stringent alignment requirements.
+                while out[0] > MIN_MPU_REGION_SIZE {
+                    let largest = out[0];
+                    let n = out.iter().filter(|c| **c == largest).count();
+                    if out.len() + n > regions {
+                        break;
+                    }
+                    // Replace `n` instances of `largest` at the start of `out`
+                    // with `n * 2` instances of `largest / 2`
+                    out[0..n].fill(largest / 2);
+                    for _ in 0..n {
+                        out.insert(0, largest / 2);
+                    }
+                }
                 out
             }
             MpuAlignment::Chunk(c) => vec![((size + c - 1) / c) * c],

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2021,7 +2021,12 @@ fn allocate_region(
             // We can always place the chunk using forward orientation, albeit
             // with padding if it's not aligned.
             let gap_forward = base - avail.start;
-            best.update(gap_forward, align, task_name, Direction::Forward);
+            best.update(
+                gap_forward,
+                *mem.last().unwrap(),
+                task_name,
+                Direction::Forward,
+            );
         }
         let Some(sizes) = t_reqs.remove(best.name) else {
             panic!("could not find a task");

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -295,7 +295,6 @@ pub fn package(
                 .as_ref()
                 .map(|c| c.tasks.contains(&t.to_string()))
                 .unwrap_or(false) as usize;
-        println!("task {t} has {} spare regions", 7 - n);
 
         task_reqs.insert(
             t,
@@ -1948,13 +1947,7 @@ fn allocate_region(
             .insert(region.to_string(), allocate_k(region, sz, avail)?);
     }
 
-    println!("PACKING!");
-    for (&task_name, mem) in t_reqs.iter() {
-        println!("  {task_name}, {mem:?}");
-    }
-
     while !t_reqs.is_empty() {
-        println!("avail: {avail:x?}");
         // At this point, we need to find a task that fits based on our existing
         // alignment.  This is tricky, because -- for efficient packing -- we
         // allow tasks to span multiple regions.  For example, a task could look
@@ -2060,9 +2053,6 @@ fn allocate_region(
                 }
             }
         }
-
-        println!("found best: {best:#x?}");
-        println!("{:x?}", allocs.tasks[best.name][region]);
 
         // Check that our allocations are all aligned and contiguous
         let ra = &allocs.tasks[best.name][region];

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2066,12 +2066,11 @@ fn allocate_region(
         while let Some(mut size) = sizes.pop_front() {
             // When building the size list, we split the largest size to reduce
             // alignment requirements.  Now, we try to merge them again, to
-            // reduce the number of regions stored in the kernel's flash. 
+            // reduce the number of regions stored in the kernel's flash.
             //
             // For example, [256, 256, 64] => [512, 64] if the initial position
             // is aligned for a 512-byte region.
             let mut n = sizes.iter().filter(|s| **s == size).count() + 1;
-            println!("{size}, {sizes:?}");
             if n > 1 {
                 n &= !1; // only consider an even number of regions
                 let possible_align = toml.task_memory_alignment(size * 2);
@@ -2083,7 +2082,6 @@ fn allocate_region(
                     for _ in 0..n / 2 - 1 {
                         sizes.push_front(size);
                     }
-                    println!("   => {size}, {sizes:?}")
                 }
             }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -283,9 +283,9 @@ impl OrderedVecDeque {
     fn push_front(&mut self, v: u32) {
         if let Some(f) = self.front() {
             if self.increasing {
-                assert!(v >= *f);
-            } else {
                 assert!(v <= *f);
+            } else {
+                assert!(v >= *f);
             }
         }
         self.data.push_front(v)

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::fmt::Write as _;
 use std::fs::{self, File};
@@ -279,9 +279,36 @@ pub fn package(
         })
         .collect::<Result<_, _>>()?;
 
+    // Build a set of requests for the memory allocator
+    let mut task_reqs = HashMap::new();
+    for (t, sz) in task_sizes {
+        let n = sz.len()
+            + cfg
+                .toml
+                .extern_regions_for(t, &cfg.toml.image_names[0])
+                .unwrap()
+                .len()
+            + cfg.toml.tasks.get(t).unwrap().uses.len()
+            + cfg
+                .toml
+                .caboose
+                .as_ref()
+                .map(|c| c.tasks.contains(&t.to_string()))
+                .unwrap_or(false) as usize;
+        println!("task {t} has {} spare regions", 7 - n);
+
+        task_reqs.insert(
+            t,
+            TaskRequest {
+                memory: sz,
+                spare_regions: 7 - n,
+            },
+        );
+    }
+
     // Allocate memories.
     let allocated =
-        allocate_all(&cfg.toml, &task_sizes, cfg.toml.caboose.as_ref())?;
+        allocate_all(&cfg.toml, &task_reqs, cfg.toml.caboose.as_ref())?;
 
     for image_name in &cfg.toml.image_names {
         // Build each task.
@@ -330,7 +357,7 @@ pub fn package(
                     task_entry_point(&cfg, name, image_name)
                 } else {
                     // Dummy entry point
-                    Ok(allocs.tasks[name]["flash"].start)
+                    Ok(allocs.tasks[name]["flash"][0].start)
                 };
                 ep.map(|ep| (name.clone(), ep))
             })
@@ -976,6 +1003,7 @@ fn link_dummy_task(
         .toml
         .memories(&cfg.toml.image_names[0])?
         .into_iter()
+        .map(|(name, r)| (name, vec![r]))
         .collect();
     let extern_regions = cfg.toml.extern_regions_for(name, image_name)?;
 
@@ -1290,7 +1318,7 @@ fn check_task_priorities(toml: &Config) -> Result<()> {
 
 fn generate_task_linker_script(
     name: &str,
-    map: &BTreeMap<String, Range<u32>>,
+    map: &BTreeMap<String, Vec<Range<u32>>>,
     sections: Option<&IndexMap<String, String>>,
     stacksize: u32,
     images: &IndexMap<String, Range<u32>>,
@@ -1311,8 +1339,8 @@ fn generate_task_linker_script(
 
     writeln!(linkscr, "MEMORY\n{{")?;
     for (name, range) in map {
-        let mut start = range.start;
-        let end = range.end;
+        let mut start = range[0].start;
+        let end = range.last().unwrap().end;
         let name = name.to_ascii_uppercase();
 
         // Our stack comes out of RAM
@@ -1735,7 +1763,11 @@ pub struct Allocations {
     /// Map from memory-name to address-range
     pub kernel: BTreeMap<String, Range<u32>>,
     /// Map from task-name to memory-name to address-range
-    pub tasks: BTreeMap<String, BTreeMap<String, Range<u32>>>,
+    ///
+    /// A task may have multiple address ranges in the same memory space for
+    /// efficient packing; if this is the case, the addresses will be contiguous
+    /// and each individual range will respect MPU requirements.
+    pub tasks: BTreeMap<String, BTreeMap<String, Vec<Range<u32>>>>,
     /// Optional trailing caboose, located in the given region
     pub caboose: Option<(String, Range<u32>)>,
 }
@@ -1759,6 +1791,18 @@ impl Allocations {
         }
         out
     }
+}
+
+/// A set of memory requests from a single task
+#[derive(Debug, Clone)]
+pub struct TaskRequest<'a> {
+    /// Memory requests, as a map from memory name -> size
+    pub memory: IndexMap<&'a str, u64>,
+
+    /// Number of extra regions available for more efficient packing
+    ///
+    /// If this is zero, then each request in `memory` can only use 1 region
+    pub spare_regions: usize,
 }
 
 /// Allocates address space from all regions for the kernel and all tasks.
@@ -1797,7 +1841,7 @@ impl Allocations {
 /// requests per alignment size.
 pub fn allocate_all(
     toml: &Config,
-    task_sizes: &HashMap<&str, IndexMap<&str, u64>>,
+    task_sizes: &HashMap<&str, TaskRequest>,
     caboose: Option<&CabooseConfig>,
 ) -> Result<BTreeMap<String, AllocationMap>> {
     // Collect all allocation requests into queues, one per memory type, indexed
@@ -1807,7 +1851,7 @@ pub fn allocate_all(
     // We keep kernel and task requests separate so we can always service the
     // kernel first.
     //
-    // The task map is: memory name -> allocation size -> queue of task name.
+    // The task map is: memory name -> task name -> requested regions
     // The kernel map is: memory name -> allocation size
     let kernel = &toml.kernel;
     let tasks = &toml.tasks;
@@ -1821,105 +1865,50 @@ pub fn allocate_all(
         let mut free = toml.memories(image_name)?;
         let kernel_requests = &kernel.requires;
 
-        let mut task_requests: BTreeMap<&str, BTreeMap<u32, VecDeque<&str>>> =
+        let mut task_requests: BTreeMap<&str, IndexMap<&str, Vec<u32>>> =
             BTreeMap::new();
 
         for name in tasks.keys() {
-            for (mem, amt) in task_sizes[name.as_str()].iter() {
-                let bytes = toml.suggest_memory_region_size(name, *amt);
+            let req = &task_sizes[name.as_str()];
+            for (&mem, &amt) in req.memory.iter() {
+                // Right now, flash is most limited, so it gets to use all of
+                // our spare regions (if present)
+                let n = if mem == "flash" {
+                    req.spare_regions + 1
+                } else {
+                    1
+                };
+                let bytes = toml.suggest_memory_region_size(name, amt, n);
                 if let Some(r) = tasks[name].max_sizes.get(&mem.to_string()) {
-                    if bytes > *r as u64 {
+                    let total_bytes = bytes.iter().sum::<u64>();
+                    if total_bytes > *r as u64 {
                         bail!(
                         "task {}: needs {} bytes of {} but max-sizes limits it to {}",
-                        name, bytes, mem, r);
+                        name, total_bytes, mem, r);
                     }
                 }
+                let bytes: Vec<u32> =
+                    bytes.into_iter().map(|v| v.try_into().unwrap()).collect();
                 task_requests
                     .entry(mem)
                     .or_default()
-                    .entry(bytes.try_into().unwrap())
-                    .or_default()
-                    .push_back(name.as_str());
+                    .insert(name.as_str(), bytes);
             }
         }
 
         // Okay! Do memory types one by one, fitting kernel first.
         for (region, avail) in &mut free {
             let mut k_req = kernel_requests.get(region.as_str());
-            let mut t_reqs = task_requests.get_mut(region.as_str());
-
-            fn reqs_map_not_empty(
-                om: &Option<&mut BTreeMap<u32, VecDeque<&str>>>,
-            ) -> bool {
-                om.iter()
-                    .flat_map(|map| map.values())
-                    .any(|q| !q.is_empty())
-            }
-
-            'fitloop: while k_req.is_some() || reqs_map_not_empty(&t_reqs) {
-                let align = if avail.start == 0 {
-                    // Lie to keep the masks in range. This could be avoided by
-                    // tracking log2 of masks rather than masks.
-                    1 << 31
-                } else {
-                    1 << avail.start.trailing_zeros()
-                };
-
-                // Search order is:
-                // - Kernel.
-                // - Task requests equal to or smaller than this alignment, in
-                //   descending order of size.
-                // - Task requests larger than this alignment, in ascending
-                //   order of size.
-
-                if let Some(&sz) = k_req.take() {
-                    // The kernel wants in on this.
-                    allocs.kernel.insert(
-                        region.to_string(),
-                        allocate_k(region, sz, avail)?,
-                    );
-                    continue 'fitloop;
-                }
-
-                if let Some(t_reqs) = t_reqs.as_mut() {
-                    for (&sz, q) in t_reqs.range_mut(..=align).rev() {
-                        if let Some(task) = q.pop_front() {
-                            // We can pack an equal or smaller one in.
-                            let align = toml.task_memory_alignment(sz);
-                            allocs
-                                .tasks
-                                .entry(task.to_string())
-                                .or_default()
-                                .insert(
-                                    region.to_string(),
-                                    allocate_one(region, sz, align, avail)?,
-                                );
-                            continue 'fitloop;
-                        }
-                    }
-
-                    for (&sz, q) in t_reqs.range_mut(align + 1..) {
-                        if let Some(task) = q.pop_front() {
-                            // We've gotta use a larger one.
-                            let align = toml.task_memory_alignment(sz);
-                            allocs
-                                .tasks
-                                .entry(task.to_string())
-                                .or_default()
-                                .insert(
-                                    region.to_string(),
-                                    allocate_one(region, sz, align, avail)?,
-                                );
-                            continue 'fitloop;
-                        }
-                    }
-                }
-
-                // If we reach this point, it means our loop condition is wrong,
-                // because one of the above things should really have happened.
-                // Panic here because otherwise it's a hang.
-                panic!("loop iteration without progess made!");
-            }
+            let t_reqs = task_requests.get_mut(region.as_str());
+            let mut t_reqs_empty = IndexMap::new();
+            allocate_region(
+                region,
+                toml,
+                &mut k_req,
+                t_reqs.unwrap_or(&mut t_reqs_empty),
+                avail,
+                &mut allocs,
+            )?;
         }
 
         if let Some(caboose) = caboose {
@@ -1942,6 +1931,140 @@ pub fn allocate_all(
         result.insert(image_name.to_string(), (allocs, free));
     }
     Ok(result)
+}
+
+fn allocate_region(
+    region: &str,
+    toml: &Config,
+    k_req: &mut Option<&u32>,
+    t_reqs: &mut IndexMap<&str, Vec<u32>>,
+    avail: &mut Range<u32>,
+    allocs: &mut Allocations,
+) -> Result<()> {
+    // The kernel gets to go first!
+    if let Some(&sz) = k_req.take() {
+        allocs
+            .kernel
+            .insert(region.to_string(), allocate_k(region, sz, avail)?);
+    }
+
+    println!("PACKING!");
+    for (&task_name, mem) in t_reqs.iter() {
+        println!("  {task_name}, {mem:?}");
+    }
+
+    while !t_reqs.is_empty() {
+        println!("avail: {avail:x?}");
+        // At this point, we need to find a task that fits based on our existing
+        // alignment.  This is tricky, because -- for efficient packing -- we
+        // allow tasks to span multiple regions.  For example, a task could look
+        // like this:
+        //
+        //   4444221
+        //
+        // representing three regions of size 4, 2, 1.
+        //
+        // Such a task could be placed in two ways:
+        //
+        //      |4444221 ("forward")
+        //   122|4444    ("reverse")
+        //      | where this line is the alignment for the largest chunk
+
+        #[derive(Debug)]
+        enum Direction {
+            Forward,
+            Reverse,
+        }
+        #[derive(Debug)]
+        struct Match<'a> {
+            gap: u32,
+            align: u32,
+            name: &'a str,
+            dir: Direction,
+        }
+        impl<'a> Match<'a> {
+            /// Updates our "current best" with new values, if they're better
+            ///
+            /// Our policy is to rank by
+            /// 1) smallest gap required, and then
+            /// 2) largest resulting alignment
+            fn update(
+                &mut self,
+                gap: u32,
+                align: u32,
+                name: &'a str,
+                dir: Direction,
+            ) {
+                if gap < self.gap || (gap == self.gap && align > self.align) {
+                    self.gap = gap;
+                    self.align = align;
+                    self.name = name;
+                    self.dir = dir;
+                }
+            }
+        }
+
+        let mut best = Match {
+            gap: u32::MAX,
+            align: 0,
+            name: "",
+            dir: Direction::Forward,
+        };
+
+        for (&task_name, mem) in t_reqs.iter() {
+            let align = toml.task_memory_alignment(mem[0]);
+
+            let size_mask = align - 1;
+            let base = (avail.start + size_mask) & !size_mask;
+
+            // Memory available before the aligned memory address
+            let bonus_chunk_len = mem[1..].iter().sum();
+            if mem.len() > 1 && base - avail.start >= bonus_chunk_len {
+                // We could place this chunk using reverse orientation
+                let gap_reverse = base - avail.start - bonus_chunk_len;
+                best.update(gap_reverse, align, task_name, Direction::Reverse);
+            }
+
+            // We can always place the chunk using forward orientation, albeit
+            // with padding if it's not aligned.
+            let gap_forward = base - avail.start;
+            best.update(gap_forward, align, task_name, Direction::Forward);
+        }
+        let Some(sizes) = t_reqs.remove(best.name) else {
+            panic!("could not find a task");
+        };
+        match best.dir {
+            Direction::Forward => {
+                for &size in sizes.iter() {
+                    let align = toml.task_memory_alignment(size);
+                    allocs
+                        .tasks
+                        .entry(best.name.to_string())
+                        .or_default()
+                        .entry(region.to_string())
+                        .or_default()
+                        .push(allocate_one(region, size, align, avail)?);
+                }
+            }
+            Direction::Reverse => {
+                avail.start += best.gap;
+                for &size in sizes.iter().rev() {
+                    let align = toml.task_memory_alignment(size);
+                    allocs
+                        .tasks
+                        .entry(best.name.to_string())
+                        .or_default()
+                        .entry(region.to_string())
+                        .or_default()
+                        .push(allocate_one(region, size, align, avail)?);
+                }
+            }
+        }
+        println!("found best: {best:#x?}");
+        println!("{:x?}", allocs.tasks[best.name][region]);
+    }
+
+    Ok(())
 }
 
 fn allocate_k(
@@ -2003,7 +2126,7 @@ fn allocate_one(
 /// system.
 pub fn make_kconfig(
     toml: &Config,
-    task_allocations: &BTreeMap<String, BTreeMap<String, Range<u32>>>,
+    task_allocations: &BTreeMap<String, BTreeMap<String, Vec<Range<u32>>>>,
     entry_points: &HashMap<String, u32>,
     image_name: &str,
 ) -> Result<build_kconfig::KernelConfig> {
@@ -2082,7 +2205,7 @@ pub fn make_kconfig(
     for (i, (name, task)) in toml.tasks.iter().enumerate() {
         let stacksize = task.stacksize.or(toml.stacksize).unwrap();
 
-        let flash = &task_allocations[name]["flash"];
+        let flash = &task_allocations[name]["flash"][0];
         let entry_offset = if flash.contains(&entry_points[name]) {
             entry_points[name] - flash.start
         } else {
@@ -2113,6 +2236,7 @@ pub fn make_kconfig(
         let extern_regions = toml.extern_regions_for(name, image_name)?;
         let owned_regions = task_allocations[name]
             .iter()
+            .flat_map(|(name, chunks)| chunks.iter().map(move |c| (name, c)))
             .chain(extern_regions.iter())
             .map(|(out_name, range)| {
                 // Look up region for this image

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1991,7 +1991,13 @@ fn allocate_region(
                 name: &'a str,
                 dir: Direction,
             ) {
-                if gap < self.gap
+                // Ignore any gap that's < 1/8 of final alignment, since that's
+                // "close enough"
+                let gap_m = gap.saturating_sub(align / 8);
+                let our_gap_m = self.gap.saturating_sub(self.align / 8);
+                if gap_m < our_gap_m
+                    || (gap_m == our_gap_m && align > self.align)
+                    || gap < self.gap
                     || (gap == self.gap && align > self.align)
                     || (gap == self.gap
                         && align == self.align

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2201,10 +2201,16 @@ fn allocate_region(
         }
 
         // Check that our allocations are all aligned and contiguous
+        let mut prev = None;
         for r in &allocs.tasks[best.name][region] {
+            if let Some(prev) = prev {
+                assert_eq!(prev.end, r.start);
+            }
             let size = r.end - r.start;
+            assert!(size >= 32); // minimum MPU size
             let align = toml.task_memory_alignment(size);
             assert!(r.start.trailing_zeros() >= align.trailing_zeros());
+            prev = Some(r.clone());
         }
     }
 

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1337,9 +1337,9 @@ fn generate_task_linker_script(
     }
 
     writeln!(linkscr, "MEMORY\n{{")?;
-    for (name, range) in map {
-        let mut start = range[0].start;
-        let end = range.last().unwrap().end;
+    for (name, ranges) in map {
+        let mut start = ranges[0].start;
+        let end = ranges.last().unwrap().end;
         let name = name.to_ascii_uppercase();
 
         // Our stack comes out of RAM

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1880,7 +1880,7 @@ pub fn allocate_all(
                 let bytes = toml.suggest_memory_region_size(name, amt, n);
                 if let Some(r) = tasks[name].max_sizes.get(&mem.to_string()) {
                     let total_bytes = bytes.iter().sum::<u64>();
-                    if total_bytes > *r as u64 {
+                    if total_bytes > u64::from(*r) {
                         bail!(
                         "task {}: needs {} bytes of {} but max-sizes limits it to {}",
                         name, total_bytes, mem, r);

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2060,8 +2060,20 @@ fn allocate_region(
                 }
             }
         }
+
         println!("found best: {best:#x?}");
         println!("{:x?}", allocs.tasks[best.name][region]);
+
+        // Check that our allocations are all aligned and contiguous
+        let ra = &allocs.tasks[best.name][region];
+        for r in ra {
+            let size = r.end - r.start;
+            let align = toml.task_memory_alignment(size);
+            assert!(r.start.trailing_zeros() >= align.trailing_zeros());
+        }
+        for (a, b) in ra.iter().zip(&ra[1..]) {
+            assert_eq!(a.end, b.start);
+        }
     }
 
     Ok(())

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -2201,7 +2201,7 @@ fn allocate_region(
         }
 
         // Check that our allocations are all aligned and contiguous
-        let mut prev = None;
+        let mut prev: Option<Range<u32>> = None;
         for r in &allocs.tasks[best.name][region] {
             if let Some(prev) = prev {
                 assert_eq!(prev.end, r.start);
@@ -2402,7 +2402,7 @@ pub fn make_kconfig(
             if p2_required && !size.is_power_of_two() {
                 bail!(
                     "memory region for task '{name}' output '{out_name}' \
-                        is required to be a power of two, but has size {size}"
+                     is required to be a power of two, but has size {size}"
                 );
             }
 

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -92,9 +92,9 @@ enum Xtask {
 
     /// Runs `xtask dist` and reports the sizes of resulting tasks
     Sizes {
-        /// Request verbosity from tools we shell out to.
-        #[clap(short)]
-        verbose: bool,
+        /// `-v` shows chunk sizes; `-vv` makes build verbose
+        #[clap(short, action = clap::ArgAction::Count)]
+        verbose: u8,
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
 
@@ -248,7 +248,7 @@ fn run(xtask: Xtask) -> Result<()> {
         } => {
             let allocs = dist::package(verbose, edges, &cfg, None, dirty)?;
             for (_, (a, _)) in allocs {
-                sizes::run(&cfg, &a, true, false, false)?;
+                sizes::run(&cfg, &a, true, false, false, false)?;
             }
         }
         Xtask::Build {
@@ -289,9 +289,9 @@ fn run(xtask: Xtask) -> Result<()> {
             save,
             dirty,
         } => {
-            let allocs = dist::package(verbose, false, &cfg, None, dirty)?;
+            let allocs = dist::package(verbose >= 2, false, &cfg, None, dirty)?;
             for (_, (a, _)) in allocs {
-                sizes::run(&cfg, &a, false, compare, save)?;
+                sizes::run(&cfg, &a, false, compare, save, verbose >= 1)?;
             }
         }
         Xtask::Humility { args } => {

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -80,7 +80,7 @@ pub fn run(
         let size = toml.kernel.requires[&mem.to_string()];
 
         let suggestion = toml.suggest_memory_region_size("kernel", used, 1);
-        assert_eq!(suggestion.len(), 1);
+        assert_eq!(suggestion.len(), 1, "kernel should not be > 1 region");
         let suggestion = suggestion[0];
 
         if suggestion >= size as u64 {


### PR DESCRIPTION
This PR modifies the build system to let flash use all available MPU regions, resulting in tighter packing and smaller total image size.  This shrinks the `sidecar-rev-c` image by 256 KiB, and the `gimlet-f` image by 188 KiB.

In other words, tasks go from having exactly 1 flash region to _at least_ 1 flash region; this is mostly plumbing that change from `suggest_memory_region_size` all the way through the `kconfig`.

The change does makes task packing trickier, because tasks can be placed in one of two orientations: largest-chunk-first, or largest-chunk-last.  I went for a very dumb O(N^2) algorithm that checks every unplaced task and picks the best; we're far from having > 100 tasks, so I'm not worried about bad scaling (famous last words!).

In addition, it updates `xtask/src/sizes.rs` to print the individual chunks when the `-v` flag is specified.

I'm expecting CI to get mad, because some kernels may need more flash space to hold the extra regions.

## Before
![before](https://github.com/oxidecomputer/hubris/assets/745333/00e1cad3-cfc9-43cc-927f-ed3880f95366)

## After
![after](https://github.com/oxidecomputer/hubris/assets/745333/90c9cb64-022e-46f1-ae3e-e8b32468651c)
