### PR TITLE
chore: Cleanup userlib namespace imports

### DIFF
--- a/drv/auxflash-api/src/lib.rs
+++ b/drv/auxflash-api/src/lib.rs
@@ -9,7 +9,7 @@
 use derive_idol_err::IdolError;
 use sha3::{Digest, Sha3_256};
 use tlvc::{TlvcRead, TlvcReader};
-use userlib::*;
+use userlib::{sys_send, FromPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
 pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -14,7 +14,7 @@ use idol_runtime::{
     ClientError, Leased, NotificationHandler, RequestError, R, W,
 };
 use tlvc::{TlvcRead, TlvcReadError, TlvcReader};
-use userlib::*;
+use userlib::{hl, task_slot, RecvMessage, UnwrapLite};
 
 #[cfg(feature = "h753")]
 use stm32h7::stm32h753 as device;

--- a/drv/eeprom/src/main.rs
+++ b/drv/eeprom/src/main.rs
@@ -17,7 +17,7 @@
 use derive_idol_err::IdolError;
 use drv_i2c_devices::at24csw080::*;
 use idol_runtime::{NotificationHandler, RequestError};
-use userlib::*;
+use userlib::{task_slot, FromPrimitive};
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 task_slot!(I2C, i2c_driver);

--- a/drv/fpga-api/src/lib.rs
+++ b/drv/fpga-api/src/lib.rs
@@ -9,7 +9,7 @@
 use core::ops::Deref;
 
 use drv_spi_api::SpiError;
-use userlib::*;
+use userlib::{FromPrimitive, UnwrapLite};
 use zerocopy::{AsBytes, BigEndian, FromBytes, U32};
 
 #[cfg(feature = "auxflash")]
@@ -438,7 +438,7 @@ pub fn load_bitstream_from_auxflash(
 
 pub mod idl {
     use super::{BitstreamType, DeviceState, FpgaError, ReadOp, WriteOp};
-    use userlib::*;
+    use userlib::sys_send;
 
     include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));
 }

--- a/drv/fpga-devices/src/ecp5.rs
+++ b/drv/fpga-devices/src/ecp5.rs
@@ -7,7 +7,7 @@ use bitfield::bitfield;
 use core::fmt::Debug;
 use drv_fpga_api::{DeviceState, FpgaError};
 use ringbuf::*;
-use userlib::*;
+use userlib::{hl, FromPrimitive, ToPrimitive};
 use zerocopy::{AsBytes, FromBytes};
 
 /// ECP5 IDCODE values, found in Table B.5, p. 58, Lattice Semi FPGA-TN-02039-2.0.

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use ringbuf::*;
-use userlib::*;
+use userlib::{task_slot, RecvMessage, TaskId};
 use zerocopy::{byteorder, AsBytes, Unaligned, U16};
 
 use drv_fpga_api::{BitstreamType, DeviceState, FpgaError, ReadOp, WriteOp};

--- a/drv/gimlet-hf-api/src/lib.rs
+++ b/drv/gimlet-hf-api/src/lib.rs
@@ -10,7 +10,7 @@ use derive_idol_err::IdolError;
 use drv_hash_api::SHA256_SZ;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
-use userlib::*;
+use userlib::{sys_send, FromPrimitive};
 use zerocopy::AsBytes;
 
 pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -28,7 +28,7 @@
 )]
 mod bsp;
 
-use userlib::*;
+use userlib::{hl, task_slot, FromPrimitive, RecvMessage};
 
 use drv_gimlet_hf_api::SECTOR_SIZE_BYTES;
 use drv_stm32h7_qspi::Qspi;

--- a/drv/gimlet-seq-api/src/lib.rs
+++ b/drv/gimlet-seq-api/src/lib.rs
@@ -8,7 +8,7 @@
 
 use counters::Count;
 use derive_idol_err::IdolError;
