### PR TITLE
Fix Sidecar fan speed sensor ordering in base.toml

### DIFF
--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -483,7 +483,7 @@ address = 0b0100_011
 device = "max31790"
 name = "East"
 description = "Fan 0/1 controller"
-sensors = { speed = 4, names = [ "SE_fan1", "NE_fan1", "ESE_fan0", "ENE_fan0" ] }
+sensors = { speed = 4, names = [ "ESE_fan0", "ENE_fan0", "SE_fan1", "NE_fan1" ] }
 refdes = "U66"
 
 [[config.i2c.devices]]
@@ -635,7 +635,7 @@ address = 0b0100_000
 device = "max31790"
 name = "West"
 description = "Fan 2/3 controller"
-sensors = { speed = 4, names = [ "WSW_fan3", "WNW_fan3", "SW_fan2", "NW_fan2" ] }
+sensors = { speed = 4, names = [ "SW_fan2", "NW_fan2", "WSW_fan3", "WNW_fan3" ] }
 refdes = "U78"
 
 [[config.i2c.devices]]


### PR DESCRIPTION
We have Sidecar's fans wired up to the controllers in a non-intuitive way. That leads to a couple places we need to have this accounted for properly in the code: speed sensor naming and controller mapping. The speed sensor naming was incorrect and fixed by this commit.

fixes #1865 