### PR TITLE
Bump sprot sizes to fix build

### DIFF
--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -183,7 +183,7 @@ task-slots = ["swd"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 47328, ram = 32768}
+max-sizes = {flash = 47360, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -77,7 +77,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 47328, ram = 32768}
+max-sizes = {flash = 47360, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -68,7 +68,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 47328, ram = 32768}
+max-sizes = {flash = 47360, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -108,7 +108,7 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 47328, ram = 32768}
+max-sizes = {flash = 47360, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true


### PR DESCRIPTION
#1597 bumped `syn` and `proc-macro2`.  For some reason, this slightly changes the size of the `sprot` task, so `master` is not building for me right now:

```console
Error: task sprot: needs 47360 bytes of flash but max-sizes limits it to 47328
```

[Last time I investigated](https://matrix.to/#/!jxnlDLnJsVaIRstnrt:oxide.computer/$pCYj2H5LWUDkQwx_svMii1GZiOkXxpHA26BOjJzXPBA?via=oxide.computer&via=unix.house&via=matrix.org), I came to the conclusion that bumping `proc-macro2` caused LLVM functions to be emitted in a different order, which changed inlining behavior, which pushed one task over the size limit (and there were literally no changes in the generated LLVM IR).