-use userlib::*;
+use userlib::{sys_send, FromPrimitive};
 
 // Re-export PowerState for client convenience.
 pub use drv_gimlet_state::PowerState;

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -12,7 +12,10 @@ mod vcore;
 
 use counters::*;
 use ringbuf::*;
-use userlib::*;
+use userlib::{
+    hl, set_timer_relative, sys_get_timer, sys_recv_notification,
+    sys_set_timer, task_slot, units, RecvMessage, TaskId, UnwrapLite,
+};
 
 use drv_gimlet_hf_api as hf_api;
 use drv_gimlet_seq_api::{PowerState, SeqError};

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -32,7 +32,7 @@ use drv_i2c_devices::raa229618::Raa229618;
 use drv_stm32xx_sys_api as sys_api;
 use ringbuf::*;
 use sys_api::IrqControl;
-use userlib::*;
+use userlib::{sys_get_timer, units};
 
 pub struct VCore {
     device: Raa229618,

--- a/drv/hash-api/src/lib.rs
+++ b/drv/hash-api/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 
 use derive_idol_err::IdolError;
-use userlib::*;
+use userlib::{sys_send, FromPrimitive};
 
 pub const SHA256_SZ: usize = 32;
 

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -25,7 +25,7 @@
 use zerocopy::{AsBytes, FromBytes};
 
 pub use drv_i2c_types::*;
-use userlib::*;
+use userlib::{sys_send, FromPrimitive, Lease, TaskId};
 
 ///
 /// The 5-tuple that uniquely identifies an I2C device.  The multiplexer and

--- a/drv/i2c-devices/src/emc2305.rs
+++ b/drv/i2c-devices/src/emc2305.rs
@@ -8,8 +8,10 @@ use crate::Validate;
 use bitfield::bitfield;
 use drv_i2c_api::*;
 use ringbuf::*;
-use userlib::units::*;
-use userlib::*;
+use userlib::{
+    units::{PWMDuty, Rpm},
+    FromPrimitive, UnwrapLite,
+};
 
 bitfield! {
     pub struct Configuration(u8);

--- a/drv/i2c-devices/src/ltc4282.rs
+++ b/drv/i2c-devices/src/ltc4282.rs
@@ -8,8 +8,10 @@ use crate::{CurrentSensor, Validate, VoltageSensor};
 use bitfield::bitfield;
 use core::cell::Cell;
 use drv_i2c_api::*;
-use userlib::units::*;
-use userlib::*;
+use userlib::{
+    units::{Amperes, Ohms, Volts},
+    FromPrimitive,
+};
 
 #[allow(dead_code, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -8,8 +8,10 @@ use crate::Validate;
 use bitfield::bitfield;
 use drv_i2c_api::*;
 use ringbuf::*;
-use userlib::units::*;
-use userlib::*;
+use userlib::{
+    units::{PWMDuty, Rpm},
+    FromPrimitive,
+};
 
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug)]

--- a/drv/i2c-devices/src/max5970.rs
+++ b/drv/i2c-devices/src/max5970.rs
@@ -7,8 +7,10 @@
 use crate::{CurrentSensor, Validate, VoltageSensor};
 use drv_i2c_api::*;
 use num_traits::float::FloatCore;
-use userlib::units::*;
-use userlib::*;
+use userlib::{
+    units::{Amperes, Ohms, Volts},
+    FromPrimitive,
+};
 
 #[allow(dead_code, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, FromPrimitive)]

--- a/drv/i2c-devices/src/pca9538.rs
+++ b/drv/i2c-devices/src/pca9538.rs
@@ -6,7 +6,7 @@
 
 use crate::Validate;
 use drv_i2c_api::*;
-use userlib::*;
+use userlib::FromPrimitive;
 
 /// `PinSet` is a bit vector indicating on which pins/ports a given operation is
 /// applied.

--- a/drv/ignition-server/src/main.rs
+++ b/drv/ignition-server/src/main.rs
@@ -10,7 +10,7 @@
 use drv_ignition_api::*;
 use drv_sidecar_mainboard_controller::ignition::*;
 use ringbuf::*;
