### PR TITLE
kern: let drivers disable double-interrupt behavior

### DIFF
--- a/doc/syscalls.adoc
+++ b/doc/syscalls.adoc
@@ -469,7 +469,9 @@ Collects information about one entry in a sender's lease table.
 ==== Arguments
 
 - 0: notification bitmask corresponding to the interrupt
-- 1: desired state (0 = disabled, 1 = enabled)
+- 1: desired state
+** bit 0: 0 = disabled, 1 = enabled
+** bit 1: 0 = leave pending, 1 = clear pending
 
 ==== Return values
 
@@ -497,6 +499,13 @@ their notification bits. However, this is quite deliberate, for two reasons:
 
 2. It makes it impossible for a task to mess with other tasks' interrupts,
    since it can only refer to its _own_ mapped interrupts, by construction.
+
+The concept of a "pending" interrupt is inherently specific to a particular
+architecture and interrupt controller. On an architecture without a concept of
+pending interrupts, bit 1 has no effect. However, on architectures with
+level-triggered interrupts from peripherals and a concept of "pending"
+interrupts, clearing the pending status when re-enabling may be important for
+avoiding a duplicate notification.
 
 === `PANIC` (8)
 

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -549,3 +549,15 @@ bitflags::bitflags! {
         const POSTED = 1 << 2;
     }
 }
+
+bitflags::bitflags! {
+    /// Bitflags that can be passed into the `IRQ_CONTROL` syscall.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct IrqControlArg: u32 {
+        /// Enables the interrupt if present, disables if not present.
+        const ENABLED = 1 << 0;
+        /// If present, requests that any pending instance of this interrupt be
+        // cleared.
+        const CLEAR_PENDING = 1 << 1;
+    }
+}

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -964,8 +964,30 @@ unsafe extern "C" fn sys_borrow_info_stub(
 
 #[inline(always)]
 pub fn sys_irq_control(mask: u32, enable: bool) {
+    let mut arg = IrqControlArg::empty();
+    if enable {
+        arg |= IrqControlArg::ENABLED;
+    }
+
     unsafe {
-        sys_irq_control_stub(mask, enable as u32);
+        sys_irq_control_stub(mask, arg.bits());
+    }
+}
+
+/// Variation on [`sys_irq_control`] that also clears any pending interrupt.
+///
+/// This sets the interrupt enable status based on `enable`, and also cancels a
+/// pending instance of this interrupt in the interrupt controller, if the
+/// interrupt controller supports such a concept (ARM M-profile NVIC does, for
+/// instance).
+#[inline(always)]
+pub fn sys_irq_control_clear_pending(mask: u32, enable: bool) {
+    let mut arg = IrqControlArg::CLEAR_PENDING;
+    if enable {
+        arg |= IrqControlArg::ENABLED;
+    }
+    unsafe {
+        sys_irq_control_stub(mask, arg.bits());
     }
 }
 


### PR DESCRIPTION
Currently drivers tend to get a spurious interrupt notification just after handling a real one. This is because the interrupt controller notices the kernel generic ISR exit while the interrupt condition is still asserted, because it doesn't expect us to be handling it in task code. So, it sets the pending bit so the 'new' interrupt condition isn't forgotten.

This causes an interrupt to occur immediately when we re-enable.

This adds an additional bit for IRQ_CONTROL that drivers can use to request any pending interrupt status be cleared.

Fixes #536.