### PR TITLE
Yo dawg i heard you like ringbufs

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -232,11 +232,14 @@ macro_rules! ringbuf_entry {
     }};
 }
 
-/// Inserts data into an unnamed ringbuffer at the root of this crate
+/// Inserts data into a ringbuffer at the root of this crate.
 #[cfg(not(feature = "disabled"))]
 #[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! ringbuf_entry_root {
+    ($buf:ident, $payload:expr) => {
+        $crate::ringbuf_entry!(crate::$buf, $payload);
+    };
     ($payload:expr) => {
         $crate::ringbuf_entry!(crate::__RINGBUF, $payload);
     };
@@ -245,6 +248,9 @@ macro_rules! ringbuf_entry_root {
 #[cfg(feature = "disabled")]
 #[macro_export]
 macro_rules! ringbuf_entry_root {
+    ($buf:ident, $payload:expr) => {{
+        let _ = &$payload;
+    }};
     ($payload:expr) => {{
         let _ = &$payload;
     }};

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -155,6 +155,24 @@ enum MgsMessage {
 
 ringbuf!(Log, 16, Log::Empty);
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum CriticalEvent {
+    Empty,
+    /// We have received a network request to change power states. This record
+    /// logs the sender, in case the request was unexpected, and the target
+    /// state.
+    SetPowerState {
+        sender: sp_impl::SocketAddrV6,
+        port: SpPort,
+        power_state: PowerState,
+        ticks_since_boot: u64,
+    },
+}
+
+// This ringbuf exists to record critical events _only_ and thus not get
+// overwritten by chatter in the debug/trace-style messages.
+ringbuf!(CRITICAL, CriticalEvent, 16, CriticalEvent::Empty);
+
 const SOCKET: SocketName = SocketName::control_plane_agent;
 
 #[export_name = "main"]

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -26,7 +26,7 @@ use gateway_messages::{
 use heapless::{Deque, Vec};
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root as ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::{
     ControlPlaneAgentError, UartClient, VpdIdentity,
     MAX_INSTALLINATOR_IMAGE_ID_LEN,
@@ -287,7 +287,7 @@ impl MgsHandler {
         };
 
         // We have data we want to flush and an attached MGS; build our packet.
-        ringbuf_entry!(Log::SerialConsoleSend {
+        ringbuf_entry_root!(Log::SerialConsoleSend {
             buffered: self.usart.from_rx.len(),
         });
 
@@ -468,7 +468,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
+            target
+        }));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -478,7 +480,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionStateIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
             offset
         }));
         Err(SpError::RequestUnsupportedForSp)
@@ -490,7 +492,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<ignition::LinkEvents, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
             target
         }));
         Err(SpError::RequestUnsupportedForSp)
@@ -502,9 +504,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
-            offset
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::BulkIgnitionLinkEvents { offset }
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -515,7 +517,9 @@ impl SpHandler for MgsHandler {
         _target: Option<u8>,
         _transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ClearIgnitionLinkEvents
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -526,7 +530,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -548,7 +552,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -564,7 +568,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -612,7 +616,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -637,7 +641,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
+        }));
 
         let status = match component {
             // Unlike `update_chunk()`, we only need to match on `SP_ITSELF`
@@ -663,7 +669,9 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
+            component
+        }));
 
         match component {
             // Unlike `update_chunk()`, we only need to match on `SP_ITSELF`
@@ -689,7 +697,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
         self.power_state_impl()
     }
 
@@ -700,7 +708,9 @@ impl SpHandler for MgsHandler {
         power_state: PowerState,
     ) -> Result<(), SpError> {
         use drv_gimlet_seq_api::PowerState as DrvPowerState;
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
+            power_state
+        )));
 
         let power_state = match power_state {
             PowerState::A0 => DrvPowerState::A0,
@@ -719,7 +729,7 @@ impl SpHandler for MgsHandler {
         port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
 
         // Including a component in the serial console messages is half-baked at
         // the moment; we can at least check that it's the one component we
@@ -758,7 +768,7 @@ impl SpHandler for MgsHandler {
         mut offset: u64,
         mut data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -800,7 +810,9 @@ impl SpHandler for MgsHandler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleKeepAlive));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::SerialConsoleKeepAlive
+        ));
         self.attached_serial_console_mgs
             .as_mut()
             .ok_or(SpError::SerialConsoleNotAttached)?
