### PR TITLE
SP reset watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#e82f1076f402deeb85b9713b60c356da2f0c6ffe"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#39144ab93afadb5965e1a8805de9bcc4412ffbce"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#78b7356edbea64fe30e96b1451806037f4a80f71"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#c6e6eb667b0ee061f77a0e40ec10e5e15f2f54cf"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#55f6dc7bec7e8cdc82cc059b6a5dec010bda242f"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#ab85ea745c6391a6d7c3fe6dc58664fc67216b88"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#39144ab93afadb5965e1a8805de9bcc4412ffbce"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#78b7356edbea64fe30e96b1451806037f4a80f71"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "abi"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "phash",
  "serde",
@@ -193,9 +193,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -251,7 +251,7 @@ dependencies = [
 name = "build-kconfig"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "serde",
 ]
 
@@ -1255,6 +1255,7 @@ dependencies = [
  "drv-lpc55-spi",
  "drv-lpc55-syscon-api",
  "drv-lpc55-update-api",
+ "drv-sp-ctrl-api",
  "drv-sprot-api",
  "drv-update-api",
  "dumper-api",
@@ -2015,7 +2016,7 @@ dependencies = [
 name = "drv-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "build-stm32xx-sys",
  "build-util",
  "cfg-if",
@@ -2346,9 +2347,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#e727e960d31f62afe6077fdfc405e0ac2379f6b2"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#1ed45fb9ec14044aa5da136fa65ddf832079fad9"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "hubpack",
  "serde",
  "serde_repr",
@@ -2547,7 +2548,7 @@ dependencies = [
 name = "host-sp-messages"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "counters",
  "drv-i2c-types",
  "fletcher",
@@ -2773,7 +2774,7 @@ dependencies = [
  "abi",
  "anyhow",
  "armv8-m-mpu",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "build-kconfig",
  "build-util",
  "byteorder",
@@ -4856,7 +4857,7 @@ name = "task-thermal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "build-i2c",
  "build-util",
  "cortex-m",
@@ -5352,7 +5353,7 @@ name = "transceiver-messages"
 version = "0.1.1"
 source = "git+https://github.com/oxidecomputer/transceiver-control/#0a18f231372069b74b72f1756e2337186e888dc0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "hubpack",
  "serde",
 ]
@@ -5415,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "vcell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#ab85ea745c6391a6d7c3fe6dc58664fc67216b88"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#e82f1076f402deeb85b9713b60c356da2f0c6ffe"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#1ed45fb9ec14044aa5da136fa65ddf832079fad9"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=sp-slot-watchdog#55f6dc7bec7e8cdc82cc059b6a5dec010bda242f"
 dependencies = [
  "bitflags 2.5.0",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
 arrayvec = { version = "0.7.4", default-features = false }
 atty = { version = "0.2", default-features = false }
 bitfield = { version = "0.13", default-features = false }
-bitflags = { version = "2.4.1", default-features = false }
+bitflags = { version = "2.5.0", default-features = false }
 bstringify = { version = "0.1.2", default-features = false }
 byteorder = { version = "1.3.4", default-features = false }
 cargo_metadata = { version = "0.12.0", default-features = false }
@@ -117,7 +117,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 # Oxide forks and repos
 attest-data = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.1.0" }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "sp-slot-watchdog" }
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol", version = "0.1.0" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 # Oxide forks and repos
 attest-data = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.1.0" }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"], branch = "sp-slot-watchdog" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol", version = "0.1.0" }
 hif = { git = "https://github.com/oxidecomputer/hif", default-features = false }
 humpty = { git = "https://github.com/oxidecomputer/humpty", default-features = false, version = "0.1.3" }

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -132,7 +132,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
-    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "Opendrain" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "opendrain" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -132,6 +132,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -132,7 +132,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
-    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "Opendrain" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -79,7 +79,7 @@ name = "drv-lpc55-sprot-server"
 priority = 6
 max-sizes = {flash = 51168, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
-features = ["spi0"]
+features = ["spi0", "sp-ctrl"]
 start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -77,14 +77,14 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 48608, ram = 32768}
+max-sizes = {flash = 51168, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}
 stacksize = 16384
-task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest"]
+task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest", "swd"]
 
 [tasks.sprot.config]
 pins = [
@@ -110,7 +110,7 @@ uses = ["flexcomm5", "iocon"]
 start = true
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
-notifications = ["spi-irq"]
+notifications = ["spi-irq", "timer"]
 interrupts = {"flexcomm5.irq" = "spi-irq"}
 
 [tasks.swd.config]

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -122,6 +122,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -122,7 +122,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
-    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "Opendrain" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -69,7 +69,7 @@ task-slots = ["syscon_driver"]
 name = "drv-lpc55-sprot-server"
 priority = 6
 uses = ["flexcomm8", "bootrom"]
-features = ["spi0"]
+features = ["spi0", "sp-ctrl"]
 start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -122,7 +122,7 @@ pins = [
     # SCK
     { pin = { port = 0, pin = 7 }, alt = 3 },
     { name = "SP_TO_ROT_JTAG_DETECT_L", pin = { port = 0, pin = 20 }, alt = 0, direction = "input" },
-    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "Opendrain" },
+    { name = "ROT_TO_SP_RESET_L", pin = { port = 0, pin = 13 }, alt = 0, value = true, direction = "output", opendrain = "opendrain" },
 ]
 spi_num = 5
 

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -74,7 +74,7 @@ start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}
 stacksize = 16384
-task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest"]
+task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest", "swd"]
 
 [tasks.sprot.config]
 pins = [
@@ -100,7 +100,7 @@ uses = ["flexcomm5", "iocon"]
 start = true
 stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
-notifications = ["spi-irq"]
+notifications = ["spi-irq", "timer"]
 interrupts = {"flexcomm5.irq" = "spi-irq"}
 
 [tasks.swd.config]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -115,7 +115,7 @@ start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}
 stacksize = 16384
-task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest", "swd"]
+task-slots = ["gpio_driver", "syscon_driver", "update_server", "attest"]
 
 [tasks.sprot.config]
 pins = [
@@ -133,47 +133,6 @@ pins = [
     { name = "SP_RESET", pin = { port = 0, pin = 9}, alt = 0, direction = "input"},
 ]
 
-[tasks.swd]
-name = "drv-lpc55-swd"
-priority = 4
-max-sizes = {flash = 16384, ram = 4096}
-uses = ["flexcomm3", "iocon"]
-start = true
-stacksize = 1000
-notifications = ["spi-irq", "timer"]
-task-slots = ["gpio_driver", "syscon_driver"]
-interrupts = {"flexcomm3.irq" = "spi-irq"}
-
-[tasks.swd.config]
-# MOSI = PIO0_3
-# MISO = PIO0_2
-
-# Out = MOSI on, MISO off
-out_cfg = [
-    { pin = { port = 0, pin = 3 }, alt = 1 },
-    { pin = { port = 0, pin = 2 }, alt = 0, mode = "pulldown" },
-]
-# In = MISO on, MOSI off
-in_cfg = [
-    { pin = { port = 0, pin = 2 }, alt = 1 },
-    { pin = { port = 0, pin = 3 }, alt = 0, mode = "pulldown" },
-]
-pins = [
-    # SCK
-    { pin =  { port = 0, pin = 6 }, alt = 1 },
-    # CS, not strictly necessary but handy for debugging
-    # { pin = {port = 0, pin = 20}, alt =  1},
-]
-spi_num = 3
-
-[tasks.dumper]
-name = "task-dumper"
-priority = 5
-max-sizes = {flash = 16384, ram = 4096}
-start = true
-stacksize = 2600
-task-slots = ["swd"]
-
 [tasks.pong]
 name = "task-pong"
 priority = 7
@@ -185,21 +144,11 @@ notifications = ["timer"]
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 6
-features = ["lpc55", "gpio", "spctrl", "spi"]
+features = ["lpc55", "gpio", "spi"]
 max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 2048
 start = true
-task-slots = ["gpio_driver", "swd", "update_server"]
-
-[tasks.sp_measure]
-name = "task-sp-measure"
-priority = 6
-max-sizes = {flash = 131072, ram = 8192}
-task-slots = ["swd"]
-stacksize = 2048
-
-[tasks.sp_measure.config]
-binary_path = "../../target/gemini-bu/dist/final.bin"
+task-slots = ["gpio_driver", "update_server"]
 
 [tasks.attest]
 name = "task-attest"

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -108,14 +108,14 @@ task-slots = ["syscon_driver"]
 [tasks.sprot]
 name = "drv-lpc55-sprot-server"
 priority = 6
-max-sizes = {flash = 48608, ram = 32768}
+max-sizes = {flash = 49728, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0"]
 start = true
 notifications = ["spi-irq"]
 interrupts = {"flexcomm8.hs_spi" = "spi-irq"}
 stacksize = 16384
-task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest"]
+task-slots = ["gpio_driver", "syscon_driver", "update_server", "dumper", "attest", "swd"]
 
 [tasks.sprot.config]
 pins = [
@@ -140,7 +140,7 @@ max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm3", "iocon"]
 start = true
 stacksize = 1000
-notifications = ["spi-irq"]
+notifications = ["spi-irq", "timer"]
 task-slots = ["gpio_driver", "syscon_driver"]
 interrupts = {"flexcomm3.irq" = "spi-irq"}
 

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -161,7 +161,7 @@ pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
         // their output mode (to avoid glitching).
         if let Some(v) = p.value {
             assert!(
-                matches!(p.direction.as_deref(), Some("output")),
+                matches!(p.direction, Some(Direction::Output)),
                 "can only set value for output pins"
             );
             writeln!(&mut file, "iocon.set_val(")?;

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -20,6 +20,7 @@ drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
 drv-lpc55-spi = { path = "../lpc55-spi" }
 drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
 drv-lpc55-update-api = { path = "../lpc55-update-api" }
+drv-sp-ctrl-api = { path = "../sp-ctrl-api" }
 drv-sprot-api = { path = "../sprot-api" }
 drv-update-api = { path = "../update-api" }
 dumper-api = { path = "../../task/dumper-api" }

--- a/drv/lpc55-sprot-server/Cargo.toml
+++ b/drv/lpc55-sprot-server/Cargo.toml
@@ -20,16 +20,17 @@ drv-lpc55-gpio-api = { path = "../lpc55-gpio-api" }
 drv-lpc55-spi = { path = "../lpc55-spi" }
 drv-lpc55-syscon-api = { path = "../lpc55-syscon-api" }
 drv-lpc55-update-api = { path = "../lpc55-update-api" }
-drv-sp-ctrl-api = { path = "../sp-ctrl-api" }
 drv-sprot-api = { path = "../sprot-api" }
 drv-update-api = { path = "../update-api" }
-dumper-api = { path = "../../task/dumper-api" }
 lpc55_romapi = { path = "../../lib/lpc55-romapi" }
 ringbuf = { path = "../../lib/ringbuf" }
 static-cell = { path = "../../lib/static-cell" }
 task-jefe-api = { path = "../../task/jefe-api" }
 userlib = { path = "../../sys/userlib" }
 lpc55-rom-data = { path = "../../lib/lpc55-rom-data" }
+
+drv-sp-ctrl-api = { path = "../sp-ctrl-api", optional = true }
+dumper-api = { path = "../../task/dumper-api", optional = true }
 
 [build-dependencies]
 build-lpc55pins = { path = "../../build/lpc55pins" }
@@ -41,6 +42,7 @@ idol = { workspace = true }
 [features]
 spi0 = []
 no-ipc-counters = ["idol/no-counters"]
+sp-ctrl = ["drv-sp-ctrl-api", "dumper-api"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -471,6 +471,18 @@ impl<'a> Handler {
                 #[cfg(not(feature = "sp-ctrl"))]
                 Err(SprotError::Protocol(SprotProtocolError::BadMessageType))
             }
+            ReqBody::Swd(SwdReq::SpSlotWatchdogSupported) => {
+                #[cfg(feature = "sp-ctrl")]
+                match self.sp_ctrl.setup() {
+                    Ok(()) => Ok((RspBody::Ok, None)),
+                    Err(_e) => Err(SprotError::Watchdog(
+                        drv_sprot_api::WatchdogError::SpCtrl,
+                    )),
+                }
+
+                #[cfg(not(feature = "sp-ctrl"))]
+                Err(SprotError::Protocol(SprotProtocolError::BadMessageType))
+            }
         }
     }
 }

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -10,8 +10,8 @@ use drv_sp_ctrl_api::SpCtrl;
 use drv_sprot_api::{
     AttestReq, AttestRsp, CabooseReq, CabooseRsp, DumpReq, DumpRsp, ReqBody,
     Request, Response, RotIoStats, RotPageRsp, RotState, RotStatus, RspBody,
-    SprocketsError, SprotError, SprotProtocolError, UpdateReq, UpdateRsp,
-    WatchdogError, CURRENT_VERSION, MIN_VERSION, REQUEST_BUF_SIZE,
+    SprocketsError, SprotError, SprotProtocolError, SwdReq, UpdateReq,
+    UpdateRsp, WatchdogError, CURRENT_VERSION, MIN_VERSION, REQUEST_BUF_SIZE,
     RESPONSE_BUF_SIZE,
 };
 use dumper_api::Dumper;
@@ -421,7 +421,7 @@ impl<'a> Handler {
                 };
                 Ok((RspBody::Attest(rsp), None))
             }
-            ReqBody::EnableSpSlotWatchdog { time_ms } => {
+            ReqBody::Swd(SwdReq::EnableSpSlotWatchdog { time_ms }) => {
                 // Enabling the watchdog doesn't actually do any SWD work, but
                 // we'll call `setup()` now to make sure that the SWD system is
                 // working.
@@ -432,7 +432,7 @@ impl<'a> Handler {
                     Err(_e) => Err(SprotError::Watchdog(WatchdogError::SpCtrl)),
                 }
             }
-            ReqBody::DisableSpSlotWatchdog => {
+            ReqBody::Swd(SwdReq::DisableSpSlotWatchdog) => {
                 self.sp_ctrl.disable_sp_slot_watchdog();
                 Ok((RspBody::Ok, None))
             }

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -67,7 +67,6 @@ use handler::Handler;
 #[derive(Copy, Clone, PartialEq)]
 pub(crate) enum Trace {
     None,
-    Dump(u32),
     ReceivedBytes(usize),
     Flush,
     FlowError,
@@ -76,6 +75,9 @@ pub(crate) enum Trace {
     Err(SprotProtocolError),
     Stats(RotIoStats),
     Desynchronized,
+
+    #[cfg(feature = "sp-ctrl")]
+    Dump(u32),
 }
 ringbuf!(Trace, 32, Trace::None);
 

--- a/drv/lpc55-swd/build.rs
+++ b/drv/lpc55-swd/build.rs
@@ -100,6 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         )?;
 
     build_util::expose_target_board();
+    build_util::build_notifications()?;
 
     let task_config = build_util::task_config::<TaskConfig>()?;
 

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -499,6 +499,8 @@ impl idl::InOrderSpCtrlImpl for ServerImpl {
         if !self.init {
             return Err(SpCtrlError::NeedInit.into());
         }
+        // This function is idempotent(ish), so we don't care if the timer was
+        // already running; set the new deadline based on current time.
         let deadline = sys_get_timer().now + time_ms as u64;
         sys_set_timer(Some(deadline), notifications::TIMER_MASK);
         Ok(())

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -775,18 +775,10 @@ impl ServerImpl {
     }
 
     fn swd_dongle_detected(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(any(
-                target_board = "oxide-rot-1",
-            ))] {
-                use drv_lpc55_gpio_api::*;
+        use drv_lpc55_gpio_api::*;
 
-                let gpio = Pins::from(self.gpio);
-                gpio.read_val(SP_TO_ROT_JTAG_DETECT_L) == Value::Zero
-            } else {
-                false
-            }
-        }
+        let gpio = Pins::from(self.gpio);
+        gpio.read_val(SP_TO_ROT_JTAG_DETECT_L) == Value::Zero
     }
 
     fn swd_setup(&mut self) -> Result<(), Ack> {

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -1058,11 +1058,9 @@ impl ServerImpl {
         self.write_single_target_addr(OPTCR, optcr)?;
 
         // Wait for option bit programming to finish
-        loop {
-            let optsr_cur = self.read_single_target_addr(OPTSR_CUR)?;
-            if optsr_cur & OPTSR_OPT_BUSY_BIT == 0 {
-                break;
-            }
+        while self.read_single_target_addr(OPTSR_CUR)? & OPTSR_OPT_BUSY_BIT != 0
+        {
+            hl::sleep_for(5);
         }
 
         // Reset the STM32, causing it to reboot into the newly-set slot

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -89,8 +89,7 @@ enum Trace {
     EnabledWatchdog,
     DisabledWatchdog,
     WatchdogFired,
-    WatchdogSwapOk,
-    WatchdogSwapErr(Ack),
+    WatchdogSwap(Result<(), Ack>),
 }
 
 ringbuf!(Trace, 128, Trace::None);
@@ -528,10 +527,8 @@ impl NotificationHandler for ServerImpl {
         sys_set_timer(None, notifications::TIMER_MASK);
 
         // Attempt to do the swap
-        match self.swap_sp_slot() {
-            Ok(()) => ringbuf_entry!(Trace::WatchdogSwapOk),
-            Err(e) => ringbuf_entry!(Trace::WatchdogSwapErr(e)),
-        }
+        let r = self.swap_sp_slot();
+        ringbuf_entry!(Trace::WatchdogSwap(r));
 
         // Force reinitialization
         self.init = false;

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -1064,14 +1064,11 @@ impl ServerImpl {
         }
 
         // Reset the STM32, causing it to reboot into the newly-set slot
-        // Details from PM0253, Section 4.3.5
-        const AIRCR: u32 = 0xE000ED0C;
-        const AIRCR_VECTKEY: u32 = 0x5FA << 16;
-        const AIRCR_SYSRESETREQ: u32 = 1 << 2;
-        self.write_single_target_addr(
-            AIRCR,
-            AIRCR_VECTKEY | AIRCR_SYSRESETREQ,
-        )?;
+        use drv_lpc55_gpio_api::{Pins, Value};
+        let gpio = Pins::from(self.gpio);
+        gpio.set_val(ROT_TO_SP_RESET_L, Value::Zero);
+        hl::sleep_for(10);
+        gpio.set_val(ROT_TO_SP_RESET_L, Value::One);
 
         Ok(())
     }

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use gateway_messages::{
     RotError, SpError, SprocketsError as GwSprocketsErr,
     SprotProtocolError as GwSprotProtocolError,
+    WatchdogError as GwWatchdogError,
 };
 use idol_runtime::RequestError;
 
@@ -37,6 +38,7 @@ pub enum SprotError {
     Spi(#[count(children)] SpiError),
     Update(#[count(children)] UpdateError),
     Sprockets(#[count(children)] SprocketsError),
+    Watchdog(#[count(children)] WatchdogError),
 }
 
 impl From<SprotError> for SpError {
@@ -46,6 +48,7 @@ impl From<SprotError> for SpError {
             SprotError::Spi(e) => Self::Spi(e.into()),
             SprotError::Update(e) => Self::Update(e.into()),
             SprotError::Sprockets(e) => Self::Sprockets(e.into()),
+            SprotError::Watchdog(e) => Self::Watchdog(e.into()),
         }
     }
 }
@@ -57,6 +60,7 @@ impl From<SprotError> for RotError {
             SprotError::Spi(e) => Self::Spi(e.into()),
             SprotError::Update(e) => Self::Update(e.into()),
             SprotError::Sprockets(e) => Self::Sprockets(e.into()),
+            SprotError::Watchdog(e) => Self::Watchdog(e.into()),
         }
     }
 }
@@ -297,5 +301,30 @@ impl<V> From<AttestOrSprotError>
 impl From<idol_runtime::ServerDeath> for AttestOrSprotError {
     fn from(_: idol_runtime::ServerDeath) -> Self {
         AttestOrSprotError::Attest(AttestError::TaskRestarted)
+    }
+}
+
+// Added in sprot protocol version 5
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    SerializedSize,
+    counters::Count,
+)]
+pub enum WatchdogError {
+    /// Could not control the SP over SWD
+    SpCtrl,
+}
+
+impl From<WatchdogError> for GwWatchdogError {
+    fn from(s: WatchdogError) -> Self {
+        match s {
+            WatchdogError::SpCtrl => Self::SpCtrl,
+        }
     }
 }

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -15,7 +15,8 @@ use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 
 use gateway_messages::{
-    RotError, SpError, SprocketsError as GwSprocketsErr,
+    RotError, RotWatchdogError as GwRotWatchdogError, SpError,
+    SprocketsError as GwSprocketsErr,
     SprotProtocolError as GwSprotProtocolError,
     WatchdogError as GwWatchdogError,
 };
@@ -318,13 +319,18 @@ impl From<idol_runtime::ServerDeath> for AttestOrSprotError {
 )]
 pub enum WatchdogError {
     /// Could not control the SP over SWD
-    SpCtrl,
+    DongleDetected,
+    /// Raw `SpCtrlError` value
+    Other(u32),
 }
 
 impl From<WatchdogError> for GwWatchdogError {
     fn from(s: WatchdogError) -> Self {
         match s {
-            WatchdogError::SpCtrl => Self::SpCtrl,
+            WatchdogError::DongleDetected => {
+                Self::Rot(GwRotWatchdogError::DongleDetected)
+            }
+            WatchdogError::Other(i) => Self::Rot(GwRotWatchdogError::Other(i)),
         }
     }
 }

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -346,8 +346,13 @@ pub enum ReqBody {
     // Added in sprot protocol version 4
     RotPage { page: RotPage },
     // Added in sprot protocol version 5
+    Swd(SwdReq),
+}
+
+// Added in sprot protocol version 5
+#[derive(Clone, Serialize, Deserialize, SerializedSize)]
+pub enum SwdReq {
     EnableSpSlotWatchdog { time_ms: u32 },
-    // Added in sprot protocol version 5
     DisableSpSlotWatchdog,
 }
 

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -352,8 +352,17 @@ pub enum ReqBody {
 // Added in sprot protocol version 5
 #[derive(Clone, Serialize, Deserialize, SerializedSize)]
 pub enum SwdReq {
-    EnableSpSlotWatchdog { time_ms: u32 },
+    EnableSpSlotWatchdog {
+        time_ms: u32,
+    },
     DisableSpSlotWatchdog,
+
+    /// Checks whether the SP slot watchdog is supported
+    ///
+    /// In practice, this calls `drv_lpc55_swd::ServerImpl::setup` to make sure
+    /// that there's no debugger attached that would prevent us from talking to
+    /// the SP.
+    SpSlotWatchdogSupported,
 }
 
 /// Instruct the RoT to take a dump of the SP via SWD

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -15,6 +15,7 @@ use dumper_api::DumperError;
 pub use error::{
     AttestOrSprotError, CabooseOrSprotError, DumpOrSprotError,
     RawCabooseOrSprotError, SprocketsError, SprotError, SprotProtocolError,
+    WatchdogError,
 };
 
 use crc::{Crc, CRC_16_XMODEM};
@@ -47,7 +48,7 @@ pub const MIN_VERSION: Version = Version(2);
 /// Code between the `CURRENT_VERSION` and `MIN_VERSION` must remain
 /// compatible. Use the rules described in the comments for [`Msg`] to evolve
 /// the protocol such that this remains true.
-pub const CURRENT_VERSION: Version = Version(4);
+pub const CURRENT_VERSION: Version = Version(5);
 
 /// We allow room in the buffer for message evolution
 pub const REQUEST_BUF_SIZE: usize = 1024;
@@ -344,6 +345,10 @@ pub enum ReqBody {
     Attest(AttestReq),
     // Added in sprot protocol version 4
     RotPage { page: RotPage },
+    // Added in sprot protocol version 5
+    EnableSpSlotWatchdog { time_ms: u32 },
+    // Added in sprot protocol version 5
+    DisableSpSlotWatchdog,
 }
 
 /// Instruct the RoT to take a dump of the SP via SWD

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1185,6 +1185,17 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         rsp.body?;
         Ok(())
     }
+
+    fn sp_slot_watchdog_supported(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        let body = ReqBody::Swd(SwdReq::SpSlotWatchdogSupported);
+        let tx_size = Request::pack(&body, self.tx_buf);
+        let rsp = self.do_send_recv_retries(tx_size, TIMEOUT_QUICK, 1)?;
+        rsp.body?;
+        Ok(())
+    }
 }
 
 impl<S: SpiServer> NotificationHandler for ServerImpl<S> {

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1162,6 +1162,29 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
             Err(e) => Err(AttestOrSprotError::Sprot(e).into()),
         }
     }
