### PR TITLE
grapefruit: add fmc-demo IP interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,9 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "serde",
+ "static-cell",
  "stm32h7",
+ "task-net-api",
  "userlib",
 ]
 

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -154,14 +154,6 @@ task-slots = ["jefe"]
 stacksize = 1200
 extern-regions = [ "sram2", "sram3", "sram4" ]
 
-[tasks.fmc_demo]
-name = "drv-stm32h7-fmc-demo-server"
-features = ["h743"]
-priority = 4
-start = true
-task-slots = ["sys"]
-uses = ["fmc_nor_psram_bank_1"]
-
 [config]
 
 [[config.i2c.controllers]]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -205,14 +205,6 @@ task-slots = ["jefe"]
 stacksize = 1200
 extern-regions = [ "sram2", "sram3", "sram4" ]
 
-[tasks.fmc_demo]
-name = "drv-stm32h7-fmc-demo-server"
-features = ["h753"]
-priority = 4
-start = true
-task-slots = ["sys"]
-uses = ["fmc", "fmc_nor_psram_bank_1"]
-
 [config]
 [[config.i2c.controllers]]
 controller = 2

--- a/app/grapefruit/app.toml
+++ b/app/grapefruit/app.toml
@@ -244,8 +244,9 @@ name = "drv-stm32h7-fmc-demo-server"
 features = ["h753"]
 priority = 4
 start = true
-task-slots = ["sys"]
+task-slots = ["sys", "net"]
 uses = ["fmc", "fmc_nor_psram_bank_1"]
+notifications = ["socket"]
 
 [tasks.fmc_nor_flash]
 name = "drv-fmc-nor-flash"
@@ -293,6 +294,13 @@ owner = {name = "dump_agent", notification = "socket"}
 port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.fmc_test]
+kind = "udp"
+owner = {name = "fmc_demo", notification = "socket"}
+port = 11114
+tx = { packets = 3, bytes = 4096 }
+rx = { packets = 3, bytes = 4096 }
 
 ################################################################################
 

--- a/drv/stm32h7-fmc-demo-server/Cargo.toml
+++ b/drv/stm32h7-fmc-demo-server/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 counters = { path = "../../lib/counters" }
+static-cell = { path = "../../lib/static-cell" }
+task-net-api = { path = "../../task/net-api", features = ["vlan"] }
 
 cortex-m = { workspace = true }
 idol-runtime = { workspace = true }

--- a/drv/stm32h7-fmc-demo-server/README.md
+++ b/drv/stm32h7-fmc-demo-server/README.md
@@ -2,3 +2,37 @@
 
 This task maps in a 16-bit multiplexed PSRAM bus and lets you do incredibly
 ill-advised things to it. It is intended for interface testing only, do not eat.
+
+
+## Network protocol
+
+This task can be bound to a UDP socket to allow ill-advised things over the
+network. Here's the UDP protocol.
+
+Packets sent to the device always begin with a two-byte header:
+- `version` (1 byte): currently 0
+- `command` (1 byte)
+
+The only currently defined `command` is 0.
+
+Following this is a series of arguments to command 0, which describe a sequence
+of memory operations. Arguments are simply concatenated together. Each starts
+with an identifier byte, and some are followed by additional bytes. Any sequence
+of the following is acceptable:
+
+- `address` (0) followed by a little-endian 32-bit address. This loads the
+  address into the internal address register used by subsequent peeks and pokes.
+- `peek` (1/2/3/4) reads an 8/16/32/64-bit (respectively) value from memory at
+  the current address and concatenates it (in little endian order) onto the
+  response packet.
+- `peek_advance` (5/6/7/8) operate like the corresponding `peek` operations, but
+  also advance the address register by the size of data being operated on.
+- `poke` (9/10/11/12), followed by an 8/16/32/64-bit (respectively)
+  little-endian value, writes that value into memory at the address in the
+  address register. Nothing is appended to the response.
+- `poke_advance` (13/14/15/16) operate like the corresponding `poke` operations,
+  but also advance the address register by the size of data being operated on.
+
+The response starts with a single byte, which is zero for success and non-zero
+for failure. On success, the results of all peek operations are concatenated
+after the first byte, in order.

--- a/drv/stm32h7-fmc-demo-server/src/main.rs
+++ b/drv/stm32h7-fmc-demo-server/src/main.rs
@@ -7,8 +7,13 @@
 #![no_std]
 #![no_main]
 
-use core::convert::Infallible;
+use core::{convert::Infallible, mem::take};
+use counters::{count, Count};
+use static_cell::ClaimOnceCell;
 use sys_api::{Alternate, OutputType, Peripheral, Port, Pull, Speed};
