### PR TITLE
stm32xx-sys: configure EXTI IRQs in app.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-stm32xx-sys"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "build-util",
+ "cfg-if",
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.94",
+]
+
+[[package]]
 name = "build-util"
 version = "0.1.0"
 dependencies = [
@@ -2001,6 +2015,7 @@ name = "drv-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.4.2",
+ "build-stm32xx-sys",
  "build-util",
  "cfg-if",
  "drv-stm32xx-gpio-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4623,6 +4623,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-nucleo-user-button"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "counters",
+ "drv-stm32xx-sys-api",
+ "drv-user-leds-api",
+ "ringbuf",
+ "task-config",
+ "userlib",
+]
+
+[[package]]
 name = "task-packrat"
 version = "0.1.0"
 dependencies = [

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -25,12 +25,26 @@ request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
-features = ["h743"]
+features = ["h743", "exti"]
 priority = 1
-max-sizes = {flash = 2048, ram = 2048}
-uses = ["rcc", "gpios", "system_flash"]
+uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
 start = true
 task-slots = ["jefe"]
+notifications = ["exti-wildcard-irq"]
+
+[tasks.sys.interrupts]
+"exti.exti0" = "exti-wildcard-irq"
+"exti.exti1" = "exti-wildcard-irq"
+"exti.exti2" = "exti-wildcard-irq"
+"exti.exti3" = "exti-wildcard-irq"
+"exti.exti4" = "exti-wildcard-irq"
+"exti.exti9_5" = "exti-wildcard-irq"
+"exti.exti15_10" = "exti-wildcard-irq"
+
+[tasks.sys.config.gpio-irqs.button]
+port = "C"
+pin = 13
+owner = {name = "user_button", notification = "button"}
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
@@ -85,22 +99,15 @@ max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 notifications = ["timer"]
+config = { blink_at_start = [ "Led::Zero" ] }
 
-[tasks.ping]
-name = "task-ping"
-features = []
-priority = 5
-max-sizes = {flash = 8192, ram = 1024}
-start = true
-task-slots = [{peer = "pong"}]
-
-[tasks.pong]
-name = "task-pong"
+[tasks.user_button]
+name = "task-nucleo-user-button"
 priority = 3
-max-sizes = {flash = 1024, ram = 1024}
 start = true
-task-slots = ["user_leds"]
-notifications = ["timer"]
+task-slots = ["sys", "user_leds"]
+notifications = ["button"]
+config = { led = 1, rising = false, falling = true }
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -27,7 +27,6 @@ request_reset = ["hiffy"]
 name = "drv-stm32xx-sys"
 features = ["h753", "exti"]
 priority = 1
-max-sizes = {flash = 4096, ram = 2048}
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
 start = true
 task-slots = ["jefe"]
@@ -45,7 +44,7 @@ notifications = ["exti-wildcard-irq"]
 [tasks.sys.config.gpio-irqs.button]
 port = "C"
 pin = 13
-owner = {name = "hiffy", notification = "button"}
+owner = {name = "user_button", notification = "button"}
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
@@ -109,22 +108,15 @@ max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 notifications = ["timer"]
+config = { blink_at_start = [ "Led::Zero" ] }
 
-[tasks.ping]
-name = "task-ping"
-features = []
-priority = 5
-max-sizes = {flash = 8192, ram = 1024}
-start = true
-task-slots = [{peer = "pong"}]
-
-[tasks.pong]
-name = "task-pong"
+[tasks.user_button]
+name = "task-nucleo-user-button"
 priority = 3
-max-sizes = {flash = 1024, ram = 1024}
 start = true
-task-slots = ["user_leds"]
-notifications = ["timer"]
+task-slots = ["sys", "user_leds"]
+notifications = ["button"]
+config = { led = 1, rising = false, falling = true }
 
 [tasks.udpecho]
 name = "task-udpecho"
@@ -161,7 +153,6 @@ max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
-notifications = ["button"]
 
 [tasks.hf]
 name = "drv-gimlet-hf-server"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -25,11 +25,22 @@ request_reset = ["hiffy"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
-features = ["h753"]
+features = ["h753", "exti"]
 priority = 1
-uses = ["rcc", "gpios", "system_flash"]
+max-sizes = {flash = 4096, ram = 2048}
+uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
 start = true
 task-slots = ["jefe"]
+notifications = ["exti-wildcard-irq"]
+
+[tasks.sys.interrupts]
+"exti.exti0" = "exti-wildcard-irq"
+"exti.exti1" = "exti-wildcard-irq"
+"exti.exti2" = "exti-wildcard-irq"
+"exti.exti3" = "exti-wildcard-irq"
+"exti.exti4" = "exti-wildcard-irq"
+"exti.exti9_5" = "exti-wildcard-irq"
+"exti.exti15_10" = "exti-wildcard-irq"
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
@@ -145,6 +156,7 @@ max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
+notifications = ["button"]
 
 [tasks.hf]
 name = "drv-gimlet-hf-server"
@@ -259,3 +271,8 @@ owner = {name = "udprpc", notification = "socket"}
 port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.sys.gpio-irqs.button]
+port = "C"
+pin = 13
+owner = {name = "hiffy", notification = "button"}

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -42,6 +42,11 @@ notifications = ["exti-wildcard-irq"]
 "exti.exti9_5" = "exti-wildcard-irq"
 "exti.exti15_10" = "exti-wildcard-irq"
 
+[tasks.sys.config.gpio-irqs.button]
+port = "C"
+pin = 13
+owner = {name = "hiffy", notification = "button"}
+
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
 stacksize = 1048
@@ -271,8 +276,3 @@ owner = {name = "udprpc", notification = "socket"}
 port = 998
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
-
-[config.sys.gpio-irqs.button]
-port = "C"
-pin = 13
-owner = {name = "hiffy", notification = "button"}

--- a/build/stm32xx-sys/Cargo.toml
+++ b/build/stm32xx-sys/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "build-stm32xx-sys"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+syn = { workspace = true }
+
+build-util = { path = "../util" }

--- a/build/stm32xx-sys/src/lib.rs
+++ b/build/stm32xx-sys/src/lib.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use quote::{quote, TokenStreamExt};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// This represents our _subset_ of global config and _must not_ be marked with
+/// `deny_unknown_fields`!
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct GlobalConfig {
+    sys: SysConfig,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct SysConfig {
+    /// EXTI interrupts
+    gpio_irqs: BTreeMap<String, GpioIrqConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct GpioIrqConfig {
+    port: Port,
+    pin: u8,
+    owner: GpioIrqOwner,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct GpioIrqOwner {
+    name: String,
+    notification: String,
+}
+
+macro_rules! to_tokens_enum {
+    ($(#[$m:meta])* enum $Enum:ident { $($Variant:ident),* }) => {
+        $(#[$m])*
+        enum $Enum {
+            $($Variant),*
+        }
+
+        impl quote::ToTokens for $Enum {
+            fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+                use proc_macro2::{Ident, Punct, Spacing, Span};
+                match self {
+                    $(Self::$Variant => {
+                        tokens.append(Ident::new(stringify!($Enum), Span::call_site()));
+                        tokens.append(Punct::new(':', Spacing::Joint));
+                        tokens.append(Punct::new(':', Spacing::Alone));
+                        tokens.append(Ident::new(stringify!($Variant), Span::call_site()));
+                    }),*
+                }
+            }
+        }
+    };
+}
+
+to_tokens_enum! {
+    #[derive(Copy, Clone, Debug, Deserialize)]
+    enum Port {
+        A,
+        B,
+        C,
+        D,
+        E,
+        F,
+        G,
+        H,
+        I,
+        J,
+        K
+    }
+}
+
+impl SysConfig {
+    pub fn load() -> anyhow::Result<Self> {
+        Ok(build_util::config::<GlobalConfig>()?.sys)
+    }
+
+    pub fn needs_exti(&self) -> bool {
+        !self.gpio_irqs.is_empty()
+    }
+
+    pub fn generate_exti_config(
+        &self,
+    ) -> anyhow::Result<proc_macro2::TokenStream> {
+        #[derive(Debug)]
+        struct DispatchEntry<'a> {
+            _name: &'a str,
+            port: Port,
+            task: syn::Ident,
+            note: syn::Ident,
+        }
+
+        const NUM_EXTI_IRQS: usize = 16;
+        let mut dispatch_table: [Option<DispatchEntry<'_>>; NUM_EXTI_IRQS] =
+            Default::default();
+
+        for (
+            _name,
+            &GpioIrqConfig {
+                port,
+                pin,
+                ref owner,
+            },
+        ) in &self.gpio_irqs
+        {
+            match dispatch_table.get_mut(pin as usize) {
+                Some(Some(curr)) => {
+                    anyhow::bail!("pin {pin} is already mapped to IRQ {curr:?}")
+                }
+                Some(slot) => {
+                    let task = syn::parse_str(&owner.name)?;
+                    let note = quote::format_ident!(
+                        "{}_MASK",
+                        owner.notification.to_uppercase().replace('-', "_")
+                    );
+                    *slot = Some(DispatchEntry {
+                        _name,
+                        port,
+                        task,
+                        note,
+                    })
+                }
+                None => anyhow::bail!(
+                    "GPIO IRQ pin numbers must be < {NUM_EXTI_IRQS}; {pin} is out of range"
+                ),
+            }
+        }
+
+        let dispatches = dispatch_table.iter().map(|slot| match slot {
+            Some(DispatchEntry {
+                port, task, note, ..
+            }) => quote! {
+                Some((
+                    #port,
+                    userlib::TaskId::for_index_and_gen(
+                        hubris_num_tasks::Task::#task as usize,
+                        userlib::Generation::ZERO,
+                    ),
+                    crate::notifications::#task::#note,
+                ))
+            },
+            None => quote! { None },
+        });
+
+        Ok(quote! {
+            pub(crate) const EXTI_DISPATCH_TABLE: [Option<(Port, TaskId, u32)>; #NUM_EXTI_IRQS] = [
+                #( #dispatches ),*
+            ];
+        })
+    }
+}

--- a/build/stm32xx-sys/src/lib.rs
+++ b/build/stm32xx-sys/src/lib.rs
@@ -6,15 +6,7 @@ use quote::{quote, TokenStreamExt};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
-/// This represents our _subset_ of global config and _must not_ be marked with
-/// `deny_unknown_fields`!
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct GlobalConfig {
-    sys: SysConfig,
-}
-
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SysConfig {
     /// EXTI interrupts
@@ -78,7 +70,7 @@ to_tokens_enum! {
 
 impl SysConfig {
     pub fn load() -> anyhow::Result<Self> {
-        Ok(build_util::config::<GlobalConfig>()?.sys)
+        Ok(build_util::task_maybe_config::<Self>()?.unwrap_or_default())
     }
 
     pub fn needs_exti(&self) -> bool {

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -22,6 +22,7 @@ zerocopy = { workspace = true }
 [build-dependencies]
 idol = { workspace = true }
 build-util = { path = "../../build/util" }
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 
 [features]
 family-stm32h7 = ["stm32h7", "drv-stm32xx-uid/family-stm32h7"]

--- a/drv/stm32xx-sys/build.rs
+++ b/drv/stm32xx-sys/build.rs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::build_notifications()?;
@@ -14,6 +15,25 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             "server_stub.rs",
             idol::server::ServerStyle::InOrder,
         )?;
+
+    let cfg = build_stm32xx_sys::SysConfig::load()?;
+
+    const EXTI_FEATURE: &str = "exti";
+
+    if build_util::has_feature(EXTI_FEATURE) {
+        let out_dir = build_util::out_dir();
+        let dest_path = out_dir.join("exti_config.rs");
+
+        let mut out = std::fs::File::create(dest_path)?;
+
+        let generated = cfg.generate_exti_config()?;
+        writeln!(out, "{generated}")?;
+    } else if cfg.needs_exti() {
+        return Err(format!(
+            "the \"drv-stm32xx-sys/{EXTI_FEATURE}\" feature is required in order to \
+            configure GPIO pin interrupts"
+        ).into());
+    }
 
     Ok(())
 }

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -81,7 +81,7 @@
 //!
 //! * Declare the named notification that we wish to receive (here,
 //!   `"my-gpio-notification"`) in `task.<taskname>.notifications`
-//! * Add a task slot for `sys` in `task.<taskname>.slots`, to allow the
+//! * Add a task slot for `sys` in `task.<taskname>.task-slots`, to allow the
 //!   `sys.gpio_irq_configure` and `sys.gpio_irq_control` IPCs (if the task
 //!   does not already depend on `sys`)
 //!
@@ -95,7 +95,7 @@
 //! notifications = ["my-gpio-notification"]
 //!
 //! # Add a slot for sys
-//! slots = ["sys"]
+//! task-slots = ["sys"]
 //! ```
 //!
 //! Next, we must add the following configurations to the `sys` task's

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -986,31 +986,5 @@ mod idl {
 mod generated {
     use super::*;
 
-    // TODO: lol jk not really generated, written by hand
-    pub(super) static EXTI_DISPATCH_TABLE: [Option<(Port, TaskId, u32)>; 16] = [
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        // 14 - HACK HACK! This is PI14 on Gimlet for power system debugging
-        Some((
-            Port::I,
-            TaskId::for_index_and_gen(
-                hubris_num_tasks::Task::power as usize,
-                userlib::Generation::ZERO,
-            ),
-            1 << 1,
-        )),
-        None,
-    ];
+    include!(concat!(env!("OUT_DIR"), "/exti_config.rs"));
 }

--- a/task/nucleo-user-button/Cargo.toml
+++ b/task/nucleo-user-button/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "task-nucleo-user-button"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+drv-user-leds-api = { path = "../../drv/user-leds-api" }
+drv-stm32xx-sys-api = { path = "../../drv/stm32xx-sys-api", features = ["family-stm32h7"] }
+
+counters = { path = "../../lib/counters" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib" }
+task-config = { path = "../../lib/task-config" }
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+
+[[bin]]
+name = "task-nucleo-user-button"
+test = false
+doctest = false
+bench = false

--- a/task/nucleo-user-button/build.rs
+++ b/task/nucleo-user-button/build.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_util::expose_target_board();
+    build_util::build_notifications()?;
+    Ok(())
+}

--- a/task/nucleo-user-button/src/main.rs
+++ b/task/nucleo-user-button/src/main.rs
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A demo task showing the use of EXTI (GPIO interrupts) on the
+//! STM32H7-NUCLEO-H753ZI2 board.
+//!
+//! This task listens for interrupts on the user button (PC13) and toggles a LED
+//! when the button is pressed, using the `user-leds` IPC interface.
+
+#![no_std]
+#![no_main]
+
+use drv_stm32xx_sys_api::{PinSet, Port, Pull};
+use ringbuf::ringbuf_entry;
+use userlib::*;
+
+#[cfg(not(any(
+    target_board = "nucleo-h753zi",
+    target_board = "nucleo-h743zi2"
+)))]
+compile_error!(
+    "the `nucleo-user-button` task is only supported on the Nucleo H753ZI and H743ZI2 boards"
+);
+
+task_slot!(USER_LEDS, user_leds);
+task_slot!(SYS, sys);
+
+task_config::optional_task_config! {
+    /// The index of the user LED to toggle
+    led: usize,
+    /// Whether to enable rising-edge interrupts
+    rising: bool,
+    /// Whether to enable falling-edge interrupts
+    falling: bool,
+}
+
+// In real life, we might not actually want to trace all of these events, but
+// for demo purposes, it's nice to be able to watch everything that happens in
+// Humility.
+#[derive(Copy, Clone, Eq, PartialEq, counters::Count)]
+enum Trace {
+    #[count(skip)]
+    None,
+
+    /// We called the `Sys.gpio_irq_configure` IPC with these arguments.
+    GpioIrqConfigure {
+        mask: u32,
+        rising: bool,
+        falling: bool,
+    },
+
+    /// We called the `Sys.gpio_irq_control` IPC with these arguments.
+    GpioIrqControl { enable_mask: u32, disable_mask: u32 },
+
+    /// We received a notification with these bits set.
+    Notification(u32),
+
+    /// We called the `UserLeds.led_toggle` IPC.
+    LedToggle { led: usize },
+}
+
+ringbuf::counted_ringbuf!(Trace, 16, Trace::None);
+
+#[export_name = "main"]
+pub fn main() -> ! {
+    let user_leds = drv_user_leds_api::UserLeds::from(USER_LEDS.get_task_id());
+    let sys = drv_stm32xx_sys_api::Sys::from(SYS.get_task_id());
+
+    let (led, rising, falling) = if let Some(config) = TASK_CONFIG {
+        (config.led, config.rising, config.falling)
+    } else {
+        (0, false, true)
+    };
+
+    sys.gpio_configure_input(
+        PinSet {
+            port: Port::C,
+            pin_mask: (1 << 13),
+        },
+        Pull::None,
+    );
+
+    ringbuf_entry!(Trace::GpioIrqConfigure {
+        mask: notifications::BUTTON_MASK,
+        rising,
+        falling,
+    });
+    sys.gpio_irq_configure(notifications::BUTTON_MASK, rising, falling);
+
+    loop {
+        // The first argument to `gpio_irq_control` is the mask of interrupts to
+        // enable, while the second is the mask to disable. So, enable the
+        // button notification.
+        let disable_mask = 0;
+        ringbuf_entry!(Trace::GpioIrqControl {
+            enable_mask: notifications::BUTTON_MASK,
+            disable_mask,
+        });
+        sys.gpio_irq_control(disable_mask, notifications::BUTTON_MASK);
+
+        // Wait for the user button to be pressed.
+        //
+        // We only care about notifications, so we can pass a zero-sized recv
+        // buffer, and the kernel's task ID.
+        let recvmsg = sys_recv_closed(
+            &mut [],
+            notifications::BUTTON_MASK,
+            TaskId::KERNEL,
+        )
+        // Recv from the kernel never returns an error.
+        .unwrap_lite();
+        let notif = recvmsg.operation;
+        ringbuf_entry!(Trace::Notification(notif));
+
+        // If the notification is for the button, toggle the LED.
+        if notif == notifications::BUTTON_MASK {
+            ringbuf_entry!(Trace::LedToggle { led });
+            user_leds.led_toggle(led).unwrap_lite();
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/notifications.rs"));


### PR DESCRIPTION
This commit adds build-time code generation for the EXTI IRQ dispatch table. Now, an app.toml can define a section like this:

```toml
[config.sys.gpio-irq.button]
port = "C"
pin = 13
owner = { name = "mytask", notification = "button" }
```

To assign PC13's EXTI IRQ to the `button` notification for task `mytask`. The dispatch table is now generated by `build/stm32xx-sys` and will include the EXTI interrupt configurations in the config.