### PR TITLE
Remove lease limit from `qspi_read`

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -268,13 +268,13 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
         addr: u32,
-        dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+        dest: Leased<W, [u8]>,
     ) -> Result<(), RequestError<HfError>> {
         self.drv.check_flash_mux_state()?;
         self.drv
             .flash_read(
                 self.flash_addr(addr),
-                &mut LeaseBufWriter::<_, 32>::from(dest.into_inner()),
+                &mut LeaseBufWriter::<_, 32>::from(dest),
             )
             .map_err(|_| RequestError::went_away())
     }
@@ -483,7 +483,7 @@ impl idl::InOrderHostFlashImpl for FailServer {
         &mut self,
         _: &RecvMessage,
         _offset: u32,
-        _dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+        _dest: Leased<W, [u8]>,
     ) -> Result<(), RequestError<HfError>> {
         Err(self.err.into())
     }

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -241,11 +241,11 @@ impl FlashDriver {
 
     /// Reads data from the given address into a `BufWriter`
     ///
-    /// This function will only return an error if it fails to read from a
+    /// This function will only return an error if it fails to write to a
     /// provided lease; when given a slice, it is infallible.
     fn flash_read(
         &mut self,
-        offset: u32,
+        mut offset: u32,
         dest: &mut dyn idol_runtime::BufWriter<'_>,
     ) -> Result<(), ()> {
         loop {
@@ -269,6 +269,7 @@ impl FlashDriver {
                     }
                 }
             }
+            offset += len as u32;
         }
         Ok(())
     }

--- a/idl/hf.idol
+++ b/idl/hf.idol
@@ -58,7 +58,7 @@ Interface(
                 "address": "u32",
             },
             leases: {
-                "data": (type: "[u8]", write: true, max_len: Some(256)),
+                "data": (type: "[u8]", write: true),
             },
             reply: Result(
                 ok: "()",


### PR DESCRIPTION
Tested on Grapefruit (where I found that we weren't updating the offset address!); eyeballed on Gimlet.