### PR TITLE
Remove array_methods flag

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -697,7 +697,6 @@ impl BuildConfig<'_> {
         let mut nightly_features = vec![];
         // nightly features that we use:
         nightly_features.extend([
-            "array_methods",
             "asm_const",
             "naked_functions",
             "used_with_arg",


### PR DESCRIPTION
This *may* need to go in "nightly features that our dependencies use", as it doesn't appear in our code. Let's try that out!