### PR TITLE
Bump Idol to get foo_ARGS struct fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idol"
 version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#b529f7b82face38cfc3851a641277fb7dfbedc4b"
+source = "git+https://github.com/oxidecomputer/idolatry.git#52c37586066b793584a18852db77b57ded70fd52"
 dependencies = [
  "indexmap 1.9.1",
  "once_cell",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "idol-runtime"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#b529f7b82face38cfc3851a641277fb7dfbedc4b"
+source = "git+https://github.com/oxidecomputer/idolatry.git#52c37586066b793584a18852db77b57ded70fd52"
 dependencies = [
  "counters",
  "userlib",


### PR DESCRIPTION
Between 46fec5217 (inclusive) and this commit (exclusive) we haven't generated DWARF info for the Idol ARGS struct in the specific case of a zero-argument function using non-zerocopy encoding. Humility 0.11.6 has been fixed to tolerate this, but in the interest of broader compatibility, we've also patched Idol to try and bring the debug info back.

This pulls in the Idol fix.

Fixes #1777