### PR TITLE
Remove unconnected QSPI reset line

### DIFF
--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -102,6 +102,10 @@ fn main() -> ! {
         sys_api::Alternate::AF10,
     );
 
+    // Ensure hold time for reset in case we just restarted.
+    // TODO look up actual hold time requirement
+    hl::sleep_for(15);
+
     // TODO: check the ID and make sure it's what we expect
     //
     // Gimlet is  MT25QU256ABA8E12

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -102,26 +102,6 @@ fn main() -> ! {
         sys_api::Alternate::AF10,
     );
 
-    let qspi_reset = sys_api::Port::F.pin(5);
-    sys.gpio_reset(qspi_reset);
-    sys.gpio_configure_output(
-        qspi_reset,
-        sys_api::OutputType::PushPull,
-        sys_api::Speed::Low,
-        sys_api::Pull::None,
-    );
-
-    // TODO: The best clock frequency to use can vary based on the flash
-    // part, the command used, and signal integrity limits of the board.
-
-    // Ensure hold time for reset in case we just restarted.
-    // TODO look up actual hold time requirement
-    hl::sleep_for(1);
-
-    // Release reset and let it stabilize.
-    sys.gpio_set(qspi_reset);
-    hl::sleep_for(10);
-
     // TODO: check the ID and make sure it's what we expect
     //
     // Gimlet is  MT25QU256ABA8E12


### PR DESCRIPTION
This is a legacy pin from the original Gemini Bringup Board, and isn't actually connected on Sidecar (PF5 is `V1P8_PG_A2`, which we're presumably fighting against)