### PR TITLE
counters: allow deriving `Count` for generic types

### DIFF
--- a/lib/counters/derive/Cargo.toml
+++ b/lib/counters/derive/Cargo.toml
@@ -9,4 +9,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
-syn = "2.0.52"
+syn = { version = "2.0.52", features = ["extra-traits"] }

--- a/lib/counters/derive/Cargo.toml
+++ b/lib/counters/derive/Cargo.toml
@@ -9,4 +9,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
-syn = "2.0.48"
+syn = "2.0.52"

--- a/lib/counters/derive/src/lib.rs
+++ b/lib/counters/derive/src/lib.rs
@@ -6,6 +6,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};
+use std::collections::HashSet;
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input, DeriveInput,
@@ -51,72 +52,89 @@ fn gen_count_impl(input: DeriveInput) -> Result<impl ToTokens, syn::Error> {
         ));
     };
     let variants = &data_enum.variants;
-    let mut state = CountGenerator::new(&input.ident, variants.len());
+    let mut state = CountGenerator::new(&input, variants.len());
 
     for variant in variants {
         state.add_variant(variant)?;
     }
 
-    Ok(state.generate(&input))
+    Ok(state.generate())
 }
 
 struct CountGenerator<'input> {
+    input: &'input DeriveInput,
     enum_name: &'input syn::Ident,
     field_defs: Vec<proc_macro2::TokenStream>,
     field_inits: Vec<proc_macro2::TokenStream>,
     variant_patterns: Vec<proc_macro2::TokenStream>,
