### PR TITLE
prevent I2C from hanging on lost interrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "bitfield 0.13.2",
  "build-util",
  "cfg-if",
+ "counters",
  "drv-i2c-api",
  "drv-stm32xx-sys-api",
  "num-traits",

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -34,6 +34,7 @@ task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h743"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -34,6 +34,7 @@ task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -32,7 +32,7 @@ task-slots = ["jefe"]
 name = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
-max-sizes = {flash = 16384, ram = 1024}
+max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys"]

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -32,7 +32,7 @@ task-slots = ["jefe"]
 name = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
-max-sizes = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 1024}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -32,6 +32,7 @@ task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -71,6 +71,7 @@ notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -125,7 +126,7 @@ name = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
-stacksize = 2504
+stacksize = 2800
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
@@ -135,7 +136,7 @@ name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
-stacksize = 1024
+stacksize = 1200
 start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -33,6 +33,7 @@ task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -43,6 +43,7 @@ task-slots = ["jefe"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
@@ -88,7 +89,7 @@ name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
-stacksize = 1024
+stacksize = 1200
 start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
@@ -207,7 +208,7 @@ notifications = ["timer"]
 name = "task-power"
 priority = 4
 max-sizes = {flash = 32768, ram = 4096}
-stacksize = 1504
+stacksize = 2504
 start = true
 task-slots = ["i2c_driver", "sensor", "sys"]
 features = ["psc"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -150,6 +150,7 @@ interrupts = {"spi2.irq" = "spi-irq"}
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
+stacksize = 1048
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
@@ -173,7 +174,7 @@ name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
-stacksize = 1024
+stacksize = 1200
 start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
@@ -264,7 +265,7 @@ name = "task-power"
 features = ["sidecar"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
-stacksize = 2048
+stacksize = 2800
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]
 notifications = ["timer"]

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -240,7 +240,7 @@ enum Trace {
     None,
 }
 
-ringbuf!(Trace, 174, Trace::None);
+ringbuf!(Trace, 160, Trace::None);
 
 fn reset(
     controller: &I2cController<'_>,

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -340,10 +340,7 @@ fn main() -> ! {
         enable: |notification| {
             sys_irq_control(notification, true);
         },
-        wfi: |notification| {
-            _ = sys_recv_closed(&mut [], notification, TaskId::KERNEL);
-        },
-        wfi_or_timeout: |notification, timeout| {
+        wfi: |notification, timeout| {
             const TIMER_NOTIFICATION: u32 = 1 << 31;
 
             let dead = sys_get_timer().now.checked_add(timeout.0).unwrap_lite();

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -349,10 +349,12 @@ fn main() -> ! {
             let dead = sys_get_timer().now.checked_add(timeout.0).unwrap_lite();
             sys_set_timer(Some(dead), TIMER_NOTIFICATION);
 
-            let m = sys_recv_closed(&mut [],
+            let m = sys_recv_closed(
+                &mut [],
                 notification | TIMER_NOTIFICATION,
-                TaskId::KERNEL
-            ).unwrap_lite();
+                TaskId::KERNEL,
+            )
+            .unwrap_lite();
 
             if m.operation == TIMER_NOTIFICATION {
                 I2cControlResult::TimedOut

--- a/drv/stm32xx-i2c/Cargo.toml
+++ b/drv/stm32xx-i2c/Cargo.toml
@@ -14,6 +14,7 @@ zerocopy = { workspace = true }
 drv-i2c-api = { path = "../i2c-api" }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 ringbuf = { path = "../../lib/ringbuf" }
+counters = { path = "../../lib/counters" }
 userlib = { path = "../../sys/userlib" }
 
 [features]

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -80,7 +80,7 @@ pub struct I2cTimeout(pub u64);
 
 pub enum I2cControlResult {
     Interrupted,
-    TimedOut
+    TimedOut,
 }
 
 ///
@@ -159,6 +159,7 @@ pub enum ReadLength {
     Variable,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum Register {
     CR1,
@@ -203,7 +204,7 @@ enum Trace {
     None,
 }
 
-counted_ringbuf!(Trace, 48, Trace::None);
+ringbuf!(Trace, 48, Trace::None);
 
 impl I2cMux<'_> {
     /// A convenience routine to translate an error induced by in-band
@@ -496,7 +497,7 @@ impl I2cController<'_> {
     /// has gone wrong with a device (which should rather be indicated by
     /// returning an error and resetting the controller if/as needed), but with
     /// the controller itself.
-    /// 
+    ///
     fn panic(&self) -> ! {
         let i2c = self.registers;
         let tgr = &i2c.timingr;
@@ -542,7 +543,7 @@ impl I2cController<'_> {
                 ringbuf_entry!(Trace::LostInterrupt);
                 self.panic();
             }
-            I2cControlResult::Interrupted => Ok(())
+            I2cControlResult::Interrupted => Ok(()),
         }
     }
 

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -74,6 +74,16 @@ pub struct I2cController<'a> {
 }
 
 ///
+/// A structure to denote an absolute number of ticks to wait.
+///
+pub struct I2cTimeout(pub u64);
+
+pub enum I2cControlResult {
+    Interrupted,
+    TimedOut
+}
+
+///
 /// A structure that defines interrupt control flow functions that will be
 /// used to pass control flow into the kernel to either enable or wait for
 /// interrupts.  Note that this is deliberately a struct and not a trait,
@@ -82,6 +92,7 @@ pub struct I2cController<'a> {
 pub struct I2cControl {
     pub enable: fn(u32),
     pub wfi: fn(u32),
+    pub wfi_or_timeout: fn(u32, I2cTimeout) -> I2cControlResult,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -149,36 +160,50 @@ pub enum ReadLength {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+enum Register {
+    CR1,
+    CR2,
+    OAR1,
+    OAR2,
+    TIMINGR,
+    TIMEOUTR,
+    ISR,
+    PECR,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, counters::Count)]
 enum Trace {
-    WaitISR(u32),
-    WriteISR(u32),
-    WriteWaitISR(u32),
-    ReadISR(u32),
-    ReadWaitISR(u32),
-    RxISR(u32),
-    KonamiISR(u32),
-    Konami(I2cKonamiCode),
-    ResetISR(u32),
-    ResetCR2(u32),
-    AddrISR(u32),
+    Wait(Register, u32),
+    Write(Register, u32),
+    WriteWait(Register, u32),
+    Read(Register, u32),
+    ReadWait(Register, u32),
+    KonamiOperation(I2cKonamiCode),
+    Konami(Register, u32),
+    Reset(Register, u32),
+    Addr(Register, u32),
     AddrMatch,
     AddrNack(u8),
+    RxReg(Register, u32),
     Rx(u8, u8),
     RxNack(u8, u8),
     Tx(u8, u8),
     TxBogus(u8),
     TxOverrun(u8),
-    TxISR(u32),
+    TxReg(Register, u32),
     WaitAddr,
     WaitRx,
     WaitTx,
     BusySleep,
     Stop,
     RepeatedStart(bool),
+    LostInterrupt,
+    Panic(Register, u32),
+    #[count(skip)]
     None,
 }
 
-ringbuf!(Trace, 48, Trace::None);
+counted_ringbuf!(Trace, 48, Trace::None);
 
 impl I2cMux<'_> {
     /// A convenience routine to translate an error induced by in-band
@@ -427,7 +452,7 @@ impl I2cController<'_> {
         // ...wait until we see it disabled.
         loop {
             let cr1 = i2c.cr1.read();
-            ringbuf_entry!(Trace::ResetISR(cr1.bits()));
+            ringbuf_entry!(Trace::Reset(Register::CR1, cr1.bits()));
             if cr1.pe().is_disabled() {
                 break;
             }
@@ -436,7 +461,7 @@ impl I2cController<'_> {
         // And then finally set it
         i2c.cr1.modify(|_, w| w.pe().set_bit());
 
-        ringbuf_entry!(Trace::ResetCR2(i2c.cr2.read().bits()));
+        ringbuf_entry!(Trace::Reset(Register::CR2, i2c.cr2.read().bits()));
     }
 
     ///
@@ -466,6 +491,61 @@ impl I2cController<'_> {
         Ok(())
     }
 
+    ///
+    /// A routine to panic.  This should not be called merely because something
+    /// has gone wrong with a device (which should rather be indicated by
+    /// returning an error and resetting the controller if/as needed), but with
+    /// the controller itself.
+    /// 
+    fn panic(&self) -> ! {
+        let i2c = self.registers;
+        let tgr = &i2c.timingr;
+        let tor = &i2c.timeoutr;
+
+        ringbuf_entry!(Trace::Panic(Register::CR1, i2c.cr1.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::CR2, i2c.cr2.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::OAR1, i2c.oar1.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::OAR2, i2c.oar2.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::TIMINGR, tgr.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::TIMEOUTR, tor.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::ISR, i2c.isr.read().bits()));
+        ringbuf_entry!(Trace::Panic(Register::PECR, i2c.pecr.read().bits()));
+
+        panic!();
+    }
+
+    ///
+    /// A common routine to wait for interrupts with a timeout.
+    ///
+    fn wfi(&self, ctrl: &I2cControl) -> Result<(), drv_i2c_api::ResponseCode> {
+        //
+        // A 100 ms timeout is much, much longer than the I2C timeouts.
+        //
+        const TIMEOUT: I2cTimeout = I2cTimeout(100);
+
+        match (ctrl.wfi_or_timeout)(self.notification, TIMEOUT) {
+            I2cControlResult::TimedOut => {
+                //
+                // This really shouldn't happen:  it means that not only did we
+                // not get our expected interrupt, but that the configured
+                // timeout in the I2C block also didn't fire an interrupt as
+                // expected.  That said, we got our OS timer interrupt (or we
+                // wouldn't be here at all), which gives us at least control.
+                // While we could conceivably return an error code in this
+                // condition, this condition is so unexpected that we want to
+                // instead make sure we can debug it: we are going to record
+                // some additional data from the I2C controller into our ring
+                // buffer and panic.  This will result in a dump that will
+                // effectively preserve this state, and will (hopefuflly) allow
+                // it to be debugged long after it happens.
+                //
+                ringbuf_entry!(Trace::LostInterrupt);
+                self.panic();
+            }
+            I2cControlResult::Interrupted => Ok(())
+        }
+    }
+
     fn wait_until_notbusy(&self) -> Result<(), drv_i2c_api::ResponseCode> {
         let i2c = self.registers;
 
@@ -484,7 +564,7 @@ impl I2cController<'_> {
 
         for lap in 0..=BUSY_SLEEP_THRESHOLD + 1 {
             let isr = i2c.isr.read();
-            ringbuf_entry!(Trace::WaitISR(isr.bits()));
+            ringbuf_entry!(Trace::Wait(Register::ISR, isr.bits()));
 
             //
             // For reasons unclear and unknown, the timeout flag can become
@@ -570,7 +650,7 @@ impl I2cController<'_> {
             while pos < wlen {
                 loop {
                     let isr = i2c.isr.read();
-                    ringbuf_entry!(Trace::WriteISR(isr.bits()));
+                    ringbuf_entry!(Trace::Write(Register::ISR, isr.bits()));
 
                     self.check_errors(&isr)?;
 
@@ -583,7 +663,7 @@ impl I2cController<'_> {
                         break;
                     }
 
-                    (ctrl.wfi)(notification);
+                    self.wfi(ctrl)?;
                     (ctrl.enable)(notification);
                 }
 
@@ -600,7 +680,7 @@ impl I2cController<'_> {
             // we've been NACK'd (denoting an illegal register value)
             loop {
                 let isr = i2c.isr.read();
-                ringbuf_entry!(Trace::WriteWaitISR(isr.bits()));
+                ringbuf_entry!(Trace::WriteWait(Register::ISR, isr.bits()));
 
                 self.check_errors(&isr)?;
 
@@ -613,7 +693,7 @@ impl I2cController<'_> {
                     break;
                 }
 
-                (ctrl.wfi)(notification);
+                self.wfi(ctrl)?;
                 (ctrl.enable)(notification);
             }
         }
@@ -661,11 +741,11 @@ impl I2cController<'_> {
                 }
 
                 loop {
-                    (ctrl.wfi)(notification);
+                    self.wfi(ctrl)?;
                     (ctrl.enable)(notification);
 
                     let isr = i2c.isr.read();
-                    ringbuf_entry!(Trace::ReadISR(isr.bits()));
+                    ringbuf_entry!(Trace::Read(Register::ISR, isr.bits()));
 
                     self.check_errors(&isr)?;
 
@@ -708,7 +788,7 @@ impl I2cController<'_> {
             // All done; now block until our transfer is complete...
             loop {
                 let isr = i2c.isr.read();
-                ringbuf_entry!(Trace::ReadWaitISR(isr.bits()));
+                ringbuf_entry!(Trace::ReadWait(Register::ISR, isr.bits()));
 
                 if isr.tc().is_complete() {
                     break;
@@ -716,7 +796,7 @@ impl I2cController<'_> {
 
                 self.check_errors(&isr)?;
 
-                (ctrl.wfi)(notification);
+                self.wfi(ctrl)?;
                 (ctrl.enable)(notification);
             }
         }
@@ -764,7 +844,7 @@ impl I2cController<'_> {
                 I2cKonamiCode::Read => true,
             };
 
-            ringbuf_entry!(Trace::Konami(*op));
+            ringbuf_entry!(Trace::KonamiOperation(*op));
 
             #[rustfmt::skip]
             i2c.cr2.modify(|_, w| { w
@@ -782,7 +862,7 @@ impl I2cController<'_> {
             // at our Konami Code sequence).
             loop {
                 let isr = i2c.isr.read();
-                ringbuf_entry!(Trace::KonamiISR(isr.bits()));
+                ringbuf_entry!(Trace::Konami(Register::ISR, isr.bits()));
 
                 self.check_errors(&isr)?;
 
@@ -866,7 +946,7 @@ impl I2cController<'_> {
             // Wait to be addressed.
             let (is_write, addr) = loop {
                 let isr = i2c.isr.read();
-                ringbuf_entry!(Trace::AddrISR(isr.bits()));
+                ringbuf_entry!(Trace::Addr(Register::ISR, isr.bits()));
 
                 // We expect STOPF to have been handled by the transaction loop
                 // below, but given that there may be other irrelevant
@@ -929,7 +1009,7 @@ impl I2cController<'_> {
                 // handle below.
                 'rxloop: loop {
                     let isr = i2c.isr.read();
-                    ringbuf_entry!(Trace::RxISR(isr.bits()));
+                    ringbuf_entry!(Trace::RxReg(Register::ISR, isr.bits()));
 
                     // Note: the order of interrupt flag handling in this
                     // routine is important. More details interleaved below.
@@ -1025,7 +1105,7 @@ impl I2cController<'_> {
 
             'txloop: loop {
                 let isr = i2c.isr.read();
-                ringbuf_entry!(Trace::TxISR(isr.bits()));
+                ringbuf_entry!(Trace::TxReg(Register::ISR, isr.bits()));
 
                 // First, we want to see if we're still transmitting.
 

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -527,18 +527,19 @@ impl I2cController<'_> {
         match (ctrl.wfi_or_timeout)(self.notification, TIMEOUT) {
             I2cControlResult::TimedOut => {
                 //
-                // This really shouldn't happen:  it means that not only did we
-                // not get our expected interrupt, but that the configured
-                // timeout in the I2C block also didn't fire an interrupt as
-                // expected.  That said, we got our OS timer interrupt (or we
-                // wouldn't be here at all), which gives us at least control.
-                // While we could conceivably return an error code in this
-                // condition, this condition is so unexpected that we want to
-                // instead make sure we can debug it: we are going to record
-                // some additional data from the I2C controller into our ring
-                // buffer and panic.  This will result in a dump that will
-                // effectively preserve this state, and will (hopefuflly) allow
-                // it to be debugged long after it happens.
+                // This really shouldn't happen:  it means that not only did
+                // we not get our expected interrupt, but that the configured
+                // timeout in the I2C block also didn't function as expected.
+                // That said, we got our OS timer interrupt (or we wouldn't be
+                // here at all), which gives us at least control.  While we
+                // could conceivably return an error code in this condition,
+                // this condition is so unexpected that we want to instead
+                // make sure we can debug it:  we are going to instead call
+                // our panic routine, which will record some additional data
+                // from the I2C controller and explicitly panic.  This will
+                // result in a dump that will effectively preserve this state,
+                // and will (hopefuflly) allow it to be debugged long after it
+                // happens.
                 //
                 ringbuf_entry!(Trace::LostInterrupt);
                 self.panic();

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -25,7 +25,7 @@ use core::cell::Cell;
 use core::cell::RefCell;
 use drv_gimlet_seq_api::NUM_SPD_BANKS;
 use drv_gimlet_state::PowerState;
-use drv_stm32xx_i2c::{I2cControl, I2cPins};
+use drv_stm32xx_i2c::{I2cPins, I2cTargetControl};
 use drv_stm32xx_sys_api::{OutputType, Pull, Speed, Sys};
 use ringbuf::{ringbuf, ringbuf_entry};
 use task_jefe_api::Jefe;
@@ -249,15 +249,12 @@ fn main() -> ! {
         rval
     };
 
-    let ctrl = I2cControl {
+    let ctrl = I2cTargetControl {
         enable: |notification| {
             sys_irq_control(notification, true);
         },
         wfi: |notification| {
             let _ = sys_recv_closed(&mut [], notification, TaskId::KERNEL);
-        },
-        wfi_or_timeout: |_notification, _timeout| {
-            panic!();
         },
     };
 

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -258,7 +258,7 @@ fn main() -> ! {
         },
         wfi_or_timeout: |_notification, _timeout| {
             panic!();
-        }
+        },
     };
 
     controller.operate_as_target(&ctrl, &mut initiate, &mut rx, &mut tx);

--- a/task/spd/src/main.rs
+++ b/task/spd/src/main.rs
@@ -256,6 +256,9 @@ fn main() -> ! {
         wfi: |notification| {
             let _ = sys_recv_closed(&mut [], notification, TaskId::KERNEL);
         },
+        wfi_or_timeout: |_notification, _timeout| {
+            panic!();
+        }
     };
 
     controller.operate_as_target(&ctrl, &mut initiate, &mut rx, &mut tx);


### PR DESCRIPTION
Draft commit message:

```
This addresses #1631 by adding a (long) timeout whenever we wait for
an interrupt from the I2C controller.  This timeout shouldn't ever
fire:  if it does, something seriously is amiss, so we record more or
less everything we can out of the I2C controller and explicitly panic.
```
