### PR TITLE
stm32xx-sys: generate constants for EXTI pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
 name = "drv-stm32xx-sys-api"
 version = "0.1.0"
 dependencies = [
+ "build-stm32xx-sys",
  "byteorder",
  "cfg-if",
  "counters",

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -42,6 +42,11 @@ pub fn target_os() -> String {
     std::env::var("CARGO_CFG_TARGET_OS").unwrap()
 }
 
+/// Reads the `HUBRIS_TASK_NAME` env var.
+pub fn task_name() -> String {
+    crate::env_var("HUBRIS_TASK_NAME").expect("missing HUBRIS_TASK_NAME")
+}
+
 /// Checks to see whether the given feature is enabled
 pub fn has_feature(s: &str) -> bool {
     std::env::var(format!(
@@ -104,12 +109,10 @@ pub fn config<T: DeserializeOwned>() -> Result<T> {
 
 /// Pulls the task configuration. See `config` for more details.
 pub fn task_config<T: DeserializeOwned>() -> Result<T> {
-    let task_name =
-        crate::env_var("HUBRIS_TASK_NAME").expect("missing HUBRIS_TASK_NAME");
     task_maybe_config()?.ok_or_else(|| {
         anyhow!(
             "app.toml missing task config section [tasks.{}.config]",
-            task_name
+            task_name()
         )
     })
 }

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -97,7 +97,10 @@ const MAX_UPDATE_ATTEMPTS: u16 = 3;
 // On the flipside, we have learned via unintended experiment that 5ms is too short!
 const DUMP_TIMEOUT: u32 = 1000;
 
-// ROT_IRQ comes from app.toml
+// On Gemini, the STM32H753 is in a LQFP176 package with ROT_IRQ
+// on pin2/PE3
+use drv_stm32xx_sys_api::gpio_irq_pins::ROT_IRQ;
+
 // We use spi3 on gimletlet and spi4 on gemini and gimlet.
 // You should be able to move the RoT board between SPI3, SPI4, and SPI6
 // without much trouble even though SPI3 is the preferred connector and
@@ -117,20 +120,10 @@ cfg_if::cfg_if! {
             target_board = "psc-c",
             target_board = "gemini-bu-1"
             ))] {
-        const ROT_IRQ: sys_api::PinSet = sys_api::PinSet {
-            // On Gemini, the STM32H753 is in a LQFP176 package with ROT_IRQ
-            // on pin2/PE3
-            port: sys_api::Port::E,
-            pin_mask: 1 << 3,
-        };
         const ROT_SPI_DEVICE: u8 = drv_spi_api::devices::ROT;
         fn debug_config(_sys: &sys_api::Sys) { }
         fn debug_set(_sys: &sys_api::Sys, _asserted: bool) { }
     } else if #[cfg(target_board = "gimletlet-2")] {
-        const ROT_IRQ: sys_api::PinSet = sys_api::PinSet {
-            port: sys_api::Port::D,
-            pin_mask: 1 << 0,
-        };
         const DEBUG_PIN: sys_api::PinSet = sys_api::PinSet {
             port: sys_api::Port::E,
             pin_mask: 1 << 6,
@@ -151,7 +144,7 @@ cfg_if::cfg_if! {
         }
         const ROT_SPI_DEVICE: u8 = drv_spi_api::devices::SPI3_HEADER;
     } else {
-        compile_error!("No configuration for ROT_IRQ");
+        compile_error!("No configuration for ROT_SPI_DEVICE");
     }
 }
 

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -18,6 +18,7 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 
 [features]
 family-stm32h7 = ["drv-stm32xx-gpio-common/family-stm32h7"]

--- a/drv/stm32xx-sys-api/build.rs
+++ b/drv/stm32xx-sys-api/build.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_stm32xx_sys::build_gpio_irq_pins()?;
     idol::client::build_client_stub(
         "../../idl/stm32xx-sys.idol",
         "client_stub.rs",

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -367,3 +367,4 @@ impl From<Option<bool>> for IrqControl {
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
+include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));

--- a/task/nucleo-user-button/src/main.rs
+++ b/task/nucleo-user-button/src/main.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![no_main]
 
-use drv_stm32xx_sys_api::{Edge, IrqControl, PinSet, Port, Pull};
+use drv_stm32xx_sys_api::{Edge, IrqControl, Pull};
 use ringbuf::ringbuf_entry;
 use userlib::*;
 
@@ -72,10 +72,7 @@ pub fn main() -> ! {
     });
 
     sys.gpio_configure_input(
-        PinSet {
-            port: Port::C,
-            pin_mask: (1 << 13),
-        },
+        drv_stm32xx_sys_api::gpio_irq_pins::BUTTON,
         Pull::None,
     );
 


### PR DESCRIPTION
Currently, pins used for EXTI IRQs are defined in the `sys` task's config in `app.toml`. When a task wishes to actually use those pins, though, it must _also_ define them separately in order to call `sys.gpio_configure_input` (and if it wants to perform its own GPIO reads on that pin). This is generally done either by hard-coding the port and pin number in the task's source code, or by defining its own config for configuring which pin to use.

This is unfortunate, as it results in a duplicated pin definition, either between the source code and the config if hard-coded, or twice in the config, if the task also gets the definition from config. And, if the task configures the pin in its own config, the author of that task must re-implement the config handling.

This commit fixes this by adding new code generation to `drv-stm32xx-sys-api` to generate a module called `gpio_irq_pins` containing `PinSet` constants with the name of the IRQ pin and the pin number and port defined in the `sys` task's config section. This way, the same pin set used by `sys` when configuring the EXTI interrupt can be referenced by the task that consumes the interrupt, removing the need to duplicate the pin definition. I've edited the `nucleo-user-button` demo task to demonstrate using this.