### PR TITLE
kerncore: Add tests for bad or uncontained memory contained in a contiguous slice

### DIFF
--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -441,4 +441,38 @@ mod tests {
             "should NOT be able to access slice that starts and ends in good ranges but passes through bad one, but can",
         );
     }
+
+    #[test]
+    fn cannot_access_slice_spanning_over_uncontained_memory() {
+        let region_table = vec![
+            TestRegion {
+                base: 0x1238_5678,
+                size: 0x0001_0000,
+                label: "good".to_string(),
+            },
+            TestRegion {
+                // 65kb separated from previous region
+                base: 0x123A_5678,
+                size: 0x0001_0000,
+                label: "good".to_string(),
+            },
+        ];
+
+        let base = region_table[GOOD_REGION_0_IDX].base + 10;
+        let end = region_table[GOOD_REGION_1_IDX].end_addr() - 10;
+        let slice = TestSlice {
+            base,
+            size: end - base,
+        };
+
+        assert!(
+            // Load-bearing tiny punctuation character:
+            !can_access(
+                slice,
+                &region_table,
+                accept_only_good_regions,
+            ),
+            "should NOT be able to access slice that starts and ends in good ranges but passes through uncontained memory, but can",
+        );
+    }
 }

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -285,12 +285,24 @@ mod tests {
                 size: 0x0001_0000,
                 label: "good".to_string(),
             },
+            TestRegion {
+                base: 0x1237_5678,
+                size: 0x0001_0000,
+                label: "bad".to_string(),
+            },
+            TestRegion {
+                base: 0x1238_5678,
+                size: 0x0001_0000,
+                label: "good".to_string(),
+            },
         ]
     }
     const GOOD_REGION_0_IDX: usize = 0;
     const GOOD_REGION_1_IDX: usize = 1;
     const BAD_REGION_0_IDX: usize = 2;
     const BAD_REGION_1_IDX: usize = 3;
+    const GOOD_REGION_2_IDX: usize = 4;
+    const GOOD_REGION_3_IDX: usize = 6;
 
     // Predicate to use when matching _any_ region would be interesting, such as
     // if a slice is expected to be outside all regions.
@@ -405,6 +417,28 @@ mod tests {
                 accept_only_good_regions,
             ),
             "should NOT be able to access slice that spans adjacent bad ranges, but can",
+        );
+    }
+
+    #[test]
+    fn cannot_access_contiguous_regions_with_bad_region_interleaved() {
+        let region_table = make_fake_region_table();
+
+        let base = region_table[GOOD_REGION_2_IDX].base + 10;
+        let end = region_table[GOOD_REGION_3_IDX].end_addr() - 10;
+        let slice = TestSlice {
+            base,
+            size: end - base,
+        };
+
+        assert!(
+            // Load-bearing tiny punctuation character:
+            !can_access(
+                slice,
+                &region_table,
+                accept_only_good_regions,
+            ),
+            "should NOT be able to access slice that starts and ends in good ranges but passes through bad one, but can",
         );
     }
 }

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -444,6 +444,8 @@ mod tests {
 
     #[test]
     fn cannot_access_slice_spanning_over_uncontained_memory() {
+        // Using a custom region table to not cause cannot_access_uncontained_memory
+        // to spuriously fail.
         let region_table = vec![
             TestRegion {
                 base: 0x1238_5678,

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -162,40 +162,24 @@ where
     let start_addr = slice.base_addr();
     let end_addr = slice.end_addr();
 
+    // First find the start region. Note that if we do not find anything,
+    // then i == table.len().
     let mut i = 0;
     for region in table {
         if region.contains(start_addr) {
-            // Make sure it's permissible!
-            if !region_ok(region) {
-                // The start region wasn't permissible, error out.
-                return false;
-            }
-
-            if end_addr <= region.end_addr() {
-                // We've exhausted the slice in this region, we don't have
-                // to continue processing.
-                return true;
-            }
-
-            // We found our start region, it is permissible and does not
-            // contain the end address. We should look for the end region
-            // starting from the next region over.
-            i += 1;
             break;
-        }
-        if region.base_addr() > end_addr {
-            // We've passed our target address without finding regions that
-            // work!
-            return false;
         }
         // Continue scanning from the next region
         i += 1;
     }
 
-    // Start region was found; now to find the end region.
-    for region in &table[i..] {
+    // Start region was found or all regions were scanned; look for the end.
+    // SAFETY: The i index is only incremented while we're iterating over
+    // the original table slice. The index is always 0 <= i <= table.len().
+    let (_, table) = unsafe { table.split_at_unchecked(i) };
+    for region in table {
         if !region_ok(region) {
-            // End or intermediate region wasn't permissible, skip to error
+            // Region wasn't permissible, skip to error
             // handling code at the end.
             break;
         }

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -159,15 +159,16 @@ where
     // Per the function's preconditions, the region table is sorted in ascending
     // order of base address, and the regions within it do not overlap. This
     // lets us use a one-pass algorithm.
-    let mut scan_addr = slice.base_addr();
+    let start_addr = slice.base_addr();
     let end_addr = slice.end_addr();
 
+    let mut i = 0;
     for region in table {
-        if region.contains(scan_addr) {
+        if region.contains(start_addr) {
             // Make sure it's permissible!
             if !region_ok(region) {
-                // bail to the fail handling code at the end.
-                break;
+                // The start region wasn't permissible, error out.
+                return false;
             }
 
             if end_addr <= region.end_addr() {
@@ -176,12 +177,32 @@ where
                 return true;
             }
 
-            // Continue scanning at the end of this region.
-            scan_addr = region.end_addr();
-        } else if region.base_addr() > scan_addr {
+            // We found our start region, it is permissible and does not
+            // contain the end address. We should look for the end region
+            // starting from the next region over.
+            i += 1;
+            break;
+        }
+        if region.base_addr() > end_addr {
             // We've passed our target address without finding regions that
             // work!
+            return false;
+        }
+        // Continue scanning from the next region
+        i += 1;
+    }
+
+    // Start region was found; now to find the end region.
+    for region in &table[i..] {
+        if !region_ok(region) {
+            // End or intermediate region wasn't permissible, skip to error
+            // handling code at the end.
             break;
+        }
+
+        if end_addr <= region.end_addr() {
+            // The slice ends in this region, the slice was okay.
+            return true;
         }
     }
 

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -281,6 +281,7 @@ mod tests {
     const BAD_REGION_0_IDX: usize = 2;
     const BAD_REGION_1_IDX: usize = 3;
     const GOOD_REGION_2_IDX: usize = 4;
+    const BAD_REGION_2_IDX: usize = 5;
     const GOOD_REGION_3_IDX: usize = 6;
 
     // Predicate to use when matching _any_ region would be interesting, such as
@@ -315,7 +316,7 @@ mod tests {
     #[test]
     fn cannot_access_single_bad_region() {
         let region_table = make_fake_region_table();
-        for i in [BAD_REGION_0_IDX, BAD_REGION_1_IDX] {
+        for i in [BAD_REGION_0_IDX, BAD_REGION_1_IDX, BAD_REGION_2_IDX] {
             assert!(
                 // load-bearing tiny punctuation character:
                 !can_access(
@@ -412,19 +413,16 @@ mod tests {
 
         assert!(
             // Load-bearing tiny punctuation character:
-            !can_access(
-                slice,
-                &region_table,
-                accept_only_good_regions,
-            ),
-            "should NOT be able to access slice that starts and ends in good ranges but passes through bad one, but can",
+            !can_access(slice, &region_table, accept_only_good_regions,),
+            "should NOT be able to access slice that starts and ends in good \
+             ranges but passes through bad one, but can",
         );
     }
 
     #[test]
     fn cannot_access_slice_spanning_over_uncontained_memory() {
-        // Using a custom region table to not cause cannot_access_uncontained_memory
-        // to spuriously fail.
+        // Using a custom region table to not cause
+        // cannot_access_uncontained_memory to spuriously fail.
         let region_table = vec![
             TestRegion {
                 base: 0x1238_5678,
@@ -432,7 +430,7 @@ mod tests {
                 label: "good".to_string(),
             },
             TestRegion {
-                // 65kb separated from previous region
+                // 64 kiB separated from previous region
                 base: 0x123A_5678,
                 size: 0x0001_0000,
                 label: "good".to_string(),
@@ -448,12 +446,9 @@ mod tests {
 
         assert!(
             // Load-bearing tiny punctuation character:
-            !can_access(
-                slice,
-                &region_table,
-                accept_only_good_regions,
-            ),
-            "should NOT be able to access slice that starts and ends in good ranges but passes through uncontained memory, but can",
+            !can_access(slice, &region_table, accept_only_good_regions,),
+            "should NOT be able to access slice that starts and ends in \
+             good ranges but passes through uncontained memory, but can",
         );
     }
 }


### PR DESCRIPTION
The recent Oxide and Friends episode mentioned this memory region spanning slices issue, and the code was interesting. I thought I saw a chance to optimise it by omitting the start address containment checking once the start region is found. (Based on benchmarking against the test impls, it isn't faster.) The obvious issue with that was of course validity of the intermediate regions but I realised that wouldn't be a problem since I still need to check the validity of each region between start and end.

I figured I'd write tests to show that the alternative solution works but then realised the actual issue: My "optimised" algorithm allows for uncontained (unmapped?) memory to be accessed as long as it is found between two good regions. I presume this makes my improvement worthless, but at least the tests are worthwhile additions. The second added test shows the error in my idea.

I've still left the original modification in this PR's commits to at least show what the idea was. There may still be some worth to it.

Side note: The idea for the two loops came from `Vec::retain_mut`'s code which uses a similar logic to find the first item that isn't retained.