### PR TITLE
ci: add test apps to `build-boards.yml`

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -246,3 +246,58 @@ jobs:
       app_toml: ${{ matrix.app_toml }}
       image: ${{ matrix.image }}
       os: ${{ inputs.os }}
+
+  build-tests:
+    if: ${{ inputs.board-set == 'tests' || inputs.board-set == 'all' }}
+    name: build-tests
+    strategy:
+      matrix:
+        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, rot-carrier, gimletlet]
+        include:
+          - build: stm32g0
+            app_name: tests-stm32g070
+            app_toml: test/tests-stm32g0/app-g070.toml
+            image: default
+          - build: stm32f3
+            app_name: tests-stm32fx
+            app_toml: test/tests-stm32fx/app-f3.toml
+            image: default
+          - build: stm32f4
+            app_name: tests-stm32fx
+            app_toml: test/tests-stm32fx/app.toml
+            image: default
+          - build: lpc55
+            app_name: tests-lpc55xpresso
+            app_toml: test/tests-lpc55xpresso/app.toml
+            image: default
+          - build: stm32h743
+            app_name: tests-stm32h743
+            app_toml: test/tests-stm32h7/app-h743.toml
+            image: default
+          - build: stm32h753
+            app_name: tests-stm32h753
+            app_toml: test/tests-stm32h7/app-h753.toml
+            image: default
+          - build: gemini
+            app_name: tests-gemini-bu
+            app_toml: test/tests-gemini-bu/app.toml
+            image: default
+          - build: rot-carrier
+            app_name: tests-rot-carrier
+            app_toml: test/tests-rot-carrier/app.toml
+            image: default
+          - build: gimletlet
+            app_name: tests-gimletlet
+            app_toml: test/tests-gimletlet/app.toml
+            image: default
+          - build: psc
+            app_name: tests-psc
+            app_toml: test/tests-psc/app.toml
+            image: default
+    uses: ./.github/workflows/build-one.yml
+    with:
+      build: ${{ matrix.build }}
+      app_name: ${{ matrix.app_name }}
+      app_toml: ${{ matrix.app_toml }}
+      image: ${{ matrix.image }}
+      os: ${{ inputs.os }}

--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -269,7 +269,7 @@ jobs:
           - build: lpc55
             app_name: tests-lpc55xpresso
             app_toml: test/tests-lpc55xpresso/app.toml
-            image: default
+            image: "a, b"
           - build: stm32h743
             app_name: tests-stm32h743
             app_toml: test/tests-stm32h7/app-h743.toml
@@ -285,7 +285,7 @@ jobs:
           - build: rot-carrier
             app_name: tests-rot-carrier
             app_toml: test/tests-rot-carrier/app.toml