+    needed_generics: HashSet<syn::Ident>,
+    all_generics: HashSet<syn::Ident>,
+    where_clause_types: HashSet<syn::Type>,
     any_skipped: bool,
 }
 
 impl<'input> CountGenerator<'input> {
-    fn new(enum_name: &'input syn::Ident, variants: usize) -> Self {
+    fn new(input: &'input DeriveInput, variants: usize) -> Self {
         Self {
-            enum_name,
+            enum_name: &input.ident,
+            input,
             field_defs: Vec::with_capacity(variants),
             field_inits: Vec::with_capacity(variants),
             variant_patterns: Vec::with_capacity(variants),
+            all_generics: input
+                .generics
+                .type_params()
+                .map(|p| p.ident.clone())
+                .collect(),
+            needed_generics: HashSet::new(),
+            where_clause_types: HashSet::new(),
             any_skipped: false,
         }
     }
 
-    fn generate(self, input: &DeriveInput) -> impl ToTokens {
-        let generics = &input.generics;
+    fn generate(self) -> impl ToTokens {
         let Self {
+            input,
             enum_name,
             field_defs,
             field_inits,
             mut variant_patterns,
             any_skipped,
+            needed_generics,
+            where_clause_types,
+            ..
         } = self;
+
+        let generics = &input.generics;
 
         // If we skipped any variants, generate a catchall case.
         if any_skipped {
             variant_patterns.push(quote! { _ => {} });
         }
         let vis = &input.vis;
-
         let counts_ty = counts_ty(enum_name);
-        let where_clauses = generics
-            .type_params()
-            .map(|p| {
-                quote! {
-                    #p: counters::Count
-                }
+        let where_clauses = where_clause_types
+            .iter()
+            .map(|ty| {
+                quote! { #ty: counters::Count }
             })
             .collect::<Vec<_>>();
+        // I'm not sure why we have to do this, but quote gets mad if it's not a vec...
+        let needed_generics = needed_generics.iter().collect::<Vec<_>>();
         quote! {
             #[doc = concat!("Total counts for [`", stringify!(#enum_name), "`].")]
             #[allow(nonstandard_style)]
-            #vis struct #counts_ty #generics
-            where #(#where_clauses),*
+            #vis struct #counts_ty<#( #needed_generics, )*>
+            where
+                #(#where_clauses, )*
             {
-                #(#field_defs),*
+                #(#field_defs, )*
             }
 
             #[automatically_derived]
             impl #generics counters::Count for #enum_name #generics
-            where #(#where_clauses),* {
-                type Counters = #counts_ty #generics;
+            where #(#where_clauses, )* {
+                type Counters = #counts_ty<#( #needed_generics, )*>;
 
                 // This is intended for use in a static initializer, so the fact that every
                 // time the constant is used it will be a different instance is not a
@@ -125,7 +143,7 @@ impl<'input> CountGenerator<'input> {
                 // `declare_interior_mutable_const` is really Not My Favorite Clippy
                 // Lint...
                 #[allow(clippy::declare_interior_mutable_const)]
-                const NEW_COUNTERS: #counts_ty #generics = #counts_ty {
+                const NEW_COUNTERS: #counts_ty<#( #needed_generics, )*> = #counts_ty {
                     #(#field_inits),*
                 };
 
@@ -248,6 +266,9 @@ impl<'input> CountGenerator<'input> {
             field_defs,
             field_inits,
             enum_name,
+            needed_generics,
+            all_generics,
+            where_clause_types,
             ..
         } = self;
         field_defs.push(quote! {
@@ -262,6 +283,14 @@ impl<'input> CountGenerator<'input> {
         field_inits.push(quote! {
             #variant_name: <#variant_type as counters::Count>::NEW_COUNTERS
         });
+        where_clause_types.insert(variant_type.clone());
+        if let syn::Type::Path(ty_path) = variant_type {
+            if let Some(ident) = ty_path.path.get_ident() {
+                if all_generics.contains(ident) {
+                    needed_generics.insert(ident.clone());
+                }
+            }
+        }
     }
 }
 

--- a/lib/counters/examples/count_generic.rs
+++ b/lib/counters/examples/count_generic.rs
@@ -10,9 +10,17 @@ use counters::*;
 
 #[derive(Count, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event<E> {
-    SomethingHappened,
-    SayHello(#[count(children)] E),
+    SomethingHappened(#[count(children)] E),
     SomeNumber(u32),
+}
+
+/// A generic type can derive `Count` even if some of its type parameters don't
+/// implement `Count`, provided those fields don't have `#[count(children)]`
+/// annotations.
+#[derive(Count, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SaySomething<P, T> {
+    Hello(#[count(children)] P),
+    Value(T),
 }
 
 #[derive(Count, Debug, Copy, Clone, PartialEq, Eq)]
@@ -26,10 +34,14 @@ pub enum Person {
     Eliza,
 }
 
-counters!(Event<Person>);
+counters!(Event<SaySomething<Person, &'static str>>);
 
 fn main() {
-    count!(Event::SomethingHappened);
-    count!(Event::SomeNumber(42));
-    count!(Event::SayHello(Person::Cliff));
+    count!(Event::SomethingHappened(SaySomething::Hello(Person::Matt)));
+    count!(Event::SomethingHappened(SaySomething::Value(
+        "Hello, world!"
+    )));
+    count!(Event::SomethingHappened(SaySomething::Value(
+        "Hello, world!"
+    )));
 }

--- a/lib/counters/examples/count_generic.rs
+++ b/lib/counters/examples/count_generic.rs
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Demonstrates the use of `counters!`, `count!`, and `#[derive(Count)]`
+//!
+//! This example is primarily intended to be used with `cargo expand` to show
+//! the macro-generated code for `#[derive(ringbuf::Count)]` and friends.
+use counters::*;
+
+#[derive(Count, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Event<E> {
+    SomethingHappened,
+    SayHello(#[count(children)] E),
+    SomeNumber(u32),
+}
+
+#[derive(Count, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Person {
+    Cliff,
+    Matt,
+    Laura,
+    Bryan,
+    John,
+    Steve,
+    Eliza,
+}
+
+counters!(Event<Person>);
+
+fn main() {
+    count!(Event::SomethingHappened);
+    count!(Event::SomeNumber(42));
+    count!(Event::SayHello(Person::Cliff));
+}

--- a/lib/counters/src/lib.rs
+++ b/lib/counters/src/lib.rs
@@ -49,12 +49,12 @@ pub trait Count {
 /// static.
 #[macro_export]
 macro_rules! counters {
-    ($name:ident, $Type:ident) => {
+    ($name:ident, $Type:ty) => {
         #[used]
         static $name: <$Type as $crate::Count>::Counters =
             <$Type as $crate::Count>::NEW_COUNTERS;
     };
-    ($Type:ident) => {
+    ($Type:ty) => {
         $crate::counters!(__COUNTERS, $Type);
     };
 }

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -18,7 +18,6 @@ fn main() -> Result<()> {
         "server_stub.rs",
         idol::server::ServerStyle::InOrder,
         &allowed_callers,
-        &Default::default(),
     )
     .unwrap();
 

--- a/task/jefe/build.rs
+++ b/task/jefe/build.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
         "server_stub.rs",
         idol::server::ServerStyle::InOrder,
         &allowed_callers,
+        &Default::default(),
     )
     .unwrap();
 


### PR DESCRIPTION
Currently, placing the `#[derive(Count)]` attribute on a generic `enum`
doesn't compile. This branch changes the `#[derive(Count)]` code
generation to support generic types. If a type parameter is used as a
field with the `#[count(children)]` attribute, the generated counters
struct will also be generic over that type parameter, and contain the
counters type for that type's `Count` implementation, with a `where`
clause requiring that type to also implement `Count`. If the type
parameter is *not* used in a field that has the `#[count(children)]`
attribute, the generated counters struct needn't be generic over that
type parameter,[^error] so we exclude it from the counter's struct list
of type params. This required a bit of a complex change to the code
generation to implement.

I've added a new example of deriving `Count` for generic types,
including one that's generic over type parameters that _don't_ get used
in a `#[count(children)]` field. This example compiles, verifying that
we now generate code that makes sense when deriving `Count` for generic
enums.

[^error]: and, in fact, if the counters struct is generic over a type
    parameter that it doesn't actually use, it won't compile, as the
    type parameter is unused.