### PR TITLE
userlib: add a critical-section impl for task code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
- "critical-section",
+ "critical-section 0.2.7",
 ]
 
 [[package]]
@@ -567,6 +567,12 @@ dependencies = [
  "cortex-m",
  "riscv",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-utils"
@@ -5405,6 +5411,7 @@ dependencies = [
  "build-util",
  "cfg-if",
  "cortex-m",
+ "critical-section 1.1.2",
  "num-derive",
  "num-traits",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,11 +88,11 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.10"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
- "critical-section 0.2.7",
+ "critical-section",
 ]
 
 [[package]]
@@ -172,12 +172,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitfield"
@@ -554,18 +548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "critical-section"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
 ]
 
 [[package]]
@@ -2472,9 +2454,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -3598,27 +3580,6 @@ version = "0.2.0"
 dependencies = [
  "counters",
  "static-cell",
-]
-
-[[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
 ]
 
 [[package]]
@@ -5411,7 +5372,7 @@ dependencies = [
  "build-util",
  "cfg-if",
  "cortex-m",
- "critical-section 1.1.2",
+ "critical-section",
  "num-derive",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ fletcher = { version = "0.3", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 getrandom = { version = "0.2", default-features = false }
 goblin = { version = "0.4.3", default-features = true } # goblin::Object doesn't work without everything enabled
-heapless = { version = "0.7.16", default-features = false }
+heapless = { version = "0.7.17", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
 hubpack = { version = "0.1.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ cortex-m = { version = "0.7", default-features = false, features = ["inline-asm"
 cortex-m-rt = { version = "0.6.12", default-features = false }
 cortex-m-semihosting = { version = "0.5.0", default-features = false }
 crc = { version = "3.0.0", default-features = false }
+critical-section = { version = "1.1.2" }
 crypto-common = { version = "0.1.6", default-features = false }
 ctrlc = { version = "3.1.5", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["from", "into"] }

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["critical-section"]
 panic-messages = []
+critical-section = ["dep:critical-section"]
 
 [dependencies]
 bstringify = { workspace = true }
 cfg-if = { workspace = true }
+critical-section = {workspace = true, optional = true, features = ["restore-state-none"]}
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }

--- a/sys/userlib/src/critical_section.rs
+++ b/sys/userlib/src/critical_section.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! An implementation to support the `critical-section` crate within a Hubris
+//! user task.
+//!
+//! Hubris is careful never to introduce non-local or asynchronous control flow
+//! into a program, and doesn't have threads. This means that, within the
+//! context of a task, we don't actually need to generate any code to implement
+//! a critical section --- they happen naturally.
+//!
+//! You might want to opt out of this implementation if you're doing something
+//! very weird with shared memory. By default, it is hard to do that in Hubris,
+//! but it is possible, and we'll assume you know what you've signed yourself up
+//! for should you choose to do it.
+
+use critical_section::RawRestoreState;
+
+struct HubrisCriticalSection;
+critical_section::set_impl!(HubrisCriticalSection);
+
+unsafe impl critical_section::Impl for HubrisCriticalSection {
+    #[inline(always)]
+    unsafe fn acquire() -> RawRestoreState {
+        // No action required.
+    }
+
+    #[inline(always)]
+    unsafe fn release(_token: RawRestoreState) {
+        // Again, no action required.
+    }
+}

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -44,6 +44,9 @@ pub mod kipc;
 pub mod task_slot;
 pub mod units;
 
+#[cfg(feature = "critical-section")]
+pub mod critical_section;
+
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct Lease<'a> {


### PR DESCRIPTION
The embedded ecosystem is starting to catch up with the fact that not all of us are running a single address space in privileged mode, and crates like `portable-atomics` may now be in a state where we could rely on them.

Implementing things like atomic polyfills on platforms without atomics requires some way to control concurrency, and crates seem to be standardizing on the `critical-section` crate -- which unlike the old critical section in `cortex-m`, can be customized for our purposes.

So, this commit adds a backing implementation to `userlib` to allow the `critical-section` crate to be used in tasks. I'm slightly alarmed to note that our dependency graph already includes a very old version of `critical-section`, but I'm _pretty sure_ that should be safe since we've never provided an impl for it. It is presumably not being linked in.

I need to do more work to evaluate the code generation of crates like `portable-atomics`, but this part, at least, I think we can probably land.