### PR TITLE
oxcon2023g0: adjust kernel size allocation

### DIFF
--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -6,7 +6,7 @@ board = "oxcon2023g0"
 
 [kernel]
 name = "oxcon2023g0"
-requires = {flash = 11104, ram = 1296}
+requires = {flash = 11264, ram = 1296}
 stacksize = 640
 
 [tasks.jefe]


### PR DESCRIPTION
The size requirement increased, because the build system managed to pack the firmware tighter and free up 9.4% of flash. But, this means bigger descriptor tables, which currently have to be accounted for in the kernel's size allotment.