-use userlib::*;
+use userlib::{sys_get_timer, sys_set_timer, task_slot, UnwrapLite};
 
 task_slot!(FPGA, fpga);
 #[cfg(feature = "sequencer")]

--- a/drv/ignition-server/src/main.rs
+++ b/drv/ignition-server/src/main.rs
@@ -10,7 +10,7 @@
 use drv_ignition_api::*;
 use drv_sidecar_mainboard_controller::ignition::*;
 use ringbuf::*;
-use userlib::{sys_get_timer, sys_set_timer, task_slot, UnwrapLite};
+use userlib::{hl, sys_get_timer, sys_set_timer, task_slot, UnwrapLite};
 
 task_slot!(FPGA, fpga);
 #[cfg(feature = "sequencer")]

--- a/drv/lpc55-gpio/src/main.rs
+++ b/drv/lpc55-gpio/src/main.rs
@@ -45,7 +45,7 @@ use lpc55_pac as device;
 use drv_lpc55_gpio_api::*;
 use drv_lpc55_syscon_api::*;
 use idol_runtime::{NotificationHandler, RequestError};
-use userlib::*;
+use userlib::{task_slot, RecvMessage};
 
 task_slot!(SYSCON, syscon_driver);
 

--- a/drv/lpc55-i2c/src/main.rs
+++ b/drv/lpc55-i2c/src/main.rs
@@ -24,7 +24,7 @@
 use drv_lpc55_gpio_api::*;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;
-use userlib::*;
+use userlib::{hl, task_slot, FromPrimitive, LeaseAttributes};
 
 task_slot!(SYSCON, syscon_driver);
 task_slot!(GPIO, gpio_driver);

--- a/drv/lpc55-rng/src/main.rs
+++ b/drv/lpc55-rng/src/main.rs
@@ -16,7 +16,7 @@ use idol_runtime::{ClientError, NotificationHandler, RequestError};
 use rand_chacha::ChaCha20Rng;
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{impls, Error, RngCore, SeedableRng};
-use userlib::*;
+use userlib::task_slot;
 
 use lpc55_pac as device;
 

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -12,7 +12,7 @@ use drv_lpc55_spi as spi_core;
 use drv_lpc55_syscon_api::{Peripheral, Syscon};
 use lpc55_pac as device;
 use ringbuf::*;
-use userlib::*;
+use userlib::{sys_irq_control, sys_recv_notification, task_slot};
 
 task_slot!(SYSCON, syscon_driver);
 task_slot!(GPIO, gpio_driver);

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -70,7 +70,10 @@ use idol_runtime::{
 };
 use lpc55_pac as device;
 use ringbuf::*;
-use userlib::*;
+use userlib::{
+    hl, set_timer_relative, sys_set_timer, task_slot, RecvMessage, TaskId,
+    UnwrapLite,
+};
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {

--- a/drv/lpc55-syscon/src/main.rs
+++ b/drv/lpc55-syscon/src/main.rs
@@ -114,7 +114,7 @@ use drv_lpc55_syscon_api::*;
 use idol_runtime::{NotificationHandler, RequestError};
 use lpc55_pac as device;
 use task_jefe_api::{Jefe, ResetReason};
-use userlib::*;
+use userlib::{task_slot, RecvMessage};
 
 task_slot!(JEFE, jefe);
 


### PR DESCRIPTION
Didn't quite have the time to get rid of all of these, but I removed a bunch of userlib namespace imports.

These were mentioned in a PR nearly half a year ago and I "helpfully" went through and pointed out those that were in the PR, so this is my atonement.

Each task is done in a separate commit here. All others except `drv-lpc55-spi-server` is tested to cause no build errors, or I think anyway. I'm randomly building tasks based on searches into the repository with the device name, and testing that they fail if I remove the `userlib::*` import entirely, and then add imports until build works.