### PR TITLE
Add a long timeout for setting boot component

### DIFF
--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1332,11 +1332,8 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
             duration,
         });
         let tx_size = Request::pack(&body, self.tx_buf);
-        let rsp = self.do_send_recv_retries(
-            tx_size,
-            TIMEOUT_QUICK,
-            DEFAULT_ATTEMPTS,
-        )?;
+        let rsp =
+            self.do_send_recv_retries(tx_size, TIMEOUT_LONG, DEFAULT_ATTEMPTS)?;
         if let RspBody::Ok = rsp.body? {
             Ok(())
         } else {


### PR DESCRIPTION
Setting the stage0 boot component involves writing to flash which requires a longer timeout