### PR TITLE
`HostPanic` and `HostBootFailure` discard bytes

### DIFF
--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -92,10 +92,7 @@ pub enum HostToSp {
     HostBootFailure {
         reason: u8,
     },
-    HostPanic {
-        code: u16,
-        // Followed by a binary data blob (panic message?)
-    },
+    HostPanic, // Followed by a binary data blob (panic data)
     GetStatus,
     // Host ack'ing SP task startup.
     AckSpStart,
@@ -810,7 +807,7 @@ mod tests {
             (0x04, HostToSp::GetIdentity),
             (0x05, HostToSp::GetMacAddresses),
             (0x06, HostToSp::HostBootFailure { reason: 0 }),
-            (0x07, HostToSp::HostPanic { code: 0 }),
+            (0x07, HostToSp::HostPanic),
             (0x08, HostToSp::GetStatus),
             (0x09, HostToSp::AckSpStart),
             (0x0a, HostToSp::GetAlert),
@@ -1199,7 +1196,7 @@ mod tests {
             version: 123,
             sequence: 456,
         };
-        let host_to_sp = HostToSp::HostPanic { code: 78 };
+        let host_to_sp = HostToSp::HostPanic;
         let data_blob = &[1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let mut buf = [0; MAX_MESSAGE_SIZE];
@@ -1224,7 +1221,7 @@ mod tests {
             version: 123,
             sequence: 456,
         };
-        let host_to_sp = HostToSp::HostPanic { code: 78 };
+        let host_to_sp = HostToSp::HostPanic;
         let data_blob = (0_u32..)
             .into_iter()
             .map(|x| x as u8)

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -126,9 +126,6 @@ enum Trace {
         #[count(children)]
         message: SpToHost,
     },
-    BootFail {
-        reason: u8,
-    },
 }
 
 counted_ringbuf!(Trace, 20, Trace::None);
@@ -803,7 +800,6 @@ impl ServerImpl {
                     *b = 0;
                 }
                 self.host_kv_storage.last_boot_fail_reason = reason;
-                ringbuf_entry!(Trace::BootFail { reason });
                 Some(SpToHost::Ack)
             }
             HostToSp::HostPanic => {

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -126,6 +126,9 @@ enum Trace {
         #[count(children)]
         message: SpToHost,
     },
+    BootFail {
+        reason: u8,
+    },
 }
 
 counted_ringbuf!(Trace, 20, Trace::None);
@@ -185,6 +188,7 @@ const MAX_DTRACE_CONF_LEN: usize = 4096;
 // data for later read back (either by the host itself or by the control plane
 // via MGS).
 struct HostKeyValueStorage {
+    last_boot_fail_reason: u8,
     last_boot_fail: &'static mut [u8; MAX_HOST_FAIL_MESSAGE_LEN],
     last_panic: &'static mut [u8; MAX_HOST_FAIL_MESSAGE_LEN],
     etc_system: &'static mut [u8; MAX_ETC_SYSTEM_LEN],
@@ -298,6 +302,7 @@ impl ServerImpl {
             packrat: Packrat::from(PACKRAT.get_task_id()),
             reboot_state: None,
             host_kv_storage: HostKeyValueStorage {
+                last_boot_fail_reason: 0,
                 last_boot_fail,
                 last_panic,
                 etc_system,
@@ -783,11 +788,11 @@ impl ServerImpl {
                 };
                 Some(response)
             }
-            HostToSp::HostBootFailure { .. } => {
+            HostToSp::HostBootFailure { reason } => {
                 // TODO forward to MGS
                 //
                 // For now, copy it into a static var we can pull out via
-                // `humility readvar LAST_HOST_BOOT_FAIL`.
+                // `humility host boot-fail`.
                 let n = usize::min(
                     data.len(),
                     self.host_kv_storage.last_boot_fail.len(),
@@ -797,13 +802,15 @@ impl ServerImpl {
                 for b in &mut self.host_kv_storage.last_boot_fail[n..] {
                     *b = 0;
                 }
+                self.host_kv_storage.last_boot_fail_reason = reason;
+                ringbuf_entry!(Trace::BootFail { reason });
                 Some(SpToHost::Ack)
             }
-            HostToSp::HostPanic { .. } => {
+            HostToSp::HostPanic => {
                 // TODO forward to MGS
                 //
                 // For now, copy it into a static var we can pull out via
-                // `humility readvar LAST_HOST_PANIC`.
+                // `humility host last-panic`.
                 let n = usize::min(
                     data.len(),
                     self.host_kv_storage.last_panic.len(),


### PR DESCRIPTION
Running with this fix:

```console
$ humility ringbuf host_sp_comms | grep BootFail
humility: attached via ST-Link V3
       1 Request(HostBootFailure)
  15  712        1        1 Request { now: 0x173bd, sequence: 0x5, message: HostBootFailure { reason: 0x2 } }
$ humility host boot-fail
humility: attached via ST-Link V3
Message is 46 bytes long:
Could not find a valid phase2 image on disk:17
$ humility host last-panic
humility: attached via ST-Link V3
version:   1 (determined)
cause:     IPCC_PANIC_CALL
error:     0
cpuid:     0
thread:    0xfffffffffbe9f1e0
addr:      0x0
pc:        0xfffffffff7cafffa
fp:        0xfffffffffbea5060
rp:        0x0
message:   Could not find a valid phase2 image on disk:17
stack:
           oxide_boot_locate+0x18a                          (0xfffffffff7cafffa)
           boot_image_locate+0xa1                           (0xfffffffffc0c4eb1)
           main+0x137                                       (0xfffffffffc0c5027)
           _locore_start+0x88                               (0xfffffffffbc47e48)
```

Prior to this, the `last_panic` version would be inferred:

```console
$ humility host last-panic
humility: attached via ST-Link V3
version:   1 (inferred)
cause:     IPCC_PANIC_CALL
error:     0
cpuid:     0
thread:    0xfffffffffbe9f1e0
addr:      0x0
pc:        0xfffffffff7cafffa
fp:        0xfffffffffbea5060
rp:        0x0
message:   Could not find a valid phase2 image on disk:17
stack:
           oxide_boot_locate+0x18a                          (0xfffffffff7cafffa)
           boot_image_locate+0xa1                           (0xfffffffffc0c4eb1)
           main+0x137                                       (0xfffffffffc0c5027)
           _locore_start+0x88                               (0xfffffffffbc47e48)
```