+
+    fn enable_sp_slot_watchdog(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+        time_ms: u32,
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        let body = ReqBody::EnableSpSlotWatchdog { time_ms };
+        let tx_size = Request::pack(&body, self.tx_buf);
+        let rsp = self.do_send_recv_retries(tx_size, TIMEOUT_QUICK, 1)?;
+        rsp.body?;
+        Ok(())
+    }
+
+    fn disable_sp_slot_watchdog(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<(), idol_runtime::RequestError<SprotError>> {
+        let body = ReqBody::DisableSpSlotWatchdog;
+        let tx_size = Request::pack(&body, self.tx_buf);
+        let rsp = self.do_send_recv_retries(tx_size, TIMEOUT_QUICK, 1)?;
+        rsp.body?;
+        Ok(())
+    }
 }
 
 impl<S: SpiServer> NotificationHandler for ServerImpl<S> {

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1168,7 +1168,7 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         _msg: &userlib::RecvMessage,
         time_ms: u32,
     ) -> Result<(), idol_runtime::RequestError<SprotError>> {
-        let body = ReqBody::EnableSpSlotWatchdog { time_ms };
+        let body = ReqBody::Swd(SwdReq::EnableSpSlotWatchdog { time_ms });
         let tx_size = Request::pack(&body, self.tx_buf);
         let rsp = self.do_send_recv_retries(tx_size, TIMEOUT_QUICK, 1)?;
         rsp.body?;
@@ -1179,7 +1179,7 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         &mut self,
         _msg: &userlib::RecvMessage,
     ) -> Result<(), idol_runtime::RequestError<SprotError>> {
-        let body = ReqBody::DisableSpSlotWatchdog;
+        let body = ReqBody::Swd(SwdReq::DisableSpSlotWatchdog);
         let tx_size = Request::pack(&body, self.tx_buf);
         let rsp = self.do_send_recv_retries(tx_size, TIMEOUT_QUICK, 1)?;
         rsp.body?;

--- a/idl/sp-ctrl.idol
+++ b/idl/sp-ctrl.idol
@@ -89,5 +89,20 @@ Interface(
                 err: CLike("SpCtrlError"),
             )
         ),
