### PR TITLE
net: wake all sockets on restart.

### DIFF
--- a/task/net/src/main.rs
+++ b/task/net/src/main.rs
@@ -242,6 +242,14 @@ fn main() -> ! {
         );
     }
 
+    // Ensure that sockets are woken at least once at startup, so that anyone
+    // who was waiting to hear back on their TX queue becoming non-full will
+    // snap out of it.
+    //
+    // This only works because we've set waiting_to_send to true for all sockets
+    // above.
+    server.wake_sockets();
+
     // Go!
     loop {
         count!(Event::Iter);

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -561,7 +561,9 @@ where
 
         Self {
             eth,
-            client_waiting_to_send: [false; SOCKET_COUNT],
+            // The 'true' here is load-bearing: it ensures that sockets receive
+            // a notification on stack restart.
+            client_waiting_to_send: [true; SOCKET_COUNT],
             vlan_state: enum_map::EnumMap::from_array(
                 vlan_state.into_array().unwrap_lite(),
             ),


### PR DESCRIPTION
This avoids a potential liveness issue described in #1844, wherein a task waiting for tx queue space would not notice net restarting.

Fixes #1844.