### PR TITLE
net: fix `gimletlet_mgmt` BSP compilation error

### DIFF
--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -28,7 +28,7 @@ use vsc85xx::VscError;
 
 task_slot!(USER_LEDS, user_leds);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
     None,
     BspConfigured,


### PR DESCRIPTION
Currently, the `gimletlet_mgmt` BSP for `task-net` fails to compile due to deriving `Debug` for its ringbuf entry type. Since @cbiffle removed a bunch of debug impls to reduce binary size, this no longer compiles. I've removed the derived `Debug` impl.