+        "enable_sp_slot_watchdog": (
+            doc: "Enable a watchdog that will reset the SP into the inactive slot",
+            args: {
+                "time_ms" : "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("SpCtrlError"),
+            ),
+        ),
+        "disable_sp_slot_watchdog": (
+            doc: "Disable the SP slot watchdog",
+            reply: Simple("()"),
+            idempotent: true,
+        ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -297,5 +297,13 @@ Interface(
             ),
             encoding: Hubpack,
         ),
+        "sp_slot_watchdog_supported": (
+            doc: "Checks if the SP slot watchdog is supported",
+            reply: Result(
+                ok: "()",
+                err: Complex("SprotError"),
+            ),
+            encoding: Hubpack,
+        ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -278,5 +278,24 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
+        "enable_sp_slot_watchdog": (
+            doc: "Enable a watchdog that will reset the SP into the alternate slot",
+            args: {
+                "time_ms" : "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: Complex("SprotError"),
+            ),
+            encoding: Hubpack,
+        ),
+        "disable_sp_slot_watchdog": (
+            doc: "Disable the SP slot watchdog",
+            reply: Result(
+                ok: "()",
+                err: Complex("SprotError"),
+            ),
+            encoding: Hubpack,
+        ),
     }
 )

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -502,6 +502,11 @@ impl MgsCommon {
         self.sprot.disable_sp_slot_watchdog()?;
         Ok(())
     }
