### PR TITLE
Add comments explaining production assumption

### DIFF
--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "gimlet-b"
 board = "gimlet-b"
 inherit = "base.toml"

--- a/app/gimlet/rev-c.toml
+++ b/app/gimlet/rev-c.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "gimlet-c"
 board = "gimlet-c"
 

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -1,5 +1,7 @@
 # The rev D hardware includes `nreset` lines on all I2C muxes and changes the
 # M.2 device type from `m2_hp_only` to `nvme_bmc` (after a hardware fix).
+#
+# This is the production image. We expect `name` to match `board`
 name = "gimlet-d"
 board = "gimlet-d"
 inherit = "base.toml"

--- a/app/gimlet/rev-e.toml
+++ b/app/gimlet/rev-e.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "gimlet-e"
 board = "gimlet-e"
 

--- a/app/gimlet/rev-f.toml
+++ b/app/gimlet/rev-f.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "gimlet-f"
 board = "gimlet-f"
 

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "oxide-rot-1"
 target = "thumbv8m.main-none-eabihf"
 board = "oxide-rot-1"

--- a/app/psc/rev-b.toml
+++ b/app/psc/rev-b.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "psc-b"
 board = "psc-b"
 

--- a/app/psc/rev-c.toml
+++ b/app/psc/rev-c.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "psc-c"
 board = "psc-c"
 

--- a/app/sidecar/rev-b.toml
+++ b/app/sidecar/rev-b.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "sidecar-b"
 board = "sidecar-b"
 inherit = "base.toml"

--- a/app/sidecar/rev-c.toml
+++ b/app/sidecar/rev-c.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "sidecar-c"
 board = "sidecar-c"
 inherit = "base.toml"

--- a/app/sidecar/rev-d.toml
+++ b/app/sidecar/rev-d.toml
@@ -1,3 +1,4 @@
+# This is the production image. We expect `name` to match `board`
 name = "sidecar-d"
 board = "sidecar-d"
 


### PR DESCRIPTION
We currently have an implicit assumption that our production images have the same name as the board. It's useful to take advantage of this in places like the control plane so document this for our future selves.