### PR TITLE
remap crates fetched via sparse registry as well

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -167,7 +167,7 @@ impl PackageConfig {
             remap_paths.insert(cargo_git, "/git");
 
             // This hash is canonical-ish: Cargo tries hard not to change it
-            // https://github.com/rust-lang/cargo/blob/master/src/cargo/core/source/source_id.rs#L607-L630
+            // https://github.com/rust-lang/cargo/blob/5dfdd59/src/cargo/core/source_id.rs#L755-L794
             //
             // It depends on system architecture, so this won't work on (for example)
             // a Raspberry Pi, but the only downside is that panic messages will
@@ -177,6 +177,15 @@ impl PackageConfig {
                 .join("src")
                 .join("github.com-1ecc6299db9ec823");
             remap_paths.insert(cargo_registry, "/crates.io");
+            // If Cargo uses the sparse registry (stabilized since ~1.72) it caches fetched crates
+            // in a slightly different path. Remap that one as well.
+            //
+            // This path has the same canonical-ish properties as above.
+            let cargo_sparse_registry = cargo_home
+                .join("registry")
+                .join("src")
+                .join("index.crates.io-6f17d22bba15001f");
+            remap_paths.insert(cargo_sparse_registry, "/crates.io");
         }
 
         if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {


### PR DESCRIPTION
on Rust nightlies [since about 2023-03-09](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-168-2023-03-09) it seems the default (-on-nightly?) Cargo protocol switched to "sparse". this has a side effect of caching fetched crates at a different path, so the `github.com` path remapping is no longer sufficient to normalize all crate paths.

we then picked that change up back at v1.0.14, bumping [nightly forward a year and change](https://github.com/oxidecomputer/hubris/commit/24bdff63d662053c097d6f84566bfae3ef772edd#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4e), so local builds of hubris between then and v1.0.26 have source paths that are not actually remapped :(

thankfully, to make it sufficient we only have to handle the new `index.crates.io-6f17d22bba15001f` path as well. this in fact is where *all* cargo-fetched crates.io dependencies end up now.

technically we could forget about `github.com-1ecc6299db9ec823` at this point, but by keeping it we'll still be correct in the unlikely event someone were to flip away from `sparse` to `git` for the Cargo protocol.

when i built `gimlet-v1.0.26` with this patch the resulting images no longer have my home directory in them.

... i am deeply perplexed that with this change the resulting `gimlet-b` image is 0x2200 bytes larger though???

a funny consequence of this is that to reproduce the hubris releases from 1.0.14 to ... now ... you actually have to remap the index.crates.io directory to `/home/runner/.cargo/registry/src/index.crates.io-6f16d22bba15001f`. by doing this i just built a `gimlet-b` that matches the one [here](https://github.com/oxidecomputer/hubris/releases/tag/gimlet-v1.0.26).