### PR TITLE
Begin removing/disabling wildcard imports.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,6 @@ tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3.0" }
 transceiver-messages = { git = "https://github.com/oxidecomputer/transceiver-control/", default-features = false}
 vsc7448-pac = { git = "https://github.com/oxidecomputer/vsc7448", default-features = false }
+
+[workspace.lints.clippy]
+wildcard_imports = "deny"

--- a/lib/multitimer/Cargo.toml
+++ b/lib/multitimer/Cargo.toml
@@ -8,3 +8,6 @@ enum-map = { workspace = true }
 
 [target.'cfg(target_os = "none")'.dependencies]
 userlib = {path = "../../sys/userlib"}
+
+[lints]
+workspace = true

--- a/lib/multitimer/src/lib.rs
+++ b/lib/multitimer/src/lib.rs
@@ -213,8 +213,8 @@ mod fakes {
     use core::cell::Cell;
 
     thread_local! {
-        pub static CURRENT_TIME: Cell<u64> = Cell::new(0);
-        pub static TIMER_SETTING: Cell<(Option<u64>, u32)> = Cell::default();
+        pub static CURRENT_TIME: Cell<u64> = const { Cell::new(0) };
+        pub static TIMER_SETTING: Cell<(Option<u64>, u32)> = const { Cell::new((None, 0)) };
     }
 
     pub fn sys_set_timer(deadline: Option<u64>, not: u32) {
@@ -239,11 +239,12 @@ mod fakes {
     }
 }
 #[cfg(not(target_os = "none"))]
-use self::fakes::*;
+use self::fakes::{sys_get_timer, sys_set_timer};
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::fakes::CURRENT_TIME;
+    use super::{sys_get_timer, EnumMap, Multitimer, Repeat, Timer};
 
     fn change_time(time: u64) {
         CURRENT_TIME.with(|t| t.set(time));

--- a/sys/abi/Cargo.toml
+++ b/sys/abi/Cargo.toml
@@ -9,3 +9,6 @@ bitflags = { workspace = true }
 byteorder = { workspace = true }
 serde = { workspace = true }
 phash = { path = "../../lib/phash" }
+
+[lints]
+workspace = true

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -41,3 +41,6 @@ nano = []
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -5,7 +5,7 @@
 //! Kernel startup.
 
 use crate::atomic::AtomicExt;
-use crate::descs::*;
+use crate::descs::{RegionAttributes, RegionDesc, TaskDesc, TaskFlags};
 use crate::task::Task;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/sys/kerncore/Cargo.toml
+++ b/sys/kerncore/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/sys/num-tasks/Cargo.toml
+++ b/sys/num-tasks/Cargo.toml
@@ -13,3 +13,6 @@ task-enum = []
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/sys/userlib/Cargo.toml
+++ b/sys/userlib/Cargo.toml
@@ -51,3 +51,6 @@ build-util = { path = "../../build/util" }
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -39,3 +39,6 @@ name = "task-jefe"
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/task/jefe/src/external.rs
+++ b/task/jefe/src/external.rs
@@ -50,8 +50,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 #[allow(unused_imports)]
 use armv6m_atomic_hack::AtomicU32Ext;
 
-use ringbuf::*;
-use userlib::*;
+use ringbuf::{ringbuf, ringbuf_entry};
+use userlib::{kipc, FromPrimitive};
 
 /// The actual requests that we honor from an external source entity
 #[derive(FromPrimitive, Copy, Clone, Debug, Eq, PartialEq)]

--- a/test/test-api/Cargo.toml
+++ b/test/test-api/Cargo.toml
@@ -17,3 +17,6 @@ build-util = { path = "../../build/util" }
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/test/test-api/src/lib.rs
+++ b/test/test-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 
-use userlib::*;
+use userlib::FromPrimitive;
 
 /// Operations that are performed by the test-assist
 #[derive(FromPrimitive, Debug, Eq, PartialEq)]

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -22,3 +22,6 @@ name = "test-assist"
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/test/test-assist/src/main.rs
+++ b/test/test-assist/src/main.rs
@@ -9,8 +9,10 @@
 
 use core::arch::asm;
 use hubris_num_tasks::NUM_TASKS;
-use test_api::*;
-use userlib::*;
+use test_api::AssistOp;
+use userlib::{
+    hl, kipc, sys_refresh_task_id, sys_send, Generation, Lease, TaskId,
+};
 use zerocopy::AsBytes;
 
 #[inline(never)]

--- a/test/test-idol-api/Cargo.toml
+++ b/test/test-idol-api/Cargo.toml
@@ -22,3 +22,6 @@ bench = false
 
 [build-dependencies]
 idol = { workspace = true }
+
+[lints]
+workspace = true

--- a/test/test-idol-api/src/lib.rs
+++ b/test/test-idol-api/src/lib.rs
@@ -8,7 +8,7 @@
 
 use derive_idol_err::IdolError;
 use serde::{Deserialize, Serialize};
-use userlib::*;
+use userlib::{sys_send, FromPrimitive};
 
 #[derive(
     Copy, Clone, Debug, Eq, PartialEq, FromPrimitive, IdolError, counters::Count,

--- a/test/test-idol-server/Cargo.toml
+++ b/test/test-idol-server/Cargo.toml
@@ -24,3 +24,6 @@ name = "test-idol-server"
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/test/test-idol-server/src/main.rs
+++ b/test/test-idol-server/src/main.rs
@@ -7,7 +7,7 @@
 
 use idol_runtime::{NotificationHandler, RequestError};
 use test_idol_api::{FancyTestType, IdolTestError, SocketName, UdpMetadata};
-use userlib::*;
+use userlib::RecvMessage;
 
 struct ServerImpl;
 
@@ -103,7 +103,8 @@ fn main() -> ! {
 }
 
 mod idl {
-    use super::*;
+    use super::FancyTestType;
+    use test_idol_api::{IdolTestError, SocketName, UdpMetadata};
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -25,3 +25,6 @@ name = "test-runner"
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -48,9 +48,9 @@
 #![no_std]
 #![no_main]
 
-use ringbuf::*;
-use test_api::*;
-use userlib::*;
+use ringbuf::{ringbuf, ringbuf_entry};
+use test_api::{RunnerOp, TestResult};
+use userlib::{hl, kipc, TaskId, TaskState};
 
 /// We are sensitive to all notifications, to catch unexpected ones in test.
 const ALL_NOTIFICATIONS: u32 = !0;

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -32,3 +32,6 @@ name = "test-suite"
 test = false
 doctest = false
 bench = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
This starts with the "core" code in sys, test, and jefe, and works out from there.

Any package can opt into this at any time by adding this to its Cargo.toml:

    [lints]
    workspace = true

This will also cause it to pick up any future lints we decide on.