### PR TITLE
fully qualify `SpiError`, `task_net_api::{SendError, RecvError}` types in Idol

### DIFF
--- a/drv/spi-api/src/lib.rs
+++ b/drv/spi-api/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![no_std]
 
+// For Idol-generated code that fully qualifies error type names.
+use crate as drv_spi_api;
 use derive_idol_err::IdolError;
 use gateway_messages::SpiError as GwSpiError;
 use hubpack::SerializedSize;

--- a/idl/net.idol
+++ b/idl/net.idol
@@ -15,7 +15,7 @@ Interface(
             },
             reply: Result(
                 ok: "UdpMetadata",
-                err: CLike("RecvError"),
+                err: CLike("task_net_api::RecvError"),
             ),
         ),
         "send_packet": (
@@ -30,7 +30,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SendError"),
+                err: CLike("task_net_api::SendError"),
             ),
         ),
         "smi_read": (

--- a/idl/spi.idol
+++ b/idl/spi.idol
@@ -14,7 +14,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SpiError"),
+                err: CLike("drv_spi_api::SpiError"),
             ),
         ),
         "write": (
@@ -27,7 +27,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SpiError"),
+                err: CLike("drv_spi_api::SpiError"),
             ),
         ),
         "exchange": (
@@ -41,7 +41,7 @@ Interface(
             },
             reply: Result(
                 ok: "()",
-                err: CLike("SpiError"),
+                err: CLike("drv_spi_api::SpiError"),
             ),
         ),
         "lock": (

--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![no_std]
 
+// For Idol-generated code that fully qualifies error type names.
+use crate as task_net_api;
 use derive_idol_err::IdolError;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};

--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -58,7 +58,7 @@ mod idl {
     use task_net_api::{
         KszError, KszMacTableEntry, LargePayloadBehavior, MacAddress,
         MacAddressBlock, ManagementCounters, ManagementLinkStatus, MgmtError,
-        PhyError, RecvError, SendError, SocketName, UdpMetadata,
+        PhyError, SocketName, UdpMetadata,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }


### PR DESCRIPTION
This fixes name collisions between `drv_spi_api::SpiError` and `gateway_messages::sp_to_mgs::SpiError`, and between `task_net_api::{SendError, RecvError}` and `smoltcp::{SendError, RecvError}` that confuses Humility, as in:

```
humility: WARNING: SpiError matches more than one enum: drv_spi_api::SpiError as GOFF 0x0000786b (object 4), gateway_messages::sp_to_mgs::SpiError as GOFF 0x00010532 (object 4)
humility: WARNING: SpiError matches more than one enum: drv_spi_api::SpiError as GOFF 0x0000786b (object 4), gateway_messages::sp_to_mgs::SpiError as GOFF 0x00010532 (object 4)
humility: WARNING: SpiError matches more than one enum: drv_spi_api::SpiError as GOFF 0x0000786b (object 4), gateway_messages::sp_to_mgs::SpiError as GOFF 0x00010532 (object 4)
humility: WARNING: SpiError matches more than one enum: drv_spi_api::SpiError as GOFF 0x0000786b (object 4), gateway_messages::sp_to_mgs::SpiError as GOFF 0x00010532 (object 4)
humility: WARNING: SpiError matches more than one enum: drv_spi_api::SpiError as GOFF 0x0000786b (object 4), gateway_messages::sp_to_mgs::SpiError as GOFF 0x00010532 (object 4)
```

I'd also like to add a CI pass for detecting these by ensuring that `humility hiffy -l` doesn't return any stderr messages on the archive. However, there's an unrelated warning from that command
```
humility: WARNING: couldn't find type (Result<f32, NoData>, u64) for Sensor.get_raw_reading
humility: WARNING: couldn't find type (NoData, u64) for Sensor.get_last_nodata
```

which I haven't fixed yet. We could maybe pipe its stdout into `grep "matches more than one enum"` though.