### PR TITLE
Add APIs to check if the RoT is dev or release

### DIFF
--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -7,11 +7,11 @@ use attest_api::Attest;
 use crc::{Crc, CRC_32_CKSUM};
 use drv_lpc55_update_api::{RotComponent, RotPage, SlotId, Update};
 use drv_sprot_api::{
-    AttestReq, AttestRsp, CabooseReq, CabooseRsp, DumpReq, PolicyDevOrRelease,
-    PolicyReq, PolicyRsp, ReqBody, Request, Response, RotIoStats, RotPageRsp,
-    RotState, RotStatus, RspBody, SprocketsError, SprotError,
-    SprotProtocolError, SwdReq, UpdateReq, UpdateRsp, CURRENT_VERSION,
-    MIN_VERSION, REQUEST_BUF_SIZE, RESPONSE_BUF_SIZE,
+    AttestReq, AttestRsp, CabooseReq, CabooseRsp, DumpReq, ReqBody, Request,
+    Response, RotIoStats, RotPageRsp, RotState, RotStatus, RspBody,
+    SprocketsError, SprotError, SprotProtocolError, StateDevOrRelease,
+    StateError, StateReq, StateRsp, SwdReq, UpdateReq, UpdateRsp,
+    CURRENT_VERSION, MIN_VERSION, REQUEST_BUF_SIZE, RESPONSE_BUF_SIZE,
 };
 use lpc55_romapi::bootrom;
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
@@ -568,37 +568,45 @@ impl<'a> Handler {
                 )?;
                 Ok((RspBody::Ok, None))
             }
-            ReqBody::Policy(PolicyReq::DevOrRelease) => {
-                let mut buf = [0u8; 512];
+            ReqBody::State(StateReq::DevOrRelease) => {
+                let out = self.state_dev_or_release();
 
-                // If the SHA-256 Digest is zeros, the CMPA is unlocked
-                self.update.read_rot_page(RotPage::Cmpa, &mut buf)?;
-                let unlocked = buf[480..].iter().all(|b| *b == 0);
-
-                // Otherwise, check which root keys are enabled
-                let dev = if unlocked {
-                    true
-                } else {
-                    self.update.read_rot_page(RotPage::CfpaActive, &mut buf)?;
-                    // Look at the ROTKH_REVOKE byte
-                    let revoke = buf[24];
-                    // Check if any of the development keys (slots 2 and 3) are
-                    // in the Valid state (0b01)
-                    [2, 3]
-                        .iter()
-                        .any(|slot| (revoke >> (slot * 2)) & 0b11 == 0b01)
-                };
-
-                Ok((
-                    RspBody::Policy(PolicyRsp::DevOrRelease(if dev {
-                        PolicyDevOrRelease::Development
-                    } else {
-                        PolicyDevOrRelease::Release
-                    })),
-                    None,
-                ))
+                Ok((RspBody::State(out.map(StateRsp::DevOrRelease)), None))
             }
         }
