### PR TITLE
xtask: require kernel flash/RAM to be 0 mod 4

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -124,6 +124,12 @@ impl Config {
             bail!("'kernel' is reserved and cannot be used as a task name");
         }
 
+        for (name, size) in &toml.kernel.requires {
+            if (size % 4) != 0 {
+                bail!("kernel region '{name}' not a multiple of 4: {size}");
+            }
+        }
+
         // The app.toml must include a `chip` key, which defines the peripheral
         // register map in a separate file.  We load it then accumulate that
         // file in the buildhash.


### PR DESCRIPTION
Our linker scripts all assume that things are aligned to at least 32-bit boundaries. Right now, if you configure an lpc55 target (at least) with a kernel flash size that isn't a multiple of 4, you get an obscure error from the linker late in the build process.

That's annoying because (1) it happens late, so iteration time is slow, and (2) linker errors are designed by space aliens to confuse humanity, or so I've inferred.

This adds an explicit check and early failure for the case.