### PR TITLE
I2C: trace IRQ status on panic

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -37,7 +37,6 @@ name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h743"]
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -32,7 +32,6 @@ task-slots = ["jefe"]
 name = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
-max-sizes = {flash = 16384, ram = 1024}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys"]

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -32,7 +32,6 @@ task-slots = ["jefe"]
 name = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
-max-sizes = {flash = 16384, ram = 1024}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys"]

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -35,7 +35,6 @@ name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c1", "i2c3", "i2c4"]
 start = true
 notifications = ["i2c1-irq", "i2c3-irq", "i2c4-irq"]

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -74,7 +74,6 @@ name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]

--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -112,7 +112,6 @@ pins = [
 [tasks.i2c_driver]
 name = "drv-lpc55-i2c"
 priority = 4
-max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm4"]
 start = true
 stacksize = 1000

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -105,7 +105,6 @@ pins = [
 [tasks.i2c_driver]
 name = "drv-lpc55-i2c"
 priority = 4
-max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm4"]
 start = true
 stacksize = 1000

--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -52,7 +52,6 @@ features = ["stm32g0", "gpio", "i2c", "g030"]
 name = "drv-stm32xx-i2c-server"
 features = ["g030"]
 priority = 2
-max-sizes = {flash = 4096, ram = 1024}
 uses = ["i2c1"]
 start = true
 task-slots = ["sys"]

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -46,7 +46,6 @@ name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c2", "i2c3"]
 start = true
 task-slots = ["sys"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -153,7 +153,6 @@ name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 start = true

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -523,18 +523,17 @@ impl I2cController<'_> {
         ringbuf_entry!(Trace::Panic(Register::TIMEOUTR, tor.read().bits()));
         ringbuf_entry!(Trace::Panic(Register::ISR, i2c.isr.read().bits()));
         ringbuf_entry!(Trace::Panic(Register::PECR, i2c.pecr.read().bits()));
-        for i in 0..32 {
-            let bit = 1 << i;
-            if self.notification & bit == bit {
-                let status = sys_irq_status(bit);
-                ringbuf_entry!(Trace::IrqStatus {
-                    notification: bit,
-                    enabled: status.contains(IrqStatus::ENABLED),
-                    pending: status.contains(IrqStatus::PENDING),
-                    posted: status.contains(IrqStatus::POSTED),
-                });
-            }
-        }
+
+        let irq_status = sys_irq_status(self.notification);
+        ringbuf_entry!(Trace::IrqStatus {
+            notification: self.notification,
+            // Yes, we *could* just record the `IrqStatus` value here, but
+            // Humility will format it as a hex value rather than knowing about
+            // the bitflags, which is a bit sad...
+            enabled: irq_status.contains(IrqStatus::ENABLED),
+            pending: irq_status.contains(IrqStatus::PENDING),
+            posted: irq_status.contains(IrqStatus::POSTED),
+        });
 
         panic!();
     }

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -60,7 +60,6 @@ start = true
 name = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 16384, ram = 2048}
 uses = ["i2c2", "i2c3", "i2c4"]
 start = true
 task-slots = ["sys"]


### PR DESCRIPTION
Using the `irq_status` system call I added in #1661, we can extend the
panic function added to `stm32xx-i2c` in #1657 to also include the state
of any IRQs currently mapped to its notification mask. This way, if an
I2C driver panics, we can also include the kernel's understanding of its
IRQ state in the dump.