### PR TITLE
ci: add what's being built to job names

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build-one:
-     name: dist-single
+     name: "cargo xtask dist ${{ inputs.app_name }}/${{ inputs.app_toml}}"
      runs-on: ${{ inputs.os }}
      env:
        VCPKGRS_DYNAMIC: 1
@@ -91,4 +91,3 @@ jobs:
         with:
           name: dist-${{ inputs.os }}-${{ inputs.build }}
           path: target/${{ inputs.app_name }}/dist/build-${{ inputs.app_name }}-image-*.zip
-


### PR DESCRIPTION
Currently, the GitHub Actions UI contains a giant list of thbings which are all called "dist-single". It would be nice if they had names that actually indicated which app was being built.

This commit does that.