### PR TITLE
gimlet-seq-server: use set_bytes not write_bytes for sequencing control

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -723,7 +723,7 @@ impl<S: SpiServer> ServerImpl<S> {
                 // failing to sequence.
                 //
                 let a1 = Reg::PWR_CTRL::A1PWREN;
-                self.seq.write_bytes(Addr::PWR_CTRL, &[a1]).unwrap_lite();
+                self.seq.set_bytes(Addr::PWR_CTRL, &[a1]).unwrap_lite();
 
                 loop {
                     let mut status = [0u8];
@@ -779,7 +779,7 @@ impl<S: SpiServer> ServerImpl<S> {
                 // Onward to A0!
                 //
                 let a0 = Reg::PWR_CTRL::A0A_EN;
-                self.seq.write_bytes(Addr::PWR_CTRL, &[a0]).unwrap_lite();
+                self.seq.set_bytes(Addr::PWR_CTRL, &[a0]).unwrap_lite();
 
                 loop {
                     let mut status = [0u8];


### PR DESCRIPTION
Fixes #1929

Since `write_bytes` uses the `Write` operation, we effectively clear the A1 bit when setting the A0 bit. Using `set_bytes` uses a `BitSet` operation, allowing us to set A0 while leaving A1 in place. The FPGA has papered over this by ignoring the A1 bit while it is in A0.