### PR TITLE
xtask lsp: optionally source app.toml from HUBRIS_APP

### DIFF
--- a/build/xtask/src/lsp.rs
+++ b/build/xtask/src/lsp.rs
@@ -346,13 +346,17 @@ fn inner(file: &PathBuf, clients: &[LspClient]) -> Result<LspConfig> {
         }
     }
 
-    let preferred_apps = [
-        "app/gimlet/rev-c.toml",
-        "app/sidecar/rev-b.toml",
-        "app/psc/rev-b.toml",
-    ];
+    let preferred_apps = if let Ok(toml) = std::env::var("HUBRIS_APP") {
+        vec![toml]
+    } else {
+        vec![
+            "app/gimlet/rev-c.toml".to_string(),
+            "app/sidecar/rev-b.toml".to_string(),
+            "app/psc/rev-b.toml".to_string(),
+        ]
+    };
     for app_name in preferred_apps {
-        let file = root.join(app_name);
+        let file = root.join(&app_name);
         let app_cfg = PackageConfig::new(&file, false, false)
             .context(format!("could not open {file:?}"))?;
 
@@ -365,7 +369,7 @@ fn inner(file: &PathBuf, clients: &[LspClient]) -> Result<LspConfig> {
                 check_task(
                     &package_name,
                     task_name,
-                    app_name,
+                    &app_name,
                     &app_cfg,
                     &packages,
                 )


### PR DESCRIPTION
If a HUBRIS_APP environment variable is defined and points to an app.toml file, cargo xtask lsp will assume this is the app you'd like to use for build context.