### PR TITLE
Avoid name conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,8 +114,8 @@ dependencies = [
 
 [[package]]
 name = "attest-data"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/dice-util#3cc953c8d0ace2f20cbcf3920b0771d25301960a"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/dice-util#a20766967f779a4bad6922d2b62593c21b384a28"
 dependencies = [
  "hubpack",
  "salty",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.2.1"
-source = "git+https://github.com/oxidecomputer/dice-util#3cc953c8d0ace2f20cbcf3920b0771d25301960a"
+source = "git+https://github.com/oxidecomputer/dice-util#a20766967f779a4bad6922d2b62593c21b384a28"
 dependencies = [
  "corncobs",
  "hubpack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["zeroize_de
 zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 # Oxide forks and repos
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.3.0" }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.4.0" }
 dice-mfg-msgs = { git = "https://github.com/oxidecomputer/dice-util", default-features = false, version = "0.2.1" }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["smoltcp"] }
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol", version = "0.1.0" }

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -14,7 +14,7 @@ use dumper_api::DumperError;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 
-use attest_data::messages::SprotError as AttestDataSprotError;
+use attest_data::messages::RecvSprotError as AttestDataSprotError;
 use gateway_messages::{
     RotError, RotWatchdogError as GwRotWatchdogError, SpError,
     SprocketsError as GwSprocketsErr,

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -9,7 +9,7 @@
 use drv_stm32h7_usart as drv_usart;
 
 use attest_data::messages::{
-    HostToRotCommand, RotToHost, SprotError as AttestDataSprotError,
+    HostToRotCommand, RecvSprotError as AttestDataSprotError, RotToHost,
     MAX_DATA_LEN,
 };
 use drv_gimlet_seq_api::{PowerState, SeqError, Sequencer};


### PR DESCRIPTION
Change the name `SprotError` in `attest-data` to avoid conflicts with the hubris `SprotError`. Rust handles this just fine but our external hiffy tooling does not handle this case.