### PR TITLE
stm32xx-sys: add interrupt acking to `gpio_irq_control`

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-stm32h7-nucleo"
-requires = {flash = 24000, ram = 5120}
+requires = {flash = 24736, ram = 5120}
 features = ["h743", "dump"]
 
 [tasks.jefe]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-stm32h7-nucleo"
-requires = {flash = 24704, ram = 5120}
+requires = {flash = 24736, ram = 5120}
 features = ["h753", "dump"]
 
 [tasks.jefe]

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -68,7 +68,7 @@ pub enum IrqControl {
     ///
     /// If an interrupt is currently enabled, it will remain enabled, while if
     /// it is currently disabled, it will remain disabled.
-    Check = 0b11,
+    Check,
 }
 
 impl Sys {

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -52,6 +52,25 @@ pub enum Edge {
     Both = 0b11,
 }
 
+/// Describes which operation is performed by the [`Sys::gpio_irq_control`] IPC.
+#[derive(
+    Copy, Clone, FromPrimitive, PartialEq, Eq, AsBytes, serde::Deserialize,
+)]
+// repr attribute is required for the derived `AsBytes` implementation
+#[repr(u8)]
+pub enum IrqControl {
+    /// Disable any interrupts mapped to the provided notification mask.
+    Disable = 0,
+    /// Enable any interrupts mapped to the provided notification mask.
+    Enable,
+    /// Check if any interrupts mapped to the provided notification mask have
+    /// been triggered, *without* enabling or disabling the interrupt.
+    ///
+    /// If an interrupt is currently enabled, it will remain enabled, while if
+    /// it is currently disabled, it will remain disabled.
+    Check = 0b11,
+}
+
 impl Sys {
     /// Requests that the clock to a peripheral be turned on.
     ///
@@ -328,6 +347,22 @@ impl core::ops::BitOr for Edge {
             (Edge::Falling, Edge::Falling) => Edge::Falling,
             _ => Edge::Both,
         }
+    }
+}
+
+impl From<bool> for IrqControl {
+    fn from(value: bool) -> Self {
+        if value {
+            IrqControl::Enable
+        } else {
+            IrqControl::Disable
+        }
+    }
+}
+
+impl From<Option<bool>> for IrqControl {
+    fn from(value: Option<bool>) -> Self {
+        value.map(Self::from).unwrap_or(Self::Check)
     }
 }
 

--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -228,7 +228,7 @@
 //! ```rust,no-run
 //! # fn handle_interrupt() {}
 //! # mod notifications { pub const MY_GPIO_NOTIFICATION_MASK: u32 = 1 << 0; }
-//! use drv_stm32xx_sys_api::{PinSet, Port, Pull, Edge};
+//! use drv_stm32xx_sys_api::{PinSet, Port, Pull, Edge, IrqControl};
 //! use userlib::*;
 //!
 //! task_slot!(SYS, sys);
@@ -251,30 +251,27 @@
 //!     );
 //!
 //!     // First, enable the interrupt, so that we can receive our
-//!     // notification:
-//!     sys.gpio_irq_control(0, notifications::MY_GPIO_NOTIFICATION_MASK)
-//!         .unwrap_lite();
+//!     // notification. We loop here to retry if the `sys` task has panicked.
+//!     while sys
+//!         .gpio_irq_control(notifications::MY_GPIO_NOTIFICATION_MASK, IrqControl::Enable)
+//!         .is_err()
+//!     {}
 //!
 //!     // Wait to recieve notifications for our GPIO interrupt in a loop:
 //!     loop {
-//!         // Wait for a notification:
-//!         //
-//!         // We only care about notifications, so we can pass a zero-sized
-//!         // recv buffer, and the kernel's task ID.
-//!         let recvmsg = sys_recv_closed(
-//!             &mut [],
-//!             notifications::BUTTON_MASK,
-//!             TaskId::KERNEL,
-//!         )
-//!         // Recv from the kernel never returns an error.
-//!         .unwrap_lite();
+//!         // Wait for a notification.
+//!         sys_recv_notification(notifications::MY_GPIO_NOTIFICATION_MASK);
 //!
 //!         // Call `sys.gpio_irq_control()` to both re-enable the interrupt
 //!         // and ask the `sys` task to confirm for us that the interrupt has
 //!         // actually fired.
+//!         //
+//!         // If we did *not* want to re-enable the interrupt here, we could
+//!         // pass `IrqControl::Check` rather than `IrqControl::Enable`.
 //!         let fired = sys
