### PR TITLE
Add MAX31790 to IPCC inventory

### DIFF
--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -458,6 +458,9 @@ pub enum InventoryData {
         voltage_sensors: [SensorId; 2],
         current_sensors: [SensorId; 2],
     },
+
+    /// MAX31790 fan controller
+    Max31790 { speed_sensors: [SensorId; 6] },
 }
 
 #[derive(

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -48,7 +48,7 @@ macro_rules! by_refdes {
 
 impl ServerImpl {
     /// Number of devices in our inventory
-    pub(crate) const INVENTORY_COUNT: u32 = 71;
+    pub(crate) const INVENTORY_COUNT: u32 = 72;
 
     /// Look up a device in our inventory, by index
     ///
@@ -536,6 +536,14 @@ impl ServerImpl {
                 let data = InventoryData::Max5970 {
                     voltage_sensors: sensors.voltage,
                     current_sensors: sensors.current,
+                };
+                self.tx_buf
+                    .try_encode_inventory(sequence, &name, || Ok(&data));
+            }
+            71 => {
+                let (name, _f, sensors) = by_refdes!(U321, max31790);
+                let data = InventoryData::Max31790 {
+                    speed_sensors: sensors.speed,
                 };
                 self.tx_buf
                     .try_encode_inventory(sequence, &name, || Ok(&data));


### PR DESCRIPTION
The host will eventually want fan tachometer data in its IPCC inventory; this PR adds MAX31790 sensor IDs to our `enum InventoryData` in preparation.

The new variant is added at the end to preserve existing serialization.