### PR TITLE
counters: add `"counters-disabled"` feature flag

### DIFF
--- a/lib/ringbuf/Cargo.toml
+++ b/lib/ringbuf/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 # To disable a ring buffer (but leave it otherwise present), enable the
 # "disabled" feature
 disabled = []
+# To disable counters as well as ring buffers, enable the "counters-disabled"
+# feature.
+counters-disabled = []
 default = ["counters"]
 
 [dependencies]


### PR DESCRIPTION
The `ringbuf` crate has a `"disabled` feature flag, which disables ring buffers, intended for use on memory-constrained targets. Currently, setting the `"disabled"` feature flag still enables counters for ring buffers declared using the `counted_ringbuf!` macro, because counters generally require less RAM than full ringbufs. However, on some targets, even counters are too large, especially when a ringbuf's entry type has too many variants (e.g. see [this comment][1] from @bcantrill --- the `i2c_driver` ringbuf must disable counters in order to fit in Donglet's RAM).

Therefore, this commit adds an additional `"counters-disabled"` feature flag to the `ringbuf` crate, to allow disabling counters as well as ring buffers.

[1]: https://github.com/oxidecomputer/hubris/pull/1657#discussion_r1525354299