### PR TITLE
drv/stm32h7-fmc-demo: ill-advised memory controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-stm32h7-fmc-demo-server"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cortex-m",
+ "counters",
+ "drv-stm32xx-sys-api",
+ "hubpack",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "serde",
+ "stm32h7",
+ "userlib",
+]
+
+[[package]]
 name = "drv-stm32h7-hash"
 version = "0.1.0"
 dependencies = [

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -148,6 +148,14 @@ task-slots = ["jefe"]
 stacksize = 1200
 extern-regions = [ "sram2", "sram3", "sram4" ]
 
+[tasks.fmc_demo]
+name = "drv-stm32h7-fmc-demo-server"
+features = ["h743"]
+priority = 4
+start = true
+task-slots = ["sys"]
+uses = ["fmc_nor_psram_bank_1"]
+
 [config]
 
 [[config.i2c.controllers]]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -198,6 +198,14 @@ task-slots = ["jefe"]
 stacksize = 1200
 extern-regions = [ "sram2", "sram3", "sram4" ]
 
+[tasks.fmc_demo]
+name = "drv-stm32h7-fmc-demo-server"
+features = ["h753"]
+priority = 4
+start = true
+task-slots = ["sys"]
+uses = ["fmc", "fmc_nor_psram_bank_1"]
+
 [config]
 [[config.i2c.controllers]]
 controller = 2

--- a/chips/stm32h7/chip.toml
+++ b/chips/stm32h7/chip.toml
@@ -140,3 +140,22 @@ size = 128 # 96 bytes of actual data, rounding up to a power of two
 #[cryp]
 #address = 0x48021000
 #size = 4096
+
+# Control registers for the memory controller, _not_ the memory itself.
+[fmc]
+address = 0x52004000
+size = 0x1000
+
+# NOTE: this is the correct thing to depend on if you want to use the PSRAM
+# interface as a memory mapped peripheral, like we do with certain FPGAs. This
+# is NOT the right way to use it as RAM! For that you probably want an
+# extern-region instead.
+#
+# Why, you ask? Because this is a peripheral mapping, and will set up this
+# section of the address space as bypassing the cache, not coalescing stores,
+# and so forth. This is what you want for memory mapped registers; it is _not_
+# what you want for RAM, at least if you want performance to be halfway
+# reasonable.
+[fmc_nor_psram_bank_1]
+address = 0x60000000
+size = 0x10000000

--- a/drv/stm32h7-fmc-demo-server/Cargo.toml
+++ b/drv/stm32h7-fmc-demo-server/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "drv-stm32h7-fmc-demo-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+counters = { path = "../../lib/counters" }
+
+cortex-m = { workspace = true }
+idol-runtime = { workspace = true }
+num-traits = { workspace = true }
+stm32h7 = { workspace = true }
+serde = { workspace = true }
+hubpack = { workspace = true }
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
+
+[features]
+default = ["h743"]
+h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]
+h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
+
+[[bin]]
+name = "drv-stm32h7-fmc-demo-server"
+test = false
+doctest = false
+bench = false

--- a/drv/stm32h7-fmc-demo-server/README.md
+++ b/drv/stm32h7-fmc-demo-server/README.md
@@ -1,0 +1,4 @@
+# Exercise fixture for the STM32H7 FMC
+
+This task maps in a 16-bit multiplexed PSRAM bus and lets you do incredibly
+ill-advised things to it. It is intended for interface testing only, do not eat.