+
+    pub(crate) fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
+        self.sprot.sp_slot_watchdog_supported()?;
+        Ok(())
+    }
 }
 
 fn translate_sensor_nodata(

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -481,6 +481,19 @@ impl MgsCommon {
 
         Ok(cnt)
     }
+
+    pub(crate) fn enable_sp_slot_watchdog(
+        &mut self,
+        time_ms: u32,
+    ) -> Result<(), SpError> {
+        self.sprot.enable_sp_slot_watchdog(time_ms)?;
+        Ok(())
+    }
+
+    pub(crate) fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
+        self.sprot.disable_sp_slot_watchdog()?;
+        Ok(())
+    }
 }
 
 fn translate_sensor_nodata(

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -487,7 +487,7 @@ impl MgsCommon {
         &mut self,
         component: SpComponent,
         time_ms: u32,
-    ) -> Result<core::convert::Infallible, SpError> {
+    ) -> Result<(), SpError> {
         if self.reset_component_requested != Some(component) {
             return Err(SpError::ResetComponentTriggerWithoutPrepare);
         }

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -482,12 +482,16 @@ impl MgsCommon {
         Ok(cnt)
     }
 
-    pub(crate) fn enable_sp_slot_watchdog(
+    pub(crate) fn reset_with_watchdog(
         &mut self,
         time_ms: u32,
-    ) -> Result<(), SpError> {
+    ) -> Result<core::convert::Infallible, SpError> {
+        if self.reset_component_requested != Some(SpComponent::SP_ITSELF) {
+            return Err(SpError::ResetComponentTriggerWithoutPrepare);
+        }
         self.sprot.enable_sp_slot_watchdog(time_ms)?;
-        Ok(())
+        task_jefe_api::Jefe::from(crate::JEFE.get_task_id()).request_reset();
+        panic!(); // we really really shouldn't get here
     }
 
     pub(crate) fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {

--- a/task/control-plane-agent/src/mgs_common.rs
+++ b/task/control-plane-agent/src/mgs_common.rs
@@ -501,7 +501,7 @@ impl MgsCommon {
                 .request_reset();
             panic!(); // we really really shouldn't get here
         } else {
-            return Err(SpError::RequestUnsupportedForComponent);
+            Err(SpError::RequestUnsupportedForComponent)
         }
     }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1132,19 +1132,27 @@ impl SpHandler for MgsHandler {
         self.common.vpd_lock_status_all(buf)
     }
 
-    fn reset_with_watchdog(
+    fn reset_component_trigger_with_watchdog(
         &mut self,
+        component: SpComponent,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        self.common.reset_with_watchdog(time_ms)
+        self.common
+            .reset_component_trigger_with_watchdog(component, time_ms)
     }
 
-    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
-        self.common.disable_sp_slot_watchdog()
+    fn disable_component_watchdog(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.disable_component_watchdog(component)
     }
 
-    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
-        self.common.sp_slot_watchdog_supported()
+    fn component_watchdog_supported(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.component_watchdog_supported(component)
     }
 }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1131,6 +1131,14 @@ impl SpHandler for MgsHandler {
     ) -> Result<usize, SpError> {
         self.common.vpd_lock_status_all(buf)
     }
+
+    fn enable_sp_slot_watchdog(&mut self, time_ms: u32) -> Result<(), SpError> {
+        self.common.enable_sp_slot_watchdog(time_ms)
+    }
+
+    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
+        self.common.disable_sp_slot_watchdog()
+    }
 }
 
 struct UsartHandler {

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1136,9 +1136,6 @@ impl SpHandler for MgsHandler {
         &mut self,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        if !matches!(self.sp_update.status(), UpdateStatus::Complete(..)) {
-            return Err(SpError::Watchdog(WatchdogError::NoCompletedUpdate));
-        }
         self.common.reset_with_watchdog(time_ms)
     }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1136,9 +1136,10 @@ impl SpHandler for MgsHandler {
         &mut self,
         component: SpComponent,
         time_ms: u32,
-    ) -> Result<core::convert::Infallible, SpError> {
+    ) -> Result<(), SpError> {
         self.common
             .reset_component_trigger_with_watchdog(component, time_ms)
+            .map(|_| ())
     }
 
     fn disable_component_watchdog(

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -19,7 +19,7 @@ use gateway_messages::{
     DiscoverResponse, Header, IgnitionCommand, IgnitionState, Message,
     MessageKind, MgsError, PowerState, RotRequest, RotResponse, SensorRequest,
     SensorResponse, SpComponent, SpError, SpPort, SpRequest, SpStateV2,
-    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus, WatchdogError,
+    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
     SERIAL_CONSOLE_IDLE_TIMEOUT,
 };
 use heapless::{Deque, Vec};
@@ -1141,6 +1141,9 @@ impl SpHandler for MgsHandler {
 
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
         self.common.disable_sp_slot_watchdog()
+    }
+    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
+        self.common.sp_slot_watchdog_supported()
     }
 }
 

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1142,6 +1142,7 @@ impl SpHandler for MgsHandler {
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
         self.common.disable_sp_slot_watchdog()
     }
+
     fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
         self.common.sp_slot_watchdog_supported()
     }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -649,18 +649,26 @@ impl SpHandler for MgsHandler {
         self.common.vpd_lock_status_all(buf)
     }
 
