### PR TITLE
Allow kernel to be built with stable toolchain.

### DIFF
--- a/build/kernel-link.x
+++ b/build/kernel-link.x
@@ -91,12 +91,14 @@ SECTIONS
     *(.PreResetTrampoline);
     *(.Reset);
 
-    *(.text .text.*);
-
     /* The HardFaultTrampoline uses the `b` instruction to enter `HardFault`,
        so must be placed close to it. */
     *(.HardFaultTrampoline);
     *(.HardFault.*);
+    *(.text.HardFault.*);
+
+    *(.text .text.*);
+
     . = ALIGN(4);
     __etext = .;
   } > FLASH

--- a/sys/kern/src/lib.rs
+++ b/sys/kern/src/lib.rs
@@ -27,7 +27,6 @@
 //!    most clever algorithms used in kernels wind up requiring `unsafe`.)
 
 #![cfg_attr(target_os = "none", no_std)]
-#![feature(naked_functions)]
 // Require an unsafe block even in an unsafe fn, because unsafe fns are about
 // contract, not implementation.
 #![forbid(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
The only nightly feature still used in the kernel is `#[naked]` on functions. This can be replaced with careful use of `global_asm!` to create functions in pure assembly language.

With this change, the kernel builds and works on stable 1.82.0 using my out-of-tree build system.