### PR TITLE
Remove most panics from timer-related operations

### DIFF
--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -500,8 +500,7 @@ impl idl::InOrderSpCtrlImpl for ServerImpl {
         }
         // This function is idempotent(ish), so we don't care if the timer was
         // already running; set the new deadline based on current time.
-        let deadline = sys_get_timer().now + time_ms as u64;
-        sys_set_timer(Some(deadline), notifications::TIMER_MASK);
+        set_timer_relative(time_ms, notifications::TIMER_MASK);
         Ok(())
     }
 

--- a/drv/sidecar-seq-server/src/main.rs
+++ b/drv/sidecar-seq-server/src/main.rs
@@ -790,7 +790,10 @@ impl NotificationHandler for ServerImpl {
         // be fine. Anyway, armed with this information, find the next deadline
         // some multiple of `TIMER_INTERVAL` in the future.
 
-        let delta = finish - start;
+        // The timer is monotonic, so finish >= start, so we use wrapping_add
+        // here to avoid an overflow check that the compiler conservatively
+        // inserts.
+        let delta = finish.wrapping_sub(start);
         let next_deadline = finish + TIMER_INTERVAL - (delta % TIMER_INTERVAL);
 
         sys_set_timer(Some(next_deadline), notifications::TIMER_MASK);

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -383,15 +383,7 @@ impl<S: SpiServer> Io<S> {
             .unwrap_lite();
 
         // Determine the deadline after which we'll give up, and start the clock.
-        let deadline = sys_get_timer()
-            .now
-            // Values passed to `max_sleep` are all constants that are small
-            // enough that this will almost certainly not overflow unless the SP
-            // has been running without a reset for at least a couple million
-            // years. Using saturating arithmetic here lets us avoid a bounds
-            // check.
-            .saturating_add(max_sleep as u64);
-        sys_set_timer(Some(deadline), TIMER_MASK);
+        let expected_wake = set_timer_relative(max_sleep, TIMER_MASK);
 
         let mut irq_fired = false;
         while self.is_rot_irq_asserted() != desired {

--- a/drv/user-leds/src/main.rs
+++ b/drv/user-leds/src/main.rs
@@ -45,7 +45,7 @@ task_config::optional_task_config! {
     blink_at_start: &'static [Led],
 }
 
-const BLINK_INTERVAL: u64 = 500;
+const BLINK_INTERVAL: u32 = 500;
 
 cfg_if::cfg_if! {
     // Target boards with 4 leds
@@ -148,10 +148,7 @@ impl idl::InOrderUserLedsImpl for ServerImpl {
         self.blinking[led] = true;
 
         if !any_blinking {
-            sys_set_timer(
-                Some(sys_get_timer().now + BLINK_INTERVAL),
-                notifications::TIMER_MASK,
-            );
+            set_timer_relative(BLINK_INTERVAL, notifications::TIMER_MASK);
         }
         Ok(())
     }
@@ -172,10 +169,7 @@ impl idol_runtime::NotificationHandler for ServerImpl {
                 }
             }
             if any_blinking {
-                sys_set_timer(
-                    Some(sys_get_timer().now + BLINK_INTERVAL),
-                    notifications::TIMER_MASK,
-                );
+                set_timer_relative(BLINK_INTERVAL, notifications::TIMER_MASK);
             }
         }
     }
@@ -193,10 +187,7 @@ fn main() -> ! {
             blinking[led] = true;
         }
         if !config.blink_at_start.is_empty() {
-            sys_set_timer(
-                Some(sys_get_timer().now + BLINK_INTERVAL),
-                notifications::TIMER_MASK,
-            );
+            set_timer_relative(BLINK_INTERVAL, notifications::TIMER_MASK);
         }
     }
     let mut server = ServerImpl { blinking };

