### PR TITLE
hf-api: knock 2 kiB off stack usage

### DIFF
--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -166,8 +166,8 @@ impl HfRawPersistentData {
     }
 
     fn expected_checksum(&self) -> u32 {
-        let c = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
-        let mut c = c.digest();
+        static CRC: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
+        let mut c = CRC.digest();
         // We do a CRC32 of everything except the checksum, which is positioned
         // at the end of the struct and is a `u32`
         let size = core::mem::size_of::<HfRawPersistentData>()


### PR DESCRIPTION
hf-api includes a function that computes a CRC32 of a chunk of data. Unfortunately, it made the (easy, common) mistake of allocating a crc::Crc on the stack.

The upstream crc crate, despite our protests, optimizes for time over space. A crc::Crc includes a lookup table to accelerate the calculation of the CRC. Creating one at runtime on the stack means

1. The lookup table is on your stack (all 2048 bytes of it, in this case), and

2. Your function now contains code to generate the lookup table.

This is a footgun in the crc API design, IMO. It's far too easy to make this mistake.

Anyway, made it static for a 2 kiB improvement in stack margin.