### PR TITLE
Add counters to `stm32xx-spi-server-core` ringbuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,7 +2636,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git?branch=eliza/derive-count-for-operation#73f0017fdefdee5a4856b10bd2573e05c5f39254"
+source = "git+https://github.com/oxidecomputer/idolatry.git#070c4dc890f8c3dc26fcadd227316ee2b771e138"
 dependencies = [
  "indexmap 1.9.1",
  "once_cell",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git?branch=eliza/derive-count-for-operation#73f0017fdefdee5a4856b10bd2573e05c5f39254"
+source = "git+https://github.com/oxidecomputer/idolatry.git#070c4dc890f8c3dc26fcadd227316ee2b771e138"
 dependencies = [
  "counters",
  "userlib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,7 @@ dependencies = [
  "call_rustfmt",
  "cfg-if",
  "cortex-m",
+ "counters",
  "drv-spi-api",
  "drv-stm32h7-spi",
  "drv-stm32xx-sys-api",
@@ -2635,7 +2636,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f86afe0a3f81ec90292c700bf44ee9fd40d7977f"
+source = "git+https://github.com/oxidecomputer/idolatry.git?branch=eliza/derive-count-for-operation#73f0017fdefdee5a4856b10bd2573e05c5f39254"
 dependencies = [
  "indexmap 1.9.1",
  "once_cell",
@@ -2652,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f86afe0a3f81ec90292c700bf44ee9fd40d7977f"
+source = "git+https://github.com/oxidecomputer/idolatry.git?branch=eliza/derive-count-for-operation#73f0017fdefdee5a4856b10bd2573e05c5f39254"
 dependencies = [
  "counters",
  "userlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,8 +124,8 @@ gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-ins
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, version = "0.4.1" }
-idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "eliza/derive-count-for-operation" }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "eliza/derive-count-for-operation"  }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
+idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,8 +124,8 @@ gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-ins
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools", default-features = false, version = "0.4.1" }
-idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
-idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "eliza/derive-count-for-operation" }
+idol-runtime = { git = "https://github.com/oxidecomputer/idolatry.git", default-features = false, branch = "eliza/derive-count-for-operation"  }
 lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
 ordered-toml = { git = "https://github.com/oxidecomputer/ordered-toml", default-features = false }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus", default-features = false }