+use task_net_api::{
+    LargePayloadBehavior, Net, RecvError, SendError, SocketName,
+};
 use userlib::*;
 
 #[cfg(feature = "h743")]
@@ -21,6 +26,16 @@ use drv_stm32xx_sys_api as sys_api;
 use idol_runtime::{NotificationHandler, RequestError};
 
 task_slot!(SYS, sys);
+task_slot!(NET, net);
+
+#[derive(Count, Copy, Clone)]
+enum Event {
+    RecvPacket,
+    RequestRejected,
+    Respond,
+}
+
+counters::counters!(Event);
 
 fn initialize_hardware() {
     let sys = sys_api::Sys::from(SYS.get_task_id());
@@ -206,6 +221,9 @@ fn initialize_hardware() {
     fmc.bcr1.modify(|_, w| w.fmcen().set_bit());
 }
 
+static RX_PACKET: ClaimOnceCell<[u8; 1024]> = ClaimOnceCell::new([0; 1024]);
+static TX_PACKET: ClaimOnceCell<[u8; 1024]> = ClaimOnceCell::new([0; 1024]);
+
 #[export_name = "main"]
 fn main() -> ! {
     if cfg!(feature = "init-hw") {
@@ -216,8 +234,17 @@ fn main() -> ! {
     // space, which is fine even if it aliases (which it doesn't).
     let fmc = unsafe { &*device::FMC::ptr() };
 
+    let net = Net::from(NET.get_task_id());
+
     // Fire up a server.
-    let mut server = ServerImpl { fmc };
+    let rx_packet = RX_PACKET.claim();
+    let tx_packet = TX_PACKET.claim();
+    let mut server = ServerImpl {
+        fmc,
+        net,
+        rx_packet,
+        tx_packet,
+    };
     let mut buffer = [0; idl::INCOMING_SIZE];
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
@@ -226,15 +253,75 @@ fn main() -> ! {
 
 struct ServerImpl {
     fmc: &'static device::fmc::RegisterBlock,
+    net: Net,
+    rx_packet: &'static mut [u8; 1024],
+    tx_packet: &'static mut [u8; 1024],
 }
 
 impl NotificationHandler for ServerImpl {
     fn current_notification_mask(&self) -> u32 {
-        0
+        notifications::SOCKET_MASK
     }
 
-    fn handle_notification(&mut self, _bits: u32) {
-        unreachable!()
+    fn handle_notification(&mut self, bits: u32) {
+        if bits & notifications::SOCKET_MASK != 0 {
+            const SOCKET: SocketName = SocketName::fmc_test;
+            loop {
+                match self.net.recv_packet(
+                    SOCKET,
+                    LargePayloadBehavior::Discard,
+                    self.rx_packet,
+                ) {
+                    Ok(mut meta) => {
+                        count!(Event::RecvPacket);
+                        let data = &mut self.rx_packet[..meta.size as usize];
+                        match process_network_packet(data, self.tx_packet) {
+                            Ok(size) => {
+                                meta.size = size as u32;
+                                count!(Event::Respond);
+                            }
+                            Err(e) => {
+                                count!(Event::RequestRejected);
+                                self.tx_packet[0] = e as u8;
+                                meta.size = 1;
+                            }
+                        }
+                        let response = &self.tx_packet[..meta.size as usize];
+                        // We're going to send best-effort because the only
+                        // thing that can really go wrong here is filling our
+                        // own queue, which, well, send slower.
+                        while let Err(e) =
+                            self.net.send_packet(SOCKET, meta, response)
+                        {
+                            match e {
+                                SendError::QueueFull => {
+                                    // We've run out of transmit space, which is
+                                    // weird, but ok. Wait for it to appear. To
+                                    // simplify the code, we won't listen for
+                                    // IPCs during this time.
+                                    sys_recv_notification(
+                                        notifications::SOCKET_MASK,
+                                    );
+                                }
+                                SendError::ServerRestarted => {
+                                    // No need to wait.
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    Err(RecvError::QueueEmpty) => {
+                        // We've got all the packets, go back to handling IPCs.
+                        break;
+                    }
+                    Err(RecvError::ServerRestarted) => {
+                        // uh, net stack restarted, chances are good whatever
+                        // packet we were reaching for has been dropped.
+                        // Nevertheless, try again until it says queue empty.
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -390,6 +477,152 @@ impl idl::InOrderFmcDemoImpl for ServerImpl {
         });
         Ok(())
     }
+}
+
+fn process_network_packet(
+    mut packet: &[u8],
+    mut response: &mut [u8],
+) -> Result<usize, NetworkError> {
+    let orig_response_len = response.len();
+
+    let version = read_byte(&mut packet)?;
+    let operation = read_byte(&mut packet)?;
+    if version != 0 || operation != 0 {
+        return Err(NetworkError::NotUnderstood);
+    }
+    let mut address = 0x6000_0000;
+
+    // Prepare for success
+    write_byte(0, &mut response)?;
+
+    while let Ok(byte) = read_byte(&mut packet) {
+        match byte {
+            0 => {
+                // Set Address
+                address = u32::from_le_bytes(read_chunk(&mut packet)?) as usize;
+            }
+            1 | 5 => {
+                // Peek8 / Peek8Advance
+                let b =
+                    unsafe { core::ptr::read_volatile(address as *const u8) };
+                write_byte(b, &mut response)?;
+                if byte == 5 {
+                    address += 1;
+                }
+            }
+            2 | 6 => {
+                // Peek16 / Peek16Advance
+                let b =
+                    unsafe { core::ptr::read_volatile(address as *const u16) };
+                write_chunk(b.to_le_bytes(), &mut response)?;
+                if byte == 6 {
+                    address += 2;
+                }
+            }
+            3 | 7 => {
+                // Peek32 / Peek32Advance
+                let b =
+                    unsafe { core::ptr::read_volatile(address as *const u32) };
+                write_chunk(b.to_le_bytes(), &mut response)?;
+                if byte == 7 {
+                    address += 4;
+                }
+            }
+            4 | 8 => {
+                // Peek64 / Peek64Advance
+                let b =
+                    unsafe { core::ptr::read_volatile(address as *const u64) };
+                write_chunk(b.to_le_bytes(), &mut response)?;
+                if byte == 8 {
+                    address += 8;
+                }
+            }
+
+            9 | 13 => {
+                // Poke8 / Poke8Advance
+                let x = read_byte(&mut packet)?;
+                unsafe {
+                    core::ptr::write_volatile(address as *mut u8, x);
+                }
+                if byte == 13 {
+                    address += 1;
+                }
+            }
+            10 | 14 => {
+                // Poke16 / Poke16Advance
+                let x = u16::from_le_bytes(read_chunk(&mut packet)?);
+                unsafe {
+                    core::ptr::write_volatile(address as *mut u16, x);
+                }
+                if byte == 14 {
+                    address += 2;
+                }
+            }
+            11 | 15 => {
+                // Poke32 / Poke32Advance
+                let x = u32::from_le_bytes(read_chunk(&mut packet)?);
+                unsafe {
+                    core::ptr::write_volatile(address as *mut u32, x);
+                }
+                if byte == 15 {
+                    address += 4;
+                }
+            }
+            12 | 16 => {
+                // Poke64 / Poke64Advance
+                let x = u64::from_le_bytes(read_chunk(&mut packet)?);
+                unsafe {
+                    core::ptr::write_volatile(address as *mut u64, x);
+                }
+                if byte == 16 {
+                    address += 8;
+                }
+            }
+            _ => return Err(NetworkError::NotUnderstood),
+        }
+    }
+
+    Ok(orig_response_len - response.len())
+}
+
+fn read_byte(buf: &mut &[u8]) -> Result<u8, NetworkError> {
+    let [byte] = read_chunk(buf)?;
+    Ok(byte)
+}
+
+fn read_chunk<const N: usize>(
+    buf: &mut &[u8],
+) -> Result<[u8; N], NetworkError> {
+    let (&first, rest) =
+        buf.split_first_chunk().ok_or(NetworkError::Truncated)?;
+    *buf = rest;
+    Ok(first)
+}
+
+fn write_byte(byte: u8, buf: &mut &mut [u8]) -> Result<(), NetworkError> {
+    write_chunk([byte], buf)
+}
+
+fn write_chunk<const N: usize>(
+    bytes: [u8; N],
+    buf: &mut &mut [u8],
+) -> Result<(), NetworkError> {
+    let tbuf = take(buf);
+    let (first, rest) = tbuf
+        .split_first_chunk_mut()
+        .ok_or(NetworkError::ResponseTooBig)?;
+    *first = bytes;
+    *buf = rest;
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+enum NetworkError {
+    // please do not use zero here.
+    Truncated = 1,
+    NotUnderstood = 2,
+    ResponseTooBig = 3,
 }
 
 mod idl {


### PR DESCRIPTION
This adds a UDP interface for messing with Grapefruit's FPGA. The protocol is documented in `drv/stm32h7-fmc-demo-server/README.md`.