### PR TITLE
userlib: add no-panic feature

### DIFF
--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = ["critical-section"]
 panic-messages = []
+no-panic = []
 critical-section = ["dep:critical-section"]
 
 [dependencies]

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -1288,6 +1288,15 @@ pub unsafe extern "C" fn _start() -> ! {
     }
 }
 
+// Make the no-panic and panic-messages features mutually exclusive.
+#[cfg(all(feature = "no-panic", feature = "panic-messages"))]
+compile_error!(
+    "Both the userlib/panic-messages and userlib/no-panic feature flags \
+     are set! This doesn't make a lot of sense and is probably not what \
+     you wanted. (If you have a use case for this combination, update \
+     this check in userlib.)"
+);
+
 /// Panic handler for user tasks with the `panic-messages` feature enabled. This
 /// handler will try its best to generate a panic message, up to a maximum
 /// buffer size (configured below).


### PR DESCRIPTION
When enabled, this will turn any panics in a task into linker errors. That's not ideal, but it's better than expecting people to manually read disassembly.

This currently has no users in the source tree, because it's factored out of some other work I'm doing. Wanted to make this available so we can start turning it on opportunistically.