### PR TITLE
transceivers: fix I2C read bug

### DIFF
--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -173,9 +173,7 @@ fn write_reg_fields(
                     writeln!(
                         output,
                         "
-{prefix}        use zerocopy::AsBytes;
-{prefix}        #[derive(Copy, Clone, Eq, PartialEq, AsBytes)]
-{prefix}        #[repr(C)]
+{prefix}        #[derive(Copy, Clone, Eq, PartialEq)]
 {prefix}        #[allow(dead_code)]
 {prefix}        pub enum {encode_name} {{"
                     )

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -173,7 +173,9 @@ fn write_reg_fields(
                     writeln!(
                         output,
                         "
-{prefix}        #[derive(Copy, Clone, Eq, PartialEq)]
+{prefix}        use zerocopy::AsBytes;
+{prefix}        #[derive(Copy, Clone, Eq, PartialEq, AsBytes)]
+{prefix}        #[repr(C)]
 {prefix}        #[allow(dead_code)]
 {prefix}        pub enum {encode_name} {{"
                     )

--- a/drv/sidecar-front-io/src/transceivers.rs
+++ b/drv/sidecar-front-io/src/transceivers.rs
@@ -675,8 +675,7 @@ impl core::ops::Index<LogicalPort> for LogicalPortFailureTypes {
     }
 }
 
-#[derive(Copy, Clone, AsBytes)]
-#[repr(C)]
+#[derive(Copy, Clone)]
 pub struct PortI2CStatus {
     pub rdata_fifo_empty: bool,
     pub wdata_fifo_empty: bool,

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -270,9 +270,9 @@ impl ServerImpl {
             // increments of 1/256 degrees Celsius"
             //
             // - SFF-8636 rev 2.10a, Section 6.2.4
-            return Ok(Celsius(out.temperature.get() as f32 / 256.0));
+            Ok(Celsius(out.temperature.get() as f32 / 256.0))
         } else {
-            return Err(FpgaError::ImplError(status.as_bytes()[0]));
+            Err(FpgaError::ImplError(status.as_bytes()[0]))
         }
     }
 

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -272,7 +272,7 @@ impl ServerImpl {
             // - SFF-8636 rev 2.10a, Section 6.2.4
             Ok(Celsius(out.temperature.get() as f32 / 256.0))
         } else {
-            Err(FpgaError::ImplError(status.as_bytes()[0]))
+            Err(FpgaError::ImplError(status.error.as_bytes()[0]))
         }
     }
 
@@ -301,7 +301,7 @@ impl ServerImpl {
         } else {
             // TODO: how should we handle this?
             // Right now, we'll retry on the next pass through the loop.
-            Err(FpgaError::ImplError(status.as_bytes()[0]))
+            Err(FpgaError::ImplError(status.error.as_bytes()[0]))
         }
     }
 

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -272,7 +272,7 @@ impl ServerImpl {
             // - SFF-8636 rev 2.10a, Section 6.2.4
             Ok(Celsius(out.temperature.get() as f32 / 256.0))
         } else {
-            Err(FpgaError::ImplError(status.error.as_bytes()[0]))
+            Err(FpgaError::ImplError(status.error as u8))
         }
     }
 
@@ -301,7 +301,7 @@ impl ServerImpl {
         } else {
             // TODO: how should we handle this?
             // Right now, we'll retry on the next pass through the loop.
-            Err(FpgaError::ImplError(status.error.as_bytes()[0]))
+            Err(FpgaError::ImplError(status.error as u8))
         }
     }
 


### PR DESCRIPTION
#1768 did not properly account for the FIFO behavior of the FPGA's data buffers. The "check the status byte" portion of the loop happened outside the part where we read the buffer, and since the buffer was just memory-mapped registers it could be repeatedly without consequence. Since the data was now in a FIFO, I was inadvertently draining the FIFO before the transaction was done. This PR consolidates the "is I2C done yet" logic into the `get_i2c_status_and_read_buffer` so calling code can just deal with the status register and the data buffer.

Fixes #1786 