### PR TITLE
Bump `host-sp-comms` stacksize

### DIFF
--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -232,7 +232,7 @@ uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
 priority = 7
 max-sizes = {flash = 65536, ram = 65536}
-stacksize = 4096
+stacksize = 5080
 start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat", "i2c_driver", { spi_driver = "spi2_driver" }]
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]


### PR DESCRIPTION
The compiler bump in https://github.com/oxidecomputer/hubris/pull/1703 left us with a mere 24 bytes of `stackmargin` on `host-sp-comms` (down from about 1 KiB).  This manifests as sporadic stack overflows, basically if we hit an interrupt at exactly the wrong time.

Cores are collected in `/staff/dogfood/cores-collected-20240507`.  All of the per-task cores show the same issue:
```
matt@cadbury /staff/dogfood/cores-collected-20240507 () $ for f in $(find . -name "hubris.core.host_sp_comms*"); do printf "\n$f\n"; h --dump $f tasks; done

./BRM42220009/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 87005911
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401fff0 (was: ready)

./BRM42220017/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 86463960
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401ffd8 (was: ready)

./BRM44220011/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 35477746
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401fff0 (was: ready)

./BRM23230018-rev-d/hubris.core.host_sp_comms.1
humility: attached to dump
system time = 86618702
ID TASK                       GEN PRI STATE
16 host_sp_comms                1   7 FAULT: stack overflow; sp=0x2401fff0 (was: ready)

./BRM23230018-rev-d/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 41216464
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401fff0 (was: ready)

./BRM44220010/hubris.core.host_sp_comms.1
humility: attached to dump
system time = 1550511
ID TASK                       GEN PRI STATE
16 host_sp_comms                1   7 FAULT: stack overflow; sp=0x2401ffe0 (was: ready)

./BRM44220010/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 1550401
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401ffd0 (was: ready)

./BRM42220057/hubris.core.host_sp_comms.0
humility: attached to dump
system time = 1584024
ID TASK                       GEN PRI STATE
16 host_sp_comms                0   7 FAULT: stack overflow; sp=0x2401fff0 (was: ready)
```

This PR bumps us back to a healthy 1 KiB of stack margin.  Figuring out why `rustc` decided to sabotage our stacks is left as an exercise for the reader.