### PR TITLE
Make enum encoded FPGA register fields more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ checksum = "bd769563b4ea2953e2825c9e6b7470a5f55f67e0be00030bf3e390a2a6071f64"
 name = "build-fpga-regmap"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "serde",
  "serde_json",
 ]

--- a/build/fpga-regmap/Cargo.toml
+++ b/build/fpga-regmap/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { workspace = true }
-serde_json = { workspace = true }
+convert_case.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -235,7 +235,7 @@ fn write_reg_fields(
 }
 
 fn write_node(
-    parents: &Vec<String>,
+    parents: &[String],
     node: &Node,
     prefix: &str,
     output: &mut String,
@@ -259,7 +259,7 @@ fn write_node(
             .unwrap();
 
             // Extend the knowledge of parents as we descend
-            let mut new_parents = parents.clone();
+            let mut new_parents = parents.to_owned();
             new_parents.push(inst_name.clone());
             write_reg_fields(new_parents, children, prefix, output);
 
@@ -292,7 +292,7 @@ fn write_node(
             )
             .unwrap();
 
-            let mut new_parents = parents.clone();
+            let mut new_parents = parents.to_owned();
             new_parents.push(inst_name.clone());
             recurse_reg_map(
                 &new_parents,
@@ -310,7 +310,7 @@ fn write_node(
 }
 
 fn recurse_reg_map(
-    parents: &Vec<String>,
+    parents: &[String],
     children: &[Node],
     prefix: &str,
     output: &mut String,

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -334,8 +334,7 @@ pub mod Reg {{"
 
     // The nested layers may require type information that requires knowledge
     // of where they are in the tree.
-    let mut root = Vec::<String>::new();
-    root.push("Reg".to_string());
+    let root = vec!["Reg".to_string()];
     recurse_reg_map(root, children, "", output);
 
     writeln!(output, "}}").unwrap();

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -730,7 +730,7 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A1Status(status[0]));
 
-                    if status[0] == Reg::A1SMSTATUS::A1SM_Encoded::DONE as u8 {
+                    if status[0] == Reg::A1SMSTATUS::A1SmEncoded::Done as u8 {
                         break;
                     }
 
@@ -786,8 +786,7 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A0Status(status[0]));
 
-                    if status[0]
-                        == Reg::A0SMSTATUS::A0SM_Encoded::GROUPC_PG as u8
+                    if status[0] == Reg::A0SMSTATUS::A0SmEncoded::GroupcPg as u8
                     {
                         break;
                     }
@@ -820,7 +819,7 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A0Power(status[0]));
 
-                    if status[0] == Reg::A0SMSTATUS::A0SM_Encoded::DONE as u8 {
+                    if status[0] == Reg::A0SMSTATUS::A0SmEncoded::Done as u8 {
                         break;
                     }
 

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -730,7 +730,7 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A1Status(status[0]));
 
-                    if status[0] == Reg::A1SMSTATUS::Encoded::DONE as u8 {
+                    if status[0] == Reg::A1SMSTATUS::A1SM_Encoded::DONE as u8 {
                         break;
                     }
 
@@ -786,7 +786,9 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A0Status(status[0]));
 
-                    if status[0] == Reg::A0SMSTATUS::Encoded::GROUPC_PG as u8 {
+                    if status[0]
+                        == Reg::A0SMSTATUS::A0SM_Encoded::GROUPC_PG as u8
+                    {
                         break;
                     }
 
@@ -818,7 +820,7 @@ impl<S: SpiServer> ServerImpl<S> {
                         .unwrap_lite();
                     ringbuf_entry!(Trace::A0Power(status[0]));
 
-                    if status[0] == Reg::A0SMSTATUS::Encoded::DONE as u8 {
+                    if status[0] == Reg::A0SMSTATUS::A0SM_Encoded::DONE as u8 {
                         break;
                     }
 

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -651,7 +651,7 @@ impl ModuleResultNoFailure {
 }
 
 /// A type to provide more ergonomic access to the FPGA generated type
-pub type FpgaI2CFailure = Reg::QSFP::PORT0_STATUS::ERROR_Encoded;
+pub type FpgaI2CFailure = Reg::QSFP::PORT0_STATUS::ErrorEncoded;
 
 /// A type to consolidate per-module failure types.
 ///

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -60,10 +60,10 @@ enum Trace {
     UnknownInterface(u8, ManagementInterface),
     UnpluggedModule(usize),
     RemovedDisabledModuleThermalModel(usize),
-    TemperatureReadError(usize, Reg::QSFP::PORT0_STATUS::ERROR_Encoded),
+    TemperatureReadError(usize, Reg::QSFP::PORT0_STATUS::ErrorEncoded),
     TemperatureReadUnexpectedError(usize, FpgaError),
     ThermalError(usize, ThermalError),
-    GetInterfaceError(usize, Reg::QSFP::PORT0_STATUS::ERROR_Encoded),
+    GetInterfaceError(usize, Reg::QSFP::PORT0_STATUS::ErrorEncoded),
     GetInterfaceUnexpectedError(usize, FpgaError),
     InvalidPortStatusError(usize, u8),
     DisablingPorts(LogicalPortMask),
@@ -359,9 +359,8 @@ impl ServerImpl {
                             self.decode_interface(port, interface)
                     }
                     Err(FpgaError::ImplError(e)) => {
-                        match Reg::QSFP::PORT0_STATUS::ERROR_Encoded::try_from(
-                            e,
-                        ) {
+                        match Reg::QSFP::PORT0_STATUS::ErrorEncoded::try_from(e)
+                        {
                             Ok(val) => {
                                 ringbuf_entry!(Trace::GetInterfaceError(i, val))
                             }
@@ -447,11 +446,11 @@ impl ServerImpl {
                 // be transient (and we'll remove the transceiver on the
                 // next pass through this function).
                 Err(FpgaError::ImplError(e)) => {
-                    use Reg::QSFP::PORT0_STATUS::ERROR_Encoded;
-                    match ERROR_Encoded::try_from(e) {
+                    use Reg::QSFP::PORT0_STATUS::ErrorEncoded;
+                    match ErrorEncoded::try_from(e) {
                         Ok(val) => {
                             got_nack |=
-                                matches!(val, ERROR_Encoded::I2cAddressNack);
+                                matches!(val, ErrorEncoded::I2CAddressNack);
                             ringbuf_entry!(Trace::TemperatureReadError(i, val))
                         }
                         Err(_) => {

--- a/drv/transceivers-server/src/udp.rs
+++ b/drv/transceivers-server/src/udp.rs
@@ -788,10 +788,10 @@ impl ServerImpl {
                         FpgaI2CFailure::NotInitialized => {
                             HwError::NotInitialized
                         }
-                        FpgaI2CFailure::I2cAddressNack => {
+                        FpgaI2CFailure::I2CAddressNack => {
                             HwError::I2cAddressNack
                         }
-                        FpgaI2CFailure::I2cByteNack => HwError::I2cByteNack,
+                        FpgaI2CFailure::I2CByteNack => HwError::I2cByteNack,
                         // We only mark failures when an error is set, so this
                         // branch should never match.
                         FpgaI2CFailure::NoError => unreachable!(),


### PR DESCRIPTION
I'll start off with a bit of context since this is a corner of the system that doesn't get looked at often. We use SystemRDL to define registers in the FPGA. When we build an FPGA, one of the outputs is a JSON file that describes the registers. We commit that JSON file alongside the bitfile in this repo, which then gets turned into Rust by `build/fpga-regmap`. A neat part of this is that we can define enums as a register field in the RTL and carry them into the Rust code via a property we call `encode`.

For example, consider the [`STATUS_PORT0` register](https://github.com/oxidecomputer/hubris/blob/master/drv/sidecar-front-io/sidecar_qsfp_x32_controller_regs.json#L1154-L1213). Today, that would generate the following code:
```rust
...
    #[allow(non_snake_case)]
        pub mod STATUS_PORT0 {
            #[allow(dead_code)]
            #[allow(non_upper_case_globals)]
            pub const ERROR: u8 = 0b00001111;

            use num_derive::{ToPrimitive, FromPrimitive};
            #[derive(Copy, Clone, Eq, PartialEq, FromPrimitive, ToPrimitive)]
            #[allow(dead_code)]
            #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
            pub enum Encoded {
                NoError = 0x00,
                NoModule = 0x01,
                NoPower = 0x02,
                PowerFault = 0x03,
                NotInitialized = 0x04,
                I2cAddressNack = 0x05,
                I2cByteNack = 0x06,
            }
            #[allow(dead_code)]
            #[allow(non_upper_case_globals)]
            pub const BUSY: u8 = 0b00010000;
        }
...
```

The presence of `encode` in the JSON yields an `Encoded` enum for the register in the Rust. This has a couple of sharp corners, both of which come from behavior that assumes an `encode` type is the only field in a register.

1. You can't have two `encoded` fields within the same register because we currently just name the enum `Encoded`.
2. If you `encoded` field lives alongside any other fields, such as is the case with `BUSY` and `ERROR` above, you need to make sure you're masking off the bits for the `encoded` field only when attempting to resolve to an `Encoded` variant.

This PR addresses both of these points by:

1. Naming the enum after the field it is encoding, i.e. `<field>_Encoded`. 
2. Implementing `TryFrom<u8>` for the enum and having that automatically handle the bit masking for the field so the programmer doesn't have to remember that.


After this PR, that would look like:
```rust
...
        #[allow(non_snake_case)]
        pub mod PORT0_STATUS {
            #[allow(dead_code)]
            #[allow(non_upper_case_globals)]
            pub const ERROR: u8 = 0b00001111;

            #[derive(Copy, Clone, Eq, PartialEq)]
            #[allow(dead_code)]
            #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
            pub enum ERROR_Encoded {
                NoError = 0x00,
                NoModule = 0x01,
                NoPower = 0x02,
                PowerFault = 0x03,
                NotInitialized = 0x04,
                I2cAddressNack = 0x05,
                I2cByteNack = 0x06,
            }

            impl TryFrom<u8> for ERROR_Encoded {
                type Error = ();
                fn try_from(x: u8) -> Result<Self, Self::Error> {
                    use crate::Reg::QSFP::PORT0_STATUS::ERROR_Encoded::*;
                    let x_masked = x & ERROR;
                    match x_masked {
                        0x00 => Ok(NoError),
                        0x01 => Ok(NoModule),
                        0x02 => Ok(NoPower),
                        0x03 => Ok(PowerFault),
                        0x04 => Ok(NotInitialized),
                        0x05 => Ok(I2cAddressNack),
                        0x06 => Ok(I2cByteNack),
                        _ => Err(()),
                    }
                }
            }

            #[allow(dead_code)]
            #[allow(non_upper_case_globals)]
            pub const BUSY: u8 = 0b00010000;
        }
...
```