--- a/drv/stm32h7-fmc-demo-server/build.rs
+++ b/drv/stm32h7-fmc-demo-server/build.rs
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_util::expose_target_board();
+    build_util::build_notifications()?;
+
+    idol::Generator::new().build_server_support(
+        "../../idl/fmc-demo.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/stm32h7-fmc-demo-server/src/main.rs
+++ b/drv/stm32h7-fmc-demo-server/src/main.rs
@@ -1,0 +1,342 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! "Server" that brings up the FMC and lets you pooooke it.
+
+#![no_std]
+#![no_main]
+
+use core::convert::Infallible;
+use sys_api::{Alternate, OutputType, Peripheral, Port, Pull, Speed};
+use userlib::*;
+
+#[cfg(feature = "h743")]
+use stm32h7::stm32h743 as device;
+
+#[cfg(feature = "h753")]
+use stm32h7::stm32h753 as device;
+
+use drv_stm32xx_sys_api as sys_api;
+use idol_runtime::{NotificationHandler, RequestError};
+
+task_slot!(SYS, sys);
+
+#[export_name = "main"]
+fn main() -> ! {
+    let sys = sys_api::Sys::from(SYS.get_task_id());
+
+    // Alright. We assume, for these purposes, that the FMC clock generation is
+    // left at its reset default of using AHB3's clock. The AHB bus in general
+    // is limited to a lower clock speed than the theoretical max of the FMC, so
+    // if the system is _running_ it means our clock constraints are likely met.
+    // We won't worry about them further.
+    //
+    // With the clock source reasonable, we need to turn on the clock to the
+    // controller itself:
+    sys.enable_clock(Peripheral::Fmc);
+
+    // We don't need a barrier here because that call implies a kernel entry,
+    // which serves as a barrier on this architecture. Programming in userland
+    // is easy and fun!
+    //
+    // Now that the clock is on we can poke the peripheral, so, manifest it:
+    let fmc = unsafe { &*device::FMC::ptr() };
+
+    // Configure all our pins. We're configuring a subset of pins for this demo.
+    // Pin mapping is as follows:
+    //  B7      FMC_NL
+    //
+    //  D0      FMC_DA2
+    //  D1      FMC_DA3
+    //  D3      FMC_CLK
+    //  D4      FMC_NOE
+    //  D5      FMC_NWE
+    //  D6      FMC_NWAIT   (also available on C6 as AF9)
+    //  D7      FMC_NE1     (also available on C7 as AF9)
+    //  D14     FMC_DA0
+    //  D15     FMC_DA1
+    //
+    //  E0      FMC_NBL0
+    //  E1      FMC_NBL1
+    //
+    //  If you're probing this on a Nucleo:
+    //
+    //  FMC_CLK     CN9 pin 10 (right side, lowest pin labeled as USART)
+    //  FMC_NOE     CN9 pin 8 (one up from FMC_CLK)
+    //  FMC_NWE     CN9 pin 6 (one up from FMC_NOE)
+    //  FMC_NWAIT   CN9 pin 4 (one up from FMC_NWE)
+    //  FMC_NE1     CN9 pin 2
+    //
+    //  FMC_DA0     CN7 pin 4
+    //  FMC_DA1     CN7 pin 2
+    //  FMC_DA2     CN9 pin 25
+    //  FMC_DA3     CN9 pin 27
+    //
+    //  FMC_NBL0    CN10 pin 33
+    //  FMC_NBL1    CN11, outside, fifth hole from bottom (no connector)
+
+    let the_pins = [
+        (Port::B.pin(7), Alternate::AF12),
+        (Port::D.pins([0, 1, 3, 4, 5, 6, 7, 14, 15]), Alternate::AF12),
+        (Port::E.pins([0, 1]), Alternate::AF12),
+    ];
+    for (pinset, af) in the_pins {
+        sys.gpio_configure_alternate(
+            pinset,
+            OutputType::PushPull,
+            Speed::VeryHigh,
+            Pull::None,
+            af,
+        );
+    }
+
+    // Program up the controller bank. Don't turn it on yet.
+    fmc.bcr1.write(|w| {
+        // Do not set FMCEN to turn on the controller just yet.
+
+        // BMAP default should be OK.
+
+        // TODO should we disable the write FIFO?
+
+        // Emit the clock continuously.
+        w.cclken().set_bit();
+
+        // Use synchronous bursts for writes.
+        w.cburstrw().set_bit();
+        // ...and also reads.
+        w.bursten().set_bit();
+
+        // Disable wait states for now.
+        w.waiten().clear_bit();
+
+        // Enable writes.
+        w.wren().set_bit();
+
+        // Disable NOR flash memory access (may not be necessary?)
+        w.faccen().clear_bit();
+
+        // Configure the memory as PSRAM (TODO: verify)
+        unsafe {
+            w.mtyp().bits(0b01);
+        }
+
+        // Turn on the memory bank.
+        w.mbken().set_bit();
+
+        // The following fields are being deliberately left in their reset
+        // states:
+        // - FMCEN is being left off
+        // - BMAP default (no remapping) is retained
+        // - Write FIFO is being left on (TODO is this correct?)
+        // - CPSIZE is being left with no special behavior on page-crossing
+        // - ASYNCWAIT is being left off since we're synchronous
+        // - EXTMOD is being left off, since it seems to only affect async
+        // - WAITCFG is being left default (TODO tweak later)
+        // - WAITPOL is treating NWAIT as active low (could change if desired)
+        // - MWID is being left at a 16 bit data bus.
+        // - MUXEN is being left with a multiplexed A/D bus.
+
+        w
+    });
+
+    // Bank timings!
+
+    // Synchronous access write/read latency, minus 2. That is, 0 means 2 cycle
+    // latency. Max value: 15 (for 17 cycles). NWAIT is not sampled until this
+    // period has elapsed, so if you're handshaking with a device using NWAIT,
+    // you almost certainly want this to be 0.
+    const DATLAT: u8 = 0;
+    // FMC_CLK division ratio relative to input (AHB3) clock, minus 1. Range:
+    // 1..=15.
+    const CLKDIV: u8 = 15; // /4, for 50 MHz
+
+    // Bus turnaround time in FMC_CLK cycles, 0..=15
+    const BUSTURN: u8 = 0;
+
+    fmc.btr1.write(|w| {
+        unsafe {
+            w.datlat().bits(DATLAT);
+        }
+        unsafe {
+            w.clkdiv().bits(CLKDIV);
+        }
+        unsafe {
+            w.busturn().bits(BUSTURN);
+        }
+
+        // Deliberately left in reset state and/or ignored:
+        // - ACCMOD: only applies when EXTMOD is set in BCR above; also probably
+        //   async only
+        // - DATAST: async only
+        // - ADDHLD: async only
+        // - ADDSET: async only
+        //
+        w
+    });
+
+    // BWTR1 register is irrelevant if we're not using EXTMOD, which we're not,
+    // currently.
+
+    // Turn on the controller.
+    fmc.bcr1.modify(|_, w| w.fmcen().set_bit());
+
+    // Fire up a server.
+    let mut server = ServerImpl { fmc };
+    let mut buffer = [0; idl::INCOMING_SIZE];
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
+    }
+}
+
+struct ServerImpl {
+    fmc: &'static device::fmc::RegisterBlock,
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
+
+impl idl::InOrderFmcDemoImpl for ServerImpl {
+    fn peek16(
+        &mut self,
+        _msg: &RecvMessage,
+        addr: u32,
+    ) -> Result<u16, RequestError<Infallible>> {
+        let ptr = addr as *const u16;
+        let val = unsafe { ptr.read_volatile() };
+        Ok(val)
+    }
+
+    fn peek32(
+        &mut self,
+        _msg: &RecvMessage,
+        addr: u32,
+    ) -> Result<u32, RequestError<Infallible>> {
+        let ptr = addr as *const u32;
+        let val = unsafe { ptr.read_volatile() };
+        Ok(val)
+    }
+
+    fn poke16(
+        &mut self,
+        _msg: &RecvMessage,
+        addr: u32,
+        value: u16,
+    ) -> Result<(), RequestError<Infallible>> {
+        let ptr = addr as *mut u16;
+        unsafe { ptr.write_volatile(value) }
+        Ok(())
+    }
+
+    fn poke32(
+        &mut self,
+        _msg: &RecvMessage,
+        addr: u32,
+        value: u32,
+    ) -> Result<(), RequestError<Infallible>> {
+        let ptr = addr as *mut u32;
+        unsafe { ptr.write_volatile(value) }
+        Ok(())
+    }
+
+    fn set_burst_enable(
+        &mut self,
+        _msg: &RecvMessage,
+        flag: bool,
+    ) -> Result<(), RequestError<Infallible>> {
+        self.fmc.bcr1.modify(|_, w| {
+            w.bursten().bit(flag);
+            w.cburstrw().bit(flag);
+            w
+        });
+        Ok(())
+    }
+    fn set_write_enable(
+        &mut self,
+        _msg: &RecvMessage,
+        flag: bool,
+    ) -> Result<(), RequestError<Infallible>> {
+        self.fmc.bcr1.modify(|_, w| {
+            w.wren().bit(flag);
+            w
+        });
+        Ok(())
+    }
+    fn set_write_fifo(
+        &mut self,
+        _msg: &RecvMessage,
+        flag: bool,
+    ) -> Result<(), RequestError<Infallible>> {
+        self.fmc.bcr1.modify(|_, w| {
+            // NOTE: PARAMETER IS INVERTED
+            w.wfdis().bit(!flag);
+            w
+        });
+        Ok(())
+    }
+    fn set_wait(
+        &mut self,
+        _msg: &RecvMessage,
+        flag: bool,
+    ) -> Result<(), RequestError<Infallible>> {
+        self.fmc.bcr1.modify(|_, w| {
+            w.waiten().bit(flag);
+            w
+        });
+        Ok(())
+    }
+    fn set_data_latency_cycles(
+        &mut self,
+        _msg: &RecvMessage,
+        n: u8,
+    ) -> Result<(), RequestError<Infallible>> {
+        let value = n.saturating_sub(2).min(15);
+        self.fmc.btr1.write(|w| {
+            unsafe {
+                w.datlat().bits(value);
+            }
+            w
+        });
+        Ok(())
+    }
+    fn set_clock_divider(
+        &mut self,
+        _msg: &RecvMessage,
+        n: u8,
+    ) -> Result<(), RequestError<Infallible>> {
+        let value = n.saturating_sub(1).clamp(1, 15);
+        self.fmc.btr1.write(|w| {
+            unsafe {
+                w.clkdiv().bits(value);
+            }
+            w
+        });
+        Ok(())
+    }
+    fn set_bus_turnaround_cycles(
+        &mut self,
+        _msg: &RecvMessage,
+        n: u8,
+    ) -> Result<(), RequestError<Infallible>> {
+        let value = n.max(15);
+        self.fmc.btr1.write(|w| {
+            unsafe {
+                w.busturn().bits(value);
+            }
+            w
+        });
+        Ok(())
+    }
+}
+
+mod idl {
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}
+include!(concat!(env!("OUT_DIR"), "/notifications.rs"));

--- a/drv/stm32xx-gpio-common/src/lib.rs
+++ b/drv/stm32xx-gpio-common/src/lib.rs
@@ -47,6 +47,23 @@ impl Port {
             pin_mask: 1 << index,
         }
     }
