### PR TITLE
net: fix several unwraps of complex errors

### DIFF
--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -12,7 +12,7 @@ pub use registers::{MIBCounter, Register};
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     SpiError(SpiError),
     WrongChipId(u16),
@@ -50,7 +50,7 @@ pub enum Mode {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     None,
     Read(Register, u16),

--- a/drv/vsc-err/src/lib.rs
+++ b/drv/vsc-err/src/lib.rs
@@ -12,7 +12,7 @@
 use drv_spi_api::SpiError;
 use idol_runtime::ServerDeath;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum VscError {
     SpiError(SpiError),
     ServerDied,

--- a/task/monorail-server/src/bsp/sidecar_bcd.rs
+++ b/task/monorail-server/src/bsp/sidecar_bcd.rs
@@ -5,7 +5,7 @@
 use drv_sidecar_front_io::phy_smi::PhySmi;
 use drv_sidecar_seq_api::Sequencer;
 use ringbuf::*;
-use userlib::{hl::sleep_for, task_slot};
+use userlib::{hl::sleep_for, task_slot, UnwrapLite};
 use vsc7448::{
     config::Speed, miim_phy::Vsc7448MiimPhy, Vsc7448, Vsc7448Rw, VscError,
 };
@@ -367,7 +367,7 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
 
         // The VSC8504 on the sidecar has its SIGDET GPIOs pulled down,
         // for some reason.
-        self.vsc8504.set_sigdet_polarity(rw, true).unwrap();
+        self.vsc8504.set_sigdet_polarity(rw, true).unwrap_lite();
 
         // Switch the GPIO to an output.  Since the output register is low
         // by default, this pulls COMA_MODE low, bringing the VSC8504 into

--- a/task/monorail-server/src/main.rs
+++ b/task/monorail-server/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> ! {
             // will ensure that any errors are available for inspection (which
             // `Jefe::restart_me` would not) while making the restart cheaper.
             ringbuf_entry!(Trace::BspInitFailed(e));
-            panic!("Could not initialize BSP: {:?}", e);
+            panic!();
         }
     };
 

--- a/task/net/src/bsp/gimletlet_nic.rs
+++ b/task/net/src/bsp/gimletlet_nic.rs
@@ -20,7 +20,7 @@ use task_net_api::PhyError;
 use userlib::hl::sleep_for;
 use vsc7448_pac::types::PhyRegisterAddress;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     None,
     BspConfigured,

--- a/task/net/src/bsp/nucleo_h7.rs
+++ b/task/net/src/bsp/nucleo_h7.rs
@@ -7,6 +7,7 @@ use crate::pins;
 use drv_stm32h7_eth as eth;
 use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_net_api::PhyError;
+use userlib::UnwrapLite;
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
 use vsc85xx::PhyRw;
 
@@ -50,12 +51,12 @@ impl crate::bsp_support::Bsp for BspImpl {
         let phy = MiimBridge::new(eth);
         let mut r = phy::standard::MODE_CONTROL::from(
             phy.read_raw(PHYADDR, phy::STANDARD::MODE_CONTROL().addr)
-                .unwrap(),
+                .unwrap_lite(),
         );
         r.set_auto_neg_ena(1);
         r.set_restart_auto_neg(1);
         phy.write_raw(PHYADDR, phy::STANDARD::MODE_CONTROL().addr, r.into())
-            .unwrap();
+            .unwrap_lite();
 
         Self {}
     }

--- a/task/net/src/bsp/sidecar_bcd.rs
+++ b/task/net/src/bsp/sidecar_bcd.rs
@@ -23,7 +23,7 @@ use drv_stm32xx_sys_api::{Alternate, Port, Sys};
 use task_net_api::{
     ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
 };
-use userlib::{hl::sleep_for, task_slot};
+use userlib::{hl::sleep_for, task_slot, UnwrapLite};
 use vsc7448_pac::types::PhyRegisterAddress;
 
 task_slot!(SEQ, seq);
@@ -98,7 +98,7 @@ impl bsp_support::Bsp for BspImpl {
         // The VSC8552 on the sidecar has its SIGDET GPIOs pulled down,
         // for some reason.
         let rw = &mut MiimBridge::new(eth);
-        bsp.vsc85x2.set_sigdet_polarity(rw, true).unwrap();
+        bsp.vsc85x2.set_sigdet_polarity(rw, true).unwrap_lite();
 
         Self(bsp)
     }

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -10,7 +10,7 @@ use ringbuf::*;
 use task_net_api::{
     ManagementCounters, ManagementLinkStatus, MgmtError, PhyError,
 };
-use userlib::hl::sleep_for;
+use userlib::{hl::sleep_for, UnwrapLite};
 use vsc7448_pac::{phy, types::PhyRegisterAddress};
 use vsc85xx::{vsc85x2::Vsc85x2, Counter, VscError};
 
@@ -26,7 +26,7 @@ pub enum Ksz8463ResetSpeed {
     Normal,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     None,
     Ksz8463Err { port: u8, err: KszError },
@@ -94,7 +94,7 @@ impl Config {
         // VSC8552 over 100-BASE FX
         self.ksz8463
             .configure(ksz8463::Mode::Fiber, self.ksz8463_vlan_mode)
-            .unwrap();
+            .unwrap_lite();
         self.ksz8463
     }
 
@@ -153,7 +153,7 @@ impl Config {
             sys.gpio_reset(coma_mode);
         }
 
-        vsc85x2.unwrap() // TODO
+        vsc85x2.unwrap_lite() // TODO
     }
 }
 


### PR DESCRIPTION
This knocks about 3.7 kiB (!) off Gimlet's netstack task size, by removing much of its dependence on the formatting machinery invoked by unwrap. (It's not all gone, because smoltcp still uses it.)