### PR TITLE
sensor: remove noop 1 Hz timer

### DIFF
--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -214,7 +214,6 @@ priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
-notifications = ["timer"]
 
 [tasks.host_sp_comms]
 name = "task-host-sp-comms"

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -60,7 +60,6 @@ priority = 5
 max-sizes = {flash = 16384, ram = 2048 }
 stacksize = 1024
 start = true
-notifications = ["timer"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -219,7 +219,6 @@ priority = 3
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
-notifications = ["timer"]
 
 [tasks.sensor_polling]
 name = "task-sensor-polling"

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -184,7 +184,6 @@ priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
-notifications = ["timer"]
 
 [tasks.ecp5_mainboard]
 name = "drv-fpga-server"

--- a/task/sensor/build.rs
+++ b/task/sensor/build.rs
@@ -4,7 +4,6 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
-    build_util::build_notifications()?;
     idol::Generator::new()
         .with_counters(
             idol::CounterSettings::default().with_server_counters(false),


### PR DESCRIPTION
task/sensor was configuring a timer to wake it every 1 Hz. Each time it woke up, it would snooze its alarm clock and go back to sleep.

While I definitely sympathize with that desire, this is essentially dead code that looks like a bug, so this commit removes it. I'm not sure what the history here is.

In addition to removing noise from the code, this knocks 114 bytes off the sensor task text size.