### PR TITLE
Move probe-rs chip name into boards/*.toml, remove scary matches

### DIFF
--- a/boards/donglet-g030.toml
+++ b/boards/donglet-g030.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32G030F6Px"

--- a/boards/donglet-g031.toml
+++ b/boards/donglet-g031.toml
@@ -1,0 +1,3 @@
+[probe-rs]
+chip-name = "STM32G031F8Px"
+

--- a/boards/gemini-bu-1.toml
+++ b/boards/gemini-bu-1.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimlet-b.toml
+++ b/boards/gimlet-b.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimlet-c.toml
+++ b/boards/gimlet-c.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimlet-d.toml
+++ b/boards/gimlet-d.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimlet-e.toml
+++ b/boards/gimlet-e.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimlet-f.toml
+++ b/boards/gimlet-f.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimletlet-1.toml
+++ b/boards/gimletlet-1.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/gimletlet-2.toml
+++ b/boards/gimletlet-2.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/grapefruit.toml
+++ b/boards/grapefruit.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/lpcxpresso55s69.toml
+++ b/boards/lpcxpresso55s69.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "LPC55S69JBD100"

--- a/boards/medusa-a.toml
+++ b/boards/medusa-a.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/nucleo-h743zi2.toml
+++ b/boards/nucleo-h743zi2.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H743ZITx"

--- a/boards/nucleo-h753zi.toml
+++ b/boards/nucleo-h753zi.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/oxcon2023g0.toml
+++ b/boards/oxcon2023g0.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32G030J6Mx"

--- a/boards/oxide-rot-1-selfsigned.toml
+++ b/boards/oxide-rot-1-selfsigned.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "LPC55S69JBD100"

--- a/boards/oxide-rot-1.toml
+++ b/boards/oxide-rot-1.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "LPC55S69JBD100"

--- a/boards/psc-b.toml
+++ b/boards/psc-b.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/psc-c.toml
+++ b/boards/psc-c.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/rot-carrier-1.toml
+++ b/boards/rot-carrier-1.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "LPC55S28JBD100"

--- a/boards/rot-carrier-2.toml
+++ b/boards/rot-carrier-2.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "LPC55S69JBD100"

--- a/boards/sidecar-b.toml
+++ b/boards/sidecar-b.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/sidecar-c.toml
+++ b/boards/sidecar-c.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/sidecar-d.toml
+++ b/boards/sidecar-d.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32H753ZITx"

--- a/boards/stm32f3-discovery.toml
+++ b/boards/stm32f3-discovery.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32F303VCTx"

--- a/boards/stm32f4-discovery.toml
+++ b/boards/stm32f4-discovery.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32F407VGTx"

--- a/boards/stm32g031-nucleo.toml
+++ b/boards/stm32g031-nucleo.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32G031Y8Yx"

--- a/boards/stm32g070-nucleo.toml
+++ b/boards/stm32g070-nucleo.toml
@@ -1,0 +1,2 @@
+[probe-rs]
+chip-name = "STM32G070KBTx"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -800,3 +800,17 @@ fn read_and_flatten_toml(
     merge_toml_documents(&mut original, doc)?;
     Ok(original)
 }
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct BoardConfig {
+    /// Info about how to interact with this board using probe-rs.
+    pub probe_rs: Option<ProbeRsBoardConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ProbeRsBoardConfig {
+    /// The "chip name" used by probe-rs for flashing.
+    pub chip_name: String,
+}

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_KERNEL_STACK: u32 = 1024;
 /// that generates the Humility binary necessary for Hubris's CI has run.
 /// Once that binary is in place, you should be able to bump this version
 /// without breaking CI.
-const HUBRIS_ARCHIVE_VERSION: u32 = 8;
+const HUBRIS_ARCHIVE_VERSION: u32 = 9;
 
 /// `PackageConfig` contains a bundle of data that's commonly used when
 /// building a full app image, grouped together to avoid passing a bunch
@@ -872,10 +872,9 @@ fn build_archive(
     // any external configuration files, serialize it, and add it to the
     // archive.
     //
-    if let Some(mut config) =
+    if let Some(config) =
         crate::flash::config(cfg.toml.board.as_str(), &chip_dir)?
     {
-        config.flatten()?;
         archive.text(
             img_dir.join("flash.ron"),
             ron::ser::to_string_pretty(

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -872,9 +872,8 @@ fn build_archive(
     // any external configuration files, serialize it, and add it to the
     // archive.
     //
-    if let Some(config) =
-        crate::flash::config(cfg.toml.board.as_str(), &chip_dir)?
     {
+        let config = crate::flash::config(&cfg.toml.board)?;
         archive.text(
             img_dir.join("flash.ron"),
             ron::ser::to_string_pretty(

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -3,83 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-//
-// We allow for enough information to be put in the archive for the image to
-// be flashed based only on the archive (e.g., by Humility).  Because flashing
-// is itself a bit of a mess (requiring different programs for different
-// targets), this is a bit gritty (e.g., any required external configuration
-// files must themselves put in the archive).  If these structures need to
-// change, be sure to make corresponding changes to Humility.
-//
-#[derive(Debug, Serialize)]
-pub enum FlashProgram {
-    PyOcd(Vec<FlashArgument>),
-    OpenOcd(FlashProgramConfig),
-}
-
-//
-// Enum describing flash programs configuration (e.g., "openocd.cfg" for
-// OpenOCD), either as a path in the file system or with the entire contents.
-//
-#[derive(Debug, Serialize)]
-pub enum FlashProgramConfig {
-    Path(PathBuf),
-    Payload(String),
-}
-
-//
-// An enum describing a single command-line argument to the flash program.
-//
-#[derive(Debug, Serialize)]
-pub enum FlashArgument {
-    // A direct string
-    Direct(String),
-
-    // The filesystem path of the binary flash payload itself
-    Payload,
-
-    // A single argument consisting of a prefix and a suffix.  When the
-    // argument is processed, a single argument should be generated consisting
-    // of the prefix, the path of the flash, and the suffix, all joined by
-    // spaces.
-    FormattedPayload(String, String),
-
-    // The filesystem path of the flash program configuration
-    Config,
-}
-
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 pub struct FlashConfig {
+    /// The name used by probe-rs to identify the chip.
     chip: Option<String>,
-    program: FlashProgram,
-    args: Vec<FlashArgument>,
-}
-
-impl FlashProgramConfig {
-    fn new(path: PathBuf) -> Self {
-        FlashProgramConfig::Path(path)
-    }
 }
 
 impl FlashConfig {
-    fn new(program: FlashProgram) -> Self {
-        FlashConfig {
-            chip: None,
-            program,
-            args: vec![],
-        }
-    }
-
-    //
-    // Add a command-line argument to the flash program
-    //
-    fn arg<'a>(&'a mut self, val: &str) -> &'a mut Self {
-        self.args.push(FlashArgument::Direct(val.to_string()));
-        self
-    }
-
     //
     // Set the chip
     //
@@ -87,119 +19,13 @@ impl FlashConfig {
         self.chip = Some(val.to_string());
         self
     }
-
-    //
-    // Add the path to the payload as an argument to the flash program
-    //
-    fn payload(&mut self) -> &mut Self {
-        self.args.push(FlashArgument::Payload);
-        self
-    }
-
-    //
-    // Add a formatted payload as a single argument to the flash program.  The
-    // argument will consists of the specified prefix, followed by the path to
-    // the payload, followed by the specified suffix.
-    //
-    fn formatted_payload<'a>(
-        &'a mut self,
-        prefix: &str,
-        suffix: &str,
-    ) -> &'a mut Self {
-        self.args.push(FlashArgument::FormattedPayload(
-            prefix.to_string(),
-            suffix.to_string(),
-        ));
-        self
-    }
-
-    //
-    // Add a flasher configuration file as an argument to the flash program
-    //
-    fn config(&mut self) -> &mut Self {
-        self.args.push(FlashArgument::Config);
-        self
-    }
-
-    //
-    // Slurp in any flash program configuration file and flatten it into
-    // our overall configuration
-    //
-    pub fn flatten(&mut self) -> anyhow::Result<()> {
-        if let FlashProgram::OpenOcd(FlashProgramConfig::Path(path)) =
-            &self.program
-        {
-            let p: PathBuf = path.iter().collect();
-            let text = std::fs::read_to_string(p)?;
-            self.program =
-                FlashProgram::OpenOcd(FlashProgramConfig::Payload(text));
-        }
-
-        Ok(())
-    }
 }
 
 pub fn config(
     board: &str,
-    chip_dir: &Path,
+    _chip_dir: &Path,
 ) -> anyhow::Result<Option<FlashConfig>> {
-    let mut flash = match board {
-        "lpcxpresso55s69"
-        | "rot-carrier-1"
-        | "rot-carrier-2"
-        | "oxide-rot-1"
-        | "oxide-rot-1-selfsigned" => {
-            let chip = if board == "rot-carrier-1" {
-                "lpc55s28"
-            } else {
-                "lpc55s69"
-            };
-
-            let mut args = vec![];
-
-            for arg in ["reset", "-t", chip].iter() {
-                args.push(FlashArgument::Direct(arg.to_string()));
-            }
-
-            let mut flash = FlashConfig::new(FlashProgram::PyOcd(args));
-
-            flash
-                .arg("flash")
-                .arg("-t")
-                .arg(chip)
-                .arg("--format")
-                .arg("hex")
-                .payload();
-
-            flash
-        }
-
-        "stm32f3-discovery" | "stm32f4-discovery" | "nucleo-h743zi2"
-        | "nucleo-h753zi" | "gemini-bu-1" | "gimletlet-1" | "gimletlet-2"
-        | "gimlet-b" | "gimlet-c" | "gimlet-d" | "gimlet-e" | "gimlet-f"
-        | "psc-b" | "psc-c" | "sidecar-b" | "sidecar-c" | "sidecar-d"
-        | "stm32g031-nucleo" | "donglet-g030" | "donglet-g031"
-        | "oxcon2023g0" | "stm32g070-nucleo" | "stm32g0b1-nucleo"
-        | "medusa-a" | "grapefruit" => {
-            let cfg = FlashProgramConfig::new(chip_dir.join("openocd.cfg"));
-
-            let mut flash = FlashConfig::new(FlashProgram::OpenOcd(cfg));
-
-            flash
-                .arg("-f")
-                .config()
-                .arg("-c")
-                .formatted_payload("program", "verify reset")
-                .arg("-c")
-                .arg("exit");
-
-            flash
-        }
-        _ => {
-            eprintln!("Warning: unrecognized board, won't know how to flash.");
-            return Ok(None);
-        }
-    };
+    let mut flash = FlashConfig::default();
 
     flash.set_chip(chip_name(board)?);
 


### PR DESCRIPTION
- Removes the old openocd/pyocd flash information from build archives and bumps the version. (I left openocd.cfg in for debugging use, but we lose the ability to flash _through Humility_ using openocd.)
- Moves the mapping from board name to probe-rs chip name out of a big scary hardcoded match, and into the board toml files I recently added.

The commit messages have a lot more detail if you're curious, but this eliminates all of the matches that I've been mad about, and should make maintenance a lot easier.

Anticipated question: why not put the chip name in the chip.toml that the app already references? It's because probe-rs is weeeeeirdly specific about chip names, and Hubris is not. For instance, probe-rs distinguishes the same chip in different _packages_ for reasons I cannot fathom. So boards need to be more precise than chip.toml.

I'd like, later, to also move the chip.toml name reference out of app.toml and into the board definition, but I have not done that here.