### PR TITLE
Add `oxide-rot-1-selfsigned` to flashing code

### DIFF
--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -144,8 +144,11 @@ pub fn config(
     chip_dir: &Path,
 ) -> anyhow::Result<Option<FlashConfig>> {
     let mut flash = match board {
-        "lpcxpresso55s69" | "rot-carrier-1" | "rot-carrier-2"
-        | "oxide-rot-1" => {
+        "lpcxpresso55s69"
+        | "rot-carrier-1"
+        | "rot-carrier-2"
+        | "oxide-rot-1"
+        | "oxide-rot-1-selfsigned" => {
             let chip = if board == "rot-carrier-1" {
                 "lpc55s28"
             } else {
@@ -205,7 +208,10 @@ pub fn config(
 
 pub fn chip_name(board: &str) -> anyhow::Result<&'static str> {
     let b = match board {
-        "lpcxpresso55s69" | "rot-carrier-2" | "oxide-rot-1" => "LPC55S69JBD100",
+        "lpcxpresso55s69"
+        | "rot-carrier-2"
+        | "oxide-rot-1"
+        | "oxide-rot-1-selfsigned" => "LPC55S69JBD100",
         "rot-carrier-1" => "LPC55S28JBD100",
         "stm32f3-discovery" => "STM32F303VCTx",
         "stm32f4-discovery" => "STM32F407VGTx",


### PR DESCRIPTION
This got missed when the board name was changed