### PR TITLE
build/util: prevent infinite loop if target/ not found

### DIFF
--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -95,7 +95,9 @@ pub fn expose_target_board() {
         std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     loop {
         let done = out_dir.file_name() == Some(OsStr::new("target"));
-        out_dir.pop();
+        if !out_dir.pop() {
+            panic!("can't find target/ in OUT_DIR");
+        }
         if done {
             break;
         }


### PR DESCRIPTION
Previously, if you attempted to use certain functions in the build_util crate...and your output directory happened to not include any parent directories with the exact name "target"...

...the build script would burn 100% of a core forever, until you killed it.

This doesn't affect Hubris-proper but _does_ affect out of tree builds. The original code was arguably wrong anyway, so, this fixes that.