### PR TITLE
Implement persistent data for Cosmo `hf` slot selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,6 @@ name = "drv-gimlet-hf-server"
 version = "0.1.0"
 dependencies = [
  "build-util",
- "crc",
  "drv-hash-api",
  "drv-hf-api",
  "drv-stm32h7-qspi",
@@ -1121,6 +1120,7 @@ name = "drv-hf-api"
 version = "0.1.0"
 dependencies = [
  "counters",
+ "crc",
  "derive-idol-err",
  "drv-hash-api",
  "drv-qspi-api",

--- a/app/grapefruit/app.toml
+++ b/app/grapefruit/app.toml
@@ -266,7 +266,7 @@ priority = 5
 start = true
 uses = ["fmc_nor_psram_bank_1"]
 task-slots = ["hash_driver", "grapefruit_seq"]
-stacksize = 1536
+stacksize = 3000
 
 [config.net]
 # VLAN configuration

--- a/app/grapefruit/app.toml
+++ b/app/grapefruit/app.toml
@@ -266,7 +266,7 @@ priority = 5
 start = true
 uses = ["fmc_nor_psram_bank_1"]
 task-slots = ["hash_driver", "grapefruit_seq"]
-stacksize = 3000
+stacksize = 4000
 
 [config.net]
 # VLAN configuration

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -78,12 +78,7 @@ fn main() -> ! {
         fail(drv_hf_api::HfError::BadChipId);
     }
 
-    let mut server = hf::ServerImpl {
-        // TODO pick based on FPGA state
-        dev: drv_hf_api::HfDevSelect::Flash0,
-        drv,
-    };
-
+    let mut server = hf::ServerImpl::new(drv);
     let mut buffer = [0; hf::idl::INCOMING_SIZE];
     loop {
         idol_runtime::dispatch(&mut buffer, &mut server);
@@ -230,6 +225,9 @@ impl FlashDriver {
     }
 
     /// Reads data from the given address into a `BufWriter`
+    ///
+    /// This function will only return an error if it fails to read from a
+    /// provided lease; when given a slice, it is infallible.
     fn flash_read(
         &mut self,
         offset: u32,
@@ -261,6 +259,9 @@ impl FlashDriver {
     }
 
     /// Writes data from a `BufReader` into the flash
+    ///
+    /// This function will only return an error if it fails to write to a
+    /// provided lease; when given a slice, it is infallible.
     fn flash_write(
         &mut self,
         addr: u32,

--- a/drv/gimlet-hf-server/Cargo.toml
+++ b/drv/gimlet-hf-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-crc.workspace = true
 hubpack.workspace = true
 idol-runtime.workspace = true
 num-traits.workspace = true

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -53,7 +53,7 @@ use drv_hash_api::SHA256_SZ;
 
 use drv_hf_api::{
     HfDevSelect, HfError, HfMuxState, HfPersistentData, HfProtectMode,
-    PAGE_SIZE_BYTES,
+    HfRawPersistentData, HF_PERSISTENT_DATA_STRIDE, PAGE_SIZE_BYTES,
 };
 
 task_slot!(SYS, sys);
@@ -188,84 +188,6 @@ fn main() -> ! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Represents persistent data that is both stored on the host flash and used to
-/// configure host boot.
-///
-/// We reserve sector 0 (i.e. the lowest 64 KiB) of both host flash ICs for
-/// Hubris data.  On both host flashes, we tile sector 0 with this 40-byte
-/// struct, placed at 128-byte intervals (in case it needs to grow in the
-/// future).
-///
-/// The current value of persistent data is the instance of `RawPersistentData`
-/// with a valid checksum and the highest `monotonic_counter` across both flash
-/// ICs.
-///
-/// When writing new data, we increment the monotonic counter and write to both
-/// ICs, one by one.  This ensures robustness in case of power loss.
-#[derive(Copy, Clone, Eq, PartialEq, AsBytes, FromBytes)]
-#[repr(C)]
-struct RawPersistentData {
-    /// Reserved field, because this is placed at address 0, which PSP firmware
-    /// may look at under certain circumstances.
-    amd_reserved_must_be_all_ones: u64,
-
-    /// Must always be `HF_PERSISTENT_DATA_MAGIC`.
-    oxide_magic: u32,
-
-    /// Must always be `HF_PERSISTENT_DATA_HEADER_VERSION` (for now)
-    header_version: u32,
-
-    /// Monotonically increasing counter
-    monotonic_counter: u64,
-
-    /// Either 0 or 1; directly translatable to `gimlet_hf_api::HfDevSelect`
-    dev_select: u32,
-
-    /// CRC-32 over the rest of the data using the iSCSI polynomial
-    checksum: u32,
-}
-
-impl RawPersistentData {
-    fn new(data: HfPersistentData, monotonic_counter: u64) -> Self {
-        let mut out = Self {
-            amd_reserved_must_be_all_ones: u64::MAX,
-            oxide_magic: HF_PERSISTENT_DATA_MAGIC,
-            header_version: HF_PERSISTENT_DATA_HEADER_VERSION,
-            monotonic_counter,
-            dev_select: data.dev_select as u32,
-            checksum: 0,
-        };
-        out.checksum = out.expected_checksum();
-        assert!(out.is_valid());
-        out
-    }
-
-    fn expected_checksum(&self) -> u32 {
-        let c = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
-        let mut c = c.digest();
-        // We do a CRC32 of everything except the checksum, which is positioned
-        // at the end of the struct and is a `u32`
-        let size = core::mem::size_of::<RawPersistentData>()
-            - core::mem::size_of::<u32>();
-        c.update(&self.as_bytes()[..size]);
-        c.finalize()
-    }
-
-    fn is_valid(&self) -> bool {
-        self.amd_reserved_must_be_all_ones == u64::MAX
-            && self.oxide_magic == HF_PERSISTENT_DATA_MAGIC
-            && self.header_version == HF_PERSISTENT_DATA_HEADER_VERSION
-            && self.dev_select <= 1
-            && self.checksum == self.expected_checksum()
-    }
-}
-
-const HF_PERSISTENT_DATA_MAGIC: u32 = 0x1dea_bcde;
-const HF_PERSISTENT_DATA_STRIDE: usize = 128;
-const HF_PERSISTENT_DATA_HEADER_VERSION: u32 = 1;
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct ServerImpl {
     qspi: Qspi,
     block: [u8; 256],
@@ -323,7 +245,7 @@ impl ServerImpl {
 
     fn get_raw_persistent_data(
         &mut self,
-    ) -> Result<RawPersistentData, HfError> {
+    ) -> Result<HfRawPersistentData, HfError> {
         self.check_muxed_to_sp()?;
         let best = if self.dev_select_pin.is_some() {
             let prev_slot = self.dev_state;
@@ -343,13 +265,7 @@ impl ServerImpl {
             let (b, _) = self.persistent_data_scan();
 
             match (a, b) {
-                (Some(a), Some(b)) => {
-                    if a.monotonic_counter > b.monotonic_counter {
-                        Some(a)
-                    } else {
-                        Some(b)
-                    }
-                }
+                (Some(a), Some(b)) => Some(a.max(b)),
                 (Some(_), None) => a,
                 (None, Some(_)) => b,
                 (None, None) => None,
@@ -367,18 +283,16 @@ impl ServerImpl {
     /// Returns a tuple containing
     /// - newest persistent data record
     /// - address of first empty slot
-    fn persistent_data_scan(&self) -> (Option<RawPersistentData>, Option<u32>) {
-        let mut best: Option<RawPersistentData> = None;
+    fn persistent_data_scan(
+        &self,
+    ) -> (Option<HfRawPersistentData>, Option<u32>) {
+        let mut best: Option<HfRawPersistentData> = None;
         let mut empty_slot: Option<u32> = None;
         for i in 0..SECTOR_SIZE_BYTES / HF_PERSISTENT_DATA_STRIDE {
             let addr = (i * HF_PERSISTENT_DATA_STRIDE) as u32;
-            let mut data = RawPersistentData::new_zeroed();
+            let mut data = HfRawPersistentData::new_zeroed();
             self.qspi.read_memory(addr, data.as_bytes_mut());
-            if data.is_valid()
-                && best
-                    .map(|b| b.monotonic_counter < data.monotonic_counter)
-                    .unwrap_or(true)
-            {
+            if data.is_valid() && best.map(|b| data > b).unwrap_or(true) {
                 best = Some(data);
             }
             if empty_slot.is_none()
@@ -420,7 +334,7 @@ impl ServerImpl {
     fn write_raw_persistent_data_to_addr(
         &mut self,
         addr: Option<u32>,
-        raw_data: &RawPersistentData,
+        raw_data: &HfRawPersistentData,
     ) -> Result<(), HfError> {
         // Clippy misfire as of 2024-04
         #[allow(clippy::manual_unwrap_or_default)]
@@ -458,7 +372,7 @@ impl ServerImpl {
 
         match (a_data, b_data) {
             (Some(a), Some(b)) => {
-                match a.monotonic_counter.cmp(&b.monotonic_counter) {
+                match a.cmp(&b) {
                     core::cmp::Ordering::Less => {
                         self.set_dev(!prev_slot).unwrap();
                         let out =
@@ -749,7 +663,8 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             };
 
             // Early exit if the previous persistent data matches
-            let prev_raw = RawPersistentData::new(data, prev_monotonic_counter);
+            let prev_raw =
+                HfRawPersistentData::new(data, prev_monotonic_counter);
             if a_data == b_data && a_data == Some(prev_raw) {
                 return Ok(());
             }
@@ -757,7 +672,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             let monotonic_counter = prev_monotonic_counter
                 .checked_add(1)
                 .ok_or(HfError::MonotonicCounterOverflow)?;
-            let raw = RawPersistentData::new(data, monotonic_counter);
+            let raw = HfRawPersistentData::new(data, monotonic_counter);
 
             // Write the persistent data to the currently inactive flash.
             self.set_dev(!prev_slot).unwrap();
@@ -782,7 +697,8 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             };
 
             // Early exit if the previous persistent data matches
-            let prev_raw = RawPersistentData::new(data, prev_monotonic_counter);
+            let prev_raw =
+                HfRawPersistentData::new(data, prev_monotonic_counter);
             if prev_data == Some(prev_raw) {
                 return Ok(());
             }
@@ -790,7 +706,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             let monotonic_counter = prev_monotonic_counter
                 .checked_add(1)
                 .ok_or(HfError::MonotonicCounterOverflow)?;
-            let raw = RawPersistentData::new(data, monotonic_counter);
+            let raw = HfRawPersistentData::new(data, monotonic_counter);
             self.write_raw_persistent_data_to_addr(next, &raw)?;
         }
         Ok(())

--- a/drv/hf-api/Cargo.toml
+++ b/drv/hf-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+crc.workspace = true
 hubpack.workspace = true
 idol-runtime.workspace = true
 num-traits.workspace = true

--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -10,7 +10,7 @@ use derive_idol_err::IdolError;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 use userlib::{sys_send, FromPrimitive};
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 pub use drv_qspi_api::{PAGE_SIZE_BYTES, SECTOR_SIZE_BYTES};
 
@@ -100,5 +100,93 @@ pub enum HfProtectMode {
 pub struct HfPersistentData {
     pub dev_select: HfDevSelect,
 }
+
+/// Represents persistent data that is both stored on the host flash and used to
+/// configure host boot.
+///
+/// We reserve sector 0 (i.e. the lowest 64 KiB) of both host flash ICs for
+/// Hubris data.  On both host flashes, we tile sector 0 with this 40-byte
+/// struct, placed at 128-byte intervals (in case it needs to grow in the
+/// future).
+///
+/// The current value of persistent data is the instance of `RawPersistentData`
+/// with a valid checksum and the highest `monotonic_counter` across both flash
+/// ICs.
+///
+/// When writing new data, we increment the monotonic counter and write to both
+/// ICs, one by one.  This ensures robustness in case of power loss.
+#[derive(Copy, Clone, Eq, PartialEq, AsBytes, FromBytes)]
+#[repr(C)]
+pub struct HfRawPersistentData {
+    /// Reserved field, because this is placed at address 0, which PSP firmware
+    /// may look at under certain circumstances.
+    amd_reserved_must_be_all_ones: u64,
+
+    /// Must always be `HF_PERSISTENT_DATA_MAGIC`.
+    oxide_magic: u32,
+
+    /// Must always be `HF_PERSISTENT_DATA_HEADER_VERSION` (for now)
+    header_version: u32,
+
+    /// Monotonically increasing counter
+    pub monotonic_counter: u64,
+
+    /// Either 0 or 1; directly translatable to [`HfDevSelect`]
+    pub dev_select: u32,
+
+    /// CRC-32 over the rest of the data using the iSCSI polynomial
+    checksum: u32,
+}
+
+impl core::cmp::PartialOrd for HfRawPersistentData {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl core::cmp::Ord for HfRawPersistentData {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.monotonic_counter.cmp(&other.monotonic_counter)
+    }
+}
+
+impl HfRawPersistentData {
+    pub fn new(data: HfPersistentData, monotonic_counter: u64) -> Self {
+        let mut out = Self {
+            amd_reserved_must_be_all_ones: u64::MAX,
+            oxide_magic: HF_PERSISTENT_DATA_MAGIC,
+            header_version: HF_PERSISTENT_DATA_HEADER_VERSION,
+            monotonic_counter,
+            dev_select: data.dev_select as u32,
+            checksum: 0,
+        };
+        out.checksum = out.expected_checksum();
+        assert!(out.is_valid());
+        out
+    }
+
+    fn expected_checksum(&self) -> u32 {
+        let c = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
+        let mut c = c.digest();
+        // We do a CRC32 of everything except the checksum, which is positioned
+        // at the end of the struct and is a `u32`
+        let size = core::mem::size_of::<HfRawPersistentData>()
+            - core::mem::size_of::<u32>();
+        c.update(&self.as_bytes()[..size]);
+        c.finalize()
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.amd_reserved_must_be_all_ones == u64::MAX
+            && self.oxide_magic == HF_PERSISTENT_DATA_MAGIC
+            && self.header_version == HF_PERSISTENT_DATA_HEADER_VERSION
+            && self.dev_select <= 1
+            && self.checksum == self.expected_checksum()
+    }
+}
+
+pub const HF_PERSISTENT_DATA_MAGIC: u32 = 0x1dea_bcde;
+pub const HF_PERSISTENT_DATA_STRIDE: usize = 128;
+pub const HF_PERSISTENT_DATA_HEADER_VERSION: u32 = 1;
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));


### PR DESCRIPTION
Staged on top of #1853

This PR implement persistent storage in host flash for Cosmo, using the same strategy as Gimlet: reserve sector 0 and tile it with a small data payload, using a CRC to ensure validity and a monotonic counter to find the newest payload.

This only works because the AMD boot sequence ignores sector 0 (other than word 0, which must be all 1s).

`RawPersistentData` is moved to `drv-hf-api` and renamed `HfRawPersistentData` for consistency.  In addition, it now implements `cmp`, making a few operations cleaner.

The new code in `drv-cosmo-hf` is _mostly_ copypasta from `drv-gimlet-hf`, but with a few tweaks (both virtual devices are on the same flash chip, the QSPI driver has a slightly different API, etc).