### PR TITLE
Add min and max output bounds to `PidConfig`

### DIFF
--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -181,6 +181,8 @@ impl Bsp {
                 gain_p: 1.75,
                 gain_i: 0.0135,
                 gain_d: 0.4,
+                min_output: 0.0,
+                max_output: 100.0,
             },
 
             inputs: &INPUTS,

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -103,6 +103,8 @@ impl Bsp {
                 gain_p: 1.75,
                 gain_i: 0.0135,
                 gain_d: 0.4,
+                min_output: 15.0,
+                max_output: 100.0,
             },
 
             inputs: &INPUTS,

--- a/task/thermal/src/bsp/medusa_a.rs
+++ b/task/thermal/src/bsp/medusa_a.rs
@@ -86,6 +86,8 @@ impl Bsp {
                 gain_p: 0.,
                 gain_i: 0.,
                 gain_d: 0.,
+                min_output: 0.,
+                max_output: 100.,
             },
 
             inputs: &INPUTS,

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -187,6 +187,8 @@ impl Bsp {
                 gain_p: 1.75,
                 gain_i: 0.0135,
                 gain_d: 0.4,
+                min_output: 0.0,
+                max_output: 100.0,
             },
 
             inputs: &INPUTS,


### PR DESCRIPTION
The EMC2305 on Grapefruit doesn't turn on the fans at 0 PWM, and we want some airflow to get better readings from the temperature sensor.  Might as well make the lower and upper bounds fully parameterized by the PID config!