### PR TITLE
Make error types in the net API more precise

### DIFF
--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -88,7 +88,6 @@ impl ServerImpl {
                 // Our incoming queue is empty or `net` restarted. Wait for more
                 // packets in dispatch, back in the main loop.
             }
-            Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }
     }
 

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -144,10 +144,7 @@ impl ServerImpl {
                 ringbuf_entry!(Trace::SendError(e));
                 match e {
                     SendError::QueueFull => (),
-                    SendError::Other
-                    | SendError::ServerRestarted
-                    | SendError::NotYours
-                    | SendError::InvalidVLan => panic!(),
+                    SendError::ServerRestarted => panic!(),
                 }
             }
         }

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -520,15 +520,6 @@ impl NetHandler {
                         self.packet_to_send = Some(meta);
                         return;
                     }
-                    Err(
-                        err @ (SendError::InvalidVLan
-                        | SendError::Other
-                        | SendError::NotYours),
-                    ) => {
-                        // Some other (fatal?) error occurred; should we panic?
-                        // For now, just discard the packet we wanted to send.
-                        ringbuf_entry!(Log::SendError(err));
-                    }
                 }
             }
 

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -541,6 +541,9 @@ impl NetHandler {
                     self.handle_received_packet(meta, mgs_handler);
                 }
                 Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
+                    // In the restart case, there may in fact be packets waiting
+                    // for us in the net stack. We'll handle them next time
+                    // through the loop when we get to recv_packet.
                     return;
                 }
             }

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -543,7 +543,6 @@ impl NetHandler {
                 Err(RecvError::QueueEmpty | RecvError::ServerRestarted) => {
                     return;
                 }
-                Err(RecvError::NotYours | RecvError::Other) => panic!(),
             }
         }
     }

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -124,16 +124,11 @@ impl ServerImpl {
                 meta,
                 &tx_data_buf[..meta.size as usize],
             ) {
-                // We'll drop packets if the outgoing queue is full or the
-                // server has died; the host is responsible for retrying.
-                //
-                // Other errors are unexpected and panic.
                 ringbuf_entry!(Trace::SendError(e));
                 match e {
+                    // We'll drop packets if the outgoing queue is full or the
+                    // server has died; the host is responsible for retrying.
                     SendError::QueueFull | SendError::ServerRestarted => (),
-                    SendError::Other
-                    | SendError::NotYours
-                    | SendError::InvalidVLan => panic!(),
                 }
             }
         }

--- a/task/dump-agent/src/udp.rs
+++ b/task/dump-agent/src/udp.rs
@@ -90,7 +90,6 @@ impl ServerImpl {
                 // Our incoming queue is empty or `net` restarted. Wait for more
                 // packets in dispatch, back in the main loop.
             }
-            Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }
     }
 

--- a/task/gimlet-inspector/src/main.rs
+++ b/task/gimlet-inspector/src/main.rs
@@ -120,17 +120,6 @@ fn main() -> ! {
                             )
                             .unwrap_lite();
                         }
-                        // These errors should be impossible if we're configured
-                        // correctly.
-                        Err(SendError::NotYours | SendError::InvalidVLan) => {
-                            unreachable!()
-                        }
-                        // Unclear under what conditions we could sse `Other` -
-                        // just panic for now? At the time of this writing
-                        // `Other` should only come back if the destination
-                        // address in `meta` is bogus or our socket is closed,
-                        // neither of which should be possible here.
-                        Err(SendError::Other) => panic!(),
                     }
                 }
             }

--- a/task/gimlet-inspector/src/main.rs
+++ b/task/gimlet-inspector/src/main.rs
@@ -135,7 +135,6 @@ fn main() -> ! {
             Err(RecvError::ServerRestarted) => {
                 // `net` restarted (probably due to the watchdog); just retry.
             }
-            Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }
     }
 }

--- a/task/gimlet-inspector/src/main.rs
+++ b/task/gimlet-inspector/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> ! {
                 .unwrap_lite();
             }
             Err(RecvError::ServerRestarted) => {
-                // `net` restarted (probably due to the watchdog); just retry.
+                // `net` restarted; just retry.
             }
         }
     }

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -36,16 +36,16 @@ pub enum SendError {
 )]
 #[repr(u32)]
 pub enum RecvError {
-    /// The selected socket is not owned by this task
-    NotYours = 1,
+    /// The incoming RX queue is empty; there are no packets able to be received
+    /// from this socket. You can wait on the notification and try again if you
+    /// like.
+    QueueEmpty = 1,
 
-    /// The incoming rx queue is empty
-    QueueEmpty = 2,
-
-    Other = 3,
-
+    /// The server has restarted. Clients may or may not actually care about
+    /// this; often you'll just want to retry, but because a netstack restart
+    /// may imply one or more lost packets, we don't want to assume that.
     #[idol(server_death)]
-    ServerRestarted = 4,
+    ServerRestarted = 2,
 }
 
 #[derive(

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -14,24 +14,21 @@ use zerocopy::{AsBytes, FromBytes};
 
 pub use task_packrat_api::MacAddressBlock;
 
