### PR TITLE
spi: A reSPIte from excessive error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ name = "ksz8463"
 version = "0.1.0"
 dependencies = [
  "drv-spi-api",
+ "idol-runtime",
  "num-traits",
  "ringbuf",
  "userlib",

--- a/drv/fpga-devices/src/ecp5_spi.rs
+++ b/drv/fpga-devices/src/ecp5_spi.rs
@@ -41,8 +41,6 @@ impl From<Ecp5UsingSpiError> for u8 {
             Ecp5UsingSpiError::SpiError(e) => match e {
                 SpiError::BadTransferSize => 3,
                 SpiError::TaskRestarted => 4,
-                SpiError::NothingToRelease => 5,
-                SpiError::BadDevice => 6,
             },
         }
     }
@@ -120,12 +118,16 @@ impl<S: SpiServer> Ecp5Driver for Ecp5UsingSpi<S> {
     }
 
     fn configuration_lock(&self) -> Result<(), Self::Error> {
-        self.configuration_port.lock(spi_api::CsState::Asserted)?;
+        self.configuration_port
+            .lock(spi_api::CsState::Asserted)
+            .map_err(|_| SpiError::TaskRestarted)?;
         Ok(())
     }
 
     fn configuration_release(&self) -> Result<(), Self::Error> {
-        self.configuration_port.release()?;
+        self.configuration_port
+            .release()
+            .map_err(|_| SpiError::TaskRestarted)?;
         Ok(())
     }
 }
@@ -165,11 +167,17 @@ impl<S: SpiServer> FpgaUserDesign for Ecp5UsingSpi<S> {
     }
 
     fn user_design_lock(&self) -> Result<(), FpgaError> {
-        Ok(self.user_design.lock(spi_api::CsState::Asserted)?)
+        Ok(self
+            .user_design
+            .lock(spi_api::CsState::Asserted)
+            .map_err(|_| SpiError::TaskRestarted)?)
     }
 
     fn user_design_release(&self) -> Result<(), FpgaError> {
-        Ok(self.user_design.release()?)
+        Ok(self
+            .user_design
+            .release()
+            .map_err(|_| SpiError::TaskRestarted)?)
     }
 }
 

--- a/drv/fpga-devices/src/ecp5_spi.rs
+++ b/drv/fpga-devices/src/ecp5_spi.rs
@@ -120,14 +120,12 @@ impl<S: SpiServer> Ecp5Driver for Ecp5UsingSpi<S> {
     fn configuration_lock(&self) -> Result<(), Self::Error> {
         self.configuration_port
             .lock(spi_api::CsState::Asserted)
-            .map_err(|_| SpiError::TaskRestarted)?;
+            .map_err(SpiError::from)?;
         Ok(())
     }
 
     fn configuration_release(&self) -> Result<(), Self::Error> {
-        self.configuration_port
-            .release()
-            .map_err(|_| SpiError::TaskRestarted)?;
+        self.configuration_port.release().map_err(SpiError::from)?;
         Ok(())
     }
 }
@@ -170,14 +168,11 @@ impl<S: SpiServer> FpgaUserDesign for Ecp5UsingSpi<S> {
         Ok(self
             .user_design
             .lock(spi_api::CsState::Asserted)
-            .map_err(|_| SpiError::TaskRestarted)?)
+            .map_err(SpiError::from)?)
     }
 
     fn user_design_release(&self) -> Result<(), FpgaError> {
-        Ok(self
-            .user_design
-            .release()
-            .map_err(|_| SpiError::TaskRestarted)?)
+        Ok(self.user_design.release().map_err(SpiError::from)?)
     }
 }
 

--- a/drv/ksz8463/Cargo.toml
+++ b/drv/ksz8463/Cargo.toml
@@ -9,6 +9,7 @@ num-traits = { workspace = true }
 drv-spi-api = {path = "../../drv/spi-api"}
 ringbuf = {path = "../../lib/ringbuf" }
 userlib = {path = "../../sys/userlib" }
+idol-runtime = { workspace = true }
 
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -24,6 +24,12 @@ impl From<SpiError> for Error {
     }
 }
 
+impl From<idol_runtime::ServerDeath> for Error {
+    fn from(_: idol_runtime::ServerDeath) -> Self {
+        Self::SpiError(SpiError::TaskRestarted)
+    }
+}
+
 pub enum VLanMode {
     /// Configure VLAN tags 0x301 and 0x302 for (upstream) ports 1 and 2
     /// respectively.  Allow untagged frames on any port, but drop tagged

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -9,23 +9,8 @@
 use derive_idol_err::IdolError;
 use gateway_messages::SpiError as GwSpiError;
 use hubpack::SerializedSize;
-use idol_runtime::RequestError;
 use serde::{Deserialize, Serialize};
 use userlib::*;
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SpiServerError {
-    /// Transfer size is 0 or exceeds maximum
-    BadTransferSize = 1,
-
-    /// Attempt to operate device N when there is no device N, or an attempt to
-    /// operate on _any other_ device when you've locked the controller to one.
-    ///
-    /// This is almost certainly a programming error on the client side.
-    BadDevice = 2,
-
-    TaskRestarted = 4,
-}
 
 #[derive(
     Copy,
@@ -55,22 +40,6 @@ impl From<SpiError> for GwSpiError {
         match value {
             SpiError::BadTransferSize => Self::BadTransferSize,
             SpiError::TaskRestarted => Self::TaskRestarted,
-        }
-    }
-}
-
-impl From<SpiServerError> for RequestError<SpiError> {
-    fn from(value: SpiServerError) -> Self {
-        match value {
-            SpiServerError::BadTransferSize => {
-                RequestError::Runtime(SpiError::BadTransferSize)
-            }
-            SpiServerError::BadDevice => {
-                idol_runtime::ClientError::BadMessageContents.fail()
-            }
-            SpiServerError::TaskRestarted => {
-                RequestError::Runtime(SpiError::TaskRestarted)
-            }
         }
     }
 }

