### PR TITLE
stm32xx-sys: move GPIO IRQ codegen to tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ version = "0.1.0"
 dependencies = [
  "build-fpga-regmap",
  "build-i2c",
+ "build-stm32xx-sys",
  "build-util",
  "byteorder",
  "cfg-if",
@@ -1978,6 +1979,7 @@ name = "drv-stm32h7-sprot-server"
 version = "0.1.0"
 dependencies = [
  "attest-api",
+ "build-stm32xx-sys",
  "build-util",
  "cfg-if",
  "drv-caboose",
@@ -2112,7 +2114,6 @@ dependencies = [
 name = "drv-stm32xx-sys-api"
 version = "0.1.0"
 dependencies = [
- "build-stm32xx-sys",
  "byteorder",
  "cfg-if",
  "counters",
@@ -4722,6 +4723,7 @@ dependencies = [
 name = "task-nucleo-user-button"
 version = "0.1.0"
 dependencies = [
+ "build-stm32xx-sys",
  "build-util",
  "counters",
  "drv-stm32xx-sys-api",

--- a/build/stm32xx-sys/src/lib.rs
+++ b/build/stm32xx-sys/src/lib.rs
@@ -117,7 +117,7 @@ pub fn build_gpio_irq_pins() -> anyhow::Result<()> {
 
     let tokens = quote! {
         pub mod gpio_irq_pins {
-            use drv_stm32xx_gpio_common::{PinSet, Port};
+            use drv_stm32xx_sys_api::{PinSet, Port};
             #( #pins )*
         }
     };

--- a/drv/gimlet-seq-server/Cargo.toml
+++ b/drv/gimlet-seq-server/Cargo.toml
@@ -34,6 +34,7 @@ spd = { workspace = true }
 build-fpga-regmap = { path = "../../build/fpga-regmap" }
 build-i2c = { path = "../../build/i2c" }
 build-util = { path = "../../build/util" }
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 gnarle = { path = "../../lib/gnarle", features=["std"] }
 
 idol = { workspace = true }

--- a/drv/gimlet-seq-server/build.rs
+++ b/drv/gimlet-seq-server/build.rs
@@ -17,6 +17,7 @@ struct Config {
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
+    build_stm32xx_sys::build_gpio_irq_pins()?;
 
     let config = build_util::task_config::<Config>()?;
 

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -1427,3 +1427,4 @@ mod idl {
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
+include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -26,11 +26,12 @@
 /// faults after this condition; we will wait until the machine next makes an
 /// A2 to A0 transition to clear faults.
 ///
+use crate::gpio_irq_pins::VCORE_TO_SP_ALERT_L;
 use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::raa229618::Raa229618;
 use drv_stm32xx_sys_api as sys_api;
 use ringbuf::*;
-use sys_api::{gpio_irq_pins::VCORE_TO_SP_ALERT_L, IrqControl};
+use sys_api::IrqControl;
 use userlib::*;
 
 pub struct VCore {

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -26,6 +26,7 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 idol = { workspace = true }
 
 [features]

--- a/drv/stm32h7-sprot-server/build.rs
+++ b/drv/stm32h7-sprot-server/build.rs
@@ -5,6 +5,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
+    build_stm32xx_sys::build_gpio_irq_pins()?;
 
     idol::Generator::new()
         .with_counters(

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -102,7 +102,7 @@ const DUMP_TIMEOUT: u32 = 1000;
 
 // On Gemini, the STM32H753 is in a LQFP176 package with ROT_IRQ
 // on pin2/PE3
-use drv_stm32xx_sys_api::gpio_irq_pins::ROT_IRQ;
+use gpio_irq_pins::ROT_IRQ;
 
 // We use spi3 on gimletlet and spi4 on gemini and gimlet.
 // You should be able to move the RoT board between SPI3, SPI4, and SPI6
@@ -1367,3 +1367,4 @@ mod idl {
 }
 
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
+include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));

--- a/drv/stm32xx-sys-api/Cargo.toml
+++ b/drv/stm32xx-sys-api/Cargo.toml
@@ -18,7 +18,6 @@ userlib = { path = "../../sys/userlib" }
 
 [build-dependencies]
 idol.workspace = true
-build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 
 [features]
 family-stm32h7 = ["drv-stm32xx-gpio-common/family-stm32h7"]

--- a/drv/stm32xx-sys-api/build.rs
+++ b/drv/stm32xx-sys-api/build.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    build_stm32xx_sys::build_gpio_irq_pins()?;
     idol::client::build_client_stub(
         "../../idl/stm32xx-sys.idol",
         "client_stub.rs",

--- a/drv/stm32xx-sys-api/src/lib.rs
+++ b/drv/stm32xx-sys-api/src/lib.rs
@@ -367,4 +367,3 @@ impl From<Option<bool>> for IrqControl {
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
-include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));

--- a/task/nucleo-user-button/Cargo.toml
+++ b/task/nucleo-user-button/Cargo.toml
@@ -16,6 +16,7 @@ task-config = { path = "../../lib/task-config" }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 
 [[bin]]
 name = "task-nucleo-user-button"

--- a/task/nucleo-user-button/build.rs
+++ b/task/nucleo-user-button/build.rs
@@ -5,5 +5,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
+
+    build_stm32xx_sys::build_gpio_irq_pins()?;
+
     Ok(())
 }

--- a/task/nucleo-user-button/src/main.rs
+++ b/task/nucleo-user-button/src/main.rs
@@ -71,10 +71,7 @@ pub fn main() -> ! {
         edge: Edge::Rising,
     });
 
-    sys.gpio_configure_input(
-        drv_stm32xx_sys_api::gpio_irq_pins::BUTTON,
-        Pull::None,
-    );
+    sys.gpio_configure_input(gpio_irq_pins::BUTTON, Pull::None);
 
     ringbuf_entry!(Trace::GpioIrqConfigure {
         mask: notifications::BUTTON_MASK,
@@ -112,3 +109,4 @@ pub fn main() -> ! {
 }
 
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
+include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));


### PR DESCRIPTION
Using GPIO interrupts (EXTI) on STM32xx devices involves code generation based on the pins mapped to EXTI interrupts in the app config. Currently, this code generation is done when building the `drv-stm32xx-sys-api` crate. Unfortunately, this codegen depends on `task_name` to determine which task's GPIO pin IRQs to build the generated code for, which results in `drv-stm32xx-sys-api` being recompiled for each task in an image when it would not otherwise be necessary to do so. This is a shame, as it results in substantially longer builds; see #1828 for details.

There isn't *really* any reason that this code needs to be generated in the `drv-stm32xx-sys-api` crate rather than in the `build.rs` files for the tasks that actually use GPIO interrupts. The only reason for doing it this way is "I thought it seemed nicer" and that it let downstream tasks avoid typing
```rust
include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));
```
but that's not as important as avoiding unnecessary recompilation. Therefore, this commit fixes this by removing the GPIO interrupt codegen from `drv-stm32xx-sys-api`, and instead having the build scripts for the individual tasks that actually require EXTI GPIO IRQs depend on `build-stm32xx-sys` and do the codegen themselves. This way, we should be able to avoid rebuilding `drv-stm32xx-sys-api` as many times.

This approach only required one very small change to the codegen, changing it to import a few types from `drv-stm32xx-sys-api` rather than `drv-stm32xx-gpio-common`, so that we don't have to add an explicit dependency on the latter in the tasks that use the codegen. This shouldn't have any real impact, since the only reason we got those types from `drv-stm32xx-gpio-common` previously was that the generated code was *in* `drv-stm32xx-sys-api`.

Fixes #1828