@@ -813,7 +825,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         self.attached_serial_console_mgs = None;
         Ok(())
     }
@@ -823,7 +835,7 @@ impl SpHandler for MgsHandler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
         // TODO: same caveats as above!
         self.attached_serial_console_mgs
             .as_mut()
@@ -834,7 +846,7 @@ impl SpHandler for MgsHandler {
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory().num_devices() as u32
     }
 
@@ -850,7 +862,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
 
         // Our `startup_options_impl` never fails, so is safe to unwrap.
         Ok(self.startup_options_impl().unwrap_lite().into())
@@ -862,7 +874,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
 
         // Our `set_startup_options_impl` never fails, so is safe to unwrap.
         self.set_startup_options_impl(options.into()).unwrap_lite();
@@ -876,7 +890,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -897,9 +911,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u16, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentGetActiveSlot { component }
+        ));
 
         match component {
             SpComponent::HOST_CPU_BOOT_FLASH => {
@@ -917,11 +931,13 @@ impl SpHandler for MgsHandler {
         slot: u16,
         persist: bool,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
-            component,
-            slot,
-            persist,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentSetActiveSlot {
+                component,
+                slot,
+                persist,
+            }
+        ));
         match component {
             SpComponent::HOST_CPU_BOOT_FLASH => {
                 self.host_flash_update.set_active_slot(slot, persist)
@@ -938,9 +954,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentClearStatus { component }
+        ));
         Err(SpError::RequestUnsupportedForComponent)
     }
 
@@ -951,7 +967,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -966,7 +982,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),
@@ -983,7 +999,7 @@ impl SpHandler for MgsHandler {
     ) -> Result<(), SpError> {
         // This can only fail if the `gimlet-seq` server is dead; in that
         // case, send `Busy` because it should be rebooting.
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SendHostNmi));
         self.sequencer
             .send_hardware_nmi()
             .map_err(|_| SpError::Busy)?;
@@ -1000,7 +1016,7 @@ impl SpHandler for MgsHandler {
         use gateway_messages::IpccKeyLookupValueError;
         use host_sp_messages::Key;
 
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
             key,
             value_len: value.len(),
         }));
@@ -1215,14 +1231,14 @@ impl UsartHandler {
         if self.to_tx.is_empty() {
             self.usart.disable_tx_fifo_empty_interrupt();
         } else {
-            ringbuf_entry!(Log::UsartTxFull {
+            ringbuf_entry_root!(Log::UsartTxFull {
                 remaining: self.to_tx.len()
             });
         }
 
         // Clear any errors.
         if self.usart.check_and_clear_rx_overrun() {
-            ringbuf_entry!(Log::UsartRxOverrun);
+            ringbuf_entry_root!(Log::UsartRxOverrun);
             // TODO-correctness Should we notify MGS of dropped data here? We
             // could increment `self.from_rx_offset`, but (a) we don't know how
             // much data we lost, and (b) it would indicate lost data in the
@@ -1289,7 +1305,7 @@ impl UsartHandler {
         // and log that fact locally via ringbuf.
         self.from_rx_offset += discarded_data;
         if discarded_data > 0 {
-            ringbuf_entry!(Log::UsartRxBufferDataDropped {
+            ringbuf_entry_root!(Log::UsartRxBufferDataDropped {
                 num_bytes: discarded_data
             });
         }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -19,7 +19,7 @@ use gateway_messages::{
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root as ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::{ControlPlaneAgentError, VpdIdentity};
 use task_net_api::{MacAddress, UdpMetadata};
 use userlib::sys_get_timer;
@@ -159,7 +159,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
+            target
+        }));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -169,7 +171,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionStateIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
             offset
         }));
         Err(SpError::RequestUnsupportedForSp)
@@ -181,7 +183,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<ignition::LinkEvents, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
             target
         }));
         Err(SpError::RequestUnsupportedForSp)
@@ -193,9 +195,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
-            offset
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::BulkIgnitionLinkEvents { offset }
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -206,7 +208,9 @@ impl SpHandler for MgsHandler {
         _target: Option<u8>,
         _transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ClearIgnitionLinkEvents
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -217,7 +221,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -239,7 +243,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -255,7 +259,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -299,7 +303,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
+        }));
 
         match component {
             SpComponent::SP_ITSELF => Ok(self.sp_update.status()),
@@ -317,7 +323,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -340,7 +346,9 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
+            component
+        }));
 
         match component {
             SpComponent::SP_ITSELF => self.sp_update.abort(&id),
@@ -356,7 +364,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
         self.power_state_impl()
     }
 