+/// Errors that can occur when trying to send a packet.
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IdolError, counters::Count,
 )]
 #[repr(u32)]
 pub enum SendError {
-    /// The selected socket is not owned by this task
-    NotYours = 1,
+    /// The outgoing tx queue is full. Wait until you get a notification that
+    /// there is queue space and try again.
+    QueueFull = 1,
 
-    /// The specified VID is not in the configured range
-    InvalidVLan = 2,
-
-    /// The outgoing tx queue is full
-    QueueFull = 3,
-
-    Other = 4,
-
+    /// The server has restarted. Clients may or may not actually care about
+    /// this; often you'll just want to retry, but because a netstack restart
+    /// may imply one or more lost packets, we don't want to assume that.
     #[idol(server_death)]
-    ServerRestarted = 5,
+    ServerRestarted = 2,
 }
 
 #[derive(

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -574,14 +574,14 @@ where
         if generated::SOCKET_OWNERS[socket_index].0.index()
             != msg.sender.index()
         {
-            return Err(SendError::NotYours.into());
+            return Err(ClientError::AccessViolation.fail());
         }
 
         #[cfg(feature = "vlan")]
         let vlan_index = {
             // Convert from absolute VID to an index in our VLAN array
             if !VLAN_RANGE.contains(&metadata.vid) {
-                return Err(SendError::InvalidVLan.into());
+                return Err(ClientError::BadMessageContents.fail());
             }
             usize::from(metadata.vid - VLAN_RANGE.start)
         };
@@ -624,9 +624,15 @@ where
                 self.client_waiting_to_send[socket_index] = true;
                 Err(SendError::QueueFull.into())
             }
-            Err(_e) => {
-                // uhhhh TODO
-                Err(SendError::Other.into())
+            Err(udp::SendError::Unaddressable) => {
+                // smoltcp's "Unaddressable" case may not be what you'd expect
+                // from the name. It indicates that the address and/or port
+                // provided by the caller are _statically invalid,_ such as port
+                // 0 or address `[::]`. It does _not_ mean unreachable.
+                //
+                // This means that this error indicates a precondition violation
+                // by the client, which in turn means: kill kill kill
+                Err(ClientError::BadMessageContents.fail())
             }
         }
     }

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -517,7 +517,7 @@ where
         if generated::SOCKET_OWNERS[socket_index].0.index()
             != msg.sender.index()
         {
-            return Err(RecvError::NotYours.into());
+            return Err(ClientError::AccessViolation.fail());
         }
 
         // Iterate over all of the per-VLAN sockets, returning the first

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> ! {
                 .unwrap();
             }
             Err(RecvError::ServerRestarted) => {
-                // `net` restarted (probably due to the watchdog); just retry.
+                // `net` restarted, the poor thing; just retry.
             }
         }
 

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -63,8 +63,6 @@ fn main() -> ! {
             Err(RecvError::ServerRestarted) => {
                 // `net` restarted (probably due to the watchdog); just retry.
             }
-            Err(RecvError::NotYours) => panic!(),
-            Err(RecvError::Other) => panic!(),
         }
 
         // Try again.

--- a/task/udpecho/src/main.rs
+++ b/task/udpecho/src/main.rs
@@ -45,12 +45,9 @@ fn main() -> ! {
                             )
                             .unwrap();
                         }
-                        Err(
-                            SendError::ServerRestarted
-                            | SendError::NotYours
-                            | SendError::InvalidVLan
-                            | SendError::Other,
-                        ) => panic!(),
+                        Err(SendError::ServerRestarted) => {
+                            // Welp, lost an echo, we'll just soldier on.
+                        }
                     }
                 }
             }

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -181,7 +181,6 @@ fn main() -> ! {
             Err(RecvError::ServerRestarted) => {
                 // `net` restarted (probably due to the watchdog); just retry.
             }
-            Err(RecvError::NotYours | RecvError::Other) => panic!(),
         }
         // Try again.
     }

--- a/task/udprpc/src/main.rs
+++ b/task/udprpc/src/main.rs
@@ -166,17 +166,6 @@ fn main() -> ! {
                             )
                             .unwrap_lite();
                         }
-                        // These errors should be impossible if we're configured
-                        // correctly.
-                        Err(SendError::NotYours | SendError::InvalidVLan) => {
-                            unreachable!()
-                        }
-                        // Unclear under what conditions we could se `Other` -
-                        // just panic for now? At the time of this writing
-                        // `Other` should only come back if the destination
-                        // address in `meta` is bogus or our socket is closed,
-                        // neither of which should be possible here.
-                        Err(SendError::Other) => panic!(),
                     }
                 }
             }


### PR DESCRIPTION
Since its original implementation, the netstack has had some error variants that were... strange. Some of them clearly indicate programming errors (like `NotYours`, which happens if you attempt to send through somebody else's socket), and others clearly indicate...well, nothing, because there was one called `Other`.

I tracked down what was generating these in practice and converted most of the cases to reply-fault, since they represented programmer errors that broke preconditions. I've cleaned up and commented the handling of the remaining error conditions in all clients.