### PR TITLE
control-plane-agent: finish ComponentUpdater

### DIFF
--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -623,10 +623,10 @@ impl SpHandler for MgsHandler {
                 .ingest_chunk(&chunk.component, &chunk.id, chunk.offset, data),
             SpComponent::HOST_CPU_BOOT_FLASH => self
                 .host_flash_update
-                .ingest_chunk(&chunk.id, chunk.offset, data),
-            SpComponent::ROT | SpComponent::STAGE0 => {
-                self.rot_update.ingest_chunk(&chunk.id, chunk.offset, data)
-            }
+                .ingest_chunk(&(), &chunk.id, chunk.offset, data),
+            SpComponent::ROT | SpComponent::STAGE0 => self
+                .rot_update
+                .ingest_chunk(&(), &chunk.id, chunk.offset, data),
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -332,9 +332,9 @@ impl SpHandler for MgsHandler {
             SpComponent::SP_ITSELF | SpComponent::SP_AUX_FLASH => self
                 .sp_update
                 .ingest_chunk(&chunk.component, &chunk.id, chunk.offset, data),
-            SpComponent::ROT | SpComponent::STAGE0 => {
-                self.rot_update.ingest_chunk(&chunk.id, chunk.offset, data)
-            }
+            SpComponent::ROT | SpComponent::STAGE0 => self
+                .rot_update
+                .ingest_chunk(&(), &chunk.id, chunk.offset, data),
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -385,9 +385,9 @@ impl SpHandler for MgsHandler {
             SpComponent::SP_ITSELF | SpComponent::SP_AUX_FLASH => self
                 .sp_update
                 .ingest_chunk(&chunk.component, &chunk.id, chunk.offset, data),
-            SpComponent::ROT | SpComponent::STAGE0 => {
-                self.rot_update.ingest_chunk(&chunk.id, chunk.offset, data)
-            }
+            SpComponent::ROT | SpComponent::STAGE0 => self
+                .rot_update
+                .ingest_chunk(&(), &chunk.id, chunk.offset, data),
             _ => Err(SpError::RequestUnsupportedForComponent),
         }
     }

--- a/task/control-plane-agent/src/update/host_flash.rs
+++ b/task/control-plane-agent/src/update/host_flash.rs
@@ -84,6 +84,9 @@ static_assertions::const_assert!(
 impl ComponentUpdater for HostFlashUpdate {
     const BLOCK_SIZE: usize = PAGE_SIZE_BYTES;
 
+    type UpdatePrepare = ComponentUpdatePrepare;
+    type SubComponent = ();
+
     fn prepare(
         &mut self,
         buffer: &'static UpdateBuffer,
@@ -243,6 +246,7 @@ impl ComponentUpdater for HostFlashUpdate {
 
     fn ingest_chunk(
         &mut self,
+        _sub: &(),
         id: &UpdateId,
         offset: u32,
         mut data: &[u8],

--- a/task/control-plane-agent/src/update/rot.rs
+++ b/task/control-plane-agent/src/update/rot.rs
@@ -51,6 +51,9 @@ enum State {
 impl ComponentUpdater for RotUpdate {
     const BLOCK_SIZE: usize = BLOCK_SIZE_BYTES;
 
+    type UpdatePrepare = ComponentUpdatePrepare;
+    type SubComponent = ();
+
     fn prepare(
         &mut self,
         buffer: &'static UpdateBuffer,
@@ -131,6 +134,7 @@ impl ComponentUpdater for RotUpdate {
 
     fn ingest_chunk(
         &mut self,
+        _sub: &(),
         id: &UpdateId,
         offset: u32,
         mut data: &[u8],


### PR DESCRIPTION
This change causes SpUpdate to impl ComponentUpdater, instead of sporting functions that look a lot _like_ ComponentUpdater but aren't actually. This fixes a warning in the newest toolchain, which was concerned that operations in the non-public trait were going unused (which they were!).

In order to adapt ComponentUpdater to be able to describe all three cases, I have added two associated types to it. UpdatePrepare parameterizes the difference between RoT/HostFlash updates (which want ComponentUpdatePrepare) and SP updates (which want a different SpUpdatePrepare type). SubComponent models the fact that only the SP seems to want a specifier for sub-components inside itself; the others set this to ().