@@ -366,7 +374,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         power_state: PowerState,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
+            power_state
+        )));
 
         // We have no states other than A2; always fail.
         Err(SpError::RequestUnsupportedForSp)
@@ -378,7 +388,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -389,7 +399,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -401,7 +411,9 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleKeepAlive));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::SerialConsoleKeepAlive
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -410,7 +422,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -419,12 +431,12 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
         Err(SpError::RequestUnsupportedForSp)
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory().num_devices() as u32
     }
 
@@ -441,7 +453,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -462,9 +474,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u16, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentGetActiveSlot { component }
+        ));
 
         self.common.component_get_active_slot(component)
     }
@@ -477,11 +489,13 @@ impl SpHandler for MgsHandler {
         slot: u16,
         persist: bool,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
-            component,
-            slot,
-            persist,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentSetActiveSlot {
+                component,
+                slot,
+                persist,
+            }
+        ));
 
         self.common
             .component_set_active_slot(component, slot, persist)
@@ -493,9 +507,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentClearStatus { component }
+        ));
         Err(SpError::RequestUnsupportedForComponent)
     }
 
@@ -504,7 +518,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -514,7 +528,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -525,7 +541,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -540,7 +556,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),
@@ -552,7 +568,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SendHostNmi));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -563,7 +579,7 @@ impl SpHandler for MgsHandler {
         key: u8,
         value: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
             key,
             value_len: value.len(),
         }));

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -22,7 +22,7 @@ use gateway_messages::{
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
-use ringbuf::ringbuf_entry_root as ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_control_plane_agent_api::{ControlPlaneAgentError, VpdIdentity};
 use task_net_api::{MacAddress, UdpMetadata};
 use userlib::sys_get_timer;
@@ -196,7 +196,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionState { target }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionState {
+            target
+        }));
         self.ignition
             .target_state(target)
             .map_err(sp_error_from_ignition_error)
@@ -208,7 +210,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionStateIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::BulkIgnitionState {
             offset
         }));
         self.ignition
@@ -222,7 +224,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         target: u8,
     ) -> Result<ignition::LinkEvents, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionLinkEvents {
             target
         }));
         self.ignition
@@ -236,9 +238,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::BulkIgnitionLinkEvents {
-            offset
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::BulkIgnitionLinkEvents { offset }
+        ));
         self.ignition
             .bulk_link_events(offset)
             .map_err(sp_error_from_ignition_error)
@@ -251,7 +253,9 @@ impl SpHandler for MgsHandler {
         target: Option<u8>,
         transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ClearIgnitionLinkEvents));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ClearIgnitionLinkEvents
+        ));
         self.ignition
             .clear_link_events(target, transceiver_select)
             .map_err(sp_error_from_ignition_error)
@@ -264,7 +268,7 @@ impl SpHandler for MgsHandler {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::IgnitionCommand {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::IgnitionCommand {
             target,
             command
         }));
@@ -288,7 +292,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.aux_flash_size + update.sp_image_size,
             component: SpComponent::SP_ITSELF,
             id: update.id,
@@ -304,7 +308,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdatePrepare {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
             length: update.total_size,
             component: update.component,
             id: update.id,
@@ -352,7 +356,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateStatus { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateStatus {
+            component
+        }));
 
         match component {
             SpComponent::SP_ITSELF => Ok(self.sp_update.status()),
@@ -370,7 +376,7 @@ impl SpHandler for MgsHandler {
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateChunk {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateChunk {
             component: chunk.component,
             offset: chunk.offset,
         }));
@@ -393,7 +399,9 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::UpdateAbort { component }));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdateAbort {
+            component
+        }));
 
         match component {
             SpComponent::SP_ITSELF => self.sp_update.abort(&id),
@@ -409,7 +417,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<PowerState, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetPowerState));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetPowerState));
         self.power_state_impl()
     }
 
