### PR TITLE
gimlet-seq: don't ignore notifications in dispatch

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -125,7 +125,7 @@ fn main() -> ! {
         Ok(mut server) => {
             let mut buffer = [0; idl::INCOMING_SIZE];
             loop {
-                idol_runtime::dispatch(&mut buffer, &mut server);
+                idol_runtime::dispatch_n(&mut buffer, &mut server);
             }
         }
 


### PR DESCRIPTION
I introduced a regression in the `gimlet-seq` task in commit 4cb9eddab7952ffa760762bfb2953b584696712f, where the call to `idol_runtime::dispatch_n` was inadvertently replaced with `idol_runtime::dispatch`. This resulted in the `gimlet-seq` task ignoring notifications that it previously handled. In particular, the bug causes the `gimlet-seq` task to ignore the timer notifications it sets for itself to poll the sequencer state after reaching A0. This manifests as a failure to power on the T6, as described in issue #1625.

This commit fixes the regression by changing `dispatch` back to `dispatch_n`. Thanks to @wesolows for identifying the root cause of this bug!

I've tested this on Gimlet c71 in the lab, and after applying this patch, the T6 once again powers on as expected:

```console
BRM42220071 # svcs t6init
STATE          STIME    FMRI
online          0:02:53 svc:/system/t6init:default
```

Fixes #1625