### PR TITLE
Disable smart packing

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -375,7 +375,8 @@ pub fn package(
     // Build a set of requests for the memory allocator
     let mut task_reqs = HashMap::new();
     for (t, sz) in task_sizes {
-        let n = sz.len()
+        // XXX disabled because leases can't span regions
+        let _n = sz.len()
             + cfg
                 .toml
                 .extern_regions_for(t, &cfg.toml.image_names[0])
@@ -393,7 +394,7 @@ pub fn package(
             t,
             TaskRequest {
                 memory: sz,
-                spare_regions: 7 - n,
+                spare_regions: 0,
             },
         );
     }


### PR DESCRIPTION
The kernel will reject leases that span multiple regions, so this PR disables smart packing entirely by forcing each task's flash into a single MPU region (just like before #1599).  Otherwise, tasks which loan out their flash memory may produce spurious faults.