### PR TITLE
Bump gimlet-seq stacksize

### DIFF
--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -163,7 +163,7 @@ name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
-stacksize = 1600
+stacksize = 2600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe", "packrat"]
 notifications = ["timer", "vcore"]


### PR DESCRIPTION
I'm seeing stack overflow for `gimlet-seq` on the `gimlet-c-dev` image.  Running with a boosted stack size, I see a `stackmargin` size of 1728, which is above the limit of 1600.  Bisecting, this appears to have been introduced in #1730; I'm guessing it's the nested `ServerImpl::handle_notifications → VCore::handle_notifications` dispatch.