-//!             .gpio_irq_control(0, notifications::MY_GPIO_NOTIFICATION_MASK)
-//!             .unwrap_lite()
+//!             .gpio_irq_control(notifications::MY_GPIO_NOTIFICATION_MASK, IrqControl::Enable)
+//!             // If the `sys` task panicked, just wait for another notification.
+//!             .unwrap_or(false)
 //!         if fired {
 //!             // If the sys task confirms that our interrupt has fired, do...
 //!             // whatever it is this task is supposed to do when that happens.
@@ -324,7 +321,7 @@ cfg_if! {
 }
 
 use drv_stm32xx_gpio_common::{server::get_gpio_regs, Port};
-use drv_stm32xx_sys_api::{Edge, Group, RccError};
+use drv_stm32xx_sys_api::{Edge, Group, IrqControl, RccError};
 use idol_runtime::{ClientError, NotificationHandler, RequestError};
 #[cfg(not(feature = "test"))]
 use task_jefe_api::{Jefe, ResetReason};
@@ -667,8 +664,8 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
     fn gpio_irq_control(
         &mut self,
         rm: &RecvMessage,
-        disable_mask: u32,
-        enable_mask: u32,
+        mask: u32,
+        op: IrqControl,
     ) -> Result<bool, RequestError<core::convert::Infallible>> {
         // We want to only include code for this if exti is requested.
         // Unfortunately the _operation_ is available unconditionally, but we'll
@@ -686,47 +683,40 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
                 // didn't.
                 let mut slot_mask = 0u16;
 
-                for (i, entry) in
-                    generated::EXTI_DISPATCH_TABLE.iter().enumerate()
-                {
-                    // Only use populated rows in the table
-                    if let &Some(ExtiDispatch { mask, task, .. }) = entry {
-                        // Ignore anything assigned to another task
-                        if task.index() == rm.sender.index() {
+                for (i, _) in exti_dispatch_for(rm.sender, mask) {
+                    // What bit do we touch for this entry?
+                    let bit = 1 << i;
 
-                            // Apply disable first so that including the same
-                            // thing in both masks is a no-op.
-                            if mask & disable_mask != 0 {
-                                // Record that these bits meant something.
-                                let bit = 1 << i;
-                                slot_mask |= bit;
+                    // Record that these bits meant something.
+                    slot_mask |= bit;
 
-                                // Disable this source by _clearing_ the
-                                // corresponding mask bit.
-                                self.exti.cpuimr1.modify(|r, w| {
-                                    let new_value = r.bits() & !(bit as u32);
-                                    // Safety: not actually unsafe, PAC didn't
-                                    // model this field right
-                                    unsafe {
-                                        w.bits(new_value)
-                                    }
-                                });
-                            }
-
-                            if mask & enable_mask != 0 {
-                                // Record that these bits meant something.
-                                let bit = 1 << i;
-                                slot_mask |= bit;
-
-                                // Enable this source by _setting_ the
-                                // corresponding mask bit.
-                                self.exti.cpuimr1.modify(|r, w| {
-                                    let new_value = r.bits() | (bit as u32);
-                                    // Safety: not actually unsafe, PAC didn't
-                                    // model this field right
-                                    unsafe { w.bits(new_value) }
-                                });
-                            }
+                    match op {
+                        IrqControl::Enable => {
+                            // Enable this source by _setting_ the
+                            // corresponding mask bit.
+                            self.exti.cpuimr1.modify(|r, w| {
+                                let new_value = r.bits() | (bit as u32);
+                                // Safety: not actually unsafe, PAC didn't
+                                // model this field right
+                                unsafe { w.bits(new_value) }
+                            });
+                        },
+                        IrqControl::Disable => {
+                            // Disable this source by _clearing_ the
+                            // corresponding mask bit.
+                            self.exti.cpuimr1.modify(|r, w| {
+                                let new_value = r.bits() & !(bit as u32);
+                                // Safety: not actually unsafe, PAC didn't
+                                // model this field right
+                                unsafe {
+                                    w.bits(new_value)
+                                }
+                            });
+                        },
+                        IrqControl::Check => {
+                            // We are just checking if an IRQ has triggered,
+                            // so don't actually mess with the source's mask
+                            // register at all.
                         }
                     }
                 }
@@ -758,7 +748,7 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
             } else {
                 // Suppress unused variable warnings (yay conditional
                 // compilation)
-                let _ = (rm, enable_mask, disable_mask);
+                let _ = (rm, mask, op);
 
                 // Fault any clients who try to use this in an image where it's
                 // not included.
@@ -783,45 +773,34 @@ impl idl::InOrderSysImpl for ServerImpl<'_> {
                 // actually matched things.
                 let mut used_bits = 0u32;
 
-                for (i, entry) in
-                    generated::EXTI_DISPATCH_TABLE.iter().enumerate()
-                {
-                    // Only use populated rows in the table
-                    if let Some(ExtiDispatch { task, mask: entry_mask, .. }) = entry {
-                        // Operate only on rows assigned to the sending task
-                        // _and_ that are relevant based on the arguments.
-                        if task.index() == rm.sender.index()
-                            && mask & entry_mask != 0
-                        {
-                            used_bits |= mask;
+                for (i, entry) in exti_dispatch_for(rm.sender, mask) {
+                    used_bits |= entry.mask;
 
-                            // Set or clear Rising Trigger Selection
-                            // Register bit according to the rising flag
-                            self.exti.rtsr1.modify(|r, w| {
-                                let new_value = if edge.is_rising() {
-                                    r.bits() | (1 << i)
-                                } else {
-                                    r.bits() & !(1 << i)
-                                };
-                                unsafe {
-                                    w.bits(new_value)
-                                }
-                            });
-
-                            // Set or clear Falling Trigger Selection
-                            // Register bit according to the rising flag
-                            self.exti.ftsr1.modify(|r, w| {
-                                let new_value = if edge.is_falling() {
-                                    r.bits() | (1 << i)
-                                } else {
-                                    r.bits() & !(1 << i)
-                                };
-                                unsafe {
-                                    w.bits(new_value)
-                                }
-                            });
+                    // Set or clear Rising Trigger Selection
+                    // Register bit according to the rising flag
+                    self.exti.rtsr1.modify(|r, w| {
+                        let new_value = if edge.is_rising() {
+                            r.bits() | (1 << i)
+                        } else {
+                            r.bits() & !(1 << i)
+                        };
+                        unsafe {
+                            w.bits(new_value)
                         }
-                    }
+                    });
+
+                    // Set or clear Falling Trigger Selection
+                    // Register bit according to the rising flag
+                    self.exti.ftsr1.modify(|r, w| {
+                        let new_value = if edge.is_falling() {
+                            r.bits() | (1 << i)
+                        } else {
+                            r.bits() & !(1 << i)
+                        };
+                        unsafe {
+                            w.bits(new_value)
+                        }
+                    });
                 }
 
                 // Check that all the set bits in the caller's provided masks
@@ -861,6 +840,26 @@ struct ExtiDispatch {
     task: TaskId,
     mask: u32,
     name: generated::ExtiIrq,
+}
+
+/// Iterates over the indices of EXTI sources mapped to the provided
+/// notification `mask` for the task with ID `task`.
+#[cfg(feature = "exti")]
+fn exti_dispatch_for(
+    task: TaskId,
+    mask: u32,
+) -> impl Iterator<Item = (usize, &'static ExtiDispatch)> {
+    generated::EXTI_DISPATCH_TABLE
+        .iter()
+        .enumerate()
+        .filter_map(move |(i, entry)| {
+            let entry = entry.as_ref()?;
+            if task.index() == entry.task.index() && mask & entry.mask != 0 {
+                Some((i, entry))
+            } else {
+                None
+            }
+        })
 }
 
 impl NotificationHandler for ServerImpl<'_> {
@@ -1218,7 +1217,7 @@ cfg_if! {
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
 
 mod idl {
-    use super::{Edge, Port, RccError};
+    use super::{Edge, IrqControl, Port, RccError};
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/idl/stm32xx-sys.idol
+++ b/idl/stm32xx-sys.idol
@@ -124,5 +124,24 @@ Interface(
             reply: Simple("()"),
             idempotent: true,
         ),
+
+        // Checks whether an EXTI interrupt is pending for a given notification
+        // mask, returning `true` if any interrupts are pending, and `false` if
+        // no interrupts are pending. Calling this method clears the pending bit
+        // for those interrupts.
+        //
+        // If the `enable` argument is `true`, any sources mapped to bits in the
+        // notification mask will be re-enabled, allowing their interrupt to
+        // trigger again.
+        "gpio_irq_check": (
+            args: {
+                "mask": u32,
+                "enable": bool,
+            },
+            reply: Result(
+                ok: "bool",
+                err: ServerDeath,
+            ),
+        )
     },
 )

--- a/idl/stm32xx-sys.idol
+++ b/idl/stm32xx-sys.idol
@@ -116,27 +116,15 @@ Interface(
         // name them. Any sources mapped to bits in the disable
         // mask will be disabled; any sources mapped to bits in
         // the enabled mask will be enabled.
+        //
+        // If any interrupts mapped to notifications in either the
+        // enable or disable masks have been triggered, this method
+        // returns `true`. Otherwise, it returns `false`. Calling
+        // this method clears the pending status for those interrupts.
         "gpio_irq_control": (
             args: {
                 "disable_mask": "u32",
                 "enable_mask": "u32",
-            },
-            reply: Simple("()"),
-            idempotent: true,
-        ),
-
-        // Checks whether an EXTI interrupt is pending for a given notification
-        // mask, returning `true` if any interrupts are pending, and `false` if
-        // no interrupts are pending. Calling this method clears the pending bit
-        // for those interrupts.
-        //
-        // If the `enable` argument is `true`, any sources mapped to bits in the
-        // notification mask will be re-enabled, allowing their interrupt to
-        // trigger again.
-        "gpio_irq_ack": (
-            args: {
-                "mask": "u32",
-                "enable": "bool",
             },
             reply: Result(
                 ok: "bool",

--- a/idl/stm32xx-sys.idol
+++ b/idl/stm32xx-sys.idol
@@ -111,20 +111,29 @@ Interface(
             idempotent: true,
         ),
 
-        // Changes a subset of EXTI sources mapped to the calling
-        // task, using the caller's notification bit space to
-        // name them. Any sources mapped to bits in the disable
-        // mask will be disabled; any sources mapped to bits in
-        // the enabled mask will be enabled.
+        // Performs an operation on a subset of EXTI sources mapped to the
+        // calling task, using the caller's notification bit space to name
+        // them, and returns whether any interrupts mapped to the provided
+        // notification bits have been triggered.
         //
-        // If any interrupts mapped to notifications in either the
-        // enable or disable masks have been triggered, this method
-        // returns `true`. Otherwise, it returns `false`. Calling
-        // this method clears the pending status for those interrupts.
+        // Depending on the value of the `op` argument, this operation can
+        // either enable the intterrupts mapped to the notification mask
+        // (if `op` is `IrqControl::Enable`), disable those interrupts (if
+        // `op` is `IrqControl::Disable`), or do neither (if `op` is
+        // `IrqControl::Check`). Regardless of which operation is performed,
+        // this IPC will always return `true` if any interrupt in the
+        // provided notification mask has been triggered since the last time
+        // this IPC was called, and resets this status for the next call to
+        // this IPC. If an interrupt was enabled when this IPC is called with
+        // `IrqControl::Check` as the `op`, that interrupt will remain
+        // enabled, and if an interrupt was disabled, it will remain disabled.
         "gpio_irq_control": (
             args: {
-                "disable_mask": "u32",
-                "enable_mask": "u32",
+                "mask": "u32",
+                "op": (
+                    type: "IrqControl",
+                    recv: FromPrimitive("u8"),
+                ),
             },
             reply: Result(
                 ok: "bool",

--- a/idl/stm32xx-sys.idol
+++ b/idl/stm32xx-sys.idol
@@ -133,15 +133,15 @@ Interface(
         // If the `enable` argument is `true`, any sources mapped to bits in the
         // notification mask will be re-enabled, allowing their interrupt to
         // trigger again.
-        "gpio_irq_check": (
+        "gpio_irq_ack": (
             args: {
-                "mask": u32,
-                "enable": bool,
+                "mask": "u32",
+                "enable": "bool",
             },
             reply: Result(
                 ok: "bool",
                 err: ServerDeath,
             ),
-        )
+        ),
     },
 )


### PR DESCRIPTION
Currently, there is no mechanism for a task woken by a notification
mapped to an EXTI GPIO interrupt to determine whether the pin it cares
about has actually changed state, rather than receiving a notification
posted by some other task (see #1700). In order to make this possible,
@cbiffle [suggested] that the `stm32xx-sys` task provide an IPC
interface that a task receiving an EXTI notification can call to ack
that the IPC actually was caused by a pin state transition.

This branch extends the `Sys::gpio_irq_control` IPC to return a bool if
any EXTI IRQs mapped to the notifications in a task's notification
maskhave triggered since the last time `gpio_irq_control` was called.

Adding this functionality to `gpio_irq_control` --- which a task that
wishes to receive another EXTI notification must call anyway --- allows
us to keep the number of IPC roundtrips the same when a task receives
such notifications in a loop. In order to support other cases, where a
task only cares about one such notification, the `gpio_irq_control`
interface has been changed to determine whether to enable or disable the
IRQs in the mask based on a second argument, rather than taking two
masks as it did previously, in order to allow a third operation which
*only* checks the state of the interrupt, leaving it enabled if it has
not been triggered but not re-enabling it if it has. We no longer have
the ability to both enable and disable disjunct sets of IRQs in one IPC,
but in practice, no task we have currently even *uses* more than one
GPIO IRQ anyway. And, getting rid of the double-mask interface also
fixes #1714.

I've implemented this by tracking a 16-bit bitmap in the `Sys` task that
mirrors the EXTI pending register. This is because `sys` must clear the
pending bit in order to receive another interrupt from _any_ EXTI
source.

Closes #1700
Closes #1714

[suggested]:
    https://github.com/oxidecomputer/hubris/issues/1700#issuecomment-2030458073