### PR TITLE
oxide-barcode: allow shorter serial and part numbers

### DIFF
--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -484,6 +484,10 @@ impl From<oxide_barcode::VpdIdentity> for Identity {
         );
 
         let mut new_id = Self::default();
+        // The incoming part number and serial are already nul-padded if they're
+        // shorter than the allocated space in VpdIdentity, so we can merely
+        // copy them into the start of our fields and the result is still
+        // nul-padded.
         new_id.model[..id.part_number.len()].copy_from_slice(&id.part_number);
         new_id.revision = id.revision;
         new_id.serial[..id.serial.len()].copy_from_slice(&id.serial);


### PR DESCRIPTION
This retains the original maximum length for both fields, but permits parsed strings to contain shorter sections. Shorter sections are right-padded with NULs for consistency with IPCC.

Fixes #1893