### PR TITLE
Add enums for LPC55 pin codegen

### DIFF
--- a/app/lpc55xpresso/app-sprot.toml
+++ b/app/lpc55xpresso/app-sprot.toml
@@ -157,12 +157,12 @@ interrupts = {"flexcomm5.irq" = "spi-irq"}
 # Out = MOSI on, MISO off
 out_cfg = [
     { pin = { port = 0, pin = 8 }, alt = 3 },
-    { pin = { port = 0, pin = 9 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 9 }, alt = 0, mode = "pulldown" },
 ]
 # In = MISO on, MOSI off
 in_cfg = [
     { pin = { port = 0, pin = 9 }, alt = 3 },
-    { pin = { port = 0, pin = 8 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 8 }, alt = 0, mode = "pulldown" },
 ]
 pins = [
     # SCK

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -121,12 +121,12 @@ interrupts = {"flexcomm5.irq" = "spi-irq"}
 # Out = MOSI on, MISO off
 out_cfg = [
     { pin = { port = 0, pin = 8 }, alt = 3 },
-    { pin = { port = 0, pin = 9 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 9 }, alt = 0, mode = "pulldown" },
 ]
 # In = MISO on, MOSI off
 in_cfg = [
     { pin = { port = 0, pin = 9 }, alt = 3 },
-    { pin = { port = 0, pin = 8 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 8 }, alt = 0, mode = "pulldown" },
 ]
 pins = [
     # SCK

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -111,12 +111,12 @@ interrupts = {"flexcomm5.irq" = "spi-irq"}
 # Out = MOSI on, MISO off
 out_cfg = [
     { pin = { port = 0, pin = 8 }, alt = 3 },
-    { pin = { port = 0, pin = 9 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 9 }, alt = 0, mode = "pulldown" },
 ]
 # In = MISO on, MOSI off
 in_cfg = [
     { pin = { port = 0, pin = 9 }, alt = 3 },
-    { pin = { port = 0, pin = 8 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 8 }, alt = 0, mode = "pulldown" },
 ]
 pins = [
     # SCK

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -151,12 +151,12 @@ interrupts = {"flexcomm3.irq" = "spi-irq"}
 # Out = MOSI on, MISO off
 out_cfg = [
     { pin = { port = 0, pin = 3 }, alt = 1 },
-    { pin = { port = 0, pin = 2 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 2 }, alt = 0, mode = "pulldown" },
 ]
 # In = MISO on, MOSI off
 in_cfg = [
     { pin = { port = 0, pin = 2 }, alt = 1 },
-    { pin = { port = 0, pin = 3 }, alt = 0, mode = "PullDown" },
+    { pin = { port = 0, pin = 3 }, alt = 0, mode = "pulldown" },
 ]
 pins = [
     # SCK

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -40,11 +40,16 @@ impl ToTokens for Pin {
 pub struct PinConfig {
     pin: Pin,
     alt: usize,
-    mode: Option<Mode>,
-    slew: Option<Slew>,
-    invert: Option<Invert>,
-    digimode: Option<Digimode>,
-    opendrain: Option<Opendrain>,
+    #[serde(default)]
+    mode: Mode,
+    #[serde(default)]
+    slew: Slew,
+    #[serde(default)]
+    invert: Invert,
+    #[serde(default)]
+    digimode: Digimode,
+    #[serde(default)]
+    opendrain: Opendrain,
     direction: Option<Direction>,
     name: Option<String>,
 }
@@ -77,18 +82,18 @@ pub enum Invert {
 
 #[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum Opendrain {
+pub enum Digimode {
     #[default]
-    Normal,
-    Opendrain,
+    Digital,
+    Analog,
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum Digimode {
-    Analog,
+pub enum Opendrain {
     #[default]
-    Digital,
+    Normal,
+    Opendrain,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
@@ -113,22 +118,11 @@ impl ToTokens for PinConfig {
         let final_pin = self.pin.to_token_stream();
         let alt_num = format_ident!("Alt{}", self.get_alt());
 
-        let mode =
-            format_ident!("{}", format!("{:?}", self.mode.unwrap_or_default()));
-        let slew =
-            format_ident!("{}", format!("{:?}", self.slew.unwrap_or_default()));
-        let invert = format_ident!(
-            "{}",
-            format!("{:?}", self.invert.unwrap_or_default())
-        );
-        let digimode = format_ident!(
-            "{}",
-            format!("{:?}", self.digimode.unwrap_or_default())
-        );
-        let od = format_ident!(
-            "{}",
-            format!("{:?}", self.opendrain.unwrap_or_default())
-        );
+        let mode = format_ident!("{}", format!("{:?}", self.mode));
+        let slew = format_ident!("{}", format!("{:?}", self.slew));
+        let invert = format_ident!("{}", format!("{:?}", self.invert));
+        let digimode = format_ident!("{}", format!("{:?}", self.digimode));
+        let od = format_ident!("{}", format!("{:?}", self.opendrain));
         tokens.append_all(final_pin);
         tokens.append_all(quote::quote! {
             AltFn::#alt_num,

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -49,40 +49,45 @@ pub struct PinConfig {
     name: Option<String>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Mode {
+    #[default]
     NoPull,
     PullDown,
     PullUp,
     Repeater,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Slew {
+    #[default]
     Standard,
     Fast,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Invert {
+    #[default]
     Disable,
     Enabled,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Opendrain {
+    #[default]
     Normal,
     Opendrain,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Digimode {
     Analog,
+    #[default]
     Digital,
 }
 
@@ -94,26 +99,6 @@ pub enum Direction {
 }
 
 impl PinConfig {
-    fn get_mode(&self) -> Mode {
-        self.mode.unwrap_or(Mode::NoPull)
-    }
-
-    fn get_slew(&self) -> Slew {
-        self.slew.unwrap_or(Slew::Standard)
-    }
-
-    fn get_invert(&self) -> Invert {
-        self.invert.unwrap_or(Invert::Disable)
-    }
-
-    fn get_digimode(&self) -> Digimode {
-        self.digimode.unwrap_or(Digimode::Digital)
-    }
-
-    fn get_opendrain(&self) -> Opendrain {
-        self.opendrain.unwrap_or(Opendrain::Normal)
-    }
-
     fn get_alt(&self) -> usize {
         if self.alt > 9 {
             panic!("Invalid alt setting {}", self.alt);
@@ -128,12 +113,22 @@ impl ToTokens for PinConfig {
         let final_pin = self.pin.to_token_stream();
         let alt_num = format_ident!("Alt{}", self.get_alt());
 
-        let mode = format_ident!("{}", format!("{:?}", self.get_mode()));
-        let slew = format_ident!("{}", format!("{:?}", self.get_slew()));
-        let invert = format_ident!("{}", format!("{:?}", self.get_invert()));
-        let digimode =
-            format_ident!("{}", format!("{:?}", self.get_digimode()));
-        let od = format_ident!("{}", format!("{:?}", self.get_opendrain()));
+        let mode =
+            format_ident!("{}", format!("{:?}", self.mode.unwrap_or_default()));
+        let slew =
+            format_ident!("{}", format!("{:?}", self.slew.unwrap_or_default()));
+        let invert = format_ident!(
+            "{}",
+            format!("{:?}", self.invert.unwrap_or_default())
+        );
+        let digimode = format_ident!(
+            "{}",
+            format!("{:?}", self.digimode.unwrap_or_default())
+        );
+        let od = format_ident!(
+            "{}",
+            format!("{:?}", self.opendrain.unwrap_or_default())
+        );
         tokens.append_all(final_pin);
         tokens.append_all(quote::quote! {
             AltFn::#alt_num,

--- a/build/lpc55pins/src/lib.rs
+++ b/build/lpc55pins/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use std::io::{BufWriter, Write};
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 struct Pin {
     port: usize,
     pin: usize,
@@ -36,53 +36,82 @@ impl ToTokens for Pin {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 pub struct PinConfig {
     pin: Pin,
     alt: usize,
-    mode: Option<String>,
-    slew: Option<String>,
-    invert: Option<String>,
-    digimode: Option<String>,
-    opendrain: Option<String>,
-    direction: Option<String>,
+    mode: Option<Mode>,
+    slew: Option<Slew>,
+    invert: Option<Invert>,
+    digimode: Option<Digimode>,
+    opendrain: Option<Opendrain>,
+    direction: Option<Direction>,
     name: Option<String>,
 }
 
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Mode {
+    NoPull,
+    PullDown,
+    PullUp,
+    Repeater,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Slew {
+    Standard,
+    Fast,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Invert {
+    Disable,
+    Enabled,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Opendrain {
+    Normal,
+    Opendrain,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Digimode {
+    Analog,
+    Digital,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Direction {
+    Input,
+    Output,
+}
+
 impl PinConfig {
-    fn get_mode(&self) -> String {
-        match &self.mode {
-            None => "NoPull".to_string(),
-            Some(s) => s.to_string(),
-        }
+    fn get_mode(&self) -> Mode {
+        self.mode.unwrap_or(Mode::NoPull)
     }
 
-    fn get_slew(&self) -> String {
-        match &self.slew {
-            None => "Standard".to_string(),
-            Some(s) => s.to_string(),
-        }
+    fn get_slew(&self) -> Slew {
+        self.slew.unwrap_or(Slew::Standard)
     }
 
-    fn get_invert(&self) -> String {
-        match &self.invert {
-            None => "Disable".to_string(),
-            Some(s) => s.to_string(),
-        }
+    fn get_invert(&self) -> Invert {
+        self.invert.unwrap_or(Invert::Disable)
     }
 
-    fn get_digimode(&self) -> String {
-        match &self.digimode {
-            None => "Digital".to_string(),
-            Some(s) => s.to_string(),
-        }
+    fn get_digimode(&self) -> Digimode {
+        self.digimode.unwrap_or(Digimode::Digital)
     }
 
-    fn get_opendrain(&self) -> String {
-        match &self.opendrain {
-            None => "Normal".to_string(),
-            Some(s) => s.to_string(),
-        }
+    fn get_opendrain(&self) -> Opendrain {
+        self.opendrain.unwrap_or(Opendrain::Normal)
     }
 
     fn get_alt(&self) -> usize {
@@ -98,12 +127,13 @@ impl ToTokens for PinConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let final_pin = self.pin.to_token_stream();
         let alt_num = format_ident!("Alt{}", self.get_alt());
-        let mode = format_ident!("{}", self.get_mode());
-        let slew = format_ident!("{}", self.get_slew());
-        let invert = format_ident!("{}", self.get_invert());
-        let digimode = format_ident!("{}", self.get_digimode());
-        let od = format_ident!("{}", self.get_opendrain());
 
+        let mode = format_ident!("{}", format!("{:?}", self.get_mode()));
+        let slew = format_ident!("{}", format!("{:?}", self.get_slew()));
+        let invert = format_ident!("{}", format!("{:?}", self.get_invert()));
+        let digimode =
+            format_ident!("{}", format!("{:?}", self.get_digimode()));
+        let od = format_ident!("{}", format!("{:?}", self.get_opendrain()));
         tokens.append_all(final_pin);
         tokens.append_all(quote::quote! {
             AltFn::#alt_num,
@@ -135,16 +165,13 @@ pub fn codegen(pins: Vec<PinConfig>) -> Result<()> {
         writeln!(&mut file, "iocon.iocon_configure(")?;
         writeln!(&mut file, "{}", p.to_token_stream())?;
         writeln!(&mut file, ");")?;
+
         match p.direction {
             None => (),
             Some(d) => {
                 writeln!(&mut file, "iocon.set_dir(")?;
                 writeln!(&mut file, "{}", p.pin.to_token_stream())?;
-                if d == "output" {
-                    writeln!(&mut file, "Direction::Output")?;
-                } else {
-                    writeln!(&mut file, "Direction::Input")?;
-                }
+                writeln!(&mut file, "Direction::{d:?}")?;
                 writeln!(&mut file, ");")?;
             }
         }


### PR DESCRIPTION
This means that invalid pin configuration parameters will fail to parse, instead of making it through codegen and then failing at (Hubris) compile time.

I don't love leaning on the derived `Debug` here:
```rust
let mode = format_ident!("{}", format!("{:?}", self.get_mode()));
let slew = format_ident!("{}", format!("{:?}", self.get_slew()));
let invert = format_ident!("{}", format!("{:?}", self.get_invert()));
let digimode = format_ident!("{}", format!("{:?}", self.get_digimode()));
let od = format_ident!("{}", format!("{:?}", self.get_opendrain()));
tokens.append_all(final_pin);
tokens.append_all(quote::quote! {
    AltFn::#alt_num,
    Mode::#mode,
    Slew::#slew,
    Invert::#invert,
    Digimode::#digimode,
    Opendrain::#od,
});
```
but my other experiments were all worse; I'm open to suggestions for how to make this cleaner!