### PR TITLE
kern: stack watermark support

### DIFF
--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -36,6 +36,7 @@ phash-gen = { path = "../../build/phash-gen" }
 [features]
 dump = []
 nano = []
+stack-watermark = []
 
 [lib]
 test = false

--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -936,6 +936,17 @@ static TICKS: [AtomicU32; 2] = {
 #[no_mangle]
 pub unsafe extern "C" fn SysTick() {
     crate::profiling::event_timer_isr_enter();
+
+    // We don't need the current task pointer in this routine, but we'll access
+    // it briefly to update the stack watermark:
+    {
+        let current = CURRENT_TASK_PTR.load(Ordering::Relaxed);
+        // Safety: `CURRENT_TASK_PTR` is valid once the kernel is started, and
+        // this interrupt is only enabled once the kernel is started.
+        let t = unsafe { &mut *current };
+        t.update_stack_watermark();
+    }
+
     with_task_table(|tasks| {
         // Load the time before this tick event.
         let t0 = TICKS[0].load(Ordering::Relaxed);
@@ -1106,6 +1117,15 @@ pub unsafe extern "C" fn DefaultHandler() {
             options(pure, nomem, preserves_flags, nostack),
         );
         ipsr & 0x1FF
+    };
+
+    let current = CURRENT_TASK_PTR.load(Ordering::Relaxed);
+    uassert!(!current.is_null()); // irq before kernel started?
+
+    let current_prio = {
+        let t = unsafe { &mut *current };
+        t.update_stack_watermark();
+        t.priority()
     };
 
     // The first 16 exceptions are architecturally defined; vendor hardware
@@ -1406,7 +1426,12 @@ unsafe extern "C" fn handle_fault(task: *mut task::Task) {
         // assembly fault handler to pass us a legitimate one. We use it
         // immediately and discard it because otherwise it would alias the task
         // table below.
-        let t = unsafe { &(*task) };
+        let t = unsafe { &mut (*task) };
+        // Take the opportunity to update the stack watermark. This is
+        // technically wasted effort if the fault is in the kernel, but it's
+        // still nice to keep it updated -- and it's critical if the fault is in
+        // the task!
+        t.update_stack_watermark();
         (
             t.save().exc_return & 0b1000 != 0,
             usize::from(t.descriptor().index),
@@ -1534,7 +1559,12 @@ unsafe extern "C" fn handle_fault(
     // of dereferencing it, as it would otherwise alias the task table obtained
     // later.
     let (exc_return, psp, idx) = unsafe {
-        let t = &(*task);
+        let t = &mut (*task);
+        // Take the opportunity to update the stack watermark. This is
+        // technically wasted effort if the fault is in the kernel, but it's
+        // still nice to keep it updated -- and it's critical if the fault is in
+        // the task!
+        t.update_stack_watermark();
         (
             t.save().exc_return,
             t.save().psp,

--- a/sys/kern/src/syscalls.rs
+++ b/sys/kern/src/syscalls.rs
@@ -70,7 +70,10 @@ pub unsafe extern "C" fn syscall_entry(nr: u32, task: *mut Task) {
     let idx = {
         // Safety: we're trusting the interrupt entry routine to pass us a valid
         // task pointer.
-        let t = unsafe { &*task };
+        let t = unsafe { &mut *task };
+
+        t.update_stack_watermark();
+
         usize::from(t.descriptor().index)
     };
 


### PR DESCRIPTION
Each task has grown a new field, `low_stack_pointer`, that tracks the lowest stack pointer value seen so far (because stacks grow down). We update this value on any kernel entry (interrupt, timer, fault, syscall), so while we will miss very brief excursions of stack _between_ syscalls or interrupts, we should still get a useful value.

In addition, the field `past_low_stack_pointer` tracks the lowest stack pointer value across _all previous incarnations_ of the task. This way if the task is periodically restarting, we can still get useful stack stats, including at stack overflow.

All of this stuff is conditional on the `stack-watermark` feature, since it increases the kernel RAM requirement, which is explicit in Oxide's Hubris build system.