+
+    /// Convenience operation for creating a `PinSet` from a `Port` with _many_
+    /// pins included.
+    #[inline(always)]
+    pub const fn pins<const N: usize>(self, indexes: [usize; N]) -> PinSet {
+        let mut pin_mask = 0;
+        // Using a manual for loop because const fn limitations
+        let mut i = 0;
+        while i < N {
+            pin_mask |= 1 << indexes[i];
+            i += 1;
+        }
+        PinSet {
+            port: self,
+            pin_mask,
+        }
+    }
 }
 
 /// The STM32xx GPIO hardware lets us configure up to 16 pins on the same port

--- a/idl/fmc-demo.idol
+++ b/idl/fmc-demo.idol
@@ -1,0 +1,90 @@
+// FMC (STM32H7 memory controller) Demo Fixture
+
+Interface(
+    name: "FmcDemo",
+    ops: {
+        "peek16": (
+            encoding: Hubpack,
+            args: {
+                "addr": (
+                    type: "u32",
+                ),
+            },
+            reply: Simple("u16"),
+        ),
+        "peek32": (
+            encoding: Hubpack,
+            args: {
+                "addr": (
+                    type: "u32",
+                ),
+            },
+            reply: Simple("u32"),
+        ),
+        "poke16": (
+            encoding: Hubpack,
+            args: {
+                "addr": (type: "u32"),
+                "value": (type: "u16"),
+            },
+            reply: Simple("()"),
+        ),
+        "poke32": (
+            encoding: Hubpack,
+            args: {
+                "addr": (type: "u32"),
+                "value": (type: "u32"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_burst_enable": (
+            encoding: Hubpack,
+            args: {
+                "flag": (type: "bool"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_write_enable": (
+            encoding: Hubpack,
+            args: {
+                "flag": (type: "bool"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_write_fifo": (
+            encoding: Hubpack,
+            args: {
+                "flag": (type: "bool"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_wait": (
+            encoding: Hubpack,
+            args: {
+                "flag": (type: "bool"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_data_latency_cycles": (
+            encoding: Hubpack,
+            args: {
+                "n": (type: "u8"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_clock_divider": (
+            encoding: Hubpack,
+            args: {
+                "n": (type: "u8"),
+            },
+            reply: Simple("()"),
+        ),
+        "set_bus_turnaround_cycles": (
+            encoding: Hubpack,
+            args: {
+                "n": (type: "u8"),
+            },
+            reply: Simple("()"),
+        ),
+    },
+)


### PR DESCRIPTION
This is an exercise fixture for the PSRAM mode of the Flexible Memory Controller on the STM32H7, for evaluating FPGA interface options. It lets you do many ill-advised things via IPC. They all appear to work, no matter what the datasheet implies.

Good luck!