-            image: default
+            image: "a, b"
           - build: gimletlet
             app_name: tests-gimletlet
             app_toml: test/tests-gimletlet/app.toml

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -33,6 +33,14 @@ g070 = ["family-stm32g0", "stm32g0/stm32g070", "drv-stm32xx-sys-api/g070", "drv-
 g0b1 = ["family-stm32g0", "stm32g0/stm32g0b1", "drv-stm32xx-sys-api/g0b1", "drv-stm32xx-gpio-common/model-stm32g0b1"]
 no-ipc-counters = ["idol/no-counters"]
 
+# Disables the Jefe dependency, for use in tests where the test-runner task is
+# used as supervisor, rather than Jefe.
+# 
+# TODO(eliza): eventually, it would be much better if tasks that depend on the
+# sys driver could run separately from the kernel tests, and use a real Jefe
+# rather than the test supervisor. But, for now, this makes it build.
+test = []
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [[bin]]

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -38,9 +38,12 @@ cfg_if::cfg_if! {
 use drv_stm32xx_gpio_common::{server::get_gpio_regs, Port};
 use drv_stm32xx_sys_api::{Group, RccError};
 use idol_runtime::{NotificationHandler, RequestError};
+#[cfg(not(feature = "test"))]
 use task_jefe_api::{Jefe, ResetReason};
+
 use userlib::*;
 
+#[cfg(not(feature = "test"))]
 task_slot!(JEFE, jefe);
 
 trait FlagsRegister {
@@ -132,6 +135,10 @@ fn main() -> ! {
     }
 
     // Read RCC_RSR and inform Jefe why we reset.
+    //
+    // If the test feature is set, don't try to talk to Jefe, as the test runner
+    // runs as the supervisor, and, therefore, there is no Jefe to talk to.
+    #[cfg(not(feature = "test"))]
     if let Some(reason) = try_read_reset_reason(rcc) {
         Jefe::from(JEFE.get_task_id()).set_reset_reason(reason);
     }
@@ -315,6 +322,7 @@ cfg_if::cfg_if! {
             }
         }
 
+        #[cfg(not(feature = "test"))]
         fn try_read_reset_reason(
             rcc: &device::rcc::RegisterBlock,
         ) -> Option<ResetReason> {
@@ -395,6 +403,7 @@ cfg_if::cfg_if! {
             }
         }
 
+        #[cfg(not(feature = "test"))]
         fn try_read_reset_reason(
             rcc: &device::rcc::RegisterBlock,
         ) -> Option<ResetReason> {

--- a/task/hiffy/src/tests.rs
+++ b/task/hiffy/src/tests.rs
@@ -19,7 +19,7 @@ pub(crate) fn run_a_test(
     _data: &[u8],
     rval: &mut [u8],
 ) -> Result<usize, Failure> {
-    if stack.len() < 1 {
+    if stack.is_empty() {
         return Err(Failure::Fault(Fault::MissingParameters));
     }
 
@@ -38,7 +38,7 @@ pub(crate) fn run_a_test(
     let (rc, _len) = sys_send(
         TEST_TASK.get_task_id(),
         SuiteOp::RunCase as u16,
-        &id.as_bytes(),
+        id.as_bytes(),
         &mut [],
         &[],
     );
@@ -54,7 +54,7 @@ pub(crate) fn run_a_test(
             RUNNER.get_task_id(),
             RunnerOp::TestResult as u16,
             &[],
-            &mut result.as_bytes_mut(),
+            result.as_bytes_mut(),
             &[],
         );
 

--- a/test/test-assist/src/main.rs
+++ b/test/test-assist/src/main.rs
@@ -72,7 +72,7 @@ fn textoob(_arg: u32) {
         // fly off the end of our text -- which will either induce
         // a memory fault (end of MPU-provided region) or a bus error
         // (reading never-written flash on some MCUs/boards, e.g. LPC55)
-        let mut val: u32 = core::mem::transmute(main as fn() -> _);
+        let mut val: u32 = main as fn() -> _ as usize as u32;
 
         loop {
             (val as *const u8).read_volatile();
@@ -129,8 +129,8 @@ fn divzero(_arg: u32) {
 fn eat_some_pi(highregs: bool) {
     let mut pi = [0x40490fdb; 16];
 
-    for i in 1..16 {
-        pi[i] += i << 23;
+    for (i, val) in pi.iter_mut().enumerate() {
+        *val += i << 23;
     }
 
     unsafe {
@@ -249,12 +249,12 @@ fn main() -> ! {
 
                     AssistOp::FaultTask => {
                         caller.reply(0);
-                        let _ = kipc::fault_task(*msg as usize);
+                        kipc::fault_task(*msg as usize);
                     }
 
                     AssistOp::RestartTask => {
                         caller.reply(0);
-                        let _ = kipc::restart_task(*msg as usize, true);
+                        kipc::restart_task(*msg as usize, true);
                     }
 
                     AssistOp::RefreshTaskIdOffByOne => {

--- a/test/test-idol-server/src/main.rs
+++ b/test/test-idol-server/src/main.rs
@@ -59,7 +59,7 @@ impl idl::InOrderIdolTestImpl for ServerImpl {
         a: FancyTestType,
     ) -> Result<FancyTestType, RequestError<IdolTestError>> {
         Ok(FancyTestType {
-            u: a.u + if a.b { 1 } else { 0 },
+            u: a.u + a.b as u32,
             ..a
         })
     }

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -52,9 +52,6 @@ use ringbuf::*;
 use test_api::*;
 use userlib::*;
 
-#[cfg(armv6m)]
-use armv6m_atomic_hack::*;
-
 /// We are sensitive to all notifications, to catch unexpected ones in test.
 const ALL_NOTIFICATIONS: u32 = !0;
 

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -538,7 +538,7 @@ fn test_idol_ssmarshal() {
     // it brings in 14K of float formatting code and overflows our smaller
     // targets.
     assert_eq!(r.u, 134);
-    assert_eq!(r.b, true);
+    assert!(r.b);
     assert!(r.f == 1.0);
 
     let r = idol
@@ -549,7 +549,7 @@ fn test_idol_ssmarshal() {
         })
         .unwrap();
     assert_eq!(r.u, 101);
-    assert_eq!(r.b, false);
+    assert!(!r.b);
     assert!(r.f == 1.0);
 }
 
@@ -1112,7 +1112,7 @@ fn test_borrow_without_peer_waiting() {
     assert_eq!(initial_id, new_id, "id should not change");
 
     // Finally, attempt to do a non-existent borrow read
-    let (rc, _n) = sys_borrow_write(initial_id, 0, 0, &mut buf);
+    let (rc, _n) = sys_borrow_write(initial_id, 0, 0, &buf);
     assert_eq!(rc, DEFECT, "expected to fail sys_borrow_write");
     let new_id = sys_refresh_task_id(initial_id);
     assert_eq!(initial_id, new_id, "id should not change");
@@ -1226,15 +1226,15 @@ fn test_floating_point(highregs: bool) {
     // registers are not being saved and restored properly, it is conceivable
     // that this test will fail on this assert on runs that aren't the first
     // run after reset.
-    for i in 0..16 {
-        assert_eq!(before[i], 0);
+    for i in before {
+        assert_eq!(i, 0);
     }
 
     // Now let's make a call to our assistant to splat its floating point regs
     let assist = assist_task_id();
 
     let mut response = 0_u32;
-    let which: u32 = if highregs { 1 } else { 0 };
+    let which = highregs as u32;
 
     let (rc, len) = sys_send(
         assist,
@@ -1251,8 +1251,8 @@ fn test_floating_point(highregs: bool) {
     }
 
     // And verify that our registers are what we think that they should be
-    for i in 0..16 {
-        assert_eq!(before[i], after[i]);
+    for (before, after) in before.iter().zip(after.iter()) {
+        assert_eq!(before, after);
     }
 }
 

--- a/test/tests-psc/app.toml
+++ b/test/tests-psc/app.toml
@@ -11,7 +11,7 @@ requires = {flash = 32768, ram = 4096}
 [tasks.runner]
 name = "test-runner"
 priority = 0
-max-sizes = {flash = 16384, ram = 2048}
+max-sizes = {flash = 16384, ram = 4096}
 start = true
 
 [tasks.suite]
@@ -38,21 +38,19 @@ tup = [[1, true], [2, true], [3, false]]
 [tasks.assist]
 name = "test-assist"
 priority = 1
-max-sizes = {flash = 16384, ram = 1024}
 start = true
 
 [tasks.idol]
 name = "test-idol-server"
 priority = 1
-max-sizes = {flash = 4096, ram = 1024}
 stacksize = 1024
 start = true
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
-features = ["h753"]
+features = ["h753", "test"]
 priority = 1
-max-sizes = {flash = 2048, ram = 1024}
+max-sizes = {flash = 2048, ram = 2048}
 uses = ["rcc", "gpios", "system_flash"]
 start = true
 
@@ -60,23 +58,19 @@ start = true
 name = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 2
-uses = ["i2c2", "i2c3", "i2c4"]
+uses = ["i2c2"]
+notifications = ["i2c2-irq"]
 start = true
 task-slots = ["sys"]
 
 [tasks.i2c_driver.interrupts]
-"i2c2.event" = 0b0000_0010
-"i2c2.error" = 0b0000_0010
-"i2c3.event" = 0b0000_0100
-"i2c3.error" = 0b0000_0100
-"i2c4.event" = 0b0000_1000
-"i2c4.error" = 0b0000_1000
+"i2c2.event" = "i2c2-irq"
+"i2c2.error" = "i2c2-irq"
 
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 4
 features = ["testsuite"]
-max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["suite", "runner"]
@@ -96,15 +90,21 @@ start = true
 [[config.i2c.controllers]]
 controller = 2
 
-# SP_I2C_LOCAL_SDA
-# SP_I2C_LOCAL_SCL
+#
+# I2C_SP_TO_LOCAL_SDA
+# I2C_SP_TO_LOCAL_SCL
+#
 [config.i2c.controllers.ports.F]
 name = "local"
 description = "Local bus"
-pins = [ { pins = [ 0, 1 ], af = 4 } ]
+scl.pin = 1
+sda.pin = 0
+af = 4
 
 [[config.i2c.devices]]
 bus = "local"
 address = 0b1010_000
 device = "at24csw080"
+name = "local_vpd"
 description = "FRU ID EEPROM"
+refdes = "U32"

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -6,7 +6,7 @@ memory = "memory-g070.toml"
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 17544, ram = 2828}
+requires = {flash = 19040, ram = 2828}
 features = ["g070"]
 stacksize = 2048
 


### PR DESCRIPTION
Currently, Hubris' CI doesn't build the tests at all. This means that it's quite easy for the various test apps to bitrot --- for example, the PSC test app doesn't build, because [it maps IRQs by bit, rather than by name][1]. Named IRQ support was added back in 2022 (e.g. #424), so this TOML clearly hasn't been touched in...kind of a while, which I think is a pretty convincing argument for building these tests on CI!

[1]: https://github.com/oxidecomputer/hubris/blob/3325c6343a3e51a4d2c63cb3eac46085ba61dac3/test/tests-psc/app.toml#L68-L74