--- a/drv/spi-api/build.rs
+++ b/drv/spi-api/build.rs
@@ -8,7 +8,9 @@ use std::fs::File;
 use std::io::Write;
 
 fn main() -> Result<()> {
-    idol::client::build_client_stub("../../idl/spi.idol", "client_stub.rs")
+    idol::Generator::new()
+        .with_op_enum_derives(std::iter::once("counters::Count"))?
+        .build_client_stub("../../idl/spi.idol", "client_stub.rs")
         .map_err(|e| anyhow!(e))?;
 
     let out_dir = build_util::out_dir();

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -14,6 +14,7 @@ zerocopy = { workspace = true }
 drv-spi-api = { path = "../spi-api" }
 drv-stm32h7-spi = { path = "../stm32h7-spi" }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
+counters = { path = "../../lib/counters" }
 mutable-statics = { path = "../../lib/mutable-statics" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/drv/stm32h7-spi-server-core/src/lib.rs
+++ b/drv/stm32h7-spi-server-core/src/lib.rs
@@ -62,16 +62,17 @@ pub struct SpiServerCore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, counters::Count)]
 enum Trace {
-    Start(SpiOperation, (u16, u16)),
+    Start(#[count(children)] SpiOperation, (u16, u16)),
     Tx(u8),
     Rx(u8),
     WaitISR(u32),
+    #[count(skip)]
     None,
 }
 
-ringbuf!(Trace, 64, Trace::None);
+counted_ringbuf!(Trace, 64, Trace::None);
 
 #[derive(Copy, Clone, Debug)]
 pub struct LockState {


### PR DESCRIPTION
The `stm32xx-spi-server-core` ringbuf fills up pretty quickly when the system is busy, so it's hard to see the total number of SPI operations that may have occurred in the past. This branch adds counters to this ring buffer.

Note that this PR depends on an upstream `idol` change, oxidecomputer/idolatry#49, to allow us to derive the `Count` trait for the `SpiOperation` generated type. So, we should merge that first, and get this pointed back at oxidecomputer/idolatry@main.

For example (on my gimletlet):

```console
$ humility ringbuf spi_server_core
humility: attached via ST-Link V3
humility: ring buffer drv_stm32h7_spi_server_core::__RINGBUF in net:
   TOTAL VARIANT
    3374 WaitISR
    3184 Tx
    3184 Rx
     590 Start(exchange)
     206 Start(write)
 NDX LINE      GEN    COUNT PAYLOAD
   6  467      117        2 Tx(0x0)
   7  531      117        2 WaitISR(0x40012)
   8  501      117        3 Rx(0x0)
   9  531      117        1 WaitISR(0x20012)
  10  531      117        1 WaitISR(0x10012)
  11  501      117        1 Rx(0x40)
  12  359      117        1 Start(exchange, (0x2, 0x4))
  13  467      117        1 Tx(0x2)
  14  467      117        1 Tx(0xcc)
  15  467      117        2 Tx(0x0)
  16  531      117        2 WaitISR(0x40012)
  17  501      117        2 Rx(0x0)
  18  501      117        1 Rx(0x56)
  19  531      117        1 WaitISR(0x20012)
  20  531      117        1 WaitISR(0x10012)
  21  501      117        1 Rx(0x9)
  22  359      117        1 Start(exchange, (0x2, 0x4))
  23  467      117        1 Tx(0x5)
  24  467      117        1 Tx(0xb0)
  25  467      117        2 Tx(0x0)
  26  531      117        2 WaitISR(0x40012)
  27  501      117        2 Rx(0x0)
  28  501      117        1 Rx(0x8)
  29  531      117        2 WaitISR(0x10012)
  30  501      117        1 Rx(0x78)
  31  359      117        1 Start(exchange, (0x2, 0x4))
  32  467      117        1 Tx(0x5)
  33  467      117        1 Tx(0x8c)
  34  467      117        2 Tx(0x0)
  35  531      117        2 WaitISR(0x40012)
  36  501      117        2 Rx(0x0)
  37  501      117        1 Rx(0x20)
  38  531      117        2 WaitISR(0x10012)
  39  501      117        1 Rx(0x31)
  40  359      117        1 Start(write, (0x4, 0x0))
  41  467      117        1 Tx(0x83)
  42  467      117        1 Tx(0xc)
  43  467      117        1 Tx(0x20)
  44  467      117        1 Tx(0x1c)
  45  531      117        2 WaitISR(0x40012)
  46  501      117        2 Rx(0x0)
  47  531      117        1 WaitISR(0x22017)
  48  501      117        1 Rx(0x20)
  49  531      117        1 WaitISR(0x10012)
  50  531      117        1 WaitISR(0x301f)
  51  501      117        1 Rx(0x31)
  52  359      117        1 Start(exchange, (0x2, 0x4))
  53  467      117        1 Tx(0x2)
  54  467      117        1 Tx(0xf0)
  55  467      117        2 Tx(0x0)
  56  531      117        2 WaitISR(0x40012)
  57  501      117        3 Rx(0x0)
  58  531      117        2 WaitISR(0x10012)
  59  501      117        1 Rx(0x40)
  60  359      117        1 Start(exchange, (0x2, 0x4))
  61  467      117        1 Tx(0x2)
  62  467      117        1 Tx(0xcc)
  63  467      117        2 Tx(0x0)
   0  531      118        2 WaitISR(0x40012)
   1  501      118        2 Rx(0x0)
   2  531      118        1 WaitISR(0x20012)
   3  501      118        1 Rx(0x0)
   4  531      118        2 WaitISR(0x10012)
   5  501      118        1 Rx(0x0)
humility: ring buffer drv_stm32h7_spi_server_core::__RINGBUF in sprot:
```