### PR TITLE
kern: suppress phantom SVCs on ARMv6-M

### DIFF
--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -6,7 +6,7 @@ board = "donglet-g031"
 
 [kernel]
 name = "app-donglet"
-requires = {flash = 19168, ram = 1820}
+requires = {flash = 19168, ram = 1824}
 features = ["g031"]
 stacksize = 936
 

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -17,6 +17,12 @@ use proc_macro2::TokenStream;
 fn main() -> Result<()> {
     build_util::expose_m_profile()?;
 
+    println!("cargo::rustc-check-cfg=cfg(hubris_phantom_svc_mitigation)");
+    if build_util::target().starts_with("thumbv6m") {
+        // Force SVC checks on for v6-M.
+        println!("cargo:rustc-cfg=hubris_phantom_svc_mitigation");
+    }
+
     let g = process_config()?;
     generate_statics(&g)?;
 

--- a/test/tests-stm32g0/app-g070.toml
+++ b/test/tests-stm32g0/app-g070.toml
@@ -6,7 +6,7 @@ memory = "memory-g070.toml"
 
 [kernel]
 name = "demo-stm32g0-nucleo"
-requires = {flash = 19112, ram = 2828}
+requires = {flash = 19112, ram = 2832}
 features = ["g070"]
 stacksize = 2048
 


### PR DESCRIPTION
You might recognize this as #1134. Well, it's back. My fix for the problem on ARMv6-M was apparently never quite correct on M0+, because the core register we were relying on to detect and cancel a pending SVC -- SHCSR -- is _implemented_ but _only visible from the debugger._ So when I tried it by hand in openocd, it worked... but from the kernel it silently fails.

ARM, you are not making friends with stuff like this.

I've worked out a different way to _detect_ the "fault during SVC" case using the always-implemented ICSR register. That register doesn't provide any way to _cancel_ the SVC, so I've added conditional code to the syscall entry path that can do it.

Fixes #1928.