@@ -420,7 +428,9 @@ impl SpHandler for MgsHandler {
         power_state: PowerState,
     ) -> Result<(), SpError> {
         use drv_sidecar_seq_api::TofinoSequencerPolicy;
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetPowerState(power_state)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
+            power_state
+        )));
 
         let policy = match power_state {
             PowerState::A0 => TofinoSequencerPolicy::LatchOffOnFault,
@@ -449,7 +459,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         _component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleAttach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -460,7 +470,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) -> Result<u64, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleWrite {
             offset,
             length: data.len() as u16
         }));
@@ -472,7 +482,9 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleKeepAlive));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::SerialConsoleKeepAlive
+        ));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -481,7 +493,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleDetach));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -490,12 +502,12 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SerialConsoleBreak));
         Err(SpError::RequestUnsupportedForSp)
     }
 
     fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::Inventory));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::Inventory));
         self.common.inventory().num_devices() as u32
     }
 
@@ -514,7 +526,7 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentDetails {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::ComponentDetails {
             component
         }));
 
@@ -546,9 +558,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<u16, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentGetActiveSlot {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentGetActiveSlot { component }
+        ));
 
         self.common.component_get_active_slot(component)
     }
@@ -561,11 +573,13 @@ impl SpHandler for MgsHandler {
         slot: u16,
         persist: bool,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentSetActiveSlot {
-            component,
-            slot,
-            persist,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentSetActiveSlot {
+                component,
+                slot,
+                persist,
+            }
+        ));
 
         self.common
             .component_set_active_slot(component, slot, persist)
@@ -577,9 +591,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::ComponentClearStatus {
-            component
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentClearStatus { component }
+        ));
 
         // Below we assume we can cast the port count to a u8; const assert that
         // that cast is valid.
@@ -613,7 +627,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<gateway_messages::StartupOptions, SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::GetStartupOptions));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::GetStartupOptions));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -623,7 +637,9 @@ impl SpHandler for MgsHandler {
         _port: SpPort,
         options: gateway_messages::StartupOptions,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetStartupOptions(options)));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetStartupOptions(
+            options
+        )));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -634,7 +650,7 @@ impl SpHandler for MgsHandler {
         message_id: u32,
         err: MgsError,
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::MgsError {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::MgsError {
             message_id,
             err
         }));
@@ -649,7 +665,7 @@ impl SpHandler for MgsHandler {
         offset: u64,
         data: &[u8],
     ) {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::HostPhase2Data {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::HostPhase2Data {
             hash,
             offset,
             data_len: data.len(),
@@ -661,7 +677,7 @@ impl SpHandler for MgsHandler {
         _sender: SocketAddrV6,
         _port: SpPort,
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SendHostNmi));
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SendHostNmi));
         Err(SpError::RequestUnsupportedForSp)
     }
 
@@ -672,7 +688,7 @@ impl SpHandler for MgsHandler {
         key: u8,
         value: &[u8],
     ) -> Result<(), SpError> {
-        ringbuf_entry!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetIpccKeyValue {
             key,
             value_len: value.len(),
         }));

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     mgs_common::MgsCommon, update::rot::RotUpdate, update::sp::SpUpdate,
-    update::ComponentUpdater, Log, MgsMessage,
+    update::ComponentUpdater, CriticalEvent, Log, MgsMessage,
 };
 use drv_ignition_api::IgnitionError;
 use drv_monorail_api::{Monorail, MonorailError};
@@ -423,10 +423,19 @@ impl SpHandler for MgsHandler {
 
     fn set_power_state(
         &mut self,
-        _sender: SocketAddrV6,
-        _port: SpPort,
+        sender: SocketAddrV6,
+        port: SpPort,
         power_state: PowerState,
     ) -> Result<(), SpError> {
+        ringbuf_entry_root!(
+            CRITICAL,
+            CriticalEvent::SetPowerState {
+                sender,
+                port,
+                power_state,
+                ticks_since_boot: sys_get_timer().now,
+            }
+        );
         use drv_sidecar_seq_api::TofinoSequencerPolicy;
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SetPowerState(
             power_state


### PR DESCRIPTION
The final commit is the relevant one, description copied below. The other two commits are cleanups on the way there.

---

Our ability to debug #1613 was hampered by the control-plane-agent
ringbuf being overwritten, on average, every 1.5 seconds. This adds a
secondary ringbuf that only holds "important" events -- specifically,
commands received from the network that affect the host.

Unfortunately due to the BSP structure in the agent right now, this
required copy-pasting a change into three files. Fixing that appears
difficult.