### PR TITLE
counters: add support for counting `bool`s

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -49,13 +49,13 @@ mod payload;
 #[derive(Copy, Clone, PartialEq, Count)]
 enum Trace {
     Ice40Rails(bool, bool),
-    IdentValid(bool),
-    ChecksumValid(bool),
-    Reprogram(bool),
+    IdentValid(#[count(children)] bool),
+    ChecksumValid(#[count(children)] bool),
+    Reprogram(#[count(children)] bool),
     Programmed,
     Programming,
-    Ice40PowerGoodV1P2(bool),
-    Ice40PowerGoodV3P3(bool),
+    Ice40PowerGoodV1P2(#[count(children)] bool),
+    Ice40PowerGoodV3P3(#[count(children)] bool),
     RailsOff,
     Ident(u16),
     A2Status(u8),
@@ -63,7 +63,7 @@ enum Trace {
     A0FailureDetails(Addr, u8),
     A0Failed(#[count(children)] SeqError),
     A1Status(u8),
-    CPUPresent(bool),
+    CPUPresent(#[count(children)] bool),
     Coretype {
         coretype: bool,
         sp3r1: bool,

--- a/lib/counters/examples/count.rs
+++ b/lib/counters/examples/count.rs
@@ -13,6 +13,7 @@ pub enum Event {
     SomethingHappened,
     SayHello(#[count(children)] people::Person),
     SomeNumber(u32),
+    ToBeOrNotToBe(#[count(children)] bool),
 }
 
 counters!(Event);

--- a/lib/counters/src/lib.rs
+++ b/lib/counters/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 pub use armv6m_atomic_hack;
+use core::sync::atomic::{AtomicU32, Ordering};
 #[cfg(feature = "derive")]
 pub use counters_derive::Count;
 
@@ -76,4 +77,34 @@ macro_rules! count {
     ($event:expr) => {
         $crate::count!(__COUNTERS, $event);
     };
+}
+/// Counters for [`bool`]s.
+///
+/// This allows placing the `#[count(children)]`
+/// attribute on `bool` fields in `enum` variants.
+pub struct BoolCounts {
+    /// The total number of times these counters have recorded a `true` value.
+    pub r#true: AtomicU32,
+    /// The total number of times these counters have recorded a `false`
+    /// value.
+    pub r#false: AtomicU32,
+}
+
+impl Count for bool {
+    type Counters = BoolCounts;
+
+    #[allow(clippy::declare_interior_mutable_const)]
+    const NEW_COUNTERS: Self::Counters = BoolCounts {
+        r#true: AtomicU32::new(0),
+        r#false: AtomicU32::new(0),
+    };
+
+    fn count(&self, counters: &Self::Counters) {
+        let ctr = match self {
+            true => &counters.r#true,
+            false => &counters.r#false,
+        };
+
+        armv6m_atomic_hack::AtomicU32Ext::fetch_add(ctr, 1, Ordering::Relaxed);
+    }
 }


### PR DESCRIPTION
Currently, we have a bunch of ringbuf enum variants with single `bool` fields, like `Trace::NICPowerEnableLow(bool)` in `gimlet-seq-server`. This commit adds a `counters::Count` implementation for `bool`, allowing us to place `#[count(children)]` on these variants and generate separate `true` and `false` counters for them.