### PR TITLE
kern: add `IRQ_STATUS` syscall

### DIFF
--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -6,7 +6,7 @@ board = "stm32g031-nucleo"
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 10752, ram = 1296}
+requires = {flash = 11104, ram = 1296}
 features = ["g031"]
 stacksize = 640
 

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -7,7 +7,7 @@ stacksize = 944
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 18976, ram = 1632}
+requires = {flash = 19040, ram = 1632}
 features = ["g070"]
 stacksize = 640
 

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -7,7 +7,7 @@ stacksize = 944
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 18448, ram = 1632}
+requires = {flash = 18976, ram = 1632}
 features = ["g070"]
 stacksize = 640
 

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-stm32h7-nucleo"
-requires = {flash = 24000, ram = 5120}
+requires = {flash = 24320, ram = 5120}
 features = ["h753", "dump"]
 
 [tasks.jefe]

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18144, ram = 1616}
+requires = {flash = 18656, ram = 1616}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18656, ram = 1616}
+requires = {flash = 18720, ram = 1616}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18880, ram = 1820}
+requires = {flash = 18944, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18272, ram = 1820}
+requires = {flash = 18880, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -17,7 +17,7 @@ fwid = true
 [kernel]
 name = "lpc55xpresso"
 features = ["dice-self"]
-requires = {flash = 53248, ram = 4096}
+requires = {flash = 53312, ram = 4096}
 
 [caboose]
 region = "flash"
@@ -183,7 +183,7 @@ task-slots = ["swd"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 47360, ram = 32768}
+max-sizes = {flash = 48512, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -9,7 +9,7 @@ fwid = true
 [kernel]
 name = "lpc55xpresso"
 features = ["dump", "dice-self"]
-requires = {flash = 54116, ram = 4096}
+requires = {flash = 54336, ram = 4096}
 
 [caboose]
 region = "flash"

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -10,7 +10,7 @@ fwid = true
 
 [kernel]
 name = "oxide-rot-1"
-requires = {flash = 52512, ram = 4096}
+requires = {flash = 61124, ram = 4096}
 features = ["dice-self"]
 
 [caboose]

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -10,7 +10,7 @@ fwid = true
 
 [kernel]
 name = "oxide-rot-1"
-requires = {flash = 60644, ram = 2696}
+requires = {flash = 61124, ram = 2696}
 features = ["dice-mfg"]
 
 [caboose]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -11,7 +11,7 @@ fwid = true
 [kernel]
 name = "rot-carrier"
 features = ["dice-self"]
-requires = {flash = 53000, ram = 4096}
+requires = {flash = 53408, ram = 4096}
 
 [caboose]
 tasks = ["caboose_reader", "sprot"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 25384, ram = 6256}
+requires = {flash = 25792, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/doc/syscalls.adoc
+++ b/doc/syscalls.adoc
@@ -659,3 +659,43 @@ return registers 0 and 1 for future compatibility.
 Like `REPLY`, this syscall just silently ignores replies to the wrong
 generation, under the assumption that the task got restarted for some reason
 while we were processing its request. (It can happen.)
+
+[#sys_irq_status]
+=== `IRQ_STATUS` (13)
+
+Returns the current status of interrupts mapped to the calling task.
+
+==== Arguments
+
+- 0: notification bitmask corresponding to the interrupt(s) to query
+
+==== Return values
+
+- 0: an `IrqStatus` (see the `abi` crate) describing the status of the
+  interrupts in the notification mask. Currently, the following bits in
+  `IrqStatus` are significant:
+  ** `0b0001`: set if any interrupt in the mask is enabled
+  ** `0b0010`: set if an IRQ is pending for any interrupt in the mask
+  ** `0b0100`: set if a notification has been posted to the caller but
+     not yet consumed
+
+==== Faults
+
+|===
+| Condition | Fault taken
+
+| The given notification bitmask is not mapped to an interrupt in this task.
+| `NoIrq`
+
+|===
+
+==== Notes
+
+As discussed in the notes for the <<sys_irq_control, IRQ_CONTROL>> syscall,
+tasks refer to interrupts using their notification bits.
+
+If the provided notification mask is zero, the syscall will return a `NoIrq`
+fault. If the provided notification mask has multiple bits set, the returned
+`IrqStatus` value will be the boolean OR of the status of all interrupts in the
+map (e.g. if any interrupt in the mask is pending, the `PENDING` bit will be
+set, and so on).

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -182,7 +182,7 @@ pub struct ULease {
     pub length: u32,
 }
 
-#[derive(Copy, Clone, Debug, FromBytes)]
+#[derive(Copy, Clone, Debug, FromBytes, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct LeaseAttributes(u32);
 

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -492,6 +492,7 @@ pub enum Kipcnum {
     Reset = 5,
     GetTaskDumpRegion = 6,
     ReadTaskDumpRegion = 7,
+    SoftwareIrq = 8,
 }
 
 impl core::convert::TryFrom<u16> for Kipcnum {
@@ -506,6 +507,7 @@ impl core::convert::TryFrom<u16> for Kipcnum {
             5 => Ok(Self::Reset),
             6 => Ok(Self::GetTaskDumpRegion),
             7 => Ok(Self::ReadTaskDumpRegion),
+            8 => Ok(Self::SoftwareIrq),
             _ => Err(()),
         }
     }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -537,7 +537,7 @@ pub struct ImageVectors {
 
 #[derive(Copy, Clone, Debug, FromBytes)]
 #[repr(transparent)]
-pub struct IrqStatus(u32);
+pub struct IrqStatus(pub u32);
 
 bitflags::bitflags! {
     impl IrqStatus: u32 {
@@ -545,7 +545,7 @@ bitflags::bitflags! {
         const ENABLED = 1 << 0;
         /// If 1, an IRQ is currently pending for this interrupt.
         const PENDING = 1 << 1;
-
+        ///If 1, a notification has been posted for this interrupt.
         const POSTED = 1 << 2;
     }
 }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -535,6 +535,8 @@ pub struct ImageVectors {
     pub entry: u32,
 }
 
+/// A set of bitflags representing the status of the interrupts mapped to a
+/// notification mask.
 #[derive(Copy, Clone, Debug, FromBytes)]
 #[repr(transparent)]
 pub struct IrqStatus(pub u32);

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -446,6 +446,7 @@ pub enum Sysnum {
     RefreshTaskId = 10,
     Post = 11,
     ReplyFault = 12,
+    IrqStatus = 13,
 }
 
 /// We're using an explicit `TryFrom` impl for `Sysnum` instead of
@@ -469,6 +470,7 @@ impl core::convert::TryFrom<u32> for Sysnum {
             10 => Ok(Self::RefreshTaskId),
             11 => Ok(Self::Post),
             12 => Ok(Self::ReplyFault),
+            13 => Ok(Self::IrqStatus),
             _ => Err(()),
         }
     }
@@ -531,4 +533,19 @@ pub struct ImageHeader {
 pub struct ImageVectors {
     pub sp: u32,
     pub entry: u32,
+}
+
+#[derive(Copy, Clone, Debug, FromBytes)]
+#[repr(transparent)]
+pub struct IrqStatus(u32);
+
+bitflags::bitflags! {
+    impl IrqStatus: u32 {
+        /// If 1, this interrupt is enabled.
+        const ENABLED = 1 << 0;
+        /// If 1, an IRQ is currently pending for this interrupt.
+        const PENDING = 1 << 1;
+
+        const POSTED = 1 << 2;
+    }
 }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -537,14 +537,11 @@ pub struct ImageVectors {
     pub entry: u32,
 }
 
-/// A set of bitflags representing the status of the interrupts mapped to a
-/// notification mask.
-#[derive(Copy, Clone, Debug, FromBytes, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct IrqStatus(pub u32);
-
 bitflags::bitflags! {
-    impl IrqStatus: u32 {
+    /// A set of bitflags representing the status of the interrupts mapped to a
+    /// notification mask.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct IrqStatus: u32 {
         /// If 1, this interrupt is enabled.
         const ENABLED = 1 << 0;
         /// If 1, an IRQ is currently pending for this interrupt.

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -539,7 +539,7 @@ pub struct ImageVectors {
 
 /// A set of bitflags representing the status of the interrupts mapped to a
 /// notification mask.
-#[derive(Copy, Clone, Debug, FromBytes)]
+#[derive(Copy, Clone, Debug, FromBytes, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct IrqStatus(pub u32);
 

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1175,8 +1175,8 @@ pub fn irq_status(n: u32) -> abi::IrqStatus {
 
     // See if the interrupt is pending by checking the bit in the Interrupt
     // Set Pending Register (ISPR).
-    let pending = nvic.ispr[reg_num].read() & bit_mask != bit_mask;
-    status.set(abi::IrqStatus::ENABLED, pending);
+    let pending = nvic.ispr[reg_num].read() & bit_mask == bit_mask;
+    status.set(abi::IrqStatus::PENDING, pending);
 
     status
 }

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1170,12 +1170,12 @@ pub fn irq_status(n: u32) -> abi::IrqStatus {
 
     // See if the interrupt is enabled by checking the bit in the Interrupt Set
     // Enable Register.
-    let enabled = unsafe { nvic.iser[reg_num].read() & bit_mask == bit_mask };
+    let enabled = nvic.iser[reg_num].read() & bit_mask == bit_mask;
     status.set(abi::IrqStatus::ENABLED, enabled);
 
     // See if the interrupt is pending by checking the bit in the Interrupt
     // Set Pending Register (ISPR).
-    let pending = unsafe { nvic.ispr[reg_num].read() & bit_mask != bit_mask };
+    let pending = nvic.ispr[reg_num].read() & bit_mask != bit_mask;
     status.set(abi::IrqStatus::ENABLED, pending);
 
     status

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -1159,6 +1159,12 @@ pub fn enable_irq(n: u32) {
     }
 }
 
+/// Looks up an interrupt in the NVIC and returns a cross-platform
+/// representation of that interrupt's status.
+pub fn irq_status(n: u32) -> abi::IrqStatus {
+    todo!("eliza")
+}
+
 #[repr(u8)]
 #[allow(dead_code)]
 #[cfg(any(armv7m, armv8m))]

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -39,9 +39,7 @@ pub fn handle_kernel_message(
         Ok(Kipcnum::ReadTaskDumpRegion) => {
             read_task_dump_region(tasks, caller, args.message?, args.response?)
         }
-        Ok(Kipcnum::SoftwareIrq) => {
-            software_irq(tasks, caller, args.message?, args.response?)
-        }
+        Ok(Kipcnum::SoftwareIrq) => software_irq(tasks, caller, args.message?),
 
         _ => {
             // Task has sent an unknown message to the kernel. That's bad.
@@ -435,7 +433,6 @@ fn software_irq(
     tasks: &mut [Task],
     caller: usize,
     message: USlice<u8>,
-    response: USlice<u8>,
 ) -> Result<NextTask, UserError> {
     if caller != 0 {
         return Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -39,6 +39,9 @@ pub fn handle_kernel_message(
         Ok(Kipcnum::ReadTaskDumpRegion) => {
             read_task_dump_region(tasks, caller, args.message?, args.response?)
         }
+        Ok(Kipcnum::SoftwareIrq) => {
+            software_irq(tasks, caller, args.message?, args.response?)
+        }
 
         _ => {
             // Task has sent an unknown message to the kernel. That's bad.
@@ -425,5 +428,37 @@ fn read_task_dump_region(
     tasks[caller]
         .save_mut()
         .set_send_response_and_length(0, response_len);
+    Ok(NextTask::Same)
+}
+
+fn software_irq(
+    tasks: &mut [Task],
+    caller: usize,
+    message: USlice<u8>,
+    response: USlice<u8>,
+) -> Result<NextTask, UserError> {
+    let (index, notification): (u32, u32) =
+        deserialize_message(&tasks[caller], message)?;
+    if index as usize >= tasks.len() {
+        return Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            UsageError::TaskOutOfRange,
+        )));
+    }
+
+    // Look up which IRQs are mapped to the target task.
+    let irqs = crate::startup::HUBRIS_TASK_IRQ_LOOKUP
+        .get(abi::InterruptOwner {
+            task: index,
+            notification,
+        })
+        .ok_or(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            UsageError::NoIrq,
+        )))?;
+
+    for &irq in irqs.iter() {
+        crate::arch::pend_software_irq(irq);
+    }
+
+    tasks[caller].save_mut().set_send_response_and_length(0, 0);
     Ok(NextTask::Same)
 }

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -437,8 +437,15 @@ fn software_irq(
     message: USlice<u8>,
     response: USlice<u8>,
 ) -> Result<NextTask, UserError> {
+    if caller != 0 {
+        return Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            UsageError::NotSupervisor,
+        )));
+    }
+
     let (index, notification): (u32, u32) =
         deserialize_message(&tasks[caller], message)?;
+
     if index as usize >= tasks.len() {
         return Err(UserError::Unrecoverable(FaultInfo::SyscallUsage(
             UsageError::TaskOutOfRange,

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -837,5 +837,18 @@ fn irq_status(
     tasks: &mut [Task],
     caller: usize,
 ) -> Result<NextTask, UserError> {
+    let args = tasks[caller].save().as_irq_status_args();
+
+    let caller = caller as u32;
+
+    let irqs = crate::startup::HUBRIS_TASK_IRQ_LOOKUP
+        .get(abi::InterruptOwner {
+            task: caller,
+            notification: args.notification_bitmask,
+        })
+        .ok_or(UserError::Unrecoverable(FaultInfo::SyscallUsage(
+            UsageError::NoIrq,
+        )))?;
+
     Ok(NextTask::Same)
 }

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -112,6 +112,7 @@ fn safe_syscall_entry(nr: u32, current: usize, tasks: &mut [Task]) -> NextTask {
         Ok(Sysnum::ReplyFault) => {
             reply_fault(tasks, current).map_err(UserError::from)
         }
+        Ok(Sysnum::IrqStatus) => irq_status(tasks, current),
         Err(_) => {
             // Bogus syscall number! That's a fault.
             Err(FaultInfo::SyscallUsage(UsageError::BadSyscallNumber).into())
@@ -817,5 +818,24 @@ fn reply_fault(
     // KEY ASSUMPTION: sends go from less important tasks to more important
     // tasks. As a result, Reply doesn't have scheduling implications unless
     // the task using it faults.
+    Ok(NextTask::Same)
+}
+
+/// Implementation of the `IRQ_STATUS` syscall.
+///
+/// `caller` is a valid task index (i.e. not directly from user code).
+///
+/// # Syscall arguments
+///
+/// - a notification mask
+///
+/// # Syscall returns
+///
+/// - an [`IrqStatus`] structure representing the current state of the interrupts
+///   mapped to the provided notification mask.
+fn irq_status(
+    tasks: &mut [Task],
+    caller: usize,
+) -> Result<NextTask, UserError> {
     Ok(NextTask::Same)
 }

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -646,7 +646,7 @@ pub trait ArchState: Default {
         &mut self,
         abi::IrqStatus(status): abi::IrqStatus,
     ) {
-        self.ret0(status);
+        self.ret0(status.bits());
     }
 }
 

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -642,10 +642,7 @@ pub trait ArchState: Default {
     }
 
     /// Sets the results of IRQ_STATUS.
-    fn set_irq_status_result(
-        &mut self,
-        abi::IrqStatus(status): abi::IrqStatus,
-    ) {
+    fn set_irq_status_result(&mut self, status: abi::IrqStatus) {
         self.ret0(status.bits());
     }
 }

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -632,6 +632,14 @@ pub trait ArchState: Default {
     fn set_refresh_task_id_result(&mut self, id: TaskId) {
         self.ret0(id.0 as u32);
     }
+
+    /// Sets the results of IRQ_STATUS.
+    fn set_irq_status_result(
+        &mut self,
+        abi::IrqStatus(status): abi::IrqStatus,
+    ) {
+        self.ret0(status);
+    }
 }
 
 /// Decoded arguments for the `SEND` syscall.

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -561,6 +561,13 @@ pub trait ArchState: Default {
         }
     }
 
+    /// Interprets arguments as for the `IRQ_STATUS` syscall and returns the results.
+    fn as_irq_status_args(&self) -> IrqStatusArgs {
+        IrqStatusArgs {
+            notification_bitmask: self.arg0(),
+        }
+    }
+
     /// Sets a recoverable error code using the generic ABI.
     fn set_error_response(&mut self, resp: u32) {
         self.ret0(resp);
@@ -700,6 +707,12 @@ pub struct RefreshTaskIdArgs {
 pub struct PostArgs {
     pub task_id: TaskId,
     pub notification_bits: NotificationSet,
+}
+
+/// Decoded arguments for the `IRQ_STATUS` syscall.
+#[derive(Clone, Debug)]
+pub struct IrqStatusArgs {
+    pub notification_bitmask: u32,
 }
 
 /// State for a task timer.

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -281,6 +281,14 @@ impl Task {
         None
     }
 
+    /// Returns `true` if any of the notification bits in `mask` are set in this
+    /// task's notification set.
+    ///
+    /// This does *not* clear any bits in the task's notification set.
+    pub fn has_notifications(&self, mask: u32) -> bool {
+        self.notifications & mask != 0
+    }
+
     /// Checks if this task is in a potentially schedulable state.
     pub fn is_runnable(&self) -> bool {
         self.state == TaskState::Healthy(SchedState::Runnable)

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1652,3 +1652,87 @@ unsafe extern "C" fn sys_reply_fault_stub(_tid: u32, _reason: u32) {
         }
     }
 }
+
+/// Returns the current status of any interrupts mapped to the provided
+/// notification mask.
+///
+/// # Arguments
+///
+/// - `mask`: a notification mask for interrupts mapped to the current task.
+///
+/// # Returns
+///
+/// An [`IrqStatus`] (see the `abi` crate) describing the status of the
+/// interrupts in the notification mask.
+///
+/// # Faults
+///
+/// This syscall faults the caller if the given notification bitmask is not
+/// mapped to an interrupt in this task.
+#[inline(always)]
+pub fn sys_irq_status(mask: u32) -> abi::IrqStatus {
+    let status = unsafe { sys_irq_status_stub(mask) };
+    abi::IrqStatus::from_bits_truncate(status)
+}
+
+/// Core implementation of the IRQ_STATUS syscall.
+///
+/// See the note on syscall stubs at the top of this module for rationale.
+#[naked]
+unsafe extern "C" fn sys_irq_status_stub(_mask: u32) -> u32 {
+    cfg_if::cfg_if! {
+        if #[cfg(armv6m)] {
+            arch::asm!("
+                @ Spill the registers we're about to use to pass stuff.
+                push {{r4, lr}}
+                mov r4, r11
+                push {{r4}}
+
+                @ Load the constant syscall number.
+                eors r4, r4
+                adds r4, #{sysnum}
+                mov r11, r4
+                @ Move register arguments into place.
+                mov r4, r0
+
+                @ To the kernel!
+                svc #0
+
+                @ Move result into place.
+                mov r0, r4
+
+                @ Restore the registers we used and return.
+                pop {{r4}}
+                mov r11, r4
+                pop {{r4, r5, pc}}
+                ",
+                sysnum = const Sysnum::IrqStatus as u32,
+                options(noreturn),
+            )
+        } else if #[cfg(any(armv7m, armv8m))] {
+            arch::asm!("
+                @ Spill the registers we're about to use to pass stuff.
+                push {{r4, r11, lr}}
+
+                @ Move register arguments into place.
+                mov r4, r0
+                @ Load the constant syscall number.
+                mov r11, {sysnum}
+
+                @ To the kernel!
+                svc #0
+
+                @ Move result into place.
+                mov r0, r4
+
+                @ Restore the registers we used and return.
+                pop {{r4, r11, pc}}
+                ",
+                sysnum = const Sysnum::IrqStatus as u32,
+                options(noreturn),
+            )
+        } else {
+            compile_error!("missing sys_irq_status stub for ARM profile")
+        }
+    }
+}

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1704,7 +1704,7 @@ unsafe extern "C" fn sys_irq_status_stub(_mask: u32) -> u32 {
                 @ Restore the registers we used and return.
                 pop {{r4}}
                 mov r11, r4
-                pop {{r4, r5, pc}}
+                pop {{r4, pc}}
                 ",
                 sysnum = const Sysnum::IrqStatus as u32,
                 options(noreturn),

--- a/test/test-api/build.rs
+++ b/test/test-api/build.rs
@@ -3,6 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_util::expose_m_profile();
+    build_util::expose_m_profile()?;
     Ok(())
 }

--- a/test/test-api/src/lib.rs
+++ b/test/test-api/src/lib.rs
@@ -51,6 +51,9 @@ pub enum RunnerOp {
     /// Reads out, and clears, the accumulated set of notifications we've
     /// received (`() -> u32`).
     ReadAndClearNotes = 0,
+    /// Indicates that the test suite would like the test runner to trigger an
+    /// IRQ.
+    SoftIrq = 1,
     /// Signals that a test is complete, and that the runner is switching back
     /// to passive mode (`() -> ()`).
     TestComplete = 0xfffe,

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -85,9 +85,12 @@ fn main() -> ! {
         test_status: None,
     };
 
+    // N.B. that this must be at least four bytes to recv a u32 notification
+    // mask in the `SoftIrq` IPC op.
+    let mut buf = [0u8; 4];
     loop {
         hl::recv(
-            &mut [],
+            &mut buf,
             ALL_NOTIFICATIONS,
             &mut state,
             |state, bits| {

--- a/test/test-suite/build.rs
+++ b/test/test-suite/build.rs
@@ -8,5 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "i2c-devices")]
     build_i2c::codegen(build_i2c::Disposition::Devices)?;
 
+    build_util::build_notifications()?;
+
     Ok(())
 }

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -991,15 +991,15 @@ fn test_borrow_info() {
 
             // Borrow 0 is expected to be 16 bytes long and R/W.
             let info0 = caller.borrow(0).info().unwrap();
-            // assert_eq!(
-            //     info0.attributes,
-            //     LeaseAttributes::READ | LeaseAttributes::WRITE
-            // );
+            assert_eq!(
+                info0.attributes,
+                LeaseAttributes::READ | LeaseAttributes::WRITE
+            );
             assert_eq!(info0.len, 16);
 
             // Borrow 1 is expected to be 5 bytes long and R/O.
             let info1 = caller.borrow(1).info().unwrap();
-            // assert_eq!(info1.attributes, LeaseAttributes::READ);
+            assert_eq!(info1.attributes, LeaseAttributes::READ);
             assert_eq!(info1.len, 5);
 
             caller.reply(0);

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -1434,9 +1434,7 @@ fn test_irq_status() {
 
     // the interrupt should not be pending
     let status = sys_irq_status(notifications::TEST_IRQ_MASK);
-    assert_eq!(status.contains(IrqStatus::ENABLED), false);
-    assert_eq!(status.contains(IrqStatus::PENDING), false);
-    assert_eq!(status.contains(IrqStatus::POSTED), false);
+    assert_eq!(status, IrqStatus::empty());
 
     // enable the interrupt
     sys_irq_control(notifications::TEST_IRQ_MASK, true);
@@ -1446,13 +1444,14 @@ fn test_irq_status() {
 
     // now, there should be an IRQ pending, and a notification waiting for us
     let status = sys_irq_status(notifications::TEST_IRQ_MASK);
-    assert_eq!(status.contains(IrqStatus::ENABLED), true);
-    assert_eq!(status.contains(IrqStatus::PENDING), true);
-    assert_eq!(status.contains(IrqStatus::POSTED), true);
+    let expected_status =
+        IrqStatus::ENABLED | IrqStatus::PENDING | IrqStatus::POSTED;
+    assert_eq!(status, expected_status);
 }
 
 /// Asks the test runner (running as supervisor) to please trigger a software
 /// interrupt for `notifications::TEST_IRQ`, thank you.
+#[track_caller]
 fn trigger_test_irq() {
     let runner = RUNNER.get_task_id();
     let mut response = 0u32;
@@ -1461,7 +1460,7 @@ fn trigger_test_irq() {
     let (rc, len) =
         sys_send(runner, op, arg.as_bytes(), response.as_bytes_mut(), &[]);
     assert_eq!(rc, 0);
-    assert_eq!(len, 4);
+    assert_eq!(len, 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/tests-gemini-bu/app.toml
+++ b/test/tests-gemini-bu/app.toml
@@ -19,7 +19,11 @@ name = "test-suite"
 priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
-task-slots = ["assist", "idol", "suite", "runner"]
+task-slots = ["assist", "idol", "suite", "runner"]# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-gimletlet/app.toml
+++ b/test/tests-gimletlet/app.toml
@@ -19,7 +19,11 @@ name = "test-suite"
 priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
-task-slots = ["assist", "idol", "suite", "runner"]
+task-slots = ["assist", "idol", "suite", "runner"]# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-lpc55xpresso/app.toml
+++ b/test/tests-lpc55xpresso/app.toml
@@ -22,6 +22,11 @@ max-sizes = {flash = 65536, ram = 4096}
 start = true
 stacksize = 2048
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use hashcrypt; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["hash_crypt"]
+notifications = ["test-irq"]
+interrupts = {"hash_crypt.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]
@@ -63,4 +68,3 @@ start = true
 signing-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 root-certs = ["../../support/fake_certs/fake_certificate.der.crt"]
 private-key = "../../support/fake_certs/fake_private_key.pem"
-

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -16,7 +16,7 @@ start = true
 
 [tasks.suite]
 name = "test-suite"
-priority = 2
+priority = 3
 max-sizes = {flash = 65536, ram = 4096}
 start = true
 stacksize = 2048
@@ -66,16 +66,16 @@ start = true
 task-slots = ["sys"]
 
 [tasks.i2c_driver.interrupts]
-"i2c2.event" = 0b0000_0010
-"i2c2.error" = 0b0000_0010
-"i2c3.event" = 0b0000_0100
-"i2c3.error" = 0b0000_0100
-"i2c4.event" = 0b0000_1000
-"i2c4.error" = 0b0000_1000
+"i2c2.event" = "0b0000_0010"
+"i2c2.error" = "0b0000_0010"
+"i2c3.event" = "0b0000_0100"
+"i2c3.error" = "0b0000_0100"
+"i2c4.event" = "0b0000_1000"
+"i2c4.error" = "0b0000_1000"
 
 [tasks.hiffy]
 name = "task-hiffy"
-priority = 3
+priority = 4
 features = ["testsuite"]
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
@@ -84,7 +84,7 @@ task-slots = ["suite", "runner"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 4
+priority = 5
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -66,12 +66,12 @@ start = true
 task-slots = ["sys"]
 
 [tasks.i2c_driver.interrupts]
-"i2c2.event" = "0b0000_0010"
-"i2c2.error" = "0b0000_0010"
-"i2c3.event" = "0b0000_0100"
-"i2c3.error" = "0b0000_0100"
-"i2c4.event" = "0b0000_1000"
-"i2c4.error" = "0b0000_1000"
+"i2c2.event" = 0b0000_0010
+"i2c2.error" = 0b0000_0010
+"i2c3.event" = 0b0000_0100
+"i2c3.error" = 0b0000_0100
+"i2c4.event" = 0b0000_1000
+"i2c4.error" = 0b0000_1000
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -22,6 +22,11 @@ start = true
 stacksize = 2048
 features = ["fru-id-eeprom"]
 task-slots = ["assist", "idol", "suite", "runner", "i2c_driver"]
+# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-rot-carrier/app.toml
+++ b/test/tests-rot-carrier/app.toml
@@ -22,6 +22,11 @@ max-sizes = {flash = 65536, ram = 4096}
 start = true
 stacksize = 2048
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use hashcrypt; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["hash_crypt"]
+notifications = ["test-irq"]
+interrupts = {"hash_crypt.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-stm32fx/app-f3.toml
+++ b/test/tests-stm32fx/app-f3.toml
@@ -21,6 +21,11 @@ priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use the USART; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["usart2"]
+notifications = ["test-irq"]
+interrupts = {"usart2.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-stm32fx/app.toml
+++ b/test/tests-stm32fx/app.toml
@@ -21,6 +21,11 @@ priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use the USART; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["usart2"]
+notifications = ["test-irq"]
+interrupts = {"usart2.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -24,6 +24,11 @@ max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
 stacksize = 1504
+# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-stm32h7/app-h743.toml
+++ b/test/tests-stm32h7/app-h743.toml
@@ -21,6 +21,11 @@ priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]

--- a/test/tests-stm32h7/app-h753.toml
+++ b/test/tests-stm32h7/app-h753.toml
@@ -21,6 +21,11 @@ priority = 2
 max-sizes = {flash = 65536, ram = 4096}
 start = true
 task-slots = ["assist", "idol", "suite", "runner"]
+# this doesn't actually use SPI; we're just mapping that interrupt to test
+# interrupt handling. chosen completely arbitrarily.
+uses = ["spi1"]
+notifications = ["test-irq"]
+interrupts = {"spi1.irq" = "test-irq"}
 
 # This block is used to test the task_config macro
 [tasks.suite.config]


### PR DESCRIPTION
As described in #1659, we currently lack a mechanism for a task to query
the state of the interrupts mapped to its notification set. Because only
the kernel can touch the NVIC, such a mechanism must be added to the
kernel. 

This branch adds a new system call, `IRQ_STATUS` (syscall 13).
`IRQ_STATUS` takes a notification mask as an argument, and returns a set
of bit flags representing the state of the interrupts mapped to that
notification set:

- bit 0 is set if the interrupt has been enabled by the task (by calling
  `IRQ_CONTROL`) and unset if the interrupt has not been enabled
- bit 1 is set if an interrupt is currently pending for any task in the
  notification set
- bit 2 is set if a notification has been posted to the task for any
  interrupt in the notification set

If multiple bits are set in the notification mask, and all of those
notification bits are set to interrupts, the returned `IrqState`
bitflags will be the boolean OR of the states of all the interrupts.

## Design Notes

We also considered hanging this off of the existing `IRQ_CONTROL` system
call, which currently takes an argument of either 0 or 1 to indicate
whether to enable or disable interrupts. We could, potentially, have
added the ability to pass 2 as well to query IRQ status. However, that
system call currently doesn't return anything, so adding a return value
would make it spill more registers, and @cbiffle liked that the argument
to it was essentially a bool. Thus, we decided to add a new system call.

I also considered a design where `IRQ_STATUS' returns three words, which
are bitmaps of which individual notifications in the notification set
are enabled, pending, and posted, respectively. This would let us return
more information when multiple bits are set in the notification mask.
However, it has a couple of downsides:
 - We would have to spill more registers in the `IRQ_STATUS` syscall
stub, a cost which is inflicted on callers who only want to look up the
status of a single IRQ
 - Currently, the generated lookup table of IRQs can't be queried for
   individual bits, only for the whole mask. We'd need to change how we
   generate that LUT to support this. This seemed kinda annoying.

## Testing

In order to test this, I've also added a new KIPC operation to trigger a
software IRQ, given a task ID and notification mask. This is a privilege
operation that can only be called by the supervisor, so I've added a
test-runner IPC to ask the test runner (which runs as supervisor) to
please do it. Incidentally, this has the nice side benefit of letting us
test that IRQs are even dispatched to tasks at all, which is probably
worth having!


Closes #1659 