### PR TITLE
Update bitflags to 2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "abi"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "byteorder",
  "phash",
  "serde",
@@ -177,9 +177,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -234,7 +234,7 @@ dependencies = [
 name = "build-kconfig"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "serde",
 ]
 
@@ -1894,7 +1894,7 @@ dependencies = [
 name = "drv-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "drv-stm32xx-gpio-common",
  "drv-stm32xx-sys-api",
@@ -2402,7 +2402,7 @@ dependencies = [
 name = "host-sp-messages"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "drv-i2c-types",
  "fletcher",
  "gateway-messages",
@@ -2573,7 +2573,7 @@ dependencies = [
  "abi",
  "anyhow",
  "armv8-m-mpu",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "build-kconfig",
  "build-util",
  "byteorder",
@@ -4617,7 +4617,7 @@ name = "task-thermal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "build-i2c",
  "build-util",
  "cortex-m",
@@ -5073,7 +5073,7 @@ name = "transceiver-messages"
 version = "0.1.1"
 source = "git+https://github.com/oxidecomputer/transceiver-control/#84e28d1263d9d07c5410fb0644469c8eb7b5fb5f"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.4.1",
  "hubpack",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
 arrayvec = { version = "0.7.4", default-features = false }
 atty = { version = "0.2", default-features = false }
 bitfield = { version = "0.13", default-features = false }
-bitflags = { version = "1.2.1", default-features = false }
+bitflags = { version = "2.4.1", default-features = false }
 bstringify = { version = "0.1.2", default-features = false }
 byteorder = { version = "1.3.4", default-features = false }
 cargo_metadata = { version = "0.12.0", default-features = false }

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -389,6 +389,7 @@ cfg_if::cfg_if! {
         ) -> Option<ResetReason> {
             bitflags::bitflags! {
                 // See RM0433 section 8.7.39 (RCC_RSR).
+                #[derive(Copy, Clone, Debug, Eq, PartialEq)]
                 #[repr(transparent)]
                 pub struct ResetFlags: u32 {
                     const LPWR = 1 << 30;

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -507,10 +507,38 @@ impl From<HubpackError> for DecodeFailureReason {
     }
 }
 
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    SerializedSize,
+    FromBytes,
+    AsBytes,
+)]
+#[repr(transparent)]
+pub struct Status(u64);
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    SerializedSize,
+    FromBytes,
+    AsBytes,
+)]
+#[repr(transparent)]
+pub struct HostStartupOptions(u64);
+
 bitflags::bitflags! {
-    #[derive(Serialize, Deserialize, SerializedSize, FromBytes, AsBytes)]
-    #[repr(transparent)]
-    pub struct Status: u64 {
+    impl Status: u64 {
         const SP_TASK_RESTARTED = 1 << 0;
         const ALERTS_AVAILABLE  = 1 << 1;
 
@@ -521,9 +549,7 @@ bitflags::bitflags! {
     // When adding fields to this struct, update the static assertions below to
     // ensure our conversions to/from `gateway_messages::StartupOptions` remain
     // valid!
-    #[derive(Serialize, Deserialize, SerializedSize, FromBytes, AsBytes)]
-    #[repr(transparent)]
-    pub struct HostStartupOptions: u64 {
+    impl HostStartupOptions: u64 {
         const PHASE2_RECOVERY_MODE = 1 << 0;
         const STARTUP_KBM = 1 << 1;
         const STARTUP_BOOTRD = 1 << 2;

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -182,10 +182,12 @@ pub struct ULease {
     pub length: u32,
 }
 
+#[derive(Copy, Clone, Debug, FromBytes)]
+#[repr(transparent)]
+pub struct LeaseAttributes(u32);
+
 bitflags::bitflags! {
-    #[derive(FromBytes)]
-    #[repr(transparent)]
-    pub struct LeaseAttributes: u32 {
+    impl LeaseAttributes: u32 {
         /// Allow the borrower to read this memory.
         const READ = 1 << 0;
         /// Allow the borrower to write this memory.

--- a/sys/kern/src/descs.rs
+++ b/sys/kern/src/descs.rs
@@ -70,6 +70,7 @@ pub struct TaskDesc {
 }
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug)]
     #[repr(transparent)]
     pub struct TaskFlags: u8 {
         const START_AT_BOOT = 1 << 0;
@@ -131,10 +132,14 @@ impl RegionDesc {
     }
 }
 
+// This is defined outside the bitflags! macro so that we can write our own
+// const constructor fn, below.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct RegionAttributes(u32);
+
 bitflags::bitflags! {
-    #[repr(transparent)]
-    #[derive(Serialize, Deserialize)]
-    pub struct RegionAttributes: u32 {
+    impl RegionAttributes: u32 {
         /// Region can be read by tasks that include it.
         const READ = 1 << 0;
         /// Region can be written by tasks that include it.
@@ -153,5 +158,11 @@ bitflags::bitflags! {
         const DMA = 1 << 4;
 
         const RESERVED = !((1 << 5) - 1);
+    }
+}
+
+impl RegionAttributes {
+    pub const unsafe fn from_bits_unchecked(bits: u32) -> Self {
+        Self(bits)
     }
 }

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -76,12 +76,13 @@ pub(crate) struct Bsp {
 }
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub struct PowerBitmask: u32 {
         // As far as I know, we don't have any devices which are active only
         // in A2; you probably want to use `A0_OR_A2` instead.
         const A2 = 0b00000001;
         const A0 = 0b00000010;
-        const A0_OR_A2 = Self::A0.bits | Self::A2.bits;
+        const A0_OR_A2 = Self::A0.bits() | Self::A2.bits();
 
         // Bonus bits for M.2 power, which is switched separately.  We *cannot*
         // read the M.2 drives when they are unpowered; otherwise, we risk

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -47,12 +47,13 @@ pub const USE_CONTROLLER: bool = true;
 ////////////////////////////////////////////////////////////////////////////////
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub struct PowerBitmask: u32 {
         // As far as I know, we don't have any devices which are active only
         // in A2; you probably want to use `POWER_STATE_A0_OR_A2` instead
         const A2 = 0b00000001;
         const A0 = 0b00000010;
-        const A0_OR_A2 = Self::A0.bits | Self::A2.bits;
+        const A0_OR_A2 = Self::A0.bits() | Self::A2.bits();
     }
 }
 


### PR DESCRIPTION
This brings us up to the most recent release, and has some nice properties, like there now being a trait that describes the bitflags API instead of it all being open-coded. (This is the property that motivated this change.)

There are some slightly annoying aspects, like the operations in that trait no longer being const (because we don't have const impls yet). So, this required some surgery.