### PR TITLE
Split `ServerImpl` versus `FlashDriver`, add `FailServer`

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -13,9 +13,13 @@ use idol_runtime::{
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use userlib::{task_slot, RecvMessage, UnwrapLite};
 
-use crate::{ServerImpl, Trace, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
+use crate::{FlashDriver, Trace, PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
 
 task_slot!(HASH, hash_driver);
+
+pub struct ServerImpl {
+    pub drv: FlashDriver,
+}
 
 impl ServerImpl {
     fn check_addr_writable(
@@ -38,14 +42,14 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
     ) -> Result<[u8; 20], RequestError<HfError>> {
-        Ok(self.flash_read_id())
+        Ok(self.drv.flash_read_id())
     }
 
     fn capacity(
         &mut self,
         _: &RecvMessage,
     ) -> Result<usize, RequestError<HfError>> {
-        todo!()
+        Ok(0x8000000) // 1 GBit = 128 MiB
     }
 
     /// Reads the STATUS_1 register from the SPI flash
@@ -53,7 +57,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
     ) -> Result<u8, RequestError<HfError>> {
-        Ok(self.read_flash_status())
+        Ok(self.drv.read_flash_status())
     }
 
     fn bulk_erase(
@@ -75,11 +79,12 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
     ) -> Result<(), RequestError<HfError>> {
         self.check_addr_writable(addr, protect)?;
-        self.flash_write(
-            addr,
-            &mut LeaseBufReader::<_, 32>::from(data.into_inner()),
-        )
-        .map_err(|()| RequestError::went_away())
+        self.drv
+            .flash_write(
+                addr,
+                &mut LeaseBufReader::<_, 32>::from(data.into_inner()),
+            )
+            .map_err(|()| RequestError::went_away())
     }
 
     fn read(
@@ -88,11 +93,12 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         offset: u32,
         dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
     ) -> Result<(), RequestError<HfError>> {
-        self.flash_read(
-            offset,
-            &mut LeaseBufWriter::<_, 32>::from(dest.into_inner()),
-        )
-        .map_err(|_| RequestError::went_away())
+        self.drv
+            .flash_read(
+                offset,
+                &mut LeaseBufWriter::<_, 32>::from(dest.into_inner()),
+            )
+            .map_err(|_| RequestError::went_away())
     }
 
     /// Erases the 64 KiB sector containing the given address
@@ -107,7 +113,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         protect: HfProtectMode,
     ) -> Result<(), RequestError<HfError>> {
         self.check_addr_writable(addr, protect)?;
-        self.flash_sector_erase(addr);
+        self.drv.flash_sector_erase(addr);
         Ok(())
     }
 
@@ -165,7 +171,8 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             // This unwrap is safe because `flash_read` can only fail when given
             // a lease (where writing into the lease fails if the client goes
             // away).  Giving it a buffer is infallible.
-            self.flash_read(addr as u32, &mut &mut buf[..size])
+            self.drv
+                .flash_read(addr as u32, &mut &mut buf[..size])
                 .unwrap_lite();
             if let Err(e) = hash_driver.update(size as u32, &buf[..size]) {
                 ringbuf_entry!(Trace::HashUpdateError(e));
@@ -198,6 +205,135 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
 }
 
 impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
+
+/// Dummy server which returns an error for every operation
+pub struct FailServer {
+    pub err: HfError,
+}
+
+impl idl::InOrderHostFlashImpl for FailServer {
+    fn read_id(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<[u8; 20], RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn capacity(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<usize, RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    /// Reads the STATUS_1 register from the SPI flash
+    fn read_status(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u8, RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn bulk_erase(
+        &mut self,
+        _: &RecvMessage,
+        _protect: HfProtectMode,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn page_program(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _protect: HfProtectMode,
+        _data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn read(
+        &mut self,
+        _: &RecvMessage,
+        _offset: u32,
+        _dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn sector_erase(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _protect: HfProtectMode,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn get_mux(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<HfMuxState, RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn set_mux(
+        &mut self,
+        _: &RecvMessage,
+        _state: HfMuxState,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn get_dev(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<HfDevSelect, RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn set_dev(
+        &mut self,
+        _: &RecvMessage,
+        _state: HfDevSelect,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn hash(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _len: u32,
+    ) -> Result<[u8; SHA256_SZ], RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn get_persistent_data(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<HfPersistentData, RequestError<HfError>> {
+        Err(self.err.into())
+    }
+
+    fn write_persistent_data(
+        &mut self,
+        _: &RecvMessage,
+        _dev_select: HfDevSelect,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(self.err.into())
+    }
+}
+
+impl NotificationHandler for FailServer {
     fn current_notification_mask(&self) -> u32 {
         0
     }

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
 
     // Check the flash chip's ID against Table 7.3.1 in the datasheet
     let id = drv.flash_read_id();
-    if &id[0..3] != [0xef, 0x40, 0x21] {
+    if id[0..3] != [0xef, 0x40, 0x21] {
         fail(drv_hf_api::HfError::BadChipId);
     }
 

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -65,18 +65,29 @@ fn main() -> ! {
     seq.ping(); // waits until the sequencer has completed configuration
 
     let id = unsafe { reg::BASE.read_volatile() };
-    assert_eq!(id, 0x1de);
+    if id != 0x1de {
+        fail(drv_hf_api::HfError::FpgaNotConfigured);
+    }
 
-    // Fire up a server.
-    let mut server = ServerImpl;
-    server.flash_set_quad_enable();
+    let drv = FlashDriver;
+    drv.flash_set_quad_enable();
+
+    // Check the flash chip's ID against Table 7.3.1 in the datasheet
+    let id = drv.flash_read_id();
+    if &id[0..3] != [0xef, 0x40, 0x21] {
+        fail(drv_hf_api::HfError::BadChipId);
+    }
+
+    let mut server = hf::ServerImpl { drv };
+
     let mut buffer = [0; hf::idl::INCOMING_SIZE];
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 
-struct ServerImpl;
+/// Driver for a QSPI NOR flash controlled by an FPGA over FMC
+struct FlashDriver;
 
 #[allow(unused)]
 mod reg {
@@ -112,7 +123,7 @@ mod instr {
     pub const QUAD_INPUT_PAGE_PROGRAM_4B: u32 = 0x34;
 }
 
-impl ServerImpl {
+impl FlashDriver {
     fn flash_read_id(&self) -> [u8; 20] {
         self.clear_fifos();
         self.write_reg(reg::DATA_BYTES, 20);
@@ -307,6 +318,15 @@ impl ServerImpl {
         self.write_reg(reg::TX_FIFO, u32::from_le_bytes([v, 0, 0, 0]));
         self.write_reg(reg::INSTR, instr::WRITE_STATUS_2);
         self.wait_fpga_busy();
+    }
+}
+
+/// Failure function, running an Idol response loop that always returns an error
+fn fail(err: drv_hf_api::HfError) {
+    let mut buffer = [0; hf::idl::INCOMING_SIZE];
+    let mut server = hf::FailServer { err };
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
     }
 }
 

--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -31,6 +31,8 @@ pub enum HfError {
     Sector0IsReserved,
     NoPersistentData,
     MonotonicCounterOverflow,
+    FpgaNotConfigured,
+    BadChipId,
 
     #[idol(server_death)]
     ServerRestarted,


### PR DESCRIPTION
Staged on top of #1851

This PR splits the FMC NOR flash into `FlashDriver` (talking to the FPGA and flash) and `ServerImpl` (implementing the `HostFlash` API).  In addition, it adds a non-panicking failure path.  In this new failure path, there's a small Idol server which replies with an error to any message.