### PR TITLE
ringbuf: Eliminate potential panics

### DIFF
--- a/lib/static-cell/src/lib.rs
+++ b/lib/static-cell/src/lib.rs
@@ -52,11 +52,7 @@ impl<T> StaticCell<T> {
     /// If a `StaticRef` for `self` still exists anywhere in the program, this
     /// will panic.
     pub fn borrow_mut(&self) -> StaticRef<'_, T> {
-        if let Some(borrow) = self.try_borrow_mut() {
-            borrow
-        } else {
-            panic!();
-        }
+        self.try_borrow_mut().unwrap()
     }
 }
 


### PR DESCRIPTION
> The ~~Hitchhiker's Guide to the Galaxy~~ ringbuf has already
> supplanted ~~the great Encyclopaedia Galactica~~ text-based logging as
> the standard repository of all knowledge and wisdom, for though it has
> many omissions, it scores over the older, more pedestrian work in two
> important respects. First, it is slightly cheaper; and secondly it has
> the words **DON'T PANIC** inscribed in large friendly letters on its
> cover.

We have support in `userlib` for statically disabling all panics at
compile-time. When a task enables the `no-panic` feature flag on
`userlib`, any panic in that task will result in a link error. This
allows us to guarantee that some tasks will never panic, and we get a
nice code size reduction from doing so. However, the `ringbuf` crate
currently cannot be used in no-panic tasks, as it does fallible array
indexing, and calls into the `StaticCell::borrow_mut` method in
`static-cell`, which can panic.

This commit removes all potential panics from `ringbuf`. I've done this
by:

1. Adding a variant of `StaticCell::borrow_mut` that returns `None` if
   the cell is already borrowed (see de83f90).
3. Changing the code in `Ringbuf::do_record` that indexes the buffer
   array to use `[T]::get_unchecked_mut` rather than `[T]::index_mut`,
   which will never panic.

Note that the `counters-derive`-generated code is already panic-free, as
it only ever does exhaustive enum matching and will never index an
array, so we didn't need to do anything there to ensure a counted
ringbuf never panics.

I decided to use `get_unchecked_mut`, which just does an out-of-bounds
access if the index is out of bounds, rather than `get_mut`, which is
safe and returns `None`, because the code that constructs the index
guarantees that it is within bounds of the ringbuf's array. Since
constructing the index checks if the next index is >=
`self.buffer.len()` and wraps it if it is, we have already done a bounds
check of our own, and shouldn't need to rely on the slice's second
bounds check. This way, we generate less code, which should benefit
everyone, not just no-panic tasks. We could, alternatively, avoid the
`unsafe` code by using `get_mut` and doing nothing if it returns
`None`, but I thought getting rid of the spurious bounds check that will
never fail was worth it. I'm open to being convinced otherwise.

I've verified that the `ringbuf` crate no longer generates panic code by
adding a dummy ringbuf to `drv-stm32xx-sys`, which is compiled with
`userlib`'s `no-panic` feature enabled, like this:

```patch
diff --git a/Cargo.lock b/Cargo.lock
index 8a15a508..20703603 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "ringbuf",
  "stm32g0",
  "stm32h7",
  "task-jefe-api",
diff --git a/drv/stm32xx-sys/Cargo.toml b/drv/stm32xx-sys/Cargo.toml
index 706b2c6f..b96b1ea9 100644
--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -11,6 +11,7 @@ hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"], opt
 task-jefe-api = { path="../../task/jefe-api" }
 userlib = { path = "../../sys/userlib" }
 counters = { path = "../../lib/counters", optional = true }
+ringbuf = { path = "../../lib/ringbuf" }

 bitflags = { workspace = true }
 cfg-if = { workspace = true }
diff --git a/drv/stm32xx-sys/src/main.rs b/drv/stm32xx-sys/src/main.rs
index 8e7849c9..6f15453c 100644
--- a/drv/stm32xx-sys/src/main.rs
+++ b/drv/stm32xx-sys/src/main.rs
@@ -373,8 +373,16 @@ where
     }
 }

+ringbuf::ringbuf!(u32, 32, 0);
+
 #[export_name = "main"]
 fn main() -> ! {
+    // Test that the ringbuf doesn't generate panic sites, since this task is
+    // guaranteed not to panic.
+    for i in 0..128 {
+        ringbuf::ringbuf_entry!(i);
+    }
+
     // From thin air, pluck a pointer to the RCC register block.
     //
     // Safety: this is needlessly unsafe in the API. The RCC is essentially a

```

I built the `demo-stm32h7-nucleo/app-h753.toml` with this change. Note
that that app.toml enables `drv-stm32xx-sys`'s `no-panic` feature, so if
panicking code is generated, the app would fail to link.

I then flashed my Nucleo board and verified that the ringbuf works
correctly:

```console
#⏲ 11:29:47 env loaded on ⎇  eliza/ringbuf-dont-panic [$!?] using ⚙️ v1.79.0-nightly
eliza@theseus ~/Code/oxide/hubris $ humility -t nucleo flash
humility: attaching with chip set to "STM32H753ZITx"
humility: attached to 0483:374e:0030003C3431511237393330 via ST-Link V3
humility: flash/archive mismatch; reflashing
humility: flashing done

#⏲ 11:30:07 env loaded on ⎇  eliza/ringbuf-dont-panic [$!?] using ⚙️ v1.79.0-nightly took 6s
eliza@theseus ~/Code/oxide/hubris $ humility -t nucleo ringbuf drv_stm32xx_sys
humility: attached to 0483:374e:0030003C3431511237393330 via ST-Link V3
humility: ring buffer drv_stm32xx_sys::__RINGBUF in sys:
 NDX LINE      GEN    COUNT PAYLOAD
   0  383        4        1 0x60
   1  383        4        1 0x61
   2  383        4        1 0x62
   3  383        4        1 0x63
   4  383        4        1 0x64
   5  383        4        1 0x65
   6  383        4        1 0x66
   7  383        4        1 0x67
   8  383        4        1 0x68
   9  383        4        1 0x69
  10  383        4        1 0x6a
  11  383        4        1 0x6b
  12  383        4        1 0x6c
  13  383        4        1 0x6d
  14  383        4        1 0x6e
  15  383        4        1 0x6f
  16  383        4        1 0x70
  17  383        4        1 0x71
  18  383        4        1 0x72
  19  383        4        1 0x73
  20  383        4        1 0x74
  21  383        4        1 0x75
  22  383        4        1 0x76
  23  383        4        1 0x77
  24  383        4        1 0x78
  25  383        4        1 0x79
  26  383        4        1 0x7a
  27  383        4        1 0x7b
  28  383        4        1 0x7c
  29  383        4        1 0x7d
  30  383        4        1 0x7e
  31  383        4        1 0x7f
```

So, it works!