### PR TITLE
thermal: don't panic if MAX31790 init fails

### DIFF
--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -26,6 +26,7 @@ pub enum ThermalError {
     InvalidWatchdogTime = 7,
     InvalidParameter = 8,
     InvalidIndex = 9,
+    FanControllerUninitialized = 10,
 
     #[idol(server_death)]
     ServerDeath,

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 pub use drv_gimlet_seq_api::SeqError;
 use drv_gimlet_seq_api::{PowerState, Sequencer};
-use drv_i2c_devices::max31790::Max31790;
 use task_sensor_api::SensorId;
 use task_thermal_api::ThermalProperties;
 use userlib::{task_slot, units::Celsius, TaskId, UnwrapLite};
@@ -166,8 +165,7 @@ impl Bsp {
 
     pub fn new(i2c_task: TaskId) -> Self {
         // Initializes and build a handle to the fan controller IC
-        let fctrl =
-            Max31790State::new(Max31790::new(&devices::max31790(i2c_task)[0]));
+        let fctrl = Max31790State::new(&devices::max31790(i2c_task)[0]);
 
         // Handle for the sequencer task, which we check for power state
         let seq = Sequencer::from(SEQ.get_task_id());

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -6,11 +6,10 @@
 
 use crate::{
     control::{
-        ChannelType, Device, FanControl, Fans, InputChannel, PidConfig,
-        TemperatureSensor,
+        ChannelType, ControllerInitError, Device, FanControl, Fans,
+        InputChannel, Max31790State, PidConfig, TemperatureSensor,
     },
     i2c_config::{devices, sensors},
-    ControllerInitError,
 };
 pub use drv_gimlet_seq_api::SeqError;
 use drv_gimlet_seq_api::{PowerState, Sequencer};
@@ -63,7 +62,7 @@ pub(crate) struct Bsp {
     pub misc_sensors: &'static [TemperatureSensor],
 
     /// Fan control IC
-    fctrl: crate::Max31790State,
+    fctrl: Max31790State,
 
     /// Handle to the sequencer task, to query power state
     seq: Sequencer,
@@ -167,9 +166,8 @@ impl Bsp {
 
     pub fn new(i2c_task: TaskId) -> Self {
         // Initializes and build a handle to the fan controller IC
-        let fctrl = crate::Max31790State::new(Max31790::new(
-            &devices::max31790(i2c_task)[0],
-        ));
+        let fctrl =
+            Max31790State::new(Max31790::new(&devices::max31790(i2c_task)[0]));
 
         // Handle for the sequencer task, which we check for power state
         let seq = Sequencer::from(SEQ.get_task_id());

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -4,12 +4,9 @@
 
 //! BSP for Sidecar
 
-use crate::{
-    control::{
-        ChannelType, Device, FanControl, Fans, InputChannel, PidConfig,
-        TemperatureSensor,
-    },
-    ControllerInitError,
+use crate::control::{
+    ChannelType, ControllerInitError, Device, FanControl, Fans, InputChannel,
+    Max31790State, PidConfig, TemperatureSensor,
 };
 use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
@@ -68,8 +65,8 @@ pub(crate) struct Bsp {
     pub misc_sensors: &'static [TemperatureSensor],
 
     /// Our two fan controllers: east for 0/1 and west for 1/2
-    fctrl_east: crate::Max31790State,
-    fctrl_west: crate::Max31790State,
+    fctrl_east: Max31790State,
+    fctrl_west: Max31790State,
 
     seq: Sequencer,
 
@@ -177,10 +174,10 @@ impl Bsp {
         // fan presence
         let seq = Sequencer::from(SEQUENCER.get_task_id());
 
-        let fctrl_east = crate::Max31790State::new(Max31790::new(
+        let fctrl_east = Max31790State::new(Max31790::new(
             &devices::max31790_east(i2c_task),
         ));
-        let fctrl_west = crate::Max31790State::new(Max31790::new(
+        let fctrl_west = Max31790State::new(Max31790::new(
             &devices::max31790_west(i2c_task),
         ));
 

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -8,7 +8,6 @@ use crate::control::{
     ChannelType, ControllerInitError, Device, FanControl, Fans, InputChannel,
     Max31790State, PidConfig, TemperatureSensor,
 };
-use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
 pub use drv_sidecar_seq_api::SeqError;
 use drv_sidecar_seq_api::{Sequencer, TofinoSeqState, TofinoSequencerPolicy};
@@ -128,11 +127,11 @@ impl Bsp {
         // Run the function on each fan control chip
         match self.fan_control(0.into()) {
             Ok(c) => fctrl(c),
-            Err(e) => last_err = Err(e.into()),
+            Err(e) => last_err = Err(e),
         }
         match self.fan_control(4.into()) {
             Ok(c) => fctrl(c),
-            Err(e) => last_err = Err(e.into()),
+            Err(e) => last_err = Err(e),
         }
         last_err
     }
@@ -174,12 +173,8 @@ impl Bsp {
         // fan presence
         let seq = Sequencer::from(SEQUENCER.get_task_id());
 
-        let fctrl_east = Max31790State::new(Max31790::new(
-            &devices::max31790_east(i2c_task),
-        ));
-        let fctrl_west = Max31790State::new(Max31790::new(
-            &devices::max31790_west(i2c_task),
-        ));
+        let fctrl_east = Max31790State::new(&devices::max31790_east(i2c_task));
+        let fctrl_west = Max31790State::new(&devices::max31790_west(i2c_task));
 
         Self {
             seq,

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -6,7 +6,7 @@ use crate::{
     bsp::{self, Bsp, PowerBitmask},
     Fan, ThermalError, Trace,
 };
-use drv_i2c_api::ResponseCode;
+use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::{
     max31790::{I2cWatchdog, Max31790},
     nvme_bmc::NvmeBmc,
@@ -295,9 +295,9 @@ pub(crate) struct Max31790State {
 }
 
 impl Max31790State {
-    pub(crate) fn new(max31790: Max31790) -> Self {
+    pub(crate) fn new(dev: &I2cDevice) -> Self {
         let mut this = Self {
-            max31790,
+            max31790: Max31790::new(dev),
             initialized: false,
         };
         // When we first start up, try to initialize the fan controller a few

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -38,7 +38,7 @@ use crate::{
     control::ThermalControl,
 };
 use drv_i2c_api::ResponseCode;
-use drv_i2c_devices::max31790::{I2cWatchdog, Max31790};
+use drv_i2c_devices::max31790::I2cWatchdog;
 use idol_runtime::{NotificationHandler, RequestError};
 use ringbuf::*;
 use task_sensor_api::{Sensor as SensorApi, SensorId};
@@ -92,71 +92,6 @@ enum Trace {
 counted_ringbuf!(Trace, 32, Trace::None);
 
 ////////////////////////////////////////////////////////////////////////////////
-
-pub(crate) struct Max31790State {
-    max31790: Max31790,
-    initialized: bool,
-}
-
-impl Max31790State {
-    pub(crate) fn new(max31790: Max31790) -> Self {
-        let mut this = Self {
-            max31790,
-            initialized: false,
-        };
-        // When we first start up, try to initialize the fan controller a few
-        // times, in case there's a transient I2C error.
-        for remaining in (0..3).rev() {
-            if this.initialize().is_ok() {
-                break;
-            }
-            ringbuf_entry!(Trace::FanControllerInitRetry { remaining });
-        }
-        this
-    }
-
-    /// Access the fan controller, attempting to initialize it if it has not yet
-    /// been initialized.
-    #[inline]
-    pub(crate) fn try_initialize(
-        &mut self,
-    ) -> Result<&mut Max31790, ControllerInitError> {
-        if self.initialized {
-            return Ok(&mut self.max31790);
-        }
-
-        self.initialize()
-    }
-
-    // Slow path that actually performs initialization. This is "outlined" so
-    // that we can avoid pushing a stack frame in the case where we just need to
-    // check a bool and return a pointer.
-    #[inline(never)]
-    fn initialize(&mut self) -> Result<&mut Max31790, ControllerInitError> {
-        self.max31790.initialize().map_err(|e| {
-            ringbuf_entry!(Trace::FanControllerInitError(e));
-            ControllerInitError(e)
-        })?;
-
-        self.initialized = true;
-        ringbuf_entry!(Trace::FanControllerInitialized);
-        Ok(&mut self.max31790)
-    }
-}
-
-pub(crate) struct ControllerInitError(ResponseCode);
-
-impl From<ControllerInitError> for ThermalError {
-    fn from(_: ControllerInitError) -> Self {
-        ThermalError::FanControllerUninitialized
-    }
-}
-
-impl From<ControllerInitError> for SensorReadError {
-    fn from(ControllerInitError(code): ControllerInitError) -> Self {
-        SensorReadError::I2cError(code)
-    }
-}
 
 struct ServerImpl<'a> {
     mode: ThermalMode,


### PR DESCRIPTION
Currently, the `thermal` task tries to initialize the MAX31790 fan
controller(s) once when the task starts, and `unwrap_lite`s the result.
This means that in the face of a transient I2C error, the whole task
panics and gets restarted. This is unfortunate: sometimes, the bus is
briefly locked or arbitration is lost or something, and then everything
is fine. Furthermore, if we can't talk to the MAX31790, its watchdog
will trip and it'll just run the fans at 100%...and would probably
prefer to just let the `thermal` task keep running and publishing sensor
readings, rather than crashlooping.

This commit changes the `thermal` task to track whether it has
initialized the MAX31790(s), and if it hasn't yet, any operation which
will attempt to talk to the MAX31790(s) will first try to initialize the
fan controller. IPC operations which require an initialized fan
controller will return an error to the caller if it can't be
fan controller. IPC operations which require an initialized fan
controller will return an error to the caller if it can't be
initialized, but the `thermal` task will stay running, reading sensor
data, and continue trying to initialize the fan controller every time
the thermal control loop runs. This way, we don't have crash loops and
can tolerate temporary I2C jank.

For example, here's what happens when I flash the `gimlet-c` firmware on
a board that doesn't have a `rear` I2C bus:

```console
eliza@niles ~ $ pfexec humility -t gimlet-c tasks
humility: attached to 0483:3754:000D00344741500820383733 via ST-Link V3
system time = 8810
ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+90)
  1 net                          0   5 notif: jefe-state-change
  2 sys                          0   1 recv, notif: exti-wildcard-irq(irq6/irq7/irq8/irq9/irq10/irq23/irq40)
  3 spi2_driver                  0   3 recv(gimlet_seq/gen0 only)
  4 i2c_driver                   0   3 recv
  5 spd                          0   2 notif: jefe-state-change
  6 packrat                      0   1 recv
  7 thermal                      0   5 wait: send to gimlet_seq/gen0
  8 power                        0   6 wait: send to gimlet_seq/gen0
  9 hiffy                        0   5 notif: bit31(T+232)
10 gimlet_seq                   0   4 notif: bit31(T+2)
11 gimlet_inspector             0   6 wait: send to net/gen0
12 hash_driver                  0   2 recv
13 hf                           0   3 notif: bit31(T+218)
14 update_server                0   3 recv
15 sensor                       0   4 recv
16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
17 udpecho                      0   6 wait: send to net/gen0
18 udpbroadcast                 0   6 wait: send to net/gen0
19 control_plane_agent          0   6 wait: send to net/gen0
20 sprot                        0   4 recv
21 validate                     0   5 recv
22 vpd                          0   4 recv
23 user_leds                    0   2 recv, notif: timer
24 dump_agent                   0   6 wait: send to net/gen0
25 sbrmi                        0   4 recv
26 idle                         0   8 RUNNING
27 udprpc                       0   6 wait: send to net/gen0
eliza@niles ~ $ pfexec humility -t gimlet-c ringbuf thermal
humility: attached to 0483:3754:000D00344741500820383733 via ST-Link V3
humility: ring buffer drv_i2c_devices::max31790::__RINGBUF in thermal:
humility: ring buffer task_thermal::__RINGBUF in thermal:
    TOTAL VARIANT
        8 FanControllerInitError(BusLocked)
        6 FanReadFailed
        6 FanAdded
        5 MiscReadFailed
        1 Start
        1 ThermalMode(Auto)
        1 AutoState(Boot)
  NDX LINE      GEN    COUNT PAYLOAD
    0  394        1        1 Start
    1  116        1        1 FanControllerInitError(BusLocked)
    2  180        1        1 ThermalMode(Auto)
    3  633        1        1 AutoState(Boot)
    4  116        1        1 FanControllerInitError(BusLocked)
    5  642        1        1 FanAdded(Fan(0x0))
    6  642        1        1 FanAdded(Fan(0x1))
    7  642        1        1 FanAdded(Fan(0x2))
    8  642        1        1 FanAdded(Fan(0x3))
    9  642        1        1 FanAdded(Fan(0x4))
  10  642        1        1 FanAdded(Fan(0x5))
  11  116        1        1 FanControllerInitError(BusLocked)
  12  675        1        1 FanReadFailed(SensorId(0x63), I2cError(BusLocked))
  13  116        1        1 FanControllerInitError(BusLocked)
  14  675        1        1 FanReadFailed(SensorId(0x64), I2cError(BusLocked))
  15  116        1        1 FanControllerInitError(BusLocked)
  16  675        1        1 FanReadFailed(SensorId(0x65), I2cError(BusLocked))
  17  116        1        1 FanControllerInitError(BusLocked)
  18  675        1        1 FanReadFailed(SensorId(0x66), I2cError(BusLocked))
  19  116        1        1 FanControllerInitError(BusLocked)
  20  675        1        1 FanReadFailed(SensorId(0x67), I2cError(BusLocked))
  21  116        1        1 FanControllerInitError(BusLocked)
  22  675        1        1 FanReadFailed(SensorId(0x68), I2cError(BusLocked))
  23  688        1        1 MiscReadFailed(SensorId(0x2), I2cError(NoDevice))
  24  688        1        1 MiscReadFailed(SensorId(0x6e), I2cError(BusLocked))
  25  688        1        1 MiscReadFailed(SensorId(0x6c), I2cError(BusLocked))
  26  688        1        1 MiscReadFailed(SensorId(0x6d), I2cError(BusLocked))
  27  688        1        1 MiscReadFailed(SensorId(0x1), I2cError(NoDevice))
eliza@niles ~ $
```

Note that:
- The `thermal` task has not crashed, even though there's no MAX31790 on
  the bus whatsoever
- Thermal control loop iterations have continued trying to poll the
  various sensors --- in this case, they *also* don't exist, but if they
  did, the sensor readings would be published successfully even though
  the thermal task isn't driving the fan controller.

Fixes #1779