### PR TITLE
Hubris-side changes for removing `dispatch_n` in `idol-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,8 +2487,8 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idol"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#86761da6c3cf95bd3f0335d08f810ba708775447"
 dependencies = [
  "indexmap",
  "quote",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
+source = "git+https://github.com/oxidecomputer/idolatry.git#86761da6c3cf95bd3f0335d08f810ba708775447"
 dependencies = [
  "userlib",
  "zerocopy 0.6.4",

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 25184, ram = 6256}
+requires = {flash = 25384, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -10,7 +10,9 @@ use drv_auxflash_api::{
     TlvcReadAuxFlash, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES, SLOT_COUNT,
     SLOT_SIZE,
 };
-use idol_runtime::{ClientError, Leased, RequestError, R, W};
+use idol_runtime::{
+    ClientError, Leased, NotificationHandler, RequestError, R, W,
+};
 use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
 use userlib::*;
 
@@ -432,6 +434,17 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
         handle
             .get_blob_by_tag(active_slot, tag)
             .map_err(RequestError::from)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/eeprom/src/main.rs
+++ b/drv/eeprom/src/main.rs
@@ -16,7 +16,7 @@
 
 use derive_idol_err::IdolError;
 use drv_i2c_devices::at24csw080::*;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use userlib::*;
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
@@ -88,6 +88,17 @@ impl idl::InOrderEepromImpl for EepromServer {
         self.dev
             .write_byte(addr, value)
             .map_err(|e| EepromError::from(e).into())
+    }
+}
+
+impl NotificationHandler for EepromServer {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -595,6 +595,19 @@ impl<'a, Device: Fpga<'a> + FpgaUserDesign> idl::InOrderFpgaImpl
     }
 }
 
+impl<'a, Device: Fpga<'a> + FpgaUserDesign> idol_runtime::NotificationHandler
+    for ServerImpl<'a, Device>
+{
+    fn current_notification_mask(&self) -> u32 {
+        // We do not expect notifications.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
+
 #[derive(AsBytes, Unaligned)]
 #[repr(C)]
 struct UserDesignRequestHeader {

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -33,7 +33,9 @@ use userlib::*;
 use drv_gimlet_hf_api::SECTOR_SIZE_BYTES;
 use drv_stm32h7_qspi::Qspi;
 use drv_stm32xx_sys_api as sys_api;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R, W};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R, W,
+};
 use zerocopy::{AsBytes, FromBytes};
 
 #[cfg(feature = "h743")]
@@ -790,6 +792,17 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             self.write_raw_persistent_data_to_addr(next, &raw)?;
         }
         Ok(())
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -125,7 +125,7 @@ fn main() -> ! {
         Ok(mut server) => {
             let mut buffer = [0; idl::INCOMING_SIZE];
             loop {
-                idol_runtime::dispatch_n(&mut buffer, &mut server);
+                idol_runtime::dispatch(&mut buffer, &mut server);
             }
         }
 

--- a/drv/ignition-server/src/main.rs
+++ b/drv/ignition-server/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> ! {
     sys_set_timer(Some(sys_get_timer().now), notifications::TIMER_MASK);
 
     loop {
-        idol_runtime::dispatch_n(&mut incoming, &mut server);
+        idol_runtime::dispatch(&mut incoming, &mut server);
     }
 }
 

--- a/drv/lpc55-gpio/src/main.rs
+++ b/drv/lpc55-gpio/src/main.rs
@@ -44,7 +44,7 @@ use lpc55_pac as device;
 
 use drv_lpc55_gpio_api::*;
 use drv_lpc55_syscon_api::*;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use userlib::*;
 
 task_slot!(SYSCON, syscon_driver);
@@ -138,6 +138,17 @@ impl idl::InOrderPinsImpl for ServerImpl<'_> {
         }
 
         Ok(())
+    }
+}
+
+impl NotificationHandler for ServerImpl<'_> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/lpc55-rng/src/main.rs
+++ b/drv/lpc55-rng/src/main.rs
@@ -12,7 +12,7 @@
 use core::mem::size_of;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use drv_rng_api::RngError;
-use idol_runtime::{ClientError, RequestError};
+use idol_runtime::{ClientError, NotificationHandler, RequestError};
 use rand_chacha::ChaCha20Rng;
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{impls, Error, RngCore, SeedableRng};
@@ -183,6 +183,17 @@ impl idl::InOrderRngImpl for Lpc55RngServer {
             cnt += remain;
         }
         Ok(cnt)
+    }
+}
+
+impl NotificationHandler for Lpc55RngServer {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -65,7 +65,8 @@ use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use drv_sp_ctrl_api::SpCtrlError;
 use idol_runtime::{
-    LeaseBufReader, LeaseBufWriter, Leased, LenLimit, RequestError, R, W,
+    LeaseBufReader, LeaseBufWriter, Leased, LenLimit, NotificationHandler,
+    RequestError, R, W,
 };
 use lpc55_pac as device;
 use ringbuf::*;
@@ -482,6 +483,17 @@ impl idl::InOrderSpCtrlImpl for ServerImpl {
             Ok(val) => Ok(val),
             Err(_) => Err(SpCtrlError::Fault.into()),
         }
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/lpc55-syscon/src/main.rs
+++ b/drv/lpc55-syscon/src/main.rs
@@ -111,7 +111,7 @@
 #![no_main]
 
 use drv_lpc55_syscon_api::*;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use lpc55_pac as device;
 use task_jefe_api::{Jefe, ResetReason};
 use userlib::*;
@@ -205,6 +205,17 @@ impl idl::InOrderSysconImpl for ServerImpl<'_> {
             .swr_reset
             .write(|w| unsafe { w.swr_reset().bits(0x5a00_0001) });
         panic!();
+    }
+}
+
+impl NotificationHandler for ServerImpl<'_> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -16,7 +16,9 @@ use drv_lpc55_update_api::{
     RawCabooseError, RotBootInfo, RotPage, SlotId, SwitchDuration, UpdateTarget,
 };
 use drv_update_api::UpdateError;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R, W};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R, W,
+};
 use stage0_handoff::{
     HandoffData, HandoffDataLoadError, ImageVersion, RotBootState,
 };
@@ -463,6 +465,17 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
             dest,
         )?;
         Ok(())
+    }
+}
+
+impl NotificationHandler for ServerImpl<'_> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/meanwell/src/main.rs
+++ b/drv/meanwell/src/main.rs
@@ -163,7 +163,7 @@ fn main() -> ! {
 
     let mut incoming = [0u8; idl::INCOMING_SIZE];
     loop {
-        idol_runtime::dispatch_n(&mut incoming, &mut serverimpl);
+        idol_runtime::dispatch(&mut incoming, &mut serverimpl);
     }
 }
 

--- a/drv/mock-gimlet-hf-server/src/main.rs
+++ b/drv/mock-gimlet-hf-server/src/main.rs
@@ -12,7 +12,9 @@
 
 use drv_gimlet_hf_api::{HfDevSelect, HfError, HfMuxState, PAGE_SIZE_BYTES};
 use drv_hash_api::SHA256_SZ;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R, W};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R, W,
+};
 use userlib::RecvMessage;
 
 #[export_name = "main"]
@@ -152,6 +154,16 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
     }
 }
 
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
 mod idl {
     use super::{HfDevSelect, HfError, HfMuxState};
 

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use drv_gimlet_seq_api::{PowerState, SeqError};
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use task_jefe_api::Jefe;
 use userlib::{FromPrimitive, RecvMessage, UnwrapLite};
 
@@ -98,6 +98,17 @@ impl idl::InOrderSequencerImpl for ServerImpl {
         _: &RecvMessage,
     ) -> Result<[u8; 64], RequestError<SeqError>> {
         Ok([0; 64])
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/sbrmi/src/main.rs
+++ b/drv/sbrmi/src/main.rs
@@ -9,7 +9,7 @@
 
 use drv_i2c_devices::sbrmi::{CpuidResult, Sbrmi};
 use drv_sbrmi_api::SbrmiError;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
 use userlib::*;
 use zerocopy::FromBytes;
@@ -137,6 +137,17 @@ impl idl::InOrderSbrmiImpl for ServerImpl {
         msr: u32,
     ) -> Result<u64, RequestError<SbrmiError>> {
         self.rdmsr::<u64>(thread, msr)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -1010,7 +1010,7 @@ fn main() -> ! {
     sys_set_timer(Some(deadline), notifications::TIMER_MASK);
 
     loop {
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/drv/stm32h7-hash-server/src/main.rs
+++ b/drv/stm32h7-hash-server/src/main.rs
@@ -15,7 +15,9 @@ use userlib::*;
 
 use drv_stm32h7_hash::Hash;
 use drv_stm32xx_sys_api as sys_api;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R,
+};
 
 #[cfg(feature = "h753")]
 use stm32h7::stm32h753 as device;
@@ -108,6 +110,17 @@ impl idl::InOrderHashImpl for ServerImpl {
         self.hash
             .digest_sha256(&self.block[..len as usize], &mut sha256_sum)?;
         Ok(sha256_sum)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/stm32h7-rng/src/main.rs
+++ b/drv/stm32h7-rng/src/main.rs
@@ -11,7 +11,7 @@
 
 use drv_rng_api::RngError;
 use drv_stm32xx_sys_api::{Peripheral, Sys};
-use idol_runtime::{ClientError, RequestError};
+use idol_runtime::{ClientError, NotificationHandler, RequestError};
 
 #[cfg(feature = "h743")]
 use stm32h7::stm32h743 as device;
@@ -129,6 +129,17 @@ impl idl::InOrderRngImpl for Stm32h7RngServer {
         }
 
         Ok(cnt)
+    }
+}
+
+impl NotificationHandler for Stm32h7RngServer {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -12,7 +12,8 @@
 
 use drv_spi_api::*;
 use idol_runtime::{
-    LeaseBufReader, LeaseBufWriter, Leased, LenLimit, RequestError, R, W,
+    LeaseBufReader, LeaseBufWriter, Leased, LenLimit, NotificationHandler,
+    RequestError, R, W,
 };
 use userlib::*;
 
@@ -113,6 +114,17 @@ impl InOrderSpiImpl for ServerImpl {
         rm: &RecvMessage,
     ) -> Result<(), RequestError<SpiError>> {
         self.core.release(rm.sender).map_err(RequestError::from)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -15,7 +15,7 @@ use drv_spi_api::{CsState, SpiDevice, SpiServer};
 use drv_sprot_api::*;
 use drv_stm32xx_sys_api as sys_api;
 use hubpack::SerializedSize;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
 use userlib::*;
 
@@ -1093,6 +1093,17 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
             .into()),
             Err(e) => Err(AttestOrSprotError::Sprot(e).into()),
         }
+    }
+}
+
+impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -15,7 +15,9 @@ use drv_stm32h7_update_api::{
     ImageVersion, BLOCK_SIZE_BYTES, FLASH_WORDS_PER_BLOCK, FLASH_WORD_BYTES,
 };
 use drv_update_api::UpdateError;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R,
+};
 use ringbuf::*;
 use stm32h7::stm32h753 as device;
 use userlib::*;
@@ -504,6 +506,17 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
         }
 
         Ok(chunk.len() as u32)
+    }
+}
+
+impl NotificationHandler for ServerImpl<'_> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -37,7 +37,7 @@ cfg_if::cfg_if! {
 
 use drv_stm32xx_gpio_common::{server::get_gpio_regs, Port};
 use drv_stm32xx_sys_api::{Group, RccError};
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use task_jefe_api::{Jefe, ResetReason};
 use userlib::*;
 
@@ -247,6 +247,17 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
         _: &RecvMessage,
     ) -> Result<[u32; 3], RequestError<core::convert::Infallible>> {
         Ok(drv_stm32xx_uid::read_uid())
+    }
+}
+
+impl NotificationHandler for ServerImpl<'_> {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -702,7 +702,7 @@ fn main() -> ! {
                 tx_data_buf.as_mut_slice(),
                 rx_data_buf.as_mut_slice(),
             );
-            idol_runtime::dispatch_n(&mut buffer, &mut server);
+            idol_runtime::dispatch(&mut buffer, &mut server);
         }
     }
 }

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -86,7 +86,7 @@ impl ServerImpl {
             Ok(meta) => self.handle_packet(meta, rx_data_buf, tx_data_buf),
             Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
                 // Our incoming queue is empty or `net` restarted. Wait for more
-                // packets in dispatch_n, back in the main loop.
+                // packets in dispatch, back in the main loop.
             }
             Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -201,7 +201,7 @@ fn main() -> ! {
     }
     let mut server = ServerImpl { blinking };
     loop {
-        idol_runtime::dispatch_n(&mut incoming, &mut server);
+        idol_runtime::dispatch(&mut incoming, &mut server);
     }
 }
 

--- a/task/attest/src/main.rs
+++ b/task/attest/src/main.rs
@@ -18,7 +18,9 @@ use attest_data::{
 use config::DataRegion;
 use core::slice;
 use hubpack::SerializedSize;
-use idol_runtime::{ClientError, Leased, LenLimit, RequestError, R, W};
+use idol_runtime::{
+    ClientError, Leased, LenLimit, NotificationHandler, RequestError, R, W,
+};
 use lib_dice::{AliasData, CertData, SeedBuf};
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
@@ -377,6 +379,17 @@ impl idl::InOrderAttestImpl for AttestServer {
         })?;
 
         Ok(len)
+    }
+}
+
+impl NotificationHandler for AttestServer {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/task/caboose-reader/src/main.rs
+++ b/task/caboose-reader/src/main.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use drv_caboose::{CabooseError, CabooseReader};
-use idol_runtime::{ClientError, Leased, RequestError, W};
+use idol_runtime::{ClientError, Leased, NotificationHandler, RequestError, W};
 use userlib::*;
 
 #[export_name = "main"]
@@ -59,6 +59,17 @@ impl idl::InOrderCabooseImpl for ServerImpl {
         data.write_range(0..chunk.len(), chunk)
             .map_err(|_| RequestError::Fail(ClientError::BadLease))?;
         Ok(chunk.len() as u32)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -182,7 +182,7 @@ fn main() {
     let mut buffer = [0; idl::INCOMING_SIZE];
     loop {
         sys_set_timer(server.timer_deadline(), notifications::TIMER_MASK);
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -196,6 +196,17 @@ impl idol_runtime::NotificationHandler for ServerImpl {
     }
 }
 
+// If we are not built with net support, we expect no notifications.
+#[cfg(not(feature = "net"))]
+impl idol_runtime::NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        0
+    }
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
+
 impl idl::InOrderDumpAgentImpl for ServerImpl {
     fn get_dump_area(
         &mut self,
@@ -288,7 +299,7 @@ fn main() -> ! {
                 rx_data_buf.as_mut_slice(),
                 tx_data_buf.as_mut_slice(),
             );
-            idol_runtime::dispatch_n(&mut buffer, &mut server);
+            idol_runtime::dispatch(&mut buffer, &mut server);
         }
     }
 

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -88,7 +88,7 @@ impl ServerImpl {
             Ok(meta) => self.handle_packet(meta, rx_data_buf, tx_data_buf),
             Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
                 // Our incoming queue is empty or `net` restarted. Wait for more
-                // packets in dispatch_n, back in the main loop.
+                // packets in dispatch, back in the main loop.
             }
             Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }

--- a/task/dumper/src/main.rs
+++ b/task/dumper/src/main.rs
@@ -9,7 +9,7 @@
 
 use drv_sp_ctrl_api::{SpCtrl, SpCtrlError};
 use dumper_api::*;
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
 use userlib::*;
 use zerocopy::FromBytes;
@@ -174,6 +174,17 @@ impl idl::InOrderDumperImpl for ServerImpl {
         r.map_err(|_| DumperError::DumpFailed)?;
 
         Ok(())
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -158,7 +158,7 @@ fn main() -> ! {
 
     let mut buffer = [0; idl::INCOMING_SIZE];
     loop {
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> ! {
     let mut buf = [0u8; idl::INCOMING_SIZE];
 
     loop {
-        idol_runtime::dispatch_n(&mut buf, &mut server);
+        idol_runtime::dispatch(&mut buf, &mut server);
     }
 }
 

--- a/task/monorail-server/src/main.rs
+++ b/task/monorail-server/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> ! {
             ringbuf_entry!(Trace::WakeErr(e));
         }
         let mut msgbuf = [0u8; server::INCOMING_SIZE];
-        idol_runtime::dispatch_n(&mut msgbuf, &mut server);
+        idol_runtime::dispatch(&mut msgbuf, &mut server);
     }
 }
 

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -258,7 +258,7 @@ fn main() -> ! {
                 }
             }
             let mut msgbuf = [0u8; idl::INCOMING_SIZE];
-            idol_runtime::dispatch_n(&mut msgbuf, &mut server);
+            idol_runtime::dispatch(&mut msgbuf, &mut server);
         }
     }
 }

--- a/task/packrat/src/main.rs
+++ b/task/packrat/src/main.rs
@@ -30,7 +30,7 @@
 #![no_main]
 
 use core::convert::Infallible;
-use idol_runtime::{Leased, LenLimit, RequestError};
+use idol_runtime::{Leased, LenLimit, NotificationHandler, RequestError};
 use mutable_statics::mutable_statics;
 use ringbuf::{ringbuf, ringbuf_entry};
 use task_packrat_api::{
@@ -309,6 +309,17 @@ impl idl::InOrderPackratImpl for ServerImpl {
         Err(RequestError::Fail(
             idol_runtime::ClientError::BadMessageContents,
         ))
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -424,7 +424,7 @@ fn main() -> ! {
         notifications::TIMER_MASK,
     );
     loop {
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/task/sensor/src/main.rs
+++ b/task/sensor/src/main.rs
@@ -322,7 +322,7 @@ fn main() -> ! {
     let mut buffer = [0; idl::INCOMING_SIZE];
 
     loop {
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -375,7 +375,7 @@ fn main() -> ! {
 
     let mut buffer = [0; idl::INCOMING_SIZE];
     loop {
-        idol_runtime::dispatch_n(&mut buffer, &mut server);
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/task/validate/src/main.rs
+++ b/task/validate/src/main.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![no_main]
 
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
 use task_validate_api::{ValidateError, ValidateOk};
 use userlib::*;
@@ -50,6 +50,17 @@ impl idl::InOrderValidateImpl for ServerImpl {
                 I2cValidation::Bad => Err(ValidateError::BadValidation.into()),
             },
         }
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/task/vpd/src/main.rs
+++ b/task/vpd/src/main.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use drv_i2c_devices::at24csw080::{At24Csw080, EEPROM_SIZE};
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use task_vpd_api::VpdError;
 use userlib::*;
 
@@ -192,6 +192,17 @@ impl idl::InOrderVpdImpl for ServerImpl {
             Err(_) => Err(VpdError::BadLock.into()),
             Ok(()) => Ok(()),
         }
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 

--- a/test/test-idol-server/src/main.rs
+++ b/test/test-idol-server/src/main.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![no_main]
 
-use idol_runtime::RequestError;
+use idol_runtime::{NotificationHandler, RequestError};
 use test_idol_api::{FancyTestType, IdolTestError, SocketName, UdpMetadata};
 use userlib::*;
 
@@ -78,6 +78,17 @@ impl idl::InOrderIdolTestImpl for ServerImpl {
         b: UdpMetadata,
     ) -> Result<u16, RequestError<IdolTestError>> {
         Ok(b.vid)
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        // We don't use notifications, don't listen for any.
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
This is the Hubris part of https://github.com/oxidecomputer/idolatry/pull/39, the description of which I've pasted below for your reference:

---

We ran into an issue last week where we inadvertently replaced a call to `idol_runtime::dispatch_n` with a call to `idol_runtime::dispatch`. This difficult-to-spot two-character change has the following implications:

1. No warnings or errors are produced.
2. Notifications to the server are silently ignored.

This is bad, and caused real failures in host startup.

This change alters the API to eliminate `dispatch_n` and make notification handling mandatory for all Idol servers -- to opt out of receiving notifications, they must explicitly implement `NotificationHandler` as stubs. This should prevent this class of error from reoccurring, and has the added benefit of simplifying the runtime implementation -- which I'd previously complicated in a misguided attempt at ergonomics.