### PR TITLE
Remove grapefruit branch from CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -2,7 +2,7 @@ name: dist
 on:
   pull_request:
   push:
-    branches: [master, grapefruit-bringup]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ "master", "grapefruit-bringup" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "grapefruit-bringup" ]
+    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
We were previously maintaining `grapefruit-bringup` as a long-running branch, but have since merged it into `master`.