### PR TITLE
Removed named-profiles feature flag

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -700,7 +700,6 @@ impl BuildConfig<'_> {
             "array_methods",
             "asm_const",
             "naked_functions",
-            "named-profiles",
             "used_with_arg",
         ]);
         // nightly features that our dependencies use:


### PR DESCRIPTION
... I think this got stabilized? A quick grep of the code doesn't show invoking the flag. Let's see what CI says, I probably missed something.