### PR TITLE
counters: implement `Count` for `Option`/`Result`

### DIFF
--- a/lib/counters/src/lib.rs
+++ b/lib/counters/src/lib.rs
@@ -178,19 +178,10 @@ impl Count for core::convert::Infallible {
     #[allow(clippy::declare_interior_mutable_const)]
     const NEW_COUNTERS: Self::Counters = AtomicU32::new(0);
 
-    fn count(&self, _counters: &Self::Counters) {
+    fn count(&self, _: &Self::Counters) {
         // `Infallible`s are not made. They should NEVER be made. We
         // will not count them. We will not help count them.
-        #[cfg(debug_assertions)]
-        unreachable!();
-
-        // but just in case...
-        #[cfg(not(debug_assertions))]
-        armv6m_atomic_hack::AtomicU32Ext::fetch_add(
-            _counters,
-            1,
-            Ordering::Relaxed,
-        );
+        match *self {}
     }
 }
 


### PR DESCRIPTION
This commit adds implementations of the `counters::Count` trait for
`Option<T> where T: Count` and `Result<T, E> where T: Count, E: Count`.
Currently, we aren't using these anywhere, but we _will_ be! :D