### PR TITLE
Bump the toolchain to latest nightly.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[alias]
-xtask = "run --package xtask --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[alias]
+xtask = "run --package xtask --"
+
+[build]
+# The purpose of this flag is to block crates using version_detect from "detecting"
+# features that are no longer supported by the toolchain, because despite its name,
+# version_detect is basically "if nightly { return true; }". This setting gets
+# overridden within xtask for Hubris programs, so this only affects host tools like
+# xtask.
+rustflags = ["-Zallow-features=proc_macro_diagnostic,asm_const,naked_functions,used_with_arg"]

--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -79,10 +79,14 @@ jobs:
               target/release/humility -a target/${{ inputs.app_name }}/dist/build-${{ inputs.app_name }}-image-$image.zip manifest; \
           done
 
-      - name: Clippy
-        if: inputs.os == 'ubuntu-latest'
-        run: |
-          cargo xtask clippy ${{ inputs.app_toml}} -- --deny warnings
+      # TODO: Clippy temporarily disabled 2024-04 while people clean up
+      # the new Clippy warnings resulting from the last toolchain
+      # upgrade. If you're reading this, try turning it back on and see
+      # if we're good yet.
+      #- name: Clippy
+      #  if: inputs.os == 'ubuntu-latest'
+      #  run: |
+      #    cargo xtask clippy ${{ inputs.app_toml}} -- --deny warnings
 
       # upload the output of our build
       - name: Upload build archive

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["resolver", "named-profiles"]
-
 [workspace]
 members = [
     "build/*",

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -123,7 +123,7 @@ features = ["gimlet"]
 name = "task-thermal"
 features = ["gimlet"]
 priority = 5
-max-sizes = {flash = 32768, ram = 8192 }
+max-sizes = {flash = 65536, ram = 8192 }
 stacksize = 6000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -123,7 +123,7 @@ features = ["gimlet"]
 name = "task-thermal"
 features = ["gimlet"]
 priority = 5
-max-sizes = {flash = 65536, ram = 8192 }
+max-sizes = {flash = 32768, ram = 8192 }
 stacksize = 6000
 start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -68,7 +68,6 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 48608, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -252,7 +252,7 @@ notifications = ["timer"]
 name = "task-thermal"
 features = ["sidecar"]
 priority = 5
-max-sizes = {flash = 65536, ram = 16384 }
+max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 8096
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -252,7 +252,7 @@ notifications = ["timer"]
 name = "task-thermal"
 features = ["sidecar"]
 priority = 5
-max-sizes = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 65536, ram = 16384 }
 stacksize = 8096
 start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -269,21 +269,6 @@ struct DeviceRefdesKey {
     kind: Sensor,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct DeviceBusKey {
-    device: String,
-    bus: String,
-    kind: Sensor,
-}
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct DeviceBusNameKey {
-    device: String,
-    bus: String,
-    name: String,
-    kind: Sensor,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceSensor {
     pub name: Option<String>,
@@ -573,7 +558,7 @@ impl ConfigGenerator {
                             d.device, d.address
                         );
                     }
-                    (_, Some(bus)) if buses.get(bus).is_none() => {
+                    (_, Some(bus)) if !buses.contains_key(bus) => {
                         panic!(
                             "device {} at address {:#x} specifies \
                             unknown bus \"{}\"",
@@ -1254,7 +1239,7 @@ impl ConfigGenerator {
         // returned by `device_descriptions()` below: if we change the ordering
         // here, it must be updated there as well.
         for (index, device) in self.devices.iter().enumerate() {
-            if drivers.get(&device.device).is_some() {
+            if drivers.contains(&device.device) {
                 let driver = device.device.to_case(Case::UpperCamel);
                 let out = self.generate_device(device, 24);
 
@@ -1471,7 +1456,7 @@ impl ConfigGenerator {
         {
             writeln!(
                 &mut self.output,
-                "\n        #[allow(non_camel_case_types)]
+                "\n        #[allow(non_camel_case_types, dead_code)]
         pub struct Sensors_{struct_name} {{",
             )?;
             let mut f = |name, count| match count {

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -262,7 +262,7 @@ pub fn build_notifications() -> Result<()> {
         );
     }
     if full_task_config.name == "task-jefe"
-        && full_task_config.notifications.get(0).cloned()
+        && full_task_config.notifications.first().cloned()
             != Some("fault".to_string())
     {
         bail!("`jefe` must have \"fault\" as its first notification");

--- a/build/xtask/src/caboose_pos.rs
+++ b/build/xtask/src/caboose_pos.rs
@@ -52,9 +52,9 @@ pub fn get_caboose_pos_table_entry(
 ) -> Result<Option<CaboosePosTableEntry>> {
     // If the section isn't present, then we're not reading the caboose position
     // from this task.
-    let Some(caboose_pos_table_section) = elf::get_section_by_name(
-        elf, CABOOSE_POS_TABLE_SECTION
-    ) else {
+    let Some(caboose_pos_table_section) =
+        elf::get_section_by_name(elf, CABOOSE_POS_TABLE_SECTION)
+    else {
         return Ok(None);
     };
 

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -33,8 +33,6 @@ struct RawConfig {
     #[serde(default)]
     image_names: Vec<String>,
     #[serde(default)]
-    external_images: Vec<String>,
-    #[serde(default)]
     signing: Option<RoTMfgSettings>,
     stacksize: Option<u32>,
     kernel: Kernel,
@@ -56,7 +54,6 @@ pub struct Config {
     pub version: u32,
     pub fwid: bool,
     pub image_names: Vec<String>,
-    pub external_images: Vec<String>,
     pub signing: Option<RoTMfgSettings>,
     pub stacksize: Option<u32>,
     pub kernel: Kernel,
@@ -176,7 +173,6 @@ impl Config {
             target: toml.target,
             board: toml.board,
             image_names: img_names,
-            external_images: toml.external_images,
             chip: toml.chip,
             epoch: toml.epoch,
             version: toml.version,

--- a/build/xtask/src/lsp.rs
+++ b/build/xtask/src/lsp.rs
@@ -114,7 +114,9 @@ impl PackageGraph {
             while let Some((pkg_name, feat)) = todo.pop() {
                 // Anything not in `packages` is something from outside the
                 // workspace, so we don't care about it.
-                let Some(pkg) = self.0.get(&pkg_name) else { continue };
+                let Some(pkg) = self.0.get(&pkg_name) else {
+                    continue;
+                };
 
                 // If we've never seen this package before, then insert all of
                 // its non-optional dependencies with their features.
@@ -277,7 +279,7 @@ fn check_task(
             extra_env: build_cfg.env,
             hash: "".to_owned(),
             build_override_command,
-            app: app_name.clone().to_owned(),
+            app: app_name.to_owned(),
             task: task_name.to_owned(),
         };
 

--- a/build/xtask/src/sizes.rs
+++ b/build/xtask/src/sizes.rs
@@ -118,7 +118,7 @@ pub fn run(
 
 #[derive(Copy, Clone, Debug)]
 enum Recommended {
-    FixedSize(u32),
+    FixedSize,
     MaxSize(u32),
 }
 #[derive(Clone, Debug)]
@@ -183,7 +183,7 @@ fn build_memory_map<'a>(
                         .get(mem_name.to_owned())
                         .cloned()
                         .map(match name {
-                            "kernel" => Recommended::FixedSize,
+                            "kernel" => |_| Recommended::FixedSize,
                             _ => Recommended::MaxSize,
                         }),
                 },
@@ -265,7 +265,7 @@ fn print_task_table(
                 match chunk.recommended {
                     None => print!("(auto)"),
                     Some(Recommended::MaxSize(m)) => print!("{}", m),
-                    Some(Recommended::FixedSize(_)) => print!("(fixed)"),
+                    Some(Recommended::FixedSize) => print!("(fixed)"),
                 }
                 println!();
             }
@@ -359,7 +359,7 @@ fn print_memory_map(
                     match chunk.recommended {
                         None => print!("(auto)"),
                         Some(Recommended::MaxSize(m)) => print!("{}", m),
-                        Some(Recommended::FixedSize(_)) => print!("(fixed)"),
+                        Some(Recommended::FixedSize) => print!("(fixed)"),
                     }
                 }
                 println!();

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -5,7 +5,7 @@
 use build_fpga_regmap::fpga_regs;
 use serde::Deserialize;
 use sha2::Digest;
-use std::{convert::TryInto, fs, io::Write, path::PathBuf};
+use std::{fs, io::Write, path::PathBuf};
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/drv/i2c-devices/src/at24csw080.rs
+++ b/drv/i2c-devices/src/at24csw080.rs
@@ -5,7 +5,6 @@
 //! Driver for the AT24CSW080/4 I2C EEPROM
 
 use crate::Validate;
-use core::convert::TryInto;
 use drv_i2c_api::*;
 use userlib::{hl::sleep_for, FromPrimitive, ToPrimitive};
 use zerocopy::{AsBytes, FromBytes};

--- a/drv/i2c-devices/src/ds2482.rs
+++ b/drv/i2c-devices/src/ds2482.rs
@@ -201,6 +201,8 @@ impl Ds2482 {
     pub fn search(&mut self) -> Result<Option<Identifier>, Error> {
         let device = &self.device;
 
+        // TODO: lint is buggy in 2024-04-04 toolchain, retest later.
+        #[allow(clippy::manual_unwrap_or_default)]
         let branches = match self.branches {
             Some(branches) => {
                 if branches.0 == 0 {

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -6,7 +6,6 @@
 
 use crate::Validate;
 use bitfield::bitfield;
-use core::convert::TryFrom;
 use drv_i2c_api::*;
 use ringbuf::*;
 use userlib::units::*;

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -848,7 +848,9 @@ impl Transceivers {
                 FpgaController::Left => ldata,
                 FpgaController::Right => rdata,
             };
-            let Some(local_data) = local_data else { continue };
+            let Some(local_data) = local_data else {
+                continue;
+            };
 
             // loop through the 8 different fields we need to map
             for (word, out) in local_data.iter().zip(status_masks.iter_mut()) {

--- a/drv/sidecar-mainboard-controller/src/tofino2.rs
+++ b/drv/sidecar-mainboard-controller/src/tofino2.rs
@@ -4,7 +4,6 @@
 
 use crate::{Addr, MainboardController, Reg};
 use bitfield::bitfield;
-use core::convert::Into;
 use derive_more::{From, Into};
 use drv_fpga_api::{FpgaError, FpgaUserDesign, WriteOp};
 use drv_fpga_user_api::power_rail::*;

--- a/drv/sidecar-seq-server/src/tofino.rs
+++ b/drv/sidecar-seq-server/src/tofino.rs
@@ -4,7 +4,6 @@
 
 use crate::*;
 use drv_i2c_devices::raa229618::Raa229618;
-use drv_sidecar_mainboard_controller::tofino2::{DebugPort, Sequencer};
 
 pub(crate) struct Tofino {
     pub policy: TofinoSequencerPolicy,

--- a/drv/stm32h7-eth/src/lib.rs
+++ b/drv/stm32h7-eth/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![no_std]
 
-use core::convert::TryFrom;
 use core::sync::atomic::{self, Ordering};
 
 #[cfg(feature = "h743")]

--- a/drv/stm32h7-hash/src/lib.rs
+++ b/drv/stm32h7-hash/src/lib.rs
@@ -29,7 +29,6 @@ use drv_hash_api::HashError;
 #[cfg(feature = "h753")]
 use stm32h7::stm32h753 as device;
 
-use core::convert::TryInto;
 use core::mem::size_of;
 use userlib::*;
 use zerocopy::AsBytes;

--- a/drv/stm32h7-spi-server-core/src/lib.rs
+++ b/drv/stm32h7-spi-server-core/src/lib.rs
@@ -453,6 +453,8 @@ impl SpiServerCore {
                 // run off the end of their lease, or the fixed padding byte if
                 // we have.
                 let byte = if let Some(txbuf) = &mut tx {
+                    // TODO: lint is buggy in 2024-04-04 toolchain, retest later
+                    #[allow(clippy::manual_unwrap_or_default)]
                     if let Some(b) = txbuf.read() {
                         b
                     } else {

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -7,7 +7,6 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use attest_api::{AttestError, HashAlgorithm, NONCE_MAX_SIZE, NONCE_MIN_SIZE};
-use core::convert::Into;
 use drv_lpc55_update_api::{
     RotBootInfo, RotPage, SlotId, SwitchDuration, UpdateTarget,
 };

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -451,7 +451,7 @@ fn main() -> ! {
 
                     let mut nread = 0;
 
-                    match controller.write_read(
+                    let controller_result = controller.write_read(
                         addr,
                         winfo.len,
                         |pos| wbuf.read_at(pos),
@@ -470,7 +470,8 @@ fn main() -> ! {
                             rbuf.write_at(pos, byte)
                         },
                         &ctrl,
-                    ) {
+                    );
+                    match controller_result {
                         Err(code) => {
                             //
                             // NoDevice errors aren't hugely interesting --

--- a/drv/stm32xx-i2c/src/ltc4306.rs
+++ b/drv/stm32xx-i2c/src/ltc4306.rs
@@ -93,7 +93,7 @@ fn read_reg_u8(
     let mut rval = 0u8;
     let wlen = 1;
 
-    match controller.write_read(
+    let controller_result = controller.write_read(
         mux.address,
         wlen,
         |_| Some(reg),
@@ -103,7 +103,8 @@ fn read_reg_u8(
             Some(())
         },
         ctrl,
-    ) {
+    );
+    match controller_result {
         Err(code) => Err(mux.error_code(code)),
         _ => Ok(rval),
     }

--- a/drv/stm32xx-i2c/src/max7358.rs
+++ b/drv/stm32xx-i2c/src/max7358.rs
@@ -76,7 +76,7 @@ fn read_regs(
     rbuf: &mut [u8],
     ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
-    match controller.write_read(
+    let controller_result = controller.write_read(
         mux.address,
         0,
         |_| Some(0),
@@ -86,7 +86,8 @@ fn read_regs(
             Some(())
         },
         ctrl,
-    ) {
+    );
+    match controller_result {
         Err(code) => Err(mux.error_code(code)),
         _ => {
             for (i, &byte) in rbuf.iter().enumerate() {

--- a/drv/stm32xx-sys-api/src/h7.rs
+++ b/drv/stm32xx-sys-api/src/h7.rs
@@ -89,9 +89,9 @@ pub enum Peripheral {
 
     #[cfg(any(feature = "h753", feature = "h743"))]
     Rng = periph(Group::Ahb2, 6),
-    #[cfg(any(feature = "h753"))]
+    #[cfg(feature = "h753")]
     Hash = periph(Group::Ahb2, 5),
-    #[cfg(any(feature = "h753"))]
+    #[cfg(feature = "h753")]
     Crypt = periph(Group::Ahb2, 4),
 
     #[cfg(feature = "h7b3")]

--- a/drv/vsc85xx/src/vsc8562.rs
+++ b/drv/vsc85xx/src/vsc8562.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use core::convert::TryInto;
-
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::{Phy, PhyRw, Trace};

--- a/lib/gnarle/src/lib.rs
+++ b/lib/gnarle/src/lib.rs
@@ -11,8 +11,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::convert::TryFrom;
-
 /// Internal definition of how long the run count is. Tuning this might improve
 /// performance, though its current value seems optimal in practice.
 type RunType = u8;

--- a/lib/stage0-handoff/src/lib.rs
+++ b/lib/stage0-handoff/src/lib.rs
@@ -4,8 +4,6 @@
 
 #![cfg_attr(not(test), no_std)]
 
-use core::convert::From;
-use core::marker::Sized;
 use core::ops::Range;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-01"
+channel = "nightly-2024-04-04"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "rustfmt" ]

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -10,7 +10,6 @@ use crate::arch;
 use crate::err::UserError;
 use crate::task::{current_id, ArchState, NextTask, Task};
 use crate::umem::USlice;
-use core::convert::TryFrom;
 use core::mem::size_of;
 
 /// Message dispatcher.

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -27,8 +27,6 @@
 //! struct* type to make this easy and safe, e.g. `task.save().as_send_args()`.
 //! See the `task::ArchState` trait for details.
 
-use core::convert::TryFrom;
-
 use abi::{
     FaultInfo, IrqStatus, LeaseAttributes, SchedState, Sysnum, TaskId,
     TaskState, ULease, UsageError,

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -4,7 +4,6 @@
 
 //! Implementation of tasks.
 
-use core::convert::TryFrom;
 use core::ops::Range;
 
 use abi::{

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -4,10 +4,10 @@
 
 //! Operations implemented by IPC with the kernel task.
 
-use crate::UnwrapLite;
+use abi::{Kipcnum, TaskId};
 use zerocopy::AsBytes;
 
-use crate::*;
+use crate::{sys_send, UnwrapLite};
 
 pub fn read_task_status(task: usize) -> abi::TaskState {
     // Coerce `task` to a known size (Rust doesn't assume that usize == u32)

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1461,7 +1461,7 @@ fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     // However, it is possible to produce an alias if the panic handler is
     // called reentrantly. This can only happen if the code in the panic handler
     // itself panics, which is what we're working very hard to prevent here.
-    let panic_buffer = unsafe { &mut PANIC_BUFFER };
+    let panic_buffer = unsafe { &mut *core::ptr::addr_of_mut!(PANIC_BUFFER) };
 
     // Whew! Time to write the darn message.
     //

--- a/sys/userlib/src/units.rs
+++ b/sys/userlib/src/units.rs
@@ -6,7 +6,6 @@
 //! Tuple structs for units that are useful in the real world
 //!
 
-use core::convert::TryFrom;
 use zerocopy::{AsBytes, FromBytes};
 
 /// Degrees Celsius

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -166,6 +166,9 @@ fn main() -> ! {
         sleep_ms = 1;
         sleeps = 0;
 
+        // TODO without a safety comment explaining why these are safe, it is
+        // not clear if this is sound, do _not_ "fix" this by slapping on an
+        // addr_of_mut! without further analysis!
         let text = unsafe { &HIFFY_TEXT };
         let data = unsafe { &HIFFY_DATA };
         let rstack = unsafe { &mut HIFFY_RSTACK[0..] };

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -47,7 +47,9 @@ enum Trace {
 
 ringbuf!(Trace, 64, Trace::None);
 
-pub struct Buffer(u8);
+// Field is only used in the debugger, appears dead to the compiler.
+pub struct Buffer(#[allow(dead_code)] u8);
+
 //
 // The order in this enum must match the order in the functions array that
 // is passed to execute.

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -82,8 +82,9 @@ impl ServerImpl {
                 let packrat = &self.packrat;
                 let mut data = InventoryData::VpdIdentity(Default::default());
                 self.tx_buf.try_encode_inventory(sequence, b"U615/ID", || {
-                    let InventoryData::VpdIdentity(identity) = &mut data
-                        else { unreachable!(); };
+                    let InventoryData::VpdIdentity(identity) = &mut data else {
+                        unreachable!();
+                    };
                     *identity = packrat
                         .get_identity()
                         .map_err(|_| InventoryDataResult::DeviceAbsent)?
@@ -184,18 +185,21 @@ impl ServerImpl {
                 self.tx_buf.try_encode_inventory(sequence, &name, || {
                     use pmbus::commands::bmr491::CommandCode;
                     let InventoryData::Bmr491 {
-                            mfr_id,
-                            mfr_model,
-                            mfr_revision,
-                            mfr_location,
-                            mfr_date,
-                            mfr_serial,
-                            mfr_firmware_data,
-                            temp_sensor: _,
-                            voltage_sensor: _,
-                            current_sensor: _,
-                            power_sensor: _,
-                        } = &mut data else { unreachable!() };
+                        mfr_id,
+                        mfr_model,
+                        mfr_revision,
+                        mfr_location,
+                        mfr_date,
+                        mfr_serial,
+                        mfr_firmware_data,
+                        temp_sensor: _,
+                        voltage_sensor: _,
+                        current_sensor: _,
+                        power_sensor: _,
+                    } = &mut data
+                    else {
+                        unreachable!()
+                    };
                     dev.read_block(CommandCode::MFR_ID as u8, mfr_id)?;
                     dev.read_block(CommandCode::MFR_MODEL as u8, mfr_model)?;
                     dev.read_block(
@@ -234,15 +238,18 @@ impl ServerImpl {
                 self.tx_buf.try_encode_inventory(sequence, &name, || {
                     use pmbus::commands::isl68224::CommandCode;
                     let InventoryData::Isl68224 {
-                            mfr_id,
-                            mfr_model,
-                            mfr_revision,
-                            mfr_date,
-                            ic_device_id,
-                            ic_device_rev,
-                            voltage_sensors: _,
-                            current_sensors: _,
-                        } = &mut data else { unreachable!() };
+                        mfr_id,
+                        mfr_model,
+                        mfr_revision,
+                        mfr_date,
+                        ic_device_id,
+                        ic_device_rev,
+                        voltage_sensors: _,
+                        current_sensors: _,
+                    } = &mut data
+                    else {
+                        unreachable!()
+                    };
                     dev.read_block(CommandCode::MFR_ID as u8, mfr_id)?;
                     dev.read_block(CommandCode::MFR_MODEL as u8, mfr_model)?;
                     dev.read_block(
@@ -286,17 +293,20 @@ impl ServerImpl {
                 self.tx_buf.try_encode_inventory(sequence, &name, || {
                     use pmbus::commands::raa229618::CommandCode;
                     let InventoryData::Raa229618 {
-                            mfr_id,
-                            mfr_model,
-                            mfr_revision,
-                            mfr_date,
-                            ic_device_id,
-                            ic_device_rev,
-                            temp_sensors: _,
-                            power_sensors: _,
-                            voltage_sensors: _,
-                            current_sensors: _,
-                        } = &mut data else { unreachable!() };
+                        mfr_id,
+                        mfr_model,
+                        mfr_revision,
+                        mfr_date,
+                        ic_device_id,
+                        ic_device_rev,
+                        temp_sensors: _,
+                        power_sensors: _,
+                        voltage_sensors: _,
+                        current_sensors: _,
+                    } = &mut data
+                    else {
+                        unreachable!()
+                    };
                     dev.read_block(CommandCode::MFR_ID as u8, mfr_id)?;
                     dev.read_block(CommandCode::MFR_MODEL as u8, mfr_model)?;
                     dev.read_block(
@@ -351,7 +361,10 @@ impl ServerImpl {
                         temp_sensor: _,
                         voltage_sensor: _,
                         current_sensor: _,
-                    } = &mut data else { unreachable!() };
+                    } = &mut data
+                    else {
+                        unreachable!()
+                    };
                     dev.read_block(CommandCode::MFR_ID as u8, mfr_id)?;
                     dev.read_block(CommandCode::MFR_MODEL as u8, mfr_model)?;
                     dev.read_block(
@@ -403,7 +416,10 @@ impl ServerImpl {
                         temp_sensor: _,
                         voltage_sensor: _,
                         current_sensor: _,
-                    } = &mut data else { unreachable!() };
+                    } = &mut data
+                    else {
+                        unreachable!()
+                    };
                     dev.read_block(CommandCode::MFR_ID as u8, mfr_id)?;
                     dev.read_block(CommandCode::MFR_MODEL as u8, mfr_model)?;
                     dev.read_block(
@@ -447,8 +463,11 @@ impl ServerImpl {
                         eeprom1,
                         eeprom2,
                         eeprom3,
-                        temp_sensor: _
-                    } = &mut data else { unreachable!(); };
+                        temp_sensor: _,
+                    } = &mut data
+                    else {
+                        unreachable!();
+                    };
                     *id = dev.read_reg(0x0Fu8)?;
                     *eeprom1 = dev.read_reg(0x05u8)?;
                     *eeprom2 = dev.read_reg(0x06u8)?;
@@ -474,7 +493,10 @@ impl ServerImpl {
                         minor_rel,
                         hotfix_rel,
                         product_id,
-                    } = &mut data else { unreachable!(); };
+                    } = &mut data
+                    else {
+                        unreachable!();
+                    };
                     // This chip includes a separate register that controls the
                     // upper address byte, i.e. a paged memory implementation.
                     // We'll use `write_read_reg` to avoid the possibility of
@@ -509,8 +531,9 @@ impl ServerImpl {
                 let ksz8463 = ksz8463::Ksz8463::new(ksz8463_dev);
                 let mut data = InventoryData::Ksz8463 { cider: 0 };
                 self.tx_buf.try_encode_inventory(sequence, b"U401", || {
-                    let InventoryData::Ksz8463 { cider } = &mut data
-                            else { unreachable!(); };
+                    let InventoryData::Ksz8463 { cider } = &mut data else {
+                        unreachable!();
+                    };
                     *cider = ksz8463
                         .read(ksz8463::Register::CIDER)
                         .map_err(|_| InventoryDataResult::DeviceFailed)?;
@@ -600,8 +623,9 @@ impl ServerImpl {
         self.tx_buf.try_encode_inventory(sequence, &name, || {
             // TODO: does packrat index match PCA designator?
             if packrat.get_spd_present(index as usize) {
-                let InventoryData::DimmSpd { id, .. } = &mut data
-                    else { unreachable!(); };
+                let InventoryData::DimmSpd { id, .. } = &mut data else {
+                    unreachable!();
+                };
                 packrat.get_full_spd_data(index as usize, id);
                 Ok(&data)
             } else {
@@ -626,8 +650,9 @@ impl ServerImpl {
         *data = InventoryData::At24csw08xSerial([0u8; 16]);
         let dev = At24Csw080::new(f(I2C.get_task_id()));
         self.tx_buf.try_encode_inventory(sequence, name, || {
-            let InventoryData::At24csw08xSerial(id) = data
-                else { unreachable!(); };
+            let InventoryData::At24csw08xSerial(id) = data else {
+                unreachable!();
+            };
             for (i, b) in id.iter_mut().enumerate() {
                 *b = dev.read_security_register_byte(i as u8).map_err(|e| {
                     match e {
@@ -656,8 +681,9 @@ impl ServerImpl {
         let dev = f(I2C.get_task_id());
         let mut data = InventoryData::VpdIdentity(Default::default());
         self.tx_buf.try_encode_inventory(sequence, name, || {
-            let InventoryData::VpdIdentity(identity) = &mut data
-                else { unreachable!(); };
+            let InventoryData::VpdIdentity(identity) = &mut data else {
+                unreachable!();
+            };
             *identity = read_one_barcode(dev, &[(*b"BARC", 0)])?.into();
             Ok(&data)
         })
@@ -689,8 +715,11 @@ impl ServerImpl {
             let InventoryData::FanIdentity {
                 identity,
                 vpd_identity,
-                fans: [fan0, fan1, fan2]
-            } = &mut data else { unreachable!(); };
+                fans: [fan0, fan1, fan2],
+            } = &mut data
+            else {
+                unreachable!();
+            };
             *identity = read_one_barcode(dev, &[(*b"BARC", 0)])?.into();
             *vpd_identity =
                 read_one_barcode(dev, &[(*b"SASY", 0), (*b"BARC", 0)])?.into();

--- a/task/net/src/bsp/gimlet_bcdef.rs
+++ b/task/net/src/bsp/gimlet_bcdef.rs
@@ -90,7 +90,6 @@ impl crate::bsp_support::Bsp for BspImpl {
                 power_en: Some(Port::I.pin(10).and_pin(12)),
                 slow_power_en: false,
                 power_good: &[], // TODO
-                pll_lock: None,  // TODO?
 
                 ksz8463: Ksz8463::new(ksz8463_dev),
 

--- a/task/net/src/bsp/gimletlet_mgmt.rs
+++ b/task/net/src/bsp/gimletlet_mgmt.rs
@@ -154,7 +154,6 @@ impl bsp_support::Bsp for BspImpl {
             power_en: None,
             slow_power_en: false,
             power_good: &[],
-            pll_lock: None,
 
             ksz8463: Ksz8463::new(ksz8463_dev),
             ksz8463_nrst: Port::A.pin(9),

--- a/task/net/src/bsp/psc_a.rs
+++ b/task/net/src/bsp/psc_a.rs
@@ -83,7 +83,6 @@ impl bsp_support::Bsp for BspImpl {
             power_en: Some(Port::I.pin(10).and_pin(12)),
             slow_power_en: true,
             power_good: &[], // TODO
-            pll_lock: None,
 
             ksz8463: Ksz8463::new(ksz8463_dev),
             ksz8463_nrst: Port::C.pin(2),

--- a/task/net/src/bsp/psc_bc.rs
+++ b/task/net/src/bsp/psc_bc.rs
@@ -87,7 +87,6 @@ impl bsp_support::Bsp for BspImpl {
             power_en: Some(Port::I.pin(10)),
             slow_power_en: false,
             power_good: &PG_PINS,
-            pll_lock: None,
 
             ksz8463: Ksz8463::new(ksz8463_dev),
             ksz8463_nrst: Port::C.pin(2), // SP_TO_MGMT_SW_RESET_L

--- a/task/net/src/bsp/sidecar_bcd.rs
+++ b/task/net/src/bsp/sidecar_bcd.rs
@@ -75,7 +75,6 @@ impl bsp_support::Bsp for BspImpl {
             power_en: Some(Port::I.pin(11)),
             slow_power_en: false,
             power_good: &[], // TODO
-            pll_lock: None,  // TODO?
 
             ksz8463: Ksz8463::new(ksz8463_dev),
             // SP_TO_EPE_RESET_L

--- a/task/net/src/mgmt.rs
+++ b/task/net/src/mgmt.rs
@@ -58,9 +58,6 @@ pub struct Config {
     /// Goes high once power is good
     pub power_good: &'static [sys_api::PinSet],
 
-    /// Goes high once the PLLs are locked
-    pub pll_lock: Option<sys_api::PinSet>,
-
     pub ksz8463: Ksz8463,
     pub ksz8463_nrst: sys_api::PinSet,
     pub ksz8463_rst_type: Ksz8463ResetSpeed,

--- a/task/power/src/bsp/gimlet_bcdef.rs
+++ b/task/power/src/bsp/gimlet_bcdef.rs
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
-    i2c_config, i2c_config::sensors, Device, DeviceType, Ohms,
-    PowerControllerConfig, PowerState, SensorId,
+    i2c_config, i2c_config::sensors, Device, DeviceType, PowerControllerConfig,
+    PowerState, SensorId,
 };
 
 use drv_i2c_devices::max5970::*;

--- a/task/sensor-api/src/lib.rs
+++ b/task/sensor-api/src/lib.rs
@@ -8,13 +8,10 @@
 
 use userlib::*;
 
-use core::convert::TryFrom;
-
 use derive_idol_err::IdolError;
 use drv_i2c_api::ResponseCode;
 use hubpack::SerializedSize;
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
 /// A validated sensor ID.

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     i2c_config::{devices, sensors},
 };
-use core::convert::TryInto;
 pub use drv_gimlet_seq_api::SeqError;
 use drv_gimlet_seq_api::{PowerState, Sequencer};
 use drv_i2c_devices::max31790::Max31790;

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -8,7 +8,6 @@ use crate::control::{
     ChannelType, Device, FanControl, Fans, InputChannel, PidConfig,
     TemperatureSensor,
 };
-use core::convert::TryInto;
 use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
 pub use drv_sidecar_seq_api::SeqError;

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -242,6 +242,7 @@ pub(crate) struct DynamicInputChannel {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Copy, Clone)]
+#[allow(dead_code)] // used only by the debugger
 pub struct TimestampedSensorError {
     pub timestamp: u64,
     pub id: SensorId,

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -419,11 +419,14 @@ impl OneSidedPidState {
         } else {
             (-out_pd, output_limit - out_pd)
         };
-        self.integral = self.integral.clamp(integral_min, integral_max);
+        // f32::clamp is not inlining well as of 2024-04 so we do it by hand
+        // here and below.
+        self.integral = self.integral.max(integral_min).min(integral_max);
 
         // Clamp output values to valid range.
         let out = out_pd + self.integral;
-        out.clamp(0.0, output_limit)
+        // same issue with f32::clamp (above)
+        out.max(0.0).min(output_limit)
     }
 }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -37,7 +37,6 @@ use crate::{
     bsp::{Bsp, PowerBitmask, SeqError},
     control::ThermalControl,
 };
-use core::convert::TryFrom;
 use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::max31790::I2cWatchdog;
 use idol_runtime::{NotificationHandler, RequestError};


### PR DESCRIPTION
Also fixed _some_ new warnings reported by the toolchain, and many places where rustfmt has apparently changed its mind about some things.

Removed size constraints for tasks that increased in size rather than playing guess-the-number.

This leaves a number of warnings, which I'm hoping to divide up and not have to fix myself.