### PR TITLE
Bump CI checkout action to fix warnings

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -32,7 +32,7 @@ jobs:
      steps:
 
       # check out our code
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # install rust toolchain
       - name: Install Rust toolchain

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,7 +8,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
     name: tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run tests
       run: cargo test --verbose --workspace


### PR DESCRIPTION
There are a zillion CI warnings (one per build) about how `checkout@v3` is going to stop working (e.g. [here](https://github.com/oxidecomputer/hubris/actions/runs/7995668611)).  This looks like an easy fix!