### PR TITLE
EXTI IRQ docs improvements

### DIFF
--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -34,7 +34,8 @@
 //! EXTI unit. From a user perspective, this works as follows:
 //!
 //! 1. `sys` gets configured in the `app.toml` to route interrupts on a specific
-//!    pin to a specific task, using a specific notification.
+//!    pin to a specific task, using a specific notification. See [the section
+//!    on EXTI configuration](#configuring-exti-notification) for details.
 //! 2. That task configures the pin using `sys.gpio_configure` and friends
 //!    (probably as an input, possibly with a pull resistor).
 //! 3. That task _also_ configures the pin's edge sensitivity, using
@@ -73,7 +74,7 @@
 //!
 //! 4. Repeat.
 //!
-//! ## Configuring EXTI GPIO notifications
+//! ## Configuring EXTI notifications
 //!
 //! In order for a task to receive notifications about GPIO pin interrupts from
 //! `sys`, we must first add the following to the task's config section in
@@ -152,6 +153,138 @@
 //! # The name of the client task and the notification to post to it.
 //! owner = { name = "my-great-task", notification = "my-gpio-notification" }
 //! ```
+//!
+//! ## Using EXTI notifications
+//!
+//! Once a task has been configured to receive notifications from `sys` for EXTI
+//! GPIO interrupts, as discussed above, it can use the `sys` task's IPC
+//! interface to configure and control the EXTI interrupts.
+//!
+//! First, the task must ensure that it includes the generated constants for
+//! notifications. If the task does not already include this code, it must add a
+//! call to `build_util::build_notifications()` in its `build.rs`, and include
+//! the generated using:
+//!
+//! ```rust
+//! include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
+//! ```
+//!
+//! In order to receive notifications, the task must first configure the pin on
+//! which it wishes to receive interrupts in input mode, using the
+//! [`Sys::gpio_configure_input`] IPC interface. Optionally, if pull-up or
+//! pull-down resistors are required, they may be configured by this IPC as
+//! well. Then, the task must use the [`Sys::gpio_irq_configure`] IPC to
+//! configure the edge sensitivity for the GPIO interrupts mapped to a
+//! notification mask. Interrupts can trigger either on the rising edge, the
+//! falling edge, or both. These configurations only need to be performed once,
+//! unless the task wishes to change the pin's configuration at runtime.
+//!
+//! For example, if we wish to use the EXTI notification
+//! `"my-gpio-notification"` for pin PC13, as shown in the above section, we
+//! might add the following to our task's `main`:
+//!
+//! ```rust,no-run
+//! # mod notifications { pub const MY_GPIO_NOTIFICATION_MASK: u32 = 1 << 0; }
+//! use drv_stm32xx_sys_api::{PinSet, Port, Pull};
+//! use userlib::*;
+//!
+//! task_slot!(SYS, sys);
+//!
+//! #[export_name = "main"]
+//! pub fn main() -> ! {
+//!     let sys = drv_stm32xx_sys_api::Sys::from(SYS.get_task_id());
+//!
+//!     // Configure the pin as an input, without pull-up or pull-down
+//!     // resistors:
+//!     sys.gpio_configure_input(
+//!         PinSet {
+//!            port: Port::C,
+//!            pin_mask: (1 << 13),
+//!         },
+//!         Pull::None,
+//!     );
+//!
+//!     // Now, configure the pin to trigger interrupts on the rising edge:
+//!     sys.gpio_irq_configure(
+//!         notifications::MY_GPIO_NOTIFICATION_MASK,
+//!         true,   // whether to enable rising edge interrupts
+//!         false,  // whether to enable falling edge interrupts
+//!     );
+//!
+//!     // Eventually we will do other things here
+//! }
+//!```
+//!
+//! Once this is done, the task can enable a GPIO interrupt by calling the
+//! [`Sys::gpio_irq_control`] IPC. This IPC takes two arguments: a mask of
+//! notification bits to disable, and a mask of notification bits to enable.
+//! Once the interrupt is enabled, the task will receive a notification when the
+//! GPIO pin's level changes, based on the edge sensitivity configured above.
+//! Once the interrupt has triggered a notification, it will be automatically
+//! disabled until the task calls `gpio_irq_control` again to re-enable it.
+//!
+//! Thus, continuing from the above example, to wait for GPIO notifications in a
+//! loop, we would write something like this:
+//!
+//! ```rust,no-run
+//! # fn handle_interrupt() {}
+//! # mod notifications { pub const MY_GPIO_NOTIFICATION_MASK: u32 = 1 << 0; }
+//! use drv_stm32xx_sys_api::{PinSet, Port, Pull};
+//! use userlib::*;
+//!
+//! task_slot!(SYS, sys);
+//!
+//! #[export_name = "main"]
+//! pub fn main() -> ! {
+//!     let sys = drv_stm32xx_sys_api::Sys::from(SYS.get_task_id());
+//!
+//!     sys.gpio_configure_input(
+//!         PinSet {
+//!            port: Port::C,
+//!            pin_mask: (1 << 13),
+//!         },
+//!         Pull::None,
+//!     );
+//!
+//!     sys.gpio_irq_configure(
+//!         notifications::MY_GPIO_NOTIFICATION_MASK,
+//!         true,   // whether to enable rising edge interrupts
+//!         false,  // whether to enable falling edge interrupts
+//!     );
+//!
+//!     // Wait to recieve notifications for our GPIO interrupt in a loop:
+//!     loop {
+//!         // First, enable the interrupt, so that we can receive our
+//!         // notification:
+//!         sys.gpio_irq_control(0, notifications::MY_GPIO_NOTIFICATION_MASK);
+//!
+//!         // Wait for a notification:
+//!         //
+//!         // We only care about notifications, so we can pass a zero-sized
+//!         // recv buffer, and the kernel's task ID.
+//!         let recvmsg = sys_recv_closed(
+//!             &mut [],
+//!             notifications::BUTTON_MASK,
+//!             TaskId::KERNEL,
+//!         )
+//!         // Recv from the kernel never returns an error.
+//!         .unwrap_lite();
+//!
+//!         // Now, do ... whatever it is this task is supposed to do when
+//!         // the interrupt fires.
+//!         handle_interrupt();
+//!
+//!         // When the loop repeats, the call to `sys.gpio_irq_control()` will
+//!         // enable the interrupt again.
+//!     }
+//! }
+//!```
+//!
+//! For a more complete example of using GPIO interrupts, see the
+//! [`nucleo-user-button`] demo task, which toggles a user LED on an
+//! STM32H7-NUCLEO dev board when the user button is pressed.
+//!
+//! [`nucleo-user-button`]: https://github.com/oxidecomputer/hubris/tree/master/task/nucleo-user-button
 
 #![no_std]
 #![no_main]

