### PR TITLE
gimlet-seq: retry I2C errors, or die trying

### DIFF
--- a/drv/gimlet-seq-api/src/lib.rs
+++ b/drv/gimlet-seq-api/src/lib.rs
@@ -23,6 +23,7 @@ pub enum SeqError {
     A1Timeout,
     A0TimeoutGroupC,
     A0Timeout,
+    I2cFault,
 
     #[idol(server_death)]
     ServerRestarted,


### PR DESCRIPTION
Currently, the sequencer task uses `unwrap()` on I2C bus operations.
However, these may fail due to transient bus errors, or fail permanently
for reasons wholly outside the sequencer task's control. As discussed in
issue #1205, it's incorrect for the sequencer task to unwap these
errors, as panicking results in the task being restarted. On fatal bus
errors, this means we crash loop.

Instead, this commit changes the `gimlet-seq` task to retry failed I2C
reads/writes up to three times, and, if they still fail, transition to a
permanent failed state, setting the FAULT net to Ignition to indicate
that the Gimlet must be power-cycled.