### PR TITLE
jefe: add counters to Jefe's ringbufs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,6 @@ dependencies = [
 name = "drv-i2c-types"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "build-util",
  "counters",
  "derive-idol-err",
@@ -4300,6 +4299,7 @@ dependencies = [
  "build-util",
  "cfg-if",
  "cortex-m",
+ "counters",
  "hubpack",
  "hubris-num-tasks",
  "humpty",

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -16,6 +16,7 @@ cfg-if = { workspace = true }
 
 abi = { path = "../../sys/abi" }
 armv6m-atomic-hack = { path = "../../lib/armv6m-atomic-hack" }
+counters = { path = "../../lib/counters" }
 hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
 ringbuf = { path = "../../lib/ringbuf"  }
 task-jefe-api = { path = "../jefe-api" }

--- a/task/jefe/src/dump.rs
+++ b/task/jefe/src/dump.rs
@@ -23,8 +23,9 @@ compile_error!(
      except on specially designated boards"
 );
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, counters::Count)]
 enum Trace {
+    #[count(skip)]
     None,
     Initialized,
     GetDumpArea(u8),
@@ -57,7 +58,7 @@ enum Trace {
     DumpDone(Result<(), humpty::DumpError<()>>),
 }
 
-ringbuf!(Trace, 8, Trace::None);
+counted_ringbuf!(Trace, 8, Trace::None);
 
 pub fn initialize_dump_areas() -> u32 {
     let areas = humpty::initialize_dump_areas(

--- a/task/jefe/src/external.rs
+++ b/task/jefe/src/external.rs
@@ -53,7 +53,7 @@ use ringbuf::*;
 use userlib::*;
 
 /// The actual requests that we honor from an external source entity
-#[derive(FromPrimitive, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(FromPrimitive, Copy, Clone, Debug, Eq, PartialEq, counters::Count)]
 enum Request {
     None = 0,
     Start = 1,
@@ -62,7 +62,7 @@ enum Request {
     Fault = 4,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, counters::Count)]
 enum Error {
     IllegalTask,
     BadTask,
@@ -72,15 +72,16 @@ enum Error {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct TaskIndex(u16);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, counters::Count)]
 enum Trace {
+    #[count(skip)]
     None,
-    Request(Request, TaskIndex),
-    Disposition(TaskIndex, Disposition),
-    Error(Error),
+    Request(#[count(children)] Request, TaskIndex),
+    Disposition(TaskIndex, #[count(children)] Disposition),
+    Error(#[count(children)] Error),
 }
 
-ringbuf!(Trace, 4, Trace::None);
+counted_ringbuf!(Trace, 4, Trace::None);
 
 #[no_mangle]
 static JEFE_EXTERNAL_READY: AtomicU32 = AtomicU32::new(0);

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -39,7 +39,7 @@ use idol_runtime::RequestError;
 use task_jefe_api::{DumpAgentError, ResetReason};
 use userlib::*;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, counters::Count)]
 pub enum Disposition {
     #[default]
     Restart,


### PR DESCRIPTION
Currently, Jefe has a few ringbufs that are quite small. This means that events may drop off the back of these ringbuffers. This commit updates these ringbufs to also count events, so that we can track the total number of times that various things have happened in Jefe.