--- a/task/nucleo-user-button/src/main.rs
+++ b/task/nucleo-user-button/src/main.rs
@@ -17,7 +17,7 @@ use userlib::*;
 
 #[cfg(not(any(
     target_board = "nucleo-h753zi",
-    target_board = "nucleo-h743zi2"
+    target_board = "nucleo-h743zi2",
 )))]
 compile_error!(
     "the `nucleo-user-button` task is only supported on the Nucleo H753ZI and H743ZI2 boards"
@@ -90,7 +90,7 @@ pub fn main() -> ! {
 
     loop {
         // The first argument to `gpio_irq_control` is the mask of interrupts to
-        // enable, while the second is the mask to disable. So, enable the
+        // disable, while the second is the mask to enable. So, enable the
         // button notification.
         let disable_mask = 0;
         ringbuf_entry!(Trace::GpioIrqControl {
@@ -110,6 +110,7 @@ pub fn main() -> ! {
         )
         // Recv from the kernel never returns an error.
         .unwrap_lite();
+
         let notif = recvmsg.operation;
         ringbuf_entry!(Trace::Notification(notif));
 


### PR DESCRIPTION
This branch contains two commits, both related to documentation for EXTI GPIO IRQs:
- 1d069b73346558111ade86cf30752a1d921c0ada fixes a wrong comment in the `nucleo-user-button` demo task
- 87c502721303a98b4811b5293db9030ff3c4003b adds example code for actually using EXTI IRQs to the `stm32xx-sys` crate