### PR TITLE
add RAA229618 VIN monitoring

### DIFF
--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -66,6 +66,12 @@ notifications = ["exti-wildcard-irq"]
 "exti.exti9_5" = "exti-wildcard-irq"
 "exti.exti15_10" = "exti-wildcard-irq"
 
+# PWR_CONT1_VCORE_TO_SP_ALERT_L
+[tasks.sys.config.gpio-irqs.vcore_to_sp_alert_l]
+port = "I"
+pin = 14
+owner = {name = "gimlet_seq", notification = "vcore"}
+
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 3
@@ -156,7 +162,7 @@ max-sizes = {flash = 131072, ram = 8192 }
 stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe", "packrat"]
-notifications = ["timer"]
+notifications = ["timer", "vcore"]
 copy-to-archive = ["register_defs"]
 
 [tasks.gimlet_seq.config]

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -158,7 +158,7 @@ task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"
 name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
-max-sizes = {flash = 131072, ram = 8192 }
+max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 1600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe", "packrat"]

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -995,7 +995,6 @@ impl ConfigGenerator {
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
-        #[allow(clippy::manual_range_patterns)]
         pub fn lookup_controller(index: usize) -> Option<Controller> {{
             match index {{"##
         )?;
@@ -1021,7 +1020,6 @@ impl ConfigGenerator {
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
-        #[allow(clippy::manual_range_patterns)]
         pub fn lookup_port(index: usize) -> Option<PortIndex> {{
             match index {{"##
         )?;

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -994,6 +994,7 @@ impl ConfigGenerator {
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
+        #[allow(clippy::manual_range_patterns)]
         pub fn lookup_controller(index: usize) -> Option<Controller> {{
             match index {{"##
         )?;
@@ -1030,6 +1031,7 @@ impl ConfigGenerator {
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
+        #[allow(clippy::manual_range_patterns)]
         pub fn lookup_port(index: usize) -> Option<PortIndex> {{
             match index {{"##
         )?;

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -118,7 +118,6 @@ enum Trace {
         code: i2c::ResponseCode,
     },
     StartFailed(#[count(children)] SeqError),
-    VCoreFault(bool),
     #[count(skip)]
     None,
 }
@@ -679,7 +678,12 @@ impl<S: SpiServer> ServerImpl<S> {
                     return Err(SeqError::MuxToHostCPUFailed);
                 }
 
-                self.vcore.initialize_uv_warning();
+                //
+                // If we fail to initialize our UV warning despite retries, we
+                // will drive on: the failures will be logged, and this isn't
+                // strictly required to sequence.
+                //
+                _ = retry_i2c_txn(|| self.vcore.initialize_uv_warning());
 
                 let start = sys_get_timer().now;
                 let deadline = start + A0_TIMEOUT_MILLIS;

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -53,6 +53,7 @@ enum I2cTxn {
     SpdLoadTop(u8, u8),
     VCoreOn,
     VCoreOff,
+    VCoreUndervoltageInitialize,
     SocOn,
     SocOff,
 }
@@ -703,7 +704,9 @@ impl<S: SpiServer> ServerImpl<S> {
                 // will drive on: the failures will be logged, and this isn't
                 // strictly required to sequence.
                 //
-                _ = retry_i2c_txn(|| self.vcore.initialize_uv_warning());
+                _ = retry_i2c_txn(I2cTxn::VCoreUndervoltageInitialize, || {
+                    self.vcore.initialize_uv_warning()
+                });
 
                 let start = sys_get_timer().now;
                 let deadline = start + A0_TIMEOUT_MILLIS;

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -809,7 +809,7 @@ impl<S: SpiServer> ServerImpl<S> {
                 );
                 sys.gpio_irq_configure(
                     notifications::VCORE_MASK,
-                    sys_api::Edge::Rising
+                    sys_api::Edge::Falling
                 );
                 sys.gpio_irq_control(0, notifications::VCORE_MASK);
 

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -457,7 +457,7 @@ impl<S: SpiServer + Clone> ServerImpl<S> {
             jefe,
             hf,
             deadline: 0,
-            vcore: vcore::VCore::new(&sys, &device, rail),
+            vcore: vcore::VCore::new(sys, &device, rail),
         };
 
         // Power on, unless suppressed by the `stay-in-a2` feature

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -86,7 +86,7 @@ cfg_if::cfg_if! {
 impl VCore {
     pub fn new(sys: &sys_api::Sys, device: &I2cDevice, rail: u8) -> Self {
         Self {
-            device: Raa229618::new(&device, rail),
+            device: Raa229618::new(device, rail),
             sys: sys.clone(),
         }
     }

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 ///
-/// We have seen adventures on the V12_SYS_A2 rail in that it will droop from
+/// We have seen adventures on the V12_SYS_A2 rail in that it will sag from
 /// 12V to ~8V over a period of about ~4ms, and then rise back 12V over ~7ms.
 /// This happens only on very few machines, and even then happens very rarely
 /// (happening once over hours or days), but the consequences are acute:  the
@@ -12,7 +12,7 @@
 /// one of the rails on of the RAA229618s (specifically, VDD_VCORE) as a
 /// witness to any V12_SYS_A2 rail fluctuation via its VIN: we set its VIN
 /// undervoltage warning limit to a value that is lower than any we expect in
-/// an operable system (but higher than the droops we have observed), and then
+/// an operable system (but higher than the sags we have observed), and then
 /// configure its fault output (PWR_CONT1_VCORE_TO_SP_ALERT_L, connected to
 /// PI14) to generate an interrupt on a falling edge.  Upon the interrupt, we
 /// will get notification here, and we will record values of VIN as quickly as

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+///
+/// We have seen adventures on the V12_SYS_A2 rail in that it will (on some
+/// machines and for unclear reason) very rarely droop from 12V to ~8V over a
+/// period of about ~4ms, and then rise back 12V over ~7ms. (This dip in power
+/// results in U.2 drives resetting, and ultimately, the system resetting
+/// itself.)  To understand these dips we are using one of the rails on of the
+/// RAA229618s (specifically, VDD_VCORE) as a witness to any V12_SYS_A2 rail
+/// fluctuation via its VIN: we set its VIN undervoltage warning limit to a
+/// value that is lower than any we expect in an operable system (but higher
+/// than the droops we have observed), and then setup its fault output
+/// (PWR_CONT1_VCORE_TO_SP_ALERT_L, on PI14) to generate an interrupt on a
+/// falling edge.  Upon the interrupt, we will get notification here, and we
+/// will record values of VIN as quickly as we can.  This is as fast as I2C,
+/// which necessitates 8 bytes per READ_VIN:
+///
+///   [Write PAGE rail] [Write READ_VIN] [Read MSB LSB]
+///
+/// At 100kHz, this is ~900µs per READ_VIN.  We gather 50 of these READ_VIN
+/// measurements, along with timestamps before and after the operations, and
+/// put them all in a ring buffer.  Note that we don't clear faults after this
+/// condition; we will wait until the machine next makes an A2 to A0
+/// transition to clear faults.
+///
+///
+use drv_i2c_api::I2cDevice;
+use drv_i2c_devices::raa229618::Raa229618;
+use drv_stm32xx_sys_api as sys_api;
+use ringbuf::*;
+use userlib::*;
+
+use crate::notifications;
+
+pub struct VCore {
+    device: Raa229618,
+    sys: sys_api::Sys,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum Trace {
+    Notified,
+    Fault,
+    Start(u64),
+    Reading(units::Volts),
+    Error(drv_i2c_api::ResponseCode),
+    Done(u64),
+    None,
+}
+
+ringbuf!(Trace, 120, Trace::None);
+
+const VCORE_NSAMPLES: usize = 50;
+const VCORE_TO_SP_ALERT_L: sys_api::PinSet = sys_api::Port::I.pin(14);
+const VCORE_TO_SP_ALERT_PULL: sys_api::Pull = sys_api::Pull::None;
+
+impl VCore {
+    pub fn new(sys: &sys_api::Sys, device: &I2cDevice, rail: u8) -> Self {
+        Self {
+            device: Raa229618::new(&device, rail),
+            sys: sys.clone(),
+        }
+    }
+
+    pub fn mask(&self) -> u32 {
+        crate::notifications::VCORE_MASK
+    }
+
+    pub fn initialize_uv_warning(&self) {
+        //
+        // We are going to set our input undervoltage warn limit to be 11.75
+        // volts.  We definitely don't expect the line to droop that far --
+        // and if it does, we assume that we are interested in collecting our
+        // VIN samples.
+        //
+        self.device.set_vin_uv_warn_limit(units::Volts(11.75));
+
+        // Clear our faults
+        self.device.clear_faults();
+
+        // Set our alert line to be an input
+        self.sys
+            .gpio_configure_input(VCORE_TO_SP_ALERT_L, VCORE_TO_SP_ALERT_PULL);
+        self.sys
+            .gpio_irq_configure(self.mask(), sys_api::Edge::Falling);
+
+        self.sys.gpio_irq_control(0, self.mask());
+    }
+
+    pub fn handle_notification(&self) {
+        let faulted = self.sys.gpio_read(VCORE_TO_SP_ALERT_L) == 0;
+
+        ringbuf_entry!(Trace::Notified);
+
+        if !faulted {
+            self.sys.gpio_irq_control(0, notifications::VCORE_MASK);
+            return;
+        }
+
+        ringbuf_entry!(Trace::Fault);
+        ringbuf_entry!(Trace::Start(sys_get_timer().now));
+
+        for _ in 0..VCORE_NSAMPLES {
+            match self.device.read_vin() {
+                Ok(val) => ringbuf_entry!(Trace::Reading(val)),
+                Err(code) => ringbuf_entry!(Trace::Error(code.into())),
+            }
+        }
+
+        ringbuf_entry!(Trace::Done(sys_get_timer().now));
+        self.sys.gpio_irq_control(0, notifications::VCORE_MASK);
+    }
+}

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -138,6 +138,19 @@ macro_rules! pmbus_write {
 }
 
 macro_rules! pmbus_rail_write {
+    ($device:expr, $rail:expr, $cmd:ident) => {{
+        let payload =
+            [PAGE::CommandData::code(), $rail, CommandCode::$cmd as u8];
+
+        match $device.write(&payload) {
+            Err(code) => Err(Error::BadWrite {
+                cmd: CommandCode::$cmd as u8,
+                code,
+            }),
+            Ok(_) => Ok(()),
+        }
+    }};
+
     ($device:expr, $rail:expr, $cmd:ident, $data:expr) => {{
         let rpayload = [PAGE::CommandData::code(), $rail];
 

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -117,6 +117,18 @@ macro_rules! pmbus_rail_phase_read {
 }
 
 macro_rules! pmbus_write {
+    ($device:expr, $cmd:ident) => {{
+        let payload = [CommandCode::$cmd as u8];
+
+        match $device.write(&payload) {
+            Err(code) => Err(Error::BadWrite {
+                cmd: CommandCode::$cmd as u8,
+                code,
+            }),
+            Ok(_) => Ok(()),
+        }
+    }};
+
     ($device:expr, $cmd:ident, $data:expr) => {{
         let mut payload = [0u8; $cmd::CommandData::len() + 1];
         payload[0] = $cmd::CommandData::code();
@@ -138,19 +150,6 @@ macro_rules! pmbus_write {
 }
 
 macro_rules! pmbus_rail_write {
-    ($device:expr, $rail:expr, $cmd:ident) => {{
-        let payload =
-            [PAGE::CommandData::code(), $rail, CommandCode::$cmd as u8];
-
-        match $device.write(&payload) {
-            Err(code) => Err(Error::BadWrite {
-                cmd: CommandCode::$cmd as u8,
-                code,
-            }),
-            Ok(_) => Ok(()),
-        }
-    }};
-
     ($device:expr, $rail:expr, $cmd:ident, $data:expr) => {{
         let rpayload = [PAGE::CommandData::code(), $rail];
 

--- a/drv/i2c-devices/src/raa229618.rs
+++ b/drv/i2c-devices/src/raa229618.rs
@@ -116,7 +116,7 @@ impl Raa229618 {
     }
 
     pub fn clear_faults(&self) -> Result<(), Error> {
-        pmbus_rail_write!(self.device, self.rail, CLEAR_FAULTS)
+        pmbus_write!(self.device, CLEAR_FAULTS)
     }
 
     pub fn set_vin_uv_warn_limit(&self, value: Volts) -> Result<(), Error> {

--- a/drv/i2c-devices/src/raa229618.rs
+++ b/drv/i2c-devices/src/raa229618.rs
@@ -115,6 +115,21 @@ impl Raa229618 {
         }
     }
 
+    pub fn clear_faults(&self) -> Result<(), Error> {
+        pmbus_rail_write!(self.device, self.rail, CLEAR_FAULTS)
+    }
+
+    pub fn set_vin_uv_warn_limit(&self, value: Volts) -> Result<(), Error> {
+        let mut vin = VIN_UV_WARN_LIMIT::CommandData(0);
+        vin.set(pmbus::units::Volts(value.0))?;
+        pmbus_rail_write!(self.device, self.rail, VIN_UV_WARN_LIMIT, vin)
+    }
+
+    pub fn read_vin(&self) -> Result<Volts, Error> {
+        let vin = pmbus_rail_read!(self.device, self.rail, READ_VIN)?;
+        Ok(Volts(vin.get()?.0))
+    }
+
     pub fn read_phase_current(&self, phase: Phase) -> Result<Amperes, Error> {
         let iout = pmbus_rail_phase_read!(
             self.device,


### PR DESCRIPTION
Draft commit comment:

```
In our ongoing attempts to characterize sags in the V12_SYS_A2 rail,
we enlist one of the RAA229618 VRs to record observed READ_VIN values
whenever the rail drops below 11.75V.
```

Example output:

```
 NDX LINE      GEN    COUNT PAYLOAD
   0   99        1        1 Initializing
   1  103        1        1 LimitLoaded
   2  107        1        1 FaultsCleared
   3  116        1        1 Initialized
   4  124        1        1 Notified
   5  127        1        1 Fault
   6  144        1        1 Reading { timestamp: 0x271cb, volts: Volts(11.680001) }
   7  144        1        1 Reading { timestamp: 0x271cc, volts: Volts(11.610001) }
   8  144        1        1 Reading { timestamp: 0x271cd, volts: Volts(11.500001) }
   9  144        1        1 Reading { timestamp: 0x271ce, volts: Volts(11.440001) }
  10  144        1        1 Reading { timestamp: 0x271cf, volts: Volts(11.380001) }
  11  144        1        1 Reading { timestamp: 0x271d0, volts: Volts(11.280001) }
  12  144        1        1 Reading { timestamp: 0x271d0, volts: Volts(11.190001) }
  13  144        1        1 Reading { timestamp: 0x271d1, volts: Volts(11.1) }
  14  144        1        1 Reading { timestamp: 0x271d2, volts: Volts(11.010001) }
  15  144        1        1 Reading { timestamp: 0x271d3, volts: Volts(10.960001) }
  16  144        1        1 Reading { timestamp: 0x271d4, volts: Volts(10.860001) }
  17  144        1        1 Reading { timestamp: 0x271d5, volts: Volts(10.77) }
  18  144        1        1 Reading { timestamp: 0x271d6, volts: Volts(10.68) }
  19  144        1        1 Reading { timestamp: 0x271d7, volts: Volts(10.610001) }
  20  144        1        1 Reading { timestamp: 0x271d7, volts: Volts(10.52) }
  21  144        1        1 Reading { timestamp: 0x271d8, volts: Volts(10.460001) }
  22  144        1        1 Reading { timestamp: 0x271d9, volts: Volts(10.35) }
  23  144        1        1 Reading { timestamp: 0x271da, volts: Volts(10.280001) }
  24  144        1        1 Reading { timestamp: 0x271db, volts: Volts(10.22) }
  25  144        1        1 Reading { timestamp: 0x271dc, volts: Volts(10.1) }
  26  144        1        1 Reading { timestamp: 0x271dd, volts: Volts(10.040001) }
  27  144        1        1 Reading { timestamp: 0x271de, volts: Volts(9.940001) }
  28  144        1        1 Reading { timestamp: 0x271df, volts: Volts(9.870001) }
  29  144        1        1 Reading { timestamp: 0x271df, volts: Volts(9.790001) }
  30  144        1        1 Reading { timestamp: 0x271e0, volts: Volts(9.710001) }
  31  144        1        1 Reading { timestamp: 0x271e1, volts: Volts(9.620001) }
  32  144        1        1 Reading { timestamp: 0x271e2, volts: Volts(9.530001) }
  33  144        1        1 Reading { timestamp: 0x271e3, volts: Volts(9.460001) }
  34  144        1        1 Reading { timestamp: 0x271e4, volts: Volts(9.370001) }
  35  144        1        1 Reading { timestamp: 0x271e5, volts: Volts(9.290001) }
  36  144        1        1 Reading { timestamp: 0x271e6, volts: Volts(9.22) }
  37  144        1        1 Reading { timestamp: 0x271e6, volts: Volts(9.120001) }
  38  144        1        1 Reading { timestamp: 0x271e7, volts: Volts(9.05) }
  39  144        1        1 Reading { timestamp: 0x271e8, volts: Volts(8.97) }
  40  144        1        1 Reading { timestamp: 0x271e9, volts: Volts(8.89) }
  41  144        1        1 Reading { timestamp: 0x271ea, volts: Volts(8.81) }
  42  144        1        1 Reading { timestamp: 0x271eb, volts: Volts(8.72) }
  43  144        1        1 Reading { timestamp: 0x271ec, volts: Volts(8.650001) }
  44  144        1        1 Reading { timestamp: 0x271ed, volts: Volts(8.56) }
  45  144        1        1 Reading { timestamp: 0x271ee, volts: Volts(8.490001) }
  46  144        1        1 Reading { timestamp: 0x271ee, volts: Volts(8.400001) }
  47  144        1        1 Reading { timestamp: 0x271ef, volts: Volts(8.31) }
  48  144        1        1 Reading { timestamp: 0x271f0, volts: Volts(8.240001) }
  49  144        1        1 Reading { timestamp: 0x271f1, volts: Volts(8.150001) }
  50  144        1        1 Reading { timestamp: 0x271f2, volts: Volts(8.040001) }
  51  144        1        1 Reading { timestamp: 0x271f3, volts: Volts(7.9900007) }
  52  144        1        1 Reading { timestamp: 0x271f4, volts: Volts(7.9800005) }
  53  144        1        1 Reading { timestamp: 0x271f5, volts: Volts(7.9900007) }
  54  144        1        1 Reading { timestamp: 0x271f5, volts: Volts(7.9800005) }
  55  144        1        1 Reading { timestamp: 0x271f6, volts: Volts(7.9900007) }
```
