### PR TITLE
build: re-enable task packing.

### DIFF
--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -7,7 +7,7 @@ stacksize = 944
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 19040, ram = 1632}
+requires = {flash = 19264, ram = 1632}
 features = ["g070"]
 stacksize = 640
 

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-stm32h7-nucleo"
-requires = {flash = 24544, ram = 5120}
+requires = {flash = 24704, ram = 5120}
 features = ["h753", "dump"]
 
 [tasks.jefe]

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18752, ram = 1616}
+requires = {flash = 18944, ram = 1616}
 features = ["g031"]
 stacksize = 936
 

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 18944, ram = 1820}
+requires = {flash = 19168, ram = 1820}
 features = ["g031"]
 stacksize = 936
 

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -6,7 +6,7 @@ fwid = true
 
 [kernel]
 name = "sidecar"
-requires = {flash = 25792, ram = 6256}
+requires = {flash = 25952, ram = 6256}
 features = ["dump"]
 
 [caboose]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -375,8 +375,7 @@ pub fn package(
     // Build a set of requests for the memory allocator
     let mut task_reqs = HashMap::new();
     for (t, sz) in task_sizes {
-        // XXX disabled because leases can't span regions
-        let _n = sz.len()
+        let n = sz.len()
             + cfg
                 .toml
                 .extern_regions_for(t, &cfg.toml.image_names[0])
@@ -394,7 +393,7 @@ pub fn package(
             t,
             TaskRequest {
                 memory: sz,
-                spare_regions: 0,
+                spare_regions: 7 - n,
             },
         );
     }

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -6,7 +6,7 @@ memory = "memory-g070.toml"
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 19040, ram = 2828}
+requires = {flash = 19112, ram = 2828}
 features = ["g070"]
 stacksize = 2048
 


### PR DESCRIPTION
Now that release 7 is closer to finalized and we've gained some confidence in the kernel fixes for #1672, it would be nice to regain the benefits of task packing and stop fretting so much about fragmentation.