### PR TITLE
fix ROT_IRQ regressions from #1696

### DIFF
--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -52,8 +52,8 @@ notifications = ["exti-wildcard-irq"]
 "exti.exti15_10" = "exti-wildcard-irq"
 
 [tasks.sys.config.gpio-irqs.rot_irq]
-port = "D"
-pin = 0
+port = "E"
+pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.i2c_driver]

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -362,13 +362,13 @@ impl<S: SpiServer> Io<S> {
     // determined based on `max_sleep`.
     fn wait_rot_irq(&mut self, desired: bool, max_sleep: u32) -> bool {
         use notifications::{sprot::TIMER_MASK, ROT_IRQ_MASK};
-        // Determine our edge sensitivity for the interrupt. If we want to wait
-        // for the line to be asserted, we want to wait for a rising edge. If
-        // the line is currently asserted, and we're waiting for it to be
-        // *deasserted*, we want to wait for a falling edge.
+        // Determine our edge sensitivity for the interrupt. The ROT_IRQ line is
+        // active low, so if we want to wait for it to be asserted, wait for the
+        // falling edge. If the line is currently asserted, and we're waiting
+        // for it to be *deasserted*, we want to wait for a rising edge.
         let sensitivity = match desired {
-            true => sys_api::Edge::Rising,
-            false => sys_api::Edge::Falling,
+            false => sys_api::Edge::Rising,
+            true => sys_api::Edge::Falling,
         };
         self.sys.gpio_irq_configure(ROT_IRQ_MASK, sensitivity);
 


### PR DESCRIPTION
This branch fixes a pair of regressions I introduced in PR #1696 : 

 - **sprot: fix backwards ROT_IRQ edge detection** (8be5f3c24b70bc4e71f8428c2552b8b90299e46d)

    In PR #1696, I broke the `drv-stm32h7-sprot-server` code for waiting for
    `ROT_IRQ` to change state. The `ROT_IRQ` signal is active low (and in
    the schematic it's called `ROT_TO_SP_IRQ_L`), but in the code, the pin
    is just referred to as `ROT_IRQ`, so I configured edge sensitivity
    backwards, meaning we missed the IRQ signal. Oops, my bad.

    This commit changes the edge sensitivity to wait for the falling edge
    when waiting for `ROT_IRQ` to be asserted, and to wait for the rising
    edge when waiting for it to be deasserted, instead of the other way
    around. Now, it actually works correctly.

    ```console
    eliza@lurch ~ $ pfexec humility -t psc-sp flash && faux-mgs --interface axf1 --discovery-addr [fe80::aa40:25ff:fe06:103%3]:11111 state
    humility: attaching with chip set to "STM32H753ZITx"
    humility: attached to 0483:374e:0037001B5553500720393256 via ST-Link V3
    humility: flash/archive mismatch; reflashing
    humility: flashing done
    Apr 07 18:07:31.725 INFO creating SP handle on interface axf1, component: faux-mgs
    Apr 07 18:07:33.727 INFO initial discovery complete, addr: [fe80::aa40:25ff:fe06:103%3]:11111, interface: axf1, component: faux-mgs
    Apr 07 18:07:33.733 INFO V2(SpStateV2 { hubris_archive_id: [53, 140, 208, 151, 27, 45, 232, 176], serial_number: [66, 82, 77, 52, 53, 50, 50, 48, 48, 48, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], model: [57, 49, 51, 45, 48, 48, 48, 48, 48, 48, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], revision: 8, base_mac_address: [168, 64, 37, 6, 1, 2], power_state: A2, rot: Ok(RotStateV2 { active: A, persistent_boot_preference: A, pending_persistent_boot_preference: None, transient_boot_preference: None, slot_a_sha3_256_digest: Some([175, 36, 236, 22, 163, 153, 65, 80, 159, 252, 36, 30, 77, 25, 52, 93, 158, 50, 246, 178, 139, 62, 218, 107, 9, 29, 129, 29, 100, 174, 133, 25]), slot_b_sha3_256_digest: Some([139, 130, 30, 66, 20, 39, 59, 105, 242, 21, 10, 7, 147, 124, 64, 253, 57, 156, 212, 176, 189, 255, 59, 243, 172, 9, 204, 75, 221, 250, 208, 53]) }) }), component: faux-mgs
    hubris archive: 358cd0971b2de8b0
    serial number: BRM45220003
    model: 913-0000003
    revision: 8
    base MAC address: a8:40:25:06:01:02
    power state: A2
    RotStateV2 {
     active: A,
     persistent_boot_preference: A,
     pending_persistent_boot_preference: None,
     transient_boot_preference: None
     slot_a_sha3_256_digest: af24ec16a39941509ffc241e4d19345d9e32f6b28b3eda6b091d811d64ae8519,
     slot_b_sha3_256_digest: 8b821e4214273b69f2150a07937c40fd399cd4b0bdff3bf3ac09cc4bddfad035,
    }
    eliza@lurch ~ $ pfexec humility -t psc-sp ringbuf sprot_server
    humility: attached to 0483:374e:0037001B5553500720393256 via ST-Link V3
    humility: ring buffer drv_stm32h7_sprot_server::__RINGBUF in sprot:
     NDX LINE      GEN    COUNT PAYLOAD
       0  243        1        1 Sent(0xa)
       1  365        1        1 WaitRotIrq(true, 0x5)
       2  285        1        1 Received(0x51)
    eliza@lurch ~ $
    ```

 - **psc: fix wrong `ROT_IRQ` pin** (5046b54aff42e2d3a8535ced765e639d6b283905)

    Whoops, I accidentally copied the configuration from Gimletlet rather
    than from Gimlet/Sidecar, so this is wrong.