### PR TITLE
stm32xx-sys: fix typo in EXTI pin configuration

### DIFF
--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -398,7 +398,7 @@ fn main() -> ! {
                 // Process entries that are filled in...
                 if let &Some(ExtiDispatch { port, .. }) = entry {
                     let register = i >> 2;
-                    let slot = i % 2;
+                    let slot = i & 0b11;
 
                     // This is an array of 4-bit fields spread across 4 32-bit
                     // registers. We're indexing them with i. There is really no


### PR DESCRIPTION
In the Giant Scary Nested Match we had to write to be able to address the EXTI register array as an array through the PAC, I typo'd the number base being used to select the field within the register, by reusing 2 from the line above. This is the _base 2 logarithm_ of the number we actually wanted, 4, because the operations are shift and mod, respectively.

Wheeee

Anyway, this fixes the situation where EXTI configuration of any pin p such that p % 4 = 2 or 3 on any port other than A mysteriously senses a different pin in port A instead.