### PR TITLE
oxcon2023g0: fix the build

### DIFF
--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -6,7 +6,7 @@ board = "oxcon2023g0"
 
 [kernel]
 name = "oxcon2023g0"
-requires = {flash = 11264, ram = 1296}
+requires = {flash = 11328, ram = 1296}
 stacksize = 640
 
 [tasks.jefe]
@@ -24,13 +24,13 @@ priority = 1
 max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio", "system_flash"]
 start = true
-features = ["g030"]
+features = ["g030", "no-ipc-counters"]
 stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.user_leds]
 name = "drv-user-leds"
-features = ["stm32g0"]
+features = ["stm32g0", "no-ipc-counters"]
 priority = 3
 max-sizes = {flash = 2048, ram = 256}
 start = true
@@ -46,11 +46,11 @@ max-sizes = {flash = 8192, ram = 4096}
 start = true
 task-slots = ["sys", "i2c_driver"]
 stacksize = 912
-features = ["stm32g0", "gpio", "i2c", "g030"]
+features = ["stm32g0", "gpio", "i2c", "g030", "micro"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
-features = ["g030"]
+features = ["g030", "no-ipc-counters"]
 priority = 2
 uses = ["i2c1"]
 start = true


### PR DESCRIPTION
The IPC counters made this too RAM hungry; opted out of them.