### PR TITLE
chore: Move interleaved uncontained memory test into cannot_access_uncontained_memory

### DIFF
--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -274,6 +274,11 @@ mod tests {
                 size: 0x0001_0000,
                 label: "good".to_string(),
             },
+            TestRegion {
+                base: 0x123A_5678,
+                size: 0x0001_0000,
+                label: "good".to_string(),
+            },
         ]
     }
     const GOOD_REGION_0_IDX: usize = 0;
@@ -416,39 +421,6 @@ mod tests {
             !can_access(slice, &region_table, accept_only_good_regions,),
             "should NOT be able to access slice that starts and ends in good \
              ranges but passes through bad one, but can",
-        );
-    }
-
-    #[test]
-    fn cannot_access_slice_spanning_over_uncontained_memory() {
-        // Using a custom region table to not cause
-        // cannot_access_uncontained_memory to spuriously fail.
-        let region_table = vec![
-            TestRegion {
-                base: 0x1238_5678,
-                size: 0x0001_0000,
-                label: "good".to_string(),
-            },
-            TestRegion {
-                // 64 kiB separated from previous region
-                base: 0x123A_5678,
-                size: 0x0001_0000,
-                label: "good".to_string(),
-            },
-        ];
-
-        let base = region_table[GOOD_REGION_0_IDX].base + 10;
-        let end = region_table[GOOD_REGION_1_IDX].end_addr() - 10;
-        let slice = TestSlice {
-            base,
-            size: end - base,
-        };
-
-        assert!(
-            // Load-bearing tiny punctuation character:
-            !can_access(slice, &region_table, accept_only_good_regions,),
-            "should NOT be able to access slice that starts and ends in \
-             good ranges but passes through uncontained memory, but can",
         );
     }
 }


### PR DESCRIPTION
Pretty-much zero-benefit PR but it started bugging me that `cannot_access_uncontained_memory` was "spuriously" failing when I'd added the "two good slices interleaved with uncontained memory" case into the fake table.

Well, it wasn't spuriously failing. It was just already testing what the `cannot_access_slice_spanning_over_uncontained_memory` test case I added tests, and it was failing because at that point the I still had my attempted improved algorithm in the branch.

So in effect: The last added test case can be just replaced with a single addition into the fake table, after which the existing uncontained memory access test takes care of testing that case.