### PR TITLE
Enable a panic-free Jefe for the first time

### DIFF
--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -15,8 +15,9 @@ name = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
-stacksize = 368
+stacksize = 192
 notifications = ["fault", "timer"]
+features = ["no-panic", "nano"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -31,6 +31,7 @@ build-util = { path = "../../build/util" }
 [features]
 dump = []
 nano = [ "ringbuf/disabled" ]
+no-panic = [ "userlib/no-panic" ]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.


### PR DESCRIPTION
The supervisor task in Hubris is not permitted to panic, since it's responsible for handling panics.

Jefe has historically contained a bunch of (static) panics, many of which aren't actually possible at runtime. I've been gradually grinding away at these in my other PRs.

As of #1937, it's now possible to build a _minimal_ Jefe (like we use on the G0) that contains no panics. So I've enabled that on donglet, and turned on the userlib/no-panic feature that will statically ensure it remains true.

Turning on dump support in Jefe causes a bunch of panics to reappear, because humpty is panic-heavy. That's a task for another day.