### PR TITLE
Fix almost all remaining warnings from the toolchain update.

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -79,14 +79,10 @@ jobs:
               target/release/humility -a target/${{ inputs.app_name }}/dist/build-${{ inputs.app_name }}-image-$image.zip manifest; \
           done
 
-      # TODO: Clippy temporarily disabled 2024-04 while people clean up
-      # the new Clippy warnings resulting from the last toolchain
-      # upgrade. If you're reading this, try turning it back on and see
-      # if we're good yet.
-      #- name: Clippy
-      #  if: inputs.os == 'ubuntu-latest'
-      #  run: |
-      #    cargo xtask clippy ${{ inputs.app_toml}} -- --deny warnings
+      - name: Clippy
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          cargo xtask clippy ${{ inputs.app_toml}} -- --deny warnings
 
       # upload the output of our build
       - name: Upload build archive

--- a/build/stm32xx-sys/src/lib.rs
+++ b/build/stm32xx-sys/src/lib.rs
@@ -160,7 +160,7 @@ impl SysConfig {
             },
         ) in &self.gpio_irqs
         {
-            match dispatch_table.get_mut(pin as usize) {
+            match dispatch_table.get_mut(pin) {
                 Some(Some(curr)) => {
                     anyhow::bail!("pin {pin} is already mapped to IRQ {curr:?}")
                 }
@@ -242,7 +242,7 @@ impl SysConfig {
 
 fn to_const_name(mut s: String) -> anyhow::Result<syn::Ident> {
     s.make_ascii_uppercase();
-    let s = s.replace("-", "_");
+    let s = s.replace('-', "_");
     syn::parse_str::<syn::Ident>(&s)
         .with_context(|| format!("`{s}` is not a valid Rust identifier"))
 }

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -422,6 +422,8 @@ impl ServerImpl {
         addr: Option<u32>,
         raw_data: &RawPersistentData,
     ) -> Result<(), HfError> {
+        // Clippy misfire as of 2024-04
+        #[allow(clippy::manual_unwrap_or_default)]
         let addr = match addr {
             Some(a) => a,
             None => {

--- a/drv/i2c-devices/src/pca9956b.rs
+++ b/drv/i2c-devices/src/pca9956b.rs
@@ -93,18 +93,13 @@ const MAX_AUTO_INC_REG: Register = Register::ALLCALLADR;
 const MAX_BUF_SIZE: usize = MAX_AUTO_INC_REG as usize;
 
 /// ERR representations per Table 21 of the datasheet
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum LedErr {
+    #[default]
     NoError = 0b00,
     ShortCircuit = 0b01,
     OpenCircuit = 0b10,
     Invalid = 0b11,
-}
-
-impl Default for LedErr {
-    fn default() -> Self {
-        LedErr::NoError
-    }
 }
 
 impl From<u8> for LedErr {

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -122,16 +122,18 @@ impl<'a> Handler {
                         tx_buf,
                     )
                 } else {
-                    match Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
-                        self.update
-                            .read_raw_caboose(
-                                slot,
-                                start,
-                                &mut buf[..blob_size],
-                            )
-                            .map_err(|e| RspBody::Caboose(Err(e)))?;
-                        Ok(blob_size)
-                    }) {
+                    let pack_result =
+                        Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
+                            self.update
+                                .read_raw_caboose(
+                                    slot,
+                                    start,
+                                    &mut buf[..blob_size],
+                                )
+                                .map_err(|e| RspBody::Caboose(Err(e)))?;
+                            Ok(blob_size)
+                        });
+                    match pack_result {
                         Ok(size) => size,
                         Err(e) => Response::pack(&Ok(e), tx_buf),
                     }
@@ -151,12 +153,14 @@ impl<'a> Handler {
                         tx_buf,
                     )
                 } else {
-                    match Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
-                        self.attest
-                            .cert(index, offset, &mut buf[..size])
-                            .map_err(|e| RspBody::Attest(Err(e)))?;
-                        Ok(size)
-                    }) {
+                    let pack_result =
+                        Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
+                            self.attest
+                                .cert(index, offset, &mut buf[..size])
+                                .map_err(|e| RspBody::Attest(Err(e)))?;
+                            Ok(size)
+                        });
+                    match pack_result {
                         Ok(size) => size,
                         Err(e) => Response::pack(&Ok(e), tx_buf),
                     }
@@ -168,12 +172,14 @@ impl<'a> Handler {
                     lpc55_rom_data::FLASH_PAGE_SIZE
                         <= drv_sprot_api::MAX_BLOB_SIZE
                 );
-                match Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
-                    self.update
-                        .read_rot_page(page, &mut buf[..size])
-                        .map_err(|e| RspBody::Page(Err(e)))?;
-                    Ok(size)
-                }) {
+                let pack_result =
+                    Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
+                        self.update
+                            .read_rot_page(page, &mut buf[..size])
+                            .map_err(|e| RspBody::Page(Err(e)))?;
+                        Ok(size)
+                    });
+                match pack_result {
                     Ok(size) => size,
                     Err(e) => Response::pack(&Ok(e), tx_buf),
                 }
@@ -188,12 +194,14 @@ impl<'a> Handler {
                         tx_buf,
                     )
                 } else {
-                    match Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
-                        self.attest
-                            .log(offset, &mut buf[..size])
-                            .map_err(|e| RspBody::Attest(Err(e)))?;
-                        Ok(size)
-                    }) {
+                    let pack_result =
+                        Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
+                            self.attest
+                                .log(offset, &mut buf[..size])
+                                .map_err(|e| RspBody::Attest(Err(e)))?;
+                            Ok(size)
+                        });
+                    match pack_result {
                         Ok(size) => size,
                         Err(e) => Response::pack(&Ok(e), tx_buf),
                     }
@@ -208,12 +216,14 @@ impl<'a> Handler {
                         tx_buf,
                     )
                 } else {
-                    match Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
-                        self.attest
-                            .attest(nonce, &mut buf[..write_size as usize])
-                            .map_err(|e| RspBody::Attest(Err(e)))?;
-                        Ok(write_size as usize)
-                    }) {
+                    let pack_result =
+                        Response::pack_with_cb(&rsp_body, tx_buf, |buf| {
+                            self.attest
+                                .attest(nonce, &mut buf[..write_size as usize])
+                                .map_err(|e| RspBody::Attest(Err(e)))?;
+                            Ok(write_size as usize)
+                        });
+                    match pack_result {
                         Ok(size) => size,
                         Err(e) => Response::pack(&Ok(e), tx_buf),
                     }

--- a/drv/lpc55-update-server/src/main.rs
+++ b/drv/lpc55-update-server/src/main.rs
@@ -910,7 +910,7 @@ fn copy_from_caboose_chunk(
     // Early exit if the caller didn't provide enough space in the lease
     let mut remaining = pos.end - pos.start;
     if remaining as usize > data.len() {
-        return Err(RequestError::Fail(ClientError::BadLease))?;
+        return Err(RequestError::Fail(ClientError::BadLease));
     }
 
     const BUF_SIZE: usize = 128;
@@ -938,7 +938,7 @@ fn copy_from_flash_range(
     // Early exit if the caller didn't provide enough space in the lease
     let mut remaining = pos.end - pos.start;
     if remaining as usize > data.len() {
-        return Err(RequestError::Fail(ClientError::BadLease))?;
+        return Err(RequestError::Fail(ClientError::BadLease));
     }
 
     const BUF_SIZE: usize = 128;

--- a/drv/sidecar-seq-server/src/front_io.rs
+++ b/drv/sidecar-seq-server/src/front_io.rs
@@ -83,9 +83,7 @@ impl FrontIOBoard {
                 });
 
                 if let Err(e) = controller.load_bitstream(self.auxflash_task) {
-                    ringbuf_entry!(Trace::FpgaBitstreamError(
-                        u32::try_from(e).unwrap()
-                    ));
+                    ringbuf_entry!(Trace::FpgaBitstreamError(u32::from(e)));
                     return Err(e);
                 }
 

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -834,7 +834,7 @@ fn main() -> ! {
                 .load_bitstream(AUXFLASH.get_task_id())
             {
                 Err(e) => {
-                    let code = u32::try_from(e).unwrap_lite();
+                    let code = u32::from(e);
                     ringbuf_entry!(Trace::FpgaBitstreamError(code));
 
                     // If this is an auxflash error indicating that we can't

--- a/drv/stm32h7-eth/src/ring.rs
+++ b/drv/stm32h7-eth/src/ring.rs
@@ -45,6 +45,7 @@ unsafe impl Sync for Buffer {}
 
 impl Buffer {
     /// Creates a zero-initialized buffer.
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self(UnsafeCell::new([0; BUFSZ]))
     }
@@ -58,6 +59,7 @@ impl Buffer {
 /// When configured in VLAN mode, we write _two_ descriptors (each 4 bytes):
 /// - the configuration descriptor, which sets the VLAN for subsequent packets
 /// - the actual packet transmit descriptor
+#[derive(Default)]
 #[repr(transparent)]
 pub struct TxDesc {
     /// Transmit descriptor
@@ -348,6 +350,7 @@ impl TxRing {
 ///
 /// This is deliberately opaque to viewers outside this module, so that we can
 /// carefully control accesses to its contents.
+#[derive(Default)]
 #[repr(transparent)]
 pub struct RxDesc {
     rdes: [AtomicU32; 4],

--- a/lib/dice/src/mfg.rs
+++ b/lib/dice/src/mfg.rs
@@ -187,8 +187,7 @@ impl<'a> SerialMfg<'a> {
     }
 
     fn send_ack(&mut self) -> Result<(), Error> {
-        let hash: MessageHash =
-            self.hash.finalize_fixed_reset().try_into().unwrap();
+        let hash: MessageHash = self.hash.finalize_fixed_reset().into();
         self.send_msg(MfgMessage::Ack(hash))
     }
 

--- a/lib/lpc55-rot-startup/src/images.rs
+++ b/lib/lpc55-rot-startup/src/images.rs
@@ -145,7 +145,7 @@ impl Image {
             }
         }
 
-        hash.finalize().try_into().unwrap_lite()
+        hash.finalize().into()
     }
 
     pub fn get_image_version(&self) -> ImageVersion {

--- a/lib/update-buffer/src/lib.rs
+++ b/lib/update-buffer/src/lib.rs
@@ -28,7 +28,6 @@ impl<T, const N: usize> Default for UpdateBuffer<T, N> {
     }
 }
 
-
 impl<T, const N: usize> UpdateBuffer<T, N> {
     pub const MAX_CAPACITY: usize = N;
 

--- a/lib/update-buffer/src/lib.rs
+++ b/lib/update-buffer/src/lib.rs
@@ -22,7 +22,14 @@ pub struct UpdateBuffer<T, const N: usize> {
     data: Mutex<[u8; N]>,
 }
 
-impl<T: Clone, const N: usize> UpdateBuffer<T, N> {
+impl<T, const N: usize> Default for UpdateBuffer<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+impl<T, const N: usize> UpdateBuffer<T, N> {
     pub const MAX_CAPACITY: usize = N;
 
     pub const fn new() -> Self {
@@ -31,7 +38,9 @@ impl<T: Clone, const N: usize> UpdateBuffer<T, N> {
             data: Mutex::new([0; N]),
         }
     }
+}
 
+impl<T: Clone, const N: usize> UpdateBuffer<T, N> {
     /// Borrow this buffer with an artifical cap of `capacity`.
     ///
     /// On success, records that this buffer is owned by `owner` until the

--- a/task/control-plane-agent/src/mgs_gimlet.rs
+++ b/task/control-plane-agent/src/mgs_gimlet.rs
@@ -1428,7 +1428,7 @@ fn claim_mgs_to_sp_usart_buf_static(
     // the AtomicBool swap above, combined with the lexical scoping of
     // `UART_TX_BUF`, means that this reference can't be aliased by any
     // other reference in the program.
-    unsafe { &mut UART_TX_BUF }
+    unsafe { &mut *core::ptr::addr_of_mut!(UART_TX_BUF) }
 }
 
 fn claim_sp_to_mgs_usart_buf_static(
@@ -1445,7 +1445,7 @@ fn claim_sp_to_mgs_usart_buf_static(
     // the AtomicBool swap above, combined with the lexical scoping of
     // `UART_RX_BUF`, means that this reference can't be aliased by any
     // other reference in the program.
-    unsafe { &mut UART_RX_BUF }
+    unsafe { &mut *core::ptr::addr_of_mut!(UART_RX_BUF) }
 }
 
 fn claim_installinator_image_id_static() -> &'static mut InstallinatorImageIdBuf
@@ -1461,5 +1461,5 @@ fn claim_installinator_image_id_static() -> &'static mut InstallinatorImageIdBuf
     // the AtomicBool swap above, combined with the lexical scoping of
     // `INSTALLINATOR_IMAGE_ID_BUF`, means that this reference can't be aliased
     // by any other reference in the program.
-    unsafe { &mut INSTALLINATOR_IMAGE_ID_BUF }
+    unsafe { &mut *core::ptr::addr_of_mut!(INSTALLINATOR_IMAGE_ID_BUF) }
 }

--- a/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
@@ -331,5 +331,5 @@ fn claim_phase2_buffer(
     // the AtomicBool swap above, combined with the lexical scoping of
     // `PHASE2_BUF`, means that this reference can't be aliased by any
     // other reference in the program.
-    unsafe { &mut PHASE2_BUF }
+    unsafe { &mut *core::ptr::addr_of_mut!(PHASE2_BUF) }
 }

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -46,8 +46,6 @@ static UPDATE_MEMORY: UpdateBuffer = UpdateBuffer::new();
 
 pub(crate) struct MgsHandler {
     common: MgsCommon,
-    sp_update: SpUpdate,
-    rot_update: RotUpdate,
     user_leds: UserLeds,
 }
 
@@ -57,8 +55,6 @@ impl MgsHandler {
     pub(crate) fn claim_static_resources(base_mac_address: MacAddress) -> Self {
         Self {
             common: MgsCommon::claim_static_resources(base_mac_address),
-            sp_update: SpUpdate::new(),
-            rot_update: RotUpdate::new(),
             user_leds: UserLeds::from(USER_LEDS.get_task_id()),
         }
     }

--- a/task/hiffy/src/generic.rs
+++ b/task/hiffy/src/generic.rs
@@ -5,7 +5,9 @@
 use hif::Function;
 use hubris_num_tasks::Task;
 
-pub struct Buffer(u8);
+// This type is only used by the debugger apparently, so its field appears
+// unused to the compiler.
+pub struct Buffer(#[allow(dead_code)] u8);
 
 pub enum Functions {
     Sleep(u16, u32),

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -26,7 +26,8 @@ enum Trace {
 
 ringbuf!(Trace, 64, Trace::None);
 
-pub struct Buffer(u8);
+// TODO: this type is copy-pasted in several modules
+pub struct Buffer(#[allow(dead_code)] u8);
 
 //
 // The order in this enum must match the order in the functions array that

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -14,6 +14,15 @@
 
 #![no_std]
 #![no_main]
+//
+// TODO: Hiffy is using unsafe and static mut in ways that are not obviously
+// sound. This became a warning in early 2024. In the interest of preventing
+// regressions in everything _else_ I'm suppressing the warning here so we can
+// turn Clippy back on. If you're reading this, this file is potentially unsound
+// and needs attention!
+//
+#![allow(static_mut_refs)]
+
 // This trait may not be needed, if compiling for a non-armv6m target.
 #[allow(unused_imports)]
 use armv6m_atomic_hack::AtomicU32Ext;

--- a/task/hiffy/src/stm32g0.rs
+++ b/task/hiffy/src/stm32g0.rs
@@ -20,7 +20,8 @@ use drv_i2c_api::{
 #[cfg(feature = "i2c")]
 task_slot!(I2C, i2c_driver);
 
-pub struct Buffer(u8);
+// TODO: this type is copy-pasted in several modules
+pub struct Buffer(#[allow(dead_code)] u8);
 
 //
 // The order in this enum must match the order in the functions array that

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1342,7 +1342,7 @@ fn claim_uart_rx_buf() -> &'static mut Vec<u8, MAX_PACKET_SIZE> {
     // the AtomicBool swap above, combined with the lexical scoping of
     // `UART_RX_BUF`, means that this reference can't be aliased by any
     // other reference in the program.
-    unsafe { &mut UART_RX_BUF }
+    unsafe { &mut *core::ptr::addr_of_mut!(UART_RX_BUF) }
 }
 
 mod idl {

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1038,20 +1038,22 @@ impl ServerImpl {
                     sequence,
                     &SpToHost::KeyLookupResult(KeyLookupResult::Ok),
                     |buf| {
-                        // `MIN_SP_TO_HOST_FILL_DATA_LEN` is calculated assuming
-                        // `SpToHost::MAX_SIZE`, but we know in this callback
-                        // we're appending to
-                        // `SpToHost::KeyLookupResult(KeyLookupResult::Ok)`,
-                        // which is only 2 bytes. Recompute the exact max space
-                        // we have for our response, then statically guarantee
-                        // we have sufficient space in `buf` for longest
-                        // possible DTRACE_CONF blob.
-                        const SP_TO_HOST_FILL_DATA_LEN: usize =
-                            MIN_SP_TO_HOST_FILL_DATA_LEN + SpToHost::MAX_SIZE
-                                - 2;
-                        const_assert!(
+                        const_assert!({
+                            // `MIN_SP_TO_HOST_FILL_DATA_LEN` is calculated
+                            // assuming `SpToHost::MAX_SIZE`, but we know in
+                            // this callback we're appending to
+                            // `SpToHost::KeyLookupResult(KeyLookupResult::Ok)`,
+                            // which is only 2 bytes. Recompute the exact max
+                            // space we have for our response, then statically
+                            // guarantee we have sufficient space in `buf` for
+                            // longest possible DTRACE_CONF blob.
+                            #[allow(dead_code)] // suppress warning in nightly
+                            const SP_TO_HOST_FILL_DATA_LEN: usize =
+                                MIN_SP_TO_HOST_FILL_DATA_LEN
+                                    + SpToHost::MAX_SIZE
+                                    - 2;
                             SP_TO_HOST_FILL_DATA_LEN >= MAX_DTRACE_CONF_LEN
-                        );
+                        });
 
                         buf[..response_len].copy_from_slice(
                             &self.host_kv_storage.dtrace_conf[..response_len],

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -365,9 +365,7 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
                 if let Some(Err(e)) = self.bsp.phy_fn(port, |phy| {
                     phy.read(phy::STANDARD::INTERRUPT_STATUS())
                 }) {
-                    return Err(e)
-                        .map_err(MonorailError::from)
-                        .map_err(RequestError::from);
+                    return Err(RequestError::from(MonorailError::from(e)));
                 }
 
                 // Clear the two bits that we use to detect link drops

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -241,9 +241,10 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
 
                 // Take the union of the "link changed" bit on the PHY and our
                 // local sticky value (since the PHY bit is self-resetting)
-                let v = match self.bsp.phy_fn(port, |phy| {
+                let r = self.bsp.phy_fn(port, |phy| {
                     phy.read(phy::STANDARD::INTERRUPT_STATUS())
-                }) {
+                });
+                let v = match r {
                     // If there is no PHY present, then the PHY link down
                     // indication is always false.
                     None => false,
@@ -456,58 +457,62 @@ impl<'a, R: Vsc7448Rw> idl::InOrderMonorailImpl for ServerImpl<'a, R> {
         port: u8,
     ) -> Result<PhyStatus, RequestError<MonorailError>> {
         self.check_port(port)?;
-        match self.bsp.phy_fn(port, |phy| -> Result<PhyStatus, VscError> {
-            let (_id, ty) = Self::decode_phy_id(&phy)?;
-            let status = phy.read(phy::STANDARD::MODE_STATUS())?;
-            let media_link_up = (status.0 & (1 << 2)) != 0;
+        let phy_result =
+            self.bsp.phy_fn(port, |phy| -> Result<PhyStatus, VscError> {
+                let (_id, ty) = Self::decode_phy_id(&phy)?;
+                let status = phy.read(phy::STANDARD::MODE_STATUS())?;
+                let media_link_up = (status.0 & (1 << 2)) != 0;
 
-            // The VSC8504 is running in forced-speed protocol transfer mode.
-            // Experimentally, packets get through without MAC_LINK_STATUS
-            // set, and despite what "ENT-AN1175" says, I don't see anything
-            // in register 24G.  As such, we'll be optimistic: if there's a
-            // valid QSGMII link and MAC_PCS_SIG_DETECT, then let's call it
-            // good.
-            let status = phy.read(phy::EXTENDED_3::MAC_SERDES_PCS_STATUS())?;
-            let mac_serdes = phy.read(phy::EXTENDED_3::MAC_SERDES_STATUS())?;
-            let qsgmii_mask = ty.qsgmii_okay_mask();
-            let mac_link_up = match ty {
-                PhyType::Vsc8504 => {
-                    if status.mac_pcs_sig_detect() == 0 {
-                        LinkStatus::Down
-                    } else if status.mac_sync_fail() != 0
-                        || status.mac_cgbad() != 0
-                        || (mac_serdes.0 & qsgmii_mask) != qsgmii_mask
-                    {
-                        LinkStatus::Error
-                    } else {
-                        LinkStatus::Up
+                // The VSC8504 is running in forced-speed protocol transfer mode.
+                // Experimentally, packets get through without MAC_LINK_STATUS
+                // set, and despite what "ENT-AN1175" says, I don't see anything
+                // in register 24G.  As such, we'll be optimistic: if there's a
+                // valid QSGMII link and MAC_PCS_SIG_DETECT, then let's call it
+                // good.
+                let status =
+                    phy.read(phy::EXTENDED_3::MAC_SERDES_PCS_STATUS())?;
+                let mac_serdes =
+                    phy.read(phy::EXTENDED_3::MAC_SERDES_STATUS())?;
+                let qsgmii_mask = ty.qsgmii_okay_mask();
+                let mac_link_up = match ty {
+                    PhyType::Vsc8504 => {
+                        if status.mac_pcs_sig_detect() == 0 {
+                            LinkStatus::Down
+                        } else if status.mac_sync_fail() != 0
+                            || status.mac_cgbad() != 0
+                            || (mac_serdes.0 & qsgmii_mask) != qsgmii_mask
+                        {
+                            LinkStatus::Error
+                        } else {
+                            LinkStatus::Up
+                        }
                     }
-                }
-                PhyType::Vsc8522 | PhyType::Vsc8552 | PhyType::Vsc8562 => {
-                    if status.mac_link_status() == 0 {
-                        LinkStatus::Down
-                    } else if status.mac_sync_fail() != 0
-                        || status.mac_cgbad() != 0
-                        || status.mac_pcs_sig_detect() == 0
-                        || (mac_serdes.0 & qsgmii_mask) != qsgmii_mask
-                    {
-                        LinkStatus::Error
-                    } else {
-                        LinkStatus::Up
+                    PhyType::Vsc8522 | PhyType::Vsc8552 | PhyType::Vsc8562 => {
+                        if status.mac_link_status() == 0 {
+                            LinkStatus::Down
+                        } else if status.mac_sync_fail() != 0
+                            || status.mac_cgbad() != 0
+                            || status.mac_pcs_sig_detect() == 0
+                            || (mac_serdes.0 & qsgmii_mask) != qsgmii_mask
+                        {
+                            LinkStatus::Error
+                        } else {
+                            LinkStatus::Up
+                        }
                     }
-                }
-            };
+                };
 
-            Ok(PhyStatus {
-                ty,
-                mac_link_up,
-                media_link_up: if media_link_up {
-                    LinkStatus::Up
-                } else {
-                    LinkStatus::Down
-                },
-            })
-        }) {
+                Ok(PhyStatus {
+                    ty,
+                    mac_link_up,
+                    media_link_up: if media_link_up {
+                        LinkStatus::Up
+                    } else {
+                        LinkStatus::Down
+                    },
+                })
+            });
+        match phy_result {
             None => Err(MonorailError::NoPhy.into()),
             Some(r) => {
                 r.map_err(MonorailError::from).map_err(RequestError::from)

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -171,7 +171,7 @@ where
         i: u16,
     ) -> Result<KszMacTableEntry, RequestError<KszError>> {
         if i >= 1024 {
-            return Err(KszError::BadMacIndex).map_err(RequestError::from);
+            return Err(RequestError::from(KszError::BadMacIndex));
         }
         let (_eth, bsp) = self.eth_bsp();
         let ksz8463 = bsp.ksz8463();

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -604,7 +604,6 @@ task_slot!(I2C, i2c_driver);
 #[cfg(feature = "fru-id-eeprom")]
 mod at24csw080 {
     use super::*;
-    use drv_i2c_devices::at24csw080::Error;
     use drv_i2c_devices::at24csw080::*;
 
     const EEPROM_SIZE: u16 = 1024;


### PR DESCRIPTION
This fixes everything but Hiffy's use of unsafe (or anything anybody has added since I started on this branch).

This change turns Clippy back on to prevent regressions.