### PR TITLE
i2c_driver: disable panic messages on g031

### DIFF
--- a/drv/stm32xx-i2c-server/Cargo.toml
+++ b/drv/stm32xx-i2c-server/Cargo.toml
@@ -46,7 +46,6 @@ g031 = [
     "drv-stm32xx-sys-api/g031",
     "build-i2c/g031",
     "ringbuf-disabled",
-    "panic-messages",
 ]
 g030 = [
     "stm32g0/stm32g030",


### PR DESCRIPTION
This unbreaks the donglet build for now, after disabling autopacking in #1671 made it too big.