--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -35,6 +35,12 @@ pub enum SpiError {
     TaskRestarted = 4,
 }
 
+impl From<idol_runtime::ServerDeath> for SpiError {
+    fn from(_: idol_runtime::ServerDeath) -> Self {
+        SpiError::TaskRestarted
+    }
+}
+
 impl From<SpiError> for GwSpiError {
     fn from(value: SpiError) -> Self {
         match value {

--- a/drv/stm32h7-spi-server-core/src/lib.rs
+++ b/drv/stm32h7-spi-server-core/src/lib.rs
@@ -769,14 +769,14 @@ impl SpiServer for SpiServerCore {
     ) -> Result<(), idol_runtime::ServerDeath> {
         // When someone is using the SpiServerCore directly (rather than through
         // RPC), we use TaskId::UNBOUND as the locking task.
-        Ok(
-            SpiServerCore::lock(self, TaskId::UNBOUND, device_index, cs_state)
-                .unwrap_lite(),
-        )
+        SpiServerCore::lock(self, TaskId::UNBOUND, device_index, cs_state)
+            .unwrap_lite();
+        Ok(())
     }
 
     fn release(&self) -> Result<(), idol_runtime::ServerDeath> {
-        Ok(SpiServerCore::release(self, TaskId::UNBOUND).unwrap_lite())
+        SpiServerCore::release(self, TaskId::UNBOUND).unwrap_lite();
+        Ok(())
     }
 }
 

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -10,6 +10,8 @@
 #![no_std]
 #![no_main]
 
+use core::convert::Infallible;
+
 use drv_spi_api::*;
 use idol_runtime::{
     LeaseBufReader, LeaseBufWriter, Leased, LenLimit, NotificationHandler,
@@ -103,17 +105,19 @@ impl InOrderSpiImpl for ServerImpl {
         rm: &RecvMessage,
         devidx: u8,
         cs_state: CsState,
-    ) -> Result<(), RequestError<SpiError>> {
+    ) -> Result<(), RequestError<Infallible>> {
         self.core
             .lock(rm.sender, devidx, cs_state)
-            .map_err(RequestError::from)
+            .map_err(|_| idol_runtime::ClientError::BadMessageContents.fail())
     }
 
     fn release(
         &mut self,
         rm: &RecvMessage,
-    ) -> Result<(), RequestError<SpiError>> {
-        self.core.release(rm.sender).map_err(RequestError::from)
+    ) -> Result<(), RequestError<Infallible>> {
+        self.core
+            .release(rm.sender)
+            .map_err(|_| idol_runtime::ClientError::BadMessageContents.fail())
     }
 }
 

--- a/idl/spi.idol
+++ b/idl/spi.idol
@@ -55,7 +55,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SpiError"),
+                err: ServerDeath,
             ),
         ),
         "release": (
@@ -63,7 +63,7 @@ Interface(
             args: {},
             reply: Result(
                 ok: "()",
-                err: CLike("SpiError"),
+                err: ServerDeath,
             ),
         ),
     },


### PR DESCRIPTION
Currently, the SPI API has a single big error enum which it returns from
all IPCs. This isn't all that great: for example, a `NothingToRelease`
error can be returned from the `Spi::read` IPC, which...doesn't make a
ton of sense. Additionally, many of these error variants are returned
only in the event of a programmer error in a client task, rather than
expected runtime errors, and probably should be `reply-fault`s rather
than error codes.

Per @cbiffle on Matrix:

> Re: the SPI errors, we've got
>
> - `TaskRestarted` - sure makes sense, also probably not appropriate to
>   unwrap though
> - `NothingToRelease` - should be reply-fault, indicates that you're
>   acting like you've locked the device when you haven't.
> - `BadDevice` - should be reply-fault, indicates that you've made up a
>   device index, that's what config is for
> - `BadTransferSize` - this one's subtle. The max transfer is
>   platform-specific, and there's currently no way to discover it. We
>   could treat this as a precondition and reply-fault it, but code that
>   wants to be diligent and check preconditions currently has no way to
>   do so! We could also define a common max value in the API and insist
>   upon it on all platforms, at which point this would be reply-fault.

Therefore, I've refactored the `SpiError` type to remove the
`NothingToRelease` and `BadDevice` variants, and changed the `Spi` IPC
interface so that the `lock` and `release` APIs only return runtime
errors on server death --- the `SpiError` type is now only returned by
`Spi::read`, `Spi::write`, and `Spi::exchange`. In situations where
`BadDevice` or `NothingToRelease` errors would previously have been
returned, the SPI server now sends a reply-fault instead.

The SPI API is a bit different from other driver APIs, as there's a
provision for running the SPI driver locally when a task has exclusive
ownership over a specific SPI bus, as well as running it as its own
driver task. In this case, the cases which would return reply-fault when
the driver is its own task now panic when the SPI interface's driver is
local to another task.

This reduces the total archive size for `gimlet/rev-f.toml` by 1%
(according to `cargo xtask sizes`), which is, honestly, not that much.
But, it still seems worthwhile.
