### PR TITLE
Make `oxide-rot-1-dev` a completely different board

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -99,14 +99,14 @@ jobs:
     name: build-rot
     strategy:
       matrix:
-        build: [oxide-rot-1, oxide-rot-1-dev]
+        build: [oxide-rot-1, oxide-rot-1-selfsigned]
         include:
           - build: oxide-rot-1
             app_name: oxide-rot-1
             app_toml: app/oxide-rot-1/app.toml
             image: "a, b"
-          - build: oxide-rot-1-dev
-            app_name: oxide-rot-1-dev
+          - build: oxide-rot-1-selfsigned
+            app_name: oxide-rot-1-selfsigned
             app_toml: app/oxide-rot-1/app-dev.toml
             image: "a, b"
     uses: ./.github/workflows/build-one.yml

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -1,6 +1,10 @@
-name = "oxide-rot-1-dev"
+# This is a different board than `oxide-rot-1` because `oxide-rot-1`
+# expects an image that has gone through the full manufacturing provisioning
+# flow. It's technically not completely new hardware but for all practical
+# purposes it might as well be electrically incompatible.
+name = "oxide-rot-1-selfsigned"
 target = "thumbv8m.main-none-eabihf"
-board = "oxide-rot-1"
+board = "oxide-rot-1-selfsigned"
 chip = "../../chips/lpc55"
 stacksize = 1024
 image-names = ["a", "b"]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -125,6 +125,13 @@ impl PackageConfig {
             file_data.hash(&mut extra_hash);
         }
 
+        // We require a board file in the `boards` directory
+        let board_path =
+            Path::new("boards").join(format!("{}.toml", toml.board));
+        if !board_path.exists() {
+            bail!("Failed to find {:?}", board_path);
+        }
+
         Ok(Self {
             app_src_dir: app_src_dir.to_path_buf(),
             toml,


### PR DESCRIPTION
`oxide-rot-1/app.toml` expects to be run on a machine that has been through the full manufacturing flow. If it is run on one that hasn't had that happen it will fail to boot (loop forever). This is mostly a concern for engineering development but it keeps tripping people up so attempt to differentiate the correct image to use by changing the board. It's not strictly incompatible but going from one to another kind is a sort of cheap and relatively easy to rework.