+    }
+
+    fn state_dev_or_release(
+        &mut self,
+    ) -> Result<StateDevOrRelease, StateError> {
+        let mut buf = [0u8; 512];
+
+        // If the SHA-256 Digest is zeros, the CMPA is unlocked
+        self.update
+            .read_rot_page(RotPage::Cmpa, &mut buf)
+            .map_err(StateError::ReadCmpa)?;
+        let unlocked = buf[480..].iter().all(|b| *b == 0);
+
+        // Otherwise, check which root keys are enabled
+        let dev = if unlocked {
+            true
+        } else {
+            self.update
+                .read_rot_page(RotPage::CfpaActive, &mut buf)
+                .map_err(StateError::ReadCfpa)?;
+            // Look at the ROTKH_REVOKE byte
+            let revoke = buf[24];
+            // Check if any of the development keys (slots 2 and 3) are
+            // in the Valid state (0b01)
+            [2, 3]
+                .iter()
+                .any(|slot| (revoke >> (slot * 2)) & 0b11 == 0b01)
+        };
+        Ok(if dev {
+            StateDevOrRelease::Development
+        } else {
+            StateDevOrRelease::Release
+        })
     }
 }
 

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -619,6 +619,10 @@ impl<'a> Handler {
                 LifecycleState::Development
             }
             [S::Revoked, S::Revoked, S::Revoked, S::Revoked] => {
+                // It would be very surprising to get here, because the RoT
+                // shouldn't be able to boot if all four trust anchors are
+                // revoked.  We'll report this seemingly-impossible state to the
+                // caller and let them figure out what to do with it.
                 LifecycleState::EndOfLife
             }
             _ => return Err(StateError::BadRevoke { revoke }),

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -579,13 +579,15 @@ impl<'a> Handler {
     fn state_dev_or_release(
         &mut self,
     ) -> Result<StateDevOrRelease, StateError> {
-        let mut buf = [0u8; 512];
+        const CMPA_SIZE: usize = 512;
+        let mut buf = [0u8; CMPA_SIZE];
 
-        // If the SHA-256 Digest is zeros, the CMPA is unlocked
+        // If the SHA-256 Digest is zeros, the CMPA is unlocked.  The SHA-256
+        // digest is located in the last 4 words of the CMPA.
         self.update
             .read_rot_page(RotPage::Cmpa, &mut buf)
             .map_err(StateError::ReadCmpa)?;
-        let unlocked = buf[480..].iter().all(|b| *b == 0);
+        let unlocked = buf[CMPA_SIZE - 32..].iter().all(|b| *b == 0);
 
         // Otherwise, check which root keys are enabled
         let dev = if unlocked {

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -342,6 +342,7 @@ impl From<WatchdogError> for GwWatchdogError {
 pub enum StateError {
     ReadCmpa(UpdateError),
     ReadCfpa(UpdateError),
+    BadRevoke { revoke: u8 },
 }
 
 #[derive(

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -334,3 +334,27 @@ impl From<WatchdogError> for GwWatchdogError {
         }
     }
 }
+
+// Added in protocol v6
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, SerializedSize, counters::Count,
+)]
+pub enum StateError {
+    ReadCmpa(UpdateError),
+    ReadCfpa(UpdateError),
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    From,
+    Deserialize,
+    Serialize,
+    SerializedSize,
+    counters::Count,
+)]
+pub enum StateOrSprotError {
+    Sprot(#[count(children)] SprotError),
+    State(#[count(children)] StateError),
+}

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -372,10 +372,8 @@ pub enum SwdReq {
 // Added in sprot protocol version 6
 #[derive(Clone, Serialize, Deserialize, SerializedSize)]
 pub enum StateReq {
-    /// Checks whether the RoT is in development or release mode
-    ///
-    /// In release mode, security policy may be more stringent
-    DevOrRelease,
+    /// Checks the RoT's lifecycle state, per RFD 286
+    LifecycleState,
 }
 
 /// Instruct the RoT to take a dump of the SP via SWD
@@ -521,15 +519,27 @@ pub enum RotPageRsp {
     RotPage,
 }
 
+/// Life-cycle state, as defined in RFD 286
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
-pub enum StateDevOrRelease {
-    Development,
+pub enum LifecycleState {
+    /// Any state in which the CMPA is unlocked counts as unprogrammed
+    Unprogrammed,
+
+    /// At least one of the release trust anchors is valid, and both of the
+    /// development trust anchors are invalid
     Release,
+
+    /// At least one of the development trust anchors is valid, and both of the
+    /// release trust anchors are revoked
+    Development,
+
+    /// All four trust anchors are revoked
+    EndOfLife,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
 pub enum StateRsp {
-    DevOrRelease(StateDevOrRelease),
+    LifecycleState(LifecycleState),
 }
 
 /// A response from the Dumper

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -50,7 +50,7 @@ pub const MIN_VERSION: Version = Version(2);
 /// Code between the `CURRENT_VERSION` and `MIN_VERSION` must remain
 /// compatible. Use the rules described in the comments for [`Msg`] to evolve
 /// the protocol such that this remains true.
-pub const CURRENT_VERSION: Version = Version(5);
+pub const CURRENT_VERSION: Version = Version(6);
 
 /// We allow room in the buffer for message evolution
 pub const REQUEST_BUF_SIZE: usize = 1024;
@@ -349,6 +349,8 @@ pub enum ReqBody {
     RotPage { page: RotPage },
     // Added in sprot protocol version 5
     Swd(SwdReq),
+    // Added in sprot protocol version 6
+    Policy(PolicyReq),
 }
 
 // Added in sprot protocol version 5
@@ -365,6 +367,15 @@ pub enum SwdReq {
     /// that there's no debugger attached that would prevent us from talking to
     /// the SP.
     SpSlotWatchdogSupported,
+}
+
+// Added in sprot protocol version 6
+#[derive(Clone, Serialize, Deserialize, SerializedSize)]
+pub enum PolicyReq {
+    /// Checks whether the RoT is in development or release mode
+    ///
+    /// In release mode, security policy may be more stringent
+    DevOrRelease,
 }
 
 /// Instruct the RoT to take a dump of the SP via SWD
@@ -499,12 +510,26 @@ pub enum RspBody {
     Attest(Result<AttestRsp, AttestError>),
 
     Page(Result<RotPageRsp, UpdateError>),
+
+    // Added in sprot protocol version 6
+    Policy(PolicyRsp),
 }
 
 /// A response for reading a ROT page
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
 pub enum RotPageRsp {
     RotPage,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
+pub enum PolicyDevOrRelease {
+    Development,
+    Release,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
+pub enum PolicyRsp {
+    DevOrRelease(PolicyDevOrRelease),
 }
 
 /// A response from the Dumper

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -15,7 +15,7 @@ use dumper_api::DumperError;
 pub use error::{
     AttestOrSprotError, CabooseOrSprotError, DumpOrSprotError,
     RawCabooseOrSprotError, SprocketsError, SprotError, SprotProtocolError,
-    WatchdogError,
+    StateError, StateOrSprotError, WatchdogError,
 };
 
 use crc::{Crc, CRC_16_XMODEM};
@@ -350,7 +350,7 @@ pub enum ReqBody {
     // Added in sprot protocol version 5
     Swd(SwdReq),
     // Added in sprot protocol version 6
-    Policy(PolicyReq),
+    State(StateReq),
 }
 
 // Added in sprot protocol version 5
@@ -371,7 +371,7 @@ pub enum SwdReq {
 
 // Added in sprot protocol version 6
 #[derive(Clone, Serialize, Deserialize, SerializedSize)]
-pub enum PolicyReq {
+pub enum StateReq {
     /// Checks whether the RoT is in development or release mode
     ///
     /// In release mode, security policy may be more stringent
@@ -512,7 +512,7 @@ pub enum RspBody {
     Page(Result<RotPageRsp, UpdateError>),
 
     // Added in sprot protocol version 6
-    Policy(PolicyRsp),
+    State(Result<StateRsp, StateError>),
 }
 
 /// A response for reading a ROT page
@@ -522,14 +522,14 @@ pub enum RotPageRsp {
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
-pub enum PolicyDevOrRelease {
+pub enum StateDevOrRelease {
     Development,
     Release,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, SerializedSize)]
-pub enum PolicyRsp {
-    DevOrRelease(PolicyDevOrRelease),
+pub enum StateRsp {
+    DevOrRelease(StateDevOrRelease),
 }
 
 /// A response from the Dumper

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1341,6 +1341,24 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
             Err(SprotProtocolError::UnexpectedResponse)?
         }
     }
+
+    fn policy_dev_or_release(
+        &mut self,
+        _msg: &userlib::RecvMessage,
+    ) -> Result<
+        drv_sprot_api::PolicyDevOrRelease,
+        idol_runtime::RequestError<SprotError>,
+    > {
+        let body = ReqBody::Policy(PolicyReq::DevOrRelease);
+        let tx_size = Request::pack(&body, self.tx_buf);
+        let rsp =
+            self.do_send_recv_retries(tx_size, TIMEOUT_LONG, DEFAULT_ATTEMPTS)?;
+        if let RspBody::Policy(PolicyRsp::DevOrRelease(d)) = rsp.body? {
+            Ok(d)
+        } else {
+            Err(SprotProtocolError::UnexpectedResponse)?
+        }
+    }
 }
 
 impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
@@ -1357,10 +1375,10 @@ impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
 
 mod idl {
     use super::{
-        AttestOrSprotError, DumpOrSprotError, HashAlgorithm, PulseStatus,
-        RawCabooseOrSprotError, RotBootInfo, RotComponent, RotPage, RotState,
-        SlotId, SprotError, SprotIoStats, SprotStatus, SwitchDuration,
-        UpdateTarget, VersionedRotBootInfo,
+        AttestOrSprotError, DumpOrSprotError, HashAlgorithm,
+        PolicyDevOrRelease, PulseStatus, RawCabooseOrSprotError, RotBootInfo,
+        RotComponent, RotPage, RotState, SlotId, SprotError, SprotIoStats,
+        SprotStatus, SwitchDuration, UpdateTarget, VersionedRotBootInfo,
     };
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1342,24 +1342,25 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         }
     }
 
-    fn policy_dev_or_release(
+    fn state_dev_or_release(
         &mut self,
         _msg: &userlib::RecvMessage,
     ) -> Result<
-        drv_sprot_api::PolicyDevOrRelease,
-        idol_runtime::RequestError<SprotError>,
+        drv_sprot_api::StateDevOrRelease,
+        idol_runtime::RequestError<StateOrSprotError>,
     > {
-        let body = ReqBody::Policy(PolicyReq::DevOrRelease);
+        let body = ReqBody::State(StateReq::DevOrRelease);
         let tx_size = Request::pack(&body, self.tx_buf);
-        let rsp = self.do_send_recv_retries(
-            tx_size,
-            TIMEOUT_QUICK,
-            DEFAULT_ATTEMPTS,
-        )?;
-        if let RspBody::Policy(PolicyRsp::DevOrRelease(d)) = rsp.body? {
-            Ok(d)
-        } else {
-            Err(SprotProtocolError::UnexpectedResponse)?
+        let rsp = self
+            .do_send_recv_retries(tx_size, TIMEOUT_QUICK, DEFAULT_ATTEMPTS)
+            .map_err(StateOrSprotError::Sprot)?;
+        match rsp.body.map_err(StateOrSprotError::Sprot)? {
+            RspBody::State(Ok(StateRsp::DevOrRelease(d))) => Ok(d),
+            RspBody::State(Err(e)) => Err(StateOrSprotError::State(e).into()),
+            _ => Err(StateOrSprotError::Sprot(SprotError::Protocol(
+                SprotProtocolError::UnexpectedResponse,
+            ))
+            .into()),
         }
     }
 }
@@ -1378,10 +1379,10 @@ impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
 
 mod idl {
     use super::{
-        AttestOrSprotError, DumpOrSprotError, HashAlgorithm,
-        PolicyDevOrRelease, PulseStatus, RawCabooseOrSprotError, RotBootInfo,
-        RotComponent, RotPage, RotState, SlotId, SprotError, SprotIoStats,
-        SprotStatus, SwitchDuration, UpdateTarget, VersionedRotBootInfo,
+        AttestOrSprotError, DumpOrSprotError, HashAlgorithm, PulseStatus,
+        RawCabooseOrSprotError, RotBootInfo, RotComponent, RotPage, RotState,
+        SlotId, SprotError, SprotIoStats, SprotStatus, StateDevOrRelease,
+        StateOrSprotError, SwitchDuration, UpdateTarget, VersionedRotBootInfo,
     };
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1342,20 +1342,20 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
         }
     }
 
-    fn state_dev_or_release(
+    fn lifecycle_state(
         &mut self,
         _msg: &userlib::RecvMessage,
     ) -> Result<
-        drv_sprot_api::StateDevOrRelease,
+        drv_sprot_api::LifecycleState,
         idol_runtime::RequestError<StateOrSprotError>,
     > {
-        let body = ReqBody::State(StateReq::DevOrRelease);
+        let body = ReqBody::State(StateReq::LifecycleState);
         let tx_size = Request::pack(&body, self.tx_buf);
         let rsp = self
             .do_send_recv_retries(tx_size, TIMEOUT_QUICK, DEFAULT_ATTEMPTS)
             .map_err(StateOrSprotError::Sprot)?;
         match rsp.body.map_err(StateOrSprotError::Sprot)? {
-            RspBody::State(Ok(StateRsp::DevOrRelease(d))) => Ok(d),
+            RspBody::State(Ok(StateRsp::LifecycleState(d))) => Ok(d),
             RspBody::State(Err(e)) => Err(StateOrSprotError::State(e).into()),
             _ => Err(StateOrSprotError::Sprot(SprotError::Protocol(
                 SprotProtocolError::UnexpectedResponse,
@@ -1379,9 +1379,9 @@ impl<S: SpiServer> NotificationHandler for ServerImpl<S> {
 
 mod idl {
     use super::{
-        AttestOrSprotError, DumpOrSprotError, HashAlgorithm, PulseStatus,
-        RawCabooseOrSprotError, RotBootInfo, RotComponent, RotPage, RotState,
-        SlotId, SprotError, SprotIoStats, SprotStatus, StateDevOrRelease,
+        AttestOrSprotError, DumpOrSprotError, HashAlgorithm, LifecycleState,
+        PulseStatus, RawCabooseOrSprotError, RotBootInfo, RotComponent,
+        RotPage, RotState, SlotId, SprotError, SprotIoStats, SprotStatus,
         StateOrSprotError, SwitchDuration, UpdateTarget, VersionedRotBootInfo,
     };
 

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -1351,8 +1351,11 @@ impl<S: SpiServer> idl::InOrderSpRotImpl for ServerImpl<S> {
     > {
         let body = ReqBody::Policy(PolicyReq::DevOrRelease);
         let tx_size = Request::pack(&body, self.tx_buf);
-        let rsp =
-            self.do_send_recv_retries(tx_size, TIMEOUT_LONG, DEFAULT_ATTEMPTS)?;
+        let rsp = self.do_send_recv_retries(
+            tx_size,
+            TIMEOUT_QUICK,
+            DEFAULT_ATTEMPTS,
+        )?;
         if let RspBody::Policy(PolicyRsp::DevOrRelease(d)) = rsp.body? {
             Ok(d)
         } else {

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -375,5 +375,14 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
+        "policy_dev_or_release": (
+            doc: "Check whether the RoT is in development or release mode",
+            reply: Result(
+                ok: "PolicyDevOrRelease",
+                err: Complex("SprotError"),
+            ),
+            encoding: Hubpack,
+            idempotent: true,
+        ),
     }
 )

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -375,10 +375,10 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
-        "state_dev_or_release": (
-            doc: "Check whether the RoT is in development or release mode",
+        "lifecycle_state": (
+            doc: "Check the RoT's lifecycle state",
             reply: Result(
-                ok: "StateDevOrRelease",
+                ok: "LifecycleState",
                 err: Complex("StateOrSprotError"),
             ),
             encoding: Hubpack,

--- a/idl/sprot.idol
+++ b/idl/sprot.idol
@@ -375,11 +375,11 @@ Interface(
             encoding: Hubpack,
             idempotent: true,
         ),
-        "policy_dev_or_release": (
+        "state_dev_or_release": (
             doc: "Check whether the RoT is in development or release mode",
             reply: Result(
-                ok: "PolicyDevOrRelease",
-                err: Complex("SprotError"),
+                ok: "StateDevOrRelease",
+                err: Complex("StateOrSprotError"),
             ),
             encoding: Hubpack,
             idempotent: true,


### PR DESCRIPTION
We want to make policy decisions based on whether a system is in development or release mode.  For example, development machines may have more lax policy on tech port unlocking; see [RFD 492](https://rfd.shared.oxide.computer/rfd/506) and [506](https://rfd.shared.oxide.computer/rfd/506)

This PR adds a `SpRot` message and Idol function to perform a "development or release" check.  The policy decision is made on the RoT, which returns either `Development` or `Release`.

--------------------------------------------------------------------------------

The RoT uses two pieces of information to make this policy decision.

First, it checks which keys are active in the Root of Trust's CFPA region, which has four slots:

- Release is `[valid, valid, invalid, invalid]`
- Development is `[revoked, revoked, valid, valid]`

The LPC55's firmware only lets keys go from `invalid → valid → revoked`; if any of slots 2/3 are `valid`, then we know that the machine is in Development mode.

However, we also distribute images with a CFPA that only enables key 0 (`[valid, invalid, invalid, invalid]`).  These images use the Bartholomew certificate ([`fake_certs` in this repository](https://github.com/oxidecomputer/hubris/tree/master/support/fake_certs)), which is not _actually_ secret and is used for convenience when developing.

To detect this case, we check whether the CMPA is unlocked.  If the CMPA is unlocked, then we treat the system as in Development.