### PR TITLE
gimlet_inspector: use a counted ringbuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ dependencies = [
  "drv-gimlet-seq-api",
  "gimlet-inspector-protocol",
  "hubpack",
+ "ringbuf",
  "serde",
  "task-net-api",
  "userlib",

--- a/task/gimlet-inspector/Cargo.toml
+++ b/task/gimlet-inspector/Cargo.toml
@@ -11,6 +11,7 @@ gimlet-inspector-protocol = { workspace = true }
 task-net-api = { path = "../net-api" }
 drv-gimlet-seq-api = { path = "../../drv/gimlet-seq-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+ringbuf = { path = "../../lib/ringbuf" }
 
 
 [build-dependencies]


### PR DESCRIPTION
This commit replaces the manually-implemented event counters in
`gimlet_inspector` with the `counted_ringbuf!` added in #1621. Since the
motivation for using counters here was primarily size, I made the actual
ringbuffer quite small; it only retains the last 8 events. This allows
some insight into the last few things that happened while tracking the
total number of events using counters.

Depends on #1621