### PR TITLE
ringbuf: clarify modulus comment.

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -313,13 +313,9 @@ impl<T: Copy + PartialEq, const N: usize> Ringbuf<T, { N }> {
         let ndx = {
             let last_plus_1 = last.wrapping_add(1);
             // You're probably wondering why this isn't a remainder operation.
-            // This is for two reasons:
-            // 1. None of our target platforms currently have hardware modulus,
-            //    and many of them don't even have hardware divide, making
-            //    remainder quite expensive.
-            // 2. The code as written here correctly turns usize::MAX into 0 for
-            //    our starting condition. Otherwise we'd have to be cleverer
-            //    about our starting number.
+            // This is because none of our target platforms currently have
+            // hardware modulus, and many of them don't even have hardware
+            // divide, making remainder quite expensive.
             if last_plus_1 >= self.buffer.len() {
                 0
             } else {


### PR DESCRIPTION
The change that introduced this comment was
automerged, and thus didn't address the comment at https://github.com/oxidecomputer/hubris/pull/1624#discussion_r1500048741. This change just massages the comment a bit to address that.