### PR TITLE
Bump stack size on control-plane-agent

### DIFF
--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -261,7 +261,8 @@ notifications = ["socket"]
 name = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
-stacksize = 4096
+# This can probably overkill and can be tuned later
+stacksize = 6000
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -197,7 +197,8 @@ notifications = ["spi-irq"]
 name = "task-control-plane-agent"
 priority = 5
 max-sizes = {flash = 131072, ram = 32768}
-stacksize = 4096
+# This is probably a bit overkill and can be tuned later
+stacksize = 6000
 start = true
 uses = []
 task-slots = [

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -107,6 +107,7 @@ task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 name = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 142900, ram = 65536 }
+# This is a big number -- do we need to tune this?
 stacksize = 12000
 start = true
 uses = []


### PR DESCRIPTION
We found a crash where the stack size was 3980. This was awfully close to 4096. 12000 is definitely a large bound but it is a safe bound.