-    fn reset_with_watchdog(
+    fn reset_component_trigger_with_watchdog(
         &mut self,
+        component: SpComponent,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        self.common.reset_with_watchdog(time_ms)
+        self.common
+            .reset_component_trigger_with_watchdog(component, time_ms)
     }
 
-    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
-        self.common.disable_sp_slot_watchdog()
+    fn disable_component_watchdog(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.disable_component_watchdog(component)
     }
 
-    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
-        self.common.sp_slot_watchdog_supported()
+    fn component_watchdog_supported(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.component_watchdog_supported(component)
     }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -659,4 +659,8 @@ impl SpHandler for MgsHandler {
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
         self.common.disable_sp_slot_watchdog()
     }
+
+    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
+        self.common.sp_slot_watchdog_supported()
+    }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -649,8 +649,14 @@ impl SpHandler for MgsHandler {
         self.common.vpd_lock_status_all(buf)
     }
 
-    fn enable_sp_slot_watchdog(&mut self, time_ms: u32) -> Result<(), SpError> {
-        self.common.enable_sp_slot_watchdog(time_ms)
+    fn reset_with_watchdog(
+        &mut self,
+        time_ms: u32,
+    ) -> Result<core::convert::Infallible, SpError> {
+        if !matches!(self.sp_update.status(), UpdateStatus::Complete(..)) {
+            return Err(SpError::Watchdog(WatchdogError::NoCompletedUpdate));
+        }
+        self.common.reset_with_watchdog(time_ms)
     }
 
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -15,7 +15,7 @@ use gateway_messages::{
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
     RotRequest, RotResponse, SensorRequest, SensorResponse, SpComponent,
     SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId,
-    UpdateStatus,
+    UpdateStatus, WatchdogError,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -15,7 +15,7 @@ use gateway_messages::{
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
     RotRequest, RotResponse, SensorRequest, SensorResponse, SpComponent,
     SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId,
-    UpdateStatus, WatchdogError,
+    UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -653,7 +653,7 @@ impl SpHandler for MgsHandler {
         &mut self,
         component: SpComponent,
         time_ms: u32,
-    ) -> Result<core::convert::Infallible, SpError> {
+    ) -> Result<(), SpError> {
         self.common
             .reset_component_trigger_with_watchdog(component, time_ms)
     }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -648,4 +648,12 @@ impl SpHandler for MgsHandler {
     ) -> Result<usize, SpError> {
         self.common.vpd_lock_status_all(buf)
     }
+
+    fn enable_sp_slot_watchdog(&mut self, time_ms: u32) -> Result<(), SpError> {
+        self.common.enable_sp_slot_watchdog(time_ms)
+    }
+
+    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
+        self.common.disable_sp_slot_watchdog()
+    }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -653,9 +653,6 @@ impl SpHandler for MgsHandler {
         &mut self,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        if !matches!(self.sp_update.status(), UpdateStatus::Complete(..)) {
-            return Err(SpError::Watchdog(WatchdogError::NoCompletedUpdate));
-        }
         self.common.reset_with_watchdog(time_ms)
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -768,6 +768,10 @@ impl SpHandler for MgsHandler {
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
         self.common.disable_sp_slot_watchdog()
     }
+
+    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
+        self.common.sp_slot_watchdog_supported()
+    }
 }
 
 // Helper function for `.map_err()`; we can't use `?` because we can't implement

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -757,6 +757,14 @@ impl SpHandler for MgsHandler {
     ) -> Result<usize, SpError> {
         self.common.vpd_lock_status_all(buf)
     }
+
+    fn enable_sp_slot_watchdog(&mut self, time_ms: u32) -> Result<(), SpError> {
+        self.common.enable_sp_slot_watchdog(time_ms)
+    }
+
+    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
+        self.common.disable_sp_slot_watchdog()
+    }
 }
 
 // Helper function for `.map_err()`; we can't use `?` because we can't implement

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -758,8 +758,14 @@ impl SpHandler for MgsHandler {
         self.common.vpd_lock_status_all(buf)
     }
 
-    fn enable_sp_slot_watchdog(&mut self, time_ms: u32) -> Result<(), SpError> {
-        self.common.enable_sp_slot_watchdog(time_ms)
+    fn reset_with_watchdog(
+        &mut self,
+        time_ms: u32,
+    ) -> Result<core::convert::Infallible, SpError> {
+        if !matches!(self.sp_update.status(), UpdateStatus::Complete(..)) {
+            return Err(SpError::Watchdog(WatchdogError::NoCompletedUpdate));
+        }
+        self.common.reset_with_watchdog(time_ms)
     }
 
     fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -762,7 +762,7 @@ impl SpHandler for MgsHandler {
         &mut self,
         component: SpComponent,
         time_ms: u32,
-    ) -> Result<core::convert::Infallible, SpError> {
+    ) -> Result<(), SpError> {
         self.common
             .reset_component_trigger_with_watchdog(component, time_ms)
     }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -18,7 +18,7 @@ use gateway_messages::{
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
     RotRequest, RotResponse, SensorRequest, SensorResponse, SpComponent,
     SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId,
-    UpdateStatus, WatchdogError,
+    UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -18,7 +18,7 @@ use gateway_messages::{
     DiscoverResponse, IgnitionCommand, IgnitionState, MgsError, PowerState,
     RotRequest, RotResponse, SensorRequest, SensorResponse, SpComponent,
     SpError, SpPort, SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId,
-    UpdateStatus,
+    UpdateStatus, WatchdogError,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -762,9 +762,6 @@ impl SpHandler for MgsHandler {
         &mut self,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        if !matches!(self.sp_update.status(), UpdateStatus::Complete(..)) {
-            return Err(SpError::Watchdog(WatchdogError::NoCompletedUpdate));
-        }
         self.common.reset_with_watchdog(time_ms)
     }
 

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -758,19 +758,27 @@ impl SpHandler for MgsHandler {
         self.common.vpd_lock_status_all(buf)
     }
 
-    fn reset_with_watchdog(
+    fn reset_component_trigger_with_watchdog(
         &mut self,
+        component: SpComponent,
         time_ms: u32,
     ) -> Result<core::convert::Infallible, SpError> {
-        self.common.reset_with_watchdog(time_ms)
+        self.common
+            .reset_component_trigger_with_watchdog(component, time_ms)
     }
 
-    fn disable_sp_slot_watchdog(&mut self) -> Result<(), SpError> {
-        self.common.disable_sp_slot_watchdog()
+    fn disable_component_watchdog(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.disable_component_watchdog(component)
     }
 
-    fn sp_slot_watchdog_supported(&mut self) -> Result<(), SpError> {
-        self.common.sp_slot_watchdog_supported()
+    fn component_watchdog_supported(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<(), SpError> {
+        self.common.component_watchdog_supported(component)
     }
 }
 


### PR DESCRIPTION
An SP update has one fundamental requirement: it has to allow for future updates.

This is not guaranteed: a sufficiently broken SP image could fail to bring up `net` or `control-plane-agent`, which would require physical intervention to reflash (not ideal in a rack!).

In https://github.com/oxidecomputer/hubris/issues/1695, we discuss a strategy for automatically rolling back updates, using the RoT as a watchdog.  This PR adds the tools to implement that strategy:

- New SP-RoT messages to enable and disable a "reset into alternate slot" watchdog timer
- RoT implementation of that watchdog
- MGS plumbing (along with https://github.com/oxidecomputer/management-gateway-service/pull/216) to accept these commands over the network