### PR TITLE
stm32h7: merge `eth` and `eth_dma` MPU regions

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -71,7 +71,7 @@ priority = 2
 max-sizes = {flash = 65536, ram = 8192, sram1 = 32768}
 features = ["h743"]
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16"]
+uses = ["eth", "tim16"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -80,7 +80,7 @@ priority = 2
 max-sizes = {flash = 131072, ram = 16384, sram1 = 32768}
 features = ["h753"]
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16"]
+uses = ["eth", "tim16"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer"]
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -42,7 +42,7 @@ priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16"]
+uses = ["eth", "tim16"]
 start = true
 interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}
 task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -55,7 +55,7 @@ priority = 3
 features = ["mgmt", "h753", "use-spi-core", "spi2"]
 max-sizes = {flash = 131072, ram = 16384, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16", "spi2"]
+uses = ["eth", "tim16", "spi2"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 task-slots = ["sys", "user_leds", "jefe"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -130,7 +130,7 @@ priority = 3
 features = ["h753", "vlan", "gimletlet-nic", "use-spi-core", "spi4"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16", "spi4"]
+uses = ["eth", "tim16", "spi4"]
 start = true
 task-slots = ["sys", "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -107,7 +107,7 @@ priority = 4
 features = ["mgmt", "h753", "psc", "vlan", "vpd-mac", "use-spi-core", "spi2"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16", "spi2"]
+uses = ["eth", "tim16", "spi2"]
 start = true
 notifications = [
     "eth-irq",

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -68,7 +68,7 @@ priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
 max-sizes = {flash = 131072, ram = 65536, sram1 = 16384}
 sections = {eth_bulk = "sram1"}
-uses = ["eth", "eth_dma", "tim16", "spi3"]
+uses = ["eth", "tim16", "spi3"]
 start = true
 notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]

--- a/chips/stm32h7/chip.toml
+++ b/chips/stm32h7/chip.toml
@@ -103,12 +103,8 @@ interrupts = { irq = 92 }
 
 [eth]
 address = 0x40028000
-size = 0x1000
+size = 0x2000
 interrupts = { irq = 61 }
-
-[eth_dma]
-address = 0x40029000
-size = 0x400
 
 [hash]
 address = 0x48021400


### PR DESCRIPTION
Currently, the stm32h7 chip config defines two separate MPU regions for the Ethernet peripheral, `eth` and `eth_dma`. But, these regions are contiguous in memory. So, we can combine them into one region and get an entire MPU slot back, which seems nice.