### PR TITLE
Enable notifications on any closed RECV.

### DIFF
--- a/doc/syscalls.adoc
+++ b/doc/syscalls.adoc
@@ -232,9 +232,10 @@ During an open receive, a task may receive messages sent by any other task, plus
 any notifications enabled by the notification mask.
 
 During a closed receive, a task will receive messages only from the chosen task.
-The task will *not* receive notifications unless the chosen sender ID is the
-kernel's task ID, `0xFFFF`. (This behavior is a little odd because it predates
-notification masks, and may change.)
+The task will still receive any notifications set in its notification mask.
+
+To listen *only* for notifications, a task can perform a closed receive against
+the kernel's task ID, `0xFFFF`.
 
 ==== Arguments
 

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -256,11 +256,7 @@ impl TaskState {
 
     /// Checks if a task in this state can be unblocked with a notification.
     pub fn can_accept_notification(&self) -> bool {
-        if let TaskState::Healthy(SchedState::InRecv(p)) = self {
-            p.is_none() || p == &Some(TaskId::KERNEL)
-        } else {
-            false
-        }
+        matches!(self, TaskState::Healthy(SchedState::InRecv(_)))
     }
 }
 

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -255,9 +255,8 @@ pub fn sys_recv_open(buffer: &mut [u8], notification_mask: u32) -> RecvMessage {
 /// its information returned.
 ///
 /// `notification_mask` determines which notification bits can interrupt this
-/// RECV (any that are 1). Note that, if `sender` is not `TaskId::KERNEL`, you
-/// can't actually receive any notifications with this operation, so
-/// `notification_mask` should always be zero in that case.
+/// RECV (any that are 1). To listen _only_ for notifications, pass the `sender`
+/// `TaskId::KERNEL`.
 ///
 /// If `sender` is stale (i.e. refers to a deceased generation of the task) when
 /// you call this, or if `sender` is rebooted while you're blocked in this


### PR DESCRIPTION
Previously, a closed RECV against the kernel was special-cased as a "listen only for notifications" operation. Closed RECV against any other task would ignore the provided notification mask and treat it as zero.

This seemed weird and limiting.

This commit alters the semantics of RECV with a non-zero notification mask and enables notifications in that specific situation.

As far as I can tell, we have no code that relies on notifications being filtered out during closed-RECV, so this should be safe.

Fixes #1761.