### PR TITLE
Another batch of syscall perf enhancements

### DIFF
--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -220,7 +220,7 @@ pub const fn extract_new_generation(code: u32) -> Option<Generation> {
 pub const DEFECT: u32 = 1;
 
 /// State used to make scheduling decisions.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub enum TaskState {
     /// Task is healthy and can be scheduled subject to the `SchedState`
     /// requirements.
@@ -252,7 +252,10 @@ impl TaskState {
     /// Checks if a task in this state is trying to deliver a message to
     /// `target`.
     pub fn is_sending_to(&self, target: TaskId) -> bool {
-        self == &TaskState::Healthy(SchedState::InSend(target))
+        match self {
+            TaskState::Healthy(SchedState::InSend(t)) => *t == target,
+            _ => false,
+        }
     }
 
     /// Checks if a task in this state can be unblocked with a notification.

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -280,7 +280,7 @@ impl Task {
 
     /// Checks if this task is in a potentially schedulable state.
     pub fn is_runnable(&self) -> bool {
-        self.state == TaskState::Healthy(SchedState::Runnable)
+        matches!(self.state, TaskState::Healthy(SchedState::Runnable))
     }
 
     /// Configures this task's timer.

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -345,6 +345,12 @@ pub fn safe_copy(
 ) -> Result<usize, InteractFault> {
     let copy_len = USlice::shorten_to_match(&mut from_slice, &mut to_slice);
 
+    if copy_len == 0 {
+        // try_read and try_write both accept _any_ empty slice, which then
+        // results in a zero-byte copy. We can skip some steps.
+        return Ok(0);
+    }
+
     let (from, to) = index2_distinct(tasks, from_index, to_index);
 
     let src = from.try_read(&from_slice);

--- a/sys/kern/src/umem.rs
+++ b/sys/kern/src/umem.rs
@@ -168,6 +168,21 @@ impl<T> USlice<T> {
             _ => false,
         }
     }
+
+    /// Adjusts `a` and `b` to have the same length, which is the shorter of the
+    /// two.
+    ///
+    /// Returns the new common length.
+    ///
+    /// Shortening `a` and `b` ensures that the slices returned from `try_read`
+    /// / `try_write` have the same length, without the need for further
+    /// slicing.
+    pub fn shorten_to_match(a: &mut Self, b: &mut Self) -> usize {
+        let n = usize::min(a.length, b.length);
+        a.length = n;
+        b.length = n;
+        n
+    }
 }
 
 impl<T> USlice<T>
@@ -324,11 +339,11 @@ impl<T> kerncore::UserSlice for USlice<T> {
 pub fn safe_copy(
     tasks: &mut [Task],
     from_index: usize,
-    from_slice: USlice<u8>,
+    mut from_slice: USlice<u8>,
     to_index: usize,
     mut to_slice: USlice<u8>,
 ) -> Result<usize, InteractFault> {
-    let copy_len = from_slice.len().min(to_slice.len());
+    let copy_len = USlice::shorten_to_match(&mut from_slice, &mut to_slice);
 
     let (from, to) = index2_distinct(tasks, from_index, to_index);
 
@@ -349,7 +364,7 @@ pub fn safe_copy(
         (Ok(from), Ok(to)) => {
             // We are now convinced, after querying the tasks, that these RAM
             // areas are legit.
-            to[..copy_len].copy_from_slice(&from[..copy_len]);
+            to.copy_from_slice(from);
             Ok(copy_len)
         }
         (src, dst) => Err(InteractFault {

--- a/sys/kerncore/src/lib.rs
+++ b/sys/kerncore/src/lib.rs
@@ -152,6 +152,8 @@ impl<T: MemoryRegion> MemoryRegion for &T {
 /// that meet the `region_ok` condition.
 ///
 /// `false` otherwise.
+#[must_use]
+#[inline(always)]
 pub fn can_access<S, R>(
     slice: S,
     table: &[R],

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -475,13 +475,13 @@ fn test_panic() {
 
     // Read status back from the kernel and check it.
     let status = kipc::read_task_status(ASSIST.get_task_index().into());
-    assert_eq!(
+    assert!(matches!(
         status,
         TaskState::Faulted {
             fault: FaultInfo::Panic,
             original_state: SchedState::Runnable,
         },
-    );
+    ));
     restart_assistant();
 }
 
@@ -940,13 +940,13 @@ fn test_restart_taskgen() {
 
     // Read status back from the kernel, check it, and bounce the assistant.
     let status = kipc::read_task_status(ASSIST.get_task_index().into());
-    assert_eq!(
+    assert!(matches!(
         status,
         TaskState::Faulted {
             fault: FaultInfo::Panic,
             original_state: SchedState::Runnable,
         },
-    );
+    ));
     restart_assistant();
 
     // Now when we make another call with the old task, this should fail


### PR DESCRIPTION
This is unspooling more commits from my performance fix branch in my fork. As with the previous performance PR, this is a collection of semi-related commits that may be easier to review commit-by-commit than as a big diff. Boy I miss Gerrit.

This is only a ~10% overall improvement because most of the truly low hanging fruit has been eaten. But, this significantly improves the performance of kernel memory copies and SEND with an empty message (unusual but not unheard of). This also knocks a few hundred bytes off a typical kernel by removing some panic sites.