### PR TITLE
xtask: Allow tasks & the kernel to specify default features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,7 @@ name = "drv-stm32h7-fmc-demo-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
+ "cfg-if",
  "cortex-m",
  "counters",
  "drv-stm32xx-sys-api",

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -222,14 +222,14 @@ impl Config {
         &self,
         verbose: bool,
         crate_name: &str,
+        no_default_features: bool,
         features: &[String],
         sysroot: Option<&'a Path>,
     ) -> BuildConfig<'a> {
-        let mut args = vec![
-            "--no-default-features".to_string(),
-            "--target".to_string(),
-            self.target.to_string(),
-        ];
+        let mut args = vec!["--target".to_string(), self.target.to_string()];
+        if no_default_features {
+            args.push("--no-default-features".to_string());
+        }
         if verbose {
             args.push("-v".to_string());
         }
@@ -305,6 +305,7 @@ impl Config {
         let mut out = self.common_build_config(
             verbose,
             &self.kernel.name,
+            self.kernel.no_default_features,
             &self.kernel.features,
             sysroot,
         );
@@ -327,6 +328,7 @@ impl Config {
         let mut out = self.common_build_config(
             verbose,
             &task_toml.name,
+            task_toml.no_default_features,
             &task_toml.features,
             sysroot,
         );
@@ -626,6 +628,8 @@ pub struct Kernel {
     pub stacksize: Option<u32>,
     #[serde(default)]
     pub features: Vec<String>,
+    #[serde(default)]
+    pub no_default_features: bool,
 }
 
 fn default_name() -> String {

--- a/drv/stm32h7-fmc-demo-server/Cargo.toml
+++ b/drv/stm32h7-fmc-demo-server/Cargo.toml
@@ -12,6 +12,7 @@ task-net-api = { path = "../../task/net-api", features = ["vlan"] }
 
 cortex-m = { workspace = true }
 idol-runtime = { workspace = true }
+cfg-if = { workspace = true }
 num-traits = { workspace = true }
 stm32h7 = { workspace = true }
 serde = { workspace = true }
@@ -22,7 +23,6 @@ build-util = { path = "../../build/util" }
 idol = { workspace = true }
 
 [features]
-default = ["h743"]
 h743 = ["stm32h7/stm32h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753"]
 init-hw = []

--- a/drv/stm32h7-fmc-demo-server/src/main.rs
+++ b/drv/stm32h7-fmc-demo-server/src/main.rs
@@ -16,11 +16,15 @@ use task_net_api::{
 };
 use userlib::*;
 
-#[cfg(feature = "h743")]
-use stm32h7::stm32h743 as device;
-
-#[cfg(feature = "h753")]
-use stm32h7::stm32h753 as device;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "h743")] {
+        use stm32h7::stm32h743 as device;
+    } else if #[cfg(feature = "h753")] {
+        use stm32h7::stm32h753 as device;
+    } else {
+        compile_error!("missing supported SoC feature");
+    }
+}
 
 use drv_stm32xx_sys_api as sys_api;
 use idol_runtime::{NotificationHandler, RequestError};

--- a/lib/toml-task/src/lib.rs
+++ b/lib/toml-task/src/lib.rs
@@ -58,6 +58,8 @@ pub struct Task<T = ordered_toml::Value> {
     pub sections: IndexMap<String, String>,
     #[serde(default)]
     pub max_sizes: IndexMap<String, u32>,
+    #[serde(default)]
+    pub no_default_features: bool,
 }
 
 impl<T> Task<T> {

--- a/task/idle/Cargo.toml
+++ b/task/idle/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
 insomniac = []
 
 [dependencies]


### PR DESCRIPTION
tasks & kernels that want to disable default features can do so using the `no-default-features` boolean in the task / kernel config sections of the relevant `app.toml` files.

this resolves #1829 