### PR TITLE
Drop gdb file from the archive

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -870,10 +870,6 @@ fn build_archive(
     }
 
     let debug_dir = PathBuf::from("debug");
-    archive.copy(
-        cfg.img_file("script.gdb", image_name),
-        debug_dir.join("script.gdb"),
-    )?;
 
     if let Some(auxflash) = cfg.toml.auxflash.as_ref() {
         let file = cfg.dist_file("auxi.tlvc");


### PR DESCRIPTION
This file contains local paths which reduces reproducibility. The local paths also mean it's not useful in the archive anyway.