### PR TITLE
Adjust sizes in donglet/app-g031-i2c.toml and lpc55xpresso/app-sprot.…

### DIFF
--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18720, ram = 1616}
+requires = {flash = 18752, ram = 1616}
 features = ["g031"]
 stacksize = 936
 

--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -17,7 +17,7 @@ fwid = true
 [kernel]
 name = "lpc55xpresso"
 features = ["dice-self"]
-requires = {flash = 53312, ram = 4096}
+requires = {flash = 53504, ram = 4096}
 
 [caboose]
 region = "flash"


### PR DESCRIPTION
…toml so that they will link.

oxcon2023g0 still fails

These changes  were extraneous in #1675 and are being factored out to here.