--- a/lib/multitimer/src/lib.rs
+++ b/lib/multitimer/src/lib.rs
@@ -140,8 +140,12 @@ impl<E: EnumArray<Timer> + Copy> Multitimer<E> {
                     // Apply the repeat setting or disable the timer.
                     if let Some(kind) = r {
                         let next = match kind {
-                            Repeat::AfterWake(period) => t + period,
-                            Repeat::AfterDeadline(period) => d + period,
+                            Repeat::AfterWake(period) => {
+                                t.saturating_add(period)
+                            }
+                            Repeat::AfterDeadline(period) => {
+                                d.saturating_add(period)
+                            }
                         };
                         timer.deadline = Some((next, r));
                     } else {

--- a/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_gimlet/host_phase2.rs
@@ -118,9 +118,12 @@ impl HostPhase2Requester {
         // in our outgoing net task queue).
         let port = match current.state {
             State::NeedToSendFirstMgs(port) => {
+                // Using saturating_add here because it's cheaper than
+                // panicking, and timestamps won't saturate for 584 million
+                // years.
                 current.state = State::WaitingForFirstMgs {
                     port,
-                    deadline: now + DELAY_TRY_OTHER_MGS,
+                    deadline: now.saturating_add(DELAY_TRY_OTHER_MGS),
                 };
                 port
             }
@@ -136,7 +139,7 @@ impl HostPhase2Requester {
                 };
                 current.state = State::WaitingForSecondMgs {
                     port,
-                    deadline: now + DELAY_RETRY,
+                    deadline: now.saturating_add(DELAY_RETRY),
                 };
                 port
             }
@@ -158,7 +161,7 @@ impl HostPhase2Requester {
                 };
                 current.state = State::WaitingForFirstMgs {
                     port,
-                    deadline: now + DELAY_TRY_OTHER_MGS,
+                    deadline: now.saturating_add(DELAY_TRY_OTHER_MGS),
                 };
                 port
             }

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -401,9 +401,13 @@ impl ServerImpl {
                     if reboot {
                         // Somehow we're already in A2 when the host wanted to
                         // reboot; set our reboot timer.
+                        //
+                        // Using saturating add here because it's cheaper than
+                        // potentially panicking, and timestamps won't saturate
+                        // for 584 million years.
                         self.timers.set_timer(
                             Timers::WaitingInA2ToReboot,
-                            sys_get_timer().now + A2_REBOOT_DELAY,
+                            sys_get_timer().now.saturating_add(A2_REBOOT_DELAY),
                             None,
                         );
                         self.reboot_state =

--- a/task/monorail-server/src/bsp/sidecar_bcd.rs
+++ b/task/monorail-server/src/bsp/sidecar_bcd.rs
@@ -16,8 +16,7 @@ task_slot!(SEQ, seq);
 task_slot!(FRONT_IO, ecp5_front_io);
 
 /// Interval at which `Bsp::wake()` is called by the main loop
-const WAKE_INTERVAL_MS: u64 = 500;
-pub const WAKE_INTERVAL: Option<u64> = Some(WAKE_INTERVAL_MS);
+pub const WAKE_INTERVAL: Option<u32> = Some(500);
 
 #[derive(Copy, Clone, PartialEq, counters::Count)]
 enum Trace {
@@ -497,7 +496,9 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             if link_down {
                 let now = userlib::sys_get_timer().now;
                 if let Some(link_down_at) = self.link_down_at {
-                    if now - link_down_at >= 20_000 {
+                    // We can use wrapping arithmetic here because the timer is
+                    // monotonic.
+                    if now.wrapping_sub(link_down_at) >= 20_000 {
                         self.link_down_at = None;
                         // This logs Trace::Reinit in the ringbuf
                         self.reinit()?;

--- a/task/monorail-server/src/server.rs
+++ b/task/monorail-server/src/server.rs
@@ -61,9 +61,8 @@ impl<'a, R: Vsc7448Rw> ServerImpl<'a, R> {
         if let Some(wake_interval) = bsp::WAKE_INTERVAL {
             if now >= self.wake_target_time {
                 let out = self.bsp.wake();
-                self.wake_target_time = now + wake_interval;
-                sys_set_timer(
-                    Some(self.wake_target_time),
+                self.wake_target_time = userlib::set_timer_relative(
+                    wake_interval,
                     notifications::WAKE_TIMER_MASK,
                 );
                 return out;

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -51,7 +51,7 @@ enum PowerState {
     A2,
 }
 
-const TIMER_INTERVAL: u64 = 1000;
+const TIMER_INTERVAL: u32 = 1000;
 
 task_slot!(I2C, i2c_driver);
 task_slot!(SENSOR, sensor);
@@ -419,10 +419,7 @@ fn main() -> ! {
     };
     let mut buffer = [0; idl::INCOMING_SIZE];
 
-    sys_set_timer(
-        Some(sys_get_timer().now + TIMER_INTERVAL),
-        notifications::TIMER_MASK,
-    );
+    userlib::set_timer_relative(TIMER_INTERVAL, notifications::TIMER_MASK);
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
     }
@@ -626,10 +623,7 @@ impl idol_runtime::NotificationHandler for ServerImpl {
 
     fn handle_notification(&mut self, _bits: u32) {
         self.handle_timer_fired();
-        sys_set_timer(
-            Some(sys_get_timer().now + TIMER_INTERVAL),
-            notifications::TIMER_MASK,
-        );
+        userlib::set_timer_relative(TIMER_INTERVAL, notifications::TIMER_MASK);
     }
 }
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -329,7 +329,8 @@ impl<'a> NotificationHandler for ServerImpl<'a> {
             }
             self.deadline = now + TIMER_INTERVAL;
         }
-        self.runtime = sys_get_timer().now - now;
+        // We can use wrapping arithmetic here because the timer is monotonic.
+        self.runtime = sys_get_timer().now.wrapping_sub(now);
         sys_set_timer(Some(self.deadline), notifications::TIMER_MASK);
     }
 }


### PR DESCRIPTION
See the commits for more detail, but in brief, this removes a panic from `userlib::hl::sleep_for` and then introduces a `set_timer_relative` operation for doing the common timer set operation in a way that won't panic.