### PR TITLE
stm32xx-sys: configure GPIO IRQ edge with an enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "serde",
  "userlib",
  "zerocopy 0.6.6",
 ]

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -107,7 +107,7 @@ priority = 3
 start = true
 task-slots = ["sys", "user_leds"]
 notifications = ["button"]
-config = { led = 1, rising = false, falling = true }
+config = { led = 1, edge = "Edge::Rising" }
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -116,7 +116,7 @@ priority = 3
 start = true
 task-slots = ["sys", "user_leds"]
 notifications = ["button"]
-config = { led = 1, rising = false, falling = true }
+config = { led = 1, edge = "Edge::Rising" }
 
 [tasks.udpecho]
 name = "task-udpecho"

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -9,6 +9,7 @@ cfg-if.workspace = true
 idol-runtime.workspace = true
 num-traits.workspace = true
 zerocopy.workspace = true
+serde.workspace = true
 
 counters = { path = "../../lib/counters" }
 derive-idol-err = { path = "../../lib/derive-idol-err"  }

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -37,6 +37,11 @@ pub enum RccError {
 #[derive(
     Copy, Clone, FromPrimitive, PartialEq, Eq, AsBytes, serde::Deserialize,
 )]
+// NOTE: This `repr` attribute is *not* necessary for
+// serialization/deserialization, but it is used to allow casting to `u8` in the
+// `Edge::{is_rising, is_falling}` methods. The current implementation of those
+// methods with bit-and tests generates substantially fewer instructions than
+// using `matches!` (see: https://godbolt.org/z/j5fdPfz3c).
 #[repr(u8)]
 pub enum Edge {
     /// The interrupt will trigger on the rising edge only.

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -34,7 +34,9 @@ pub enum RccError {
 }
 
 /// Configures edge sensitivity for a GPIO interrupt
-#[derive(Copy, Clone, FromPrimitive, PartialEq, Eq, AsBytes)]
+#[derive(
+    Copy, Clone, FromPrimitive, PartialEq, Eq, AsBytes, serde::Deserialize,
+)]
 #[repr(u8)]
 pub enum Edge {
     /// The interrupt will trigger on the rising edge only.

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -20,6 +20,7 @@ cfg_if::cfg_if! {
 
 use derive_idol_err::IdolError;
 use userlib::*;
+use zerocopy::AsBytes;
 
 pub use drv_stm32xx_gpio_common::{
     Alternate, Mode, OutputType, PinSet, Port, Pull, Speed,
@@ -30,6 +31,18 @@ pub use drv_stm32xx_gpio_common::{
 #[derive(counters::Count)]
 pub enum RccError {
     NoSuchPeripheral = 1,
+}
+
+/// Configures edge sensitivity for a GPIO interrupt
+#[derive(Copy, Clone, FromPrimitive, PartialEq, Eq, AsBytes)]
+#[repr(u8)]
+pub enum Edge {
+    /// The interrupt will trigger on the rising edge only.
+    Rising = 0b01,
+    /// The interrupt will trigger on the falling edge only.
+    Falling = 0b10,
+    /// The interrupt will trigger on both teh rising and falling edge.
+    Both = 0b11,
 }
 
 impl Sys {
@@ -282,6 +295,32 @@ impl Sys {
         userlib::hl::sleep_for(low_time_ms as u64);
         self.gpio_set(pinset);
         userlib::hl::sleep_for(wait_time_ms as u64);
+    }
+}
+
+impl Edge {
+    /// Returns `true` if this edge sensitivity should trigger on the rising
+    /// edge.
+    pub fn is_rising(&self) -> bool {
+        *self as u8 & Self::Rising as u8 != 0
+    }
+
+    /// Returns `true` if this edge sensitivity should trigger on the falling
+    /// edge.
+    pub fn is_falling(&self) -> bool {
+        *self as u8 & Self::Falling as u8 != 0
+    }
+}
+
+impl core::ops::BitOr for Edge {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Edge::Rising, Edge::Rising) => Edge::Rising,
+            (Edge::Falling, Edge::Falling) => Edge::Falling,
+            _ => Edge::Both,
+        }
     }
 }
 

--- a/idl/stm32xx-sys.idol
+++ b/idl/stm32xx-sys.idol
@@ -99,14 +99,13 @@ Interface(
         // Configures some set of EXTI sources associated with the caller,
         // using the caller's notification bit space to name them. Any
         // sources included in the `mask` will be affected.
-        //
-        // If neither rising nor falling is true, the pin will not be
-        // capable of producing an interrupt, even if enabled.
         "gpio_irq_configure": (
             args: {
                 "mask": "u32",
-                "rising": "bool",
-                "falling": "bool",
+                "sensitivity": (
+                    type: "Edge",
+                    recv: FromPrimitive("u8"),
+                ),
             },
             reply: Simple("()"),
             idempotent: true,


### PR DESCRIPTION
The current `Sys::gpio_irq_configure` IPC interface is a bit confusing, as it takes two `bool`s for the rising and falling edge sensitivities, as in:

```rust
sys.gpio_irq_configure(mask, true, false);
```

This isn't particularly clear for a reader, who then has to remember the order of the arguments to determine which edge sensitivity is being enabled here. This is a case of ["boolean blindness"][1].

This commit improves the interface by changing it to take an `enum` with variants for `Rising`, `Falling`, and `Both`. Now, the same call to the IPC looks like this:

```rust
sys.gpio_irq_configure(mask, Edge::Rising);
```

which should be much more obvious to a reader, who no longer needs to remember the argument ordering to decypher calls to this function.

Also, this has the advantage of preventing the case where both rising and falling edge sensitivities are disabled at compile-time. Currently, this is a runtime error (reply fault), but with the new interface, a caller can provide an invalid configuration if they hand-write the input buffer rather than using the Idol client stub, so it should be harder to mess up.

[1]: https://runtimeverification.com/blog/code-smell-boolean-blindness