### PR TITLE
Disable periodic IPCC zero bytes on Grapefruit

### DIFF
--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -103,7 +103,7 @@ task-slots = ["jefe"]
 
 [tasks.host_sp_comms]
 name = "task-host-sp-comms"
-features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
+features = ["gimlet", "stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
 priority = 8

--- a/task/host-sp-comms/src/tx_buf.rs
+++ b/task/host-sp-comms/src/tx_buf.rs
@@ -139,8 +139,14 @@ impl TxBuf {
     }
 
     /// Should we be sending periodic 0 bytes?
+    #[cfg(feature = "gimlet")]
     pub(crate) fn should_send_periodic_zero_bytes(&self) -> bool {
         matches!(self.state, State::Idle)
+    }
+
+    #[cfg(feature = "grapefruit")]
+    pub(crate) fn should_send_periodic_zero_bytes(&self) -> bool {
+        false
     }
 
     /// Encodes `reason` into our outgoing buffer.


### PR DESCRIPTION
In the current IPCC design, the SP sends zero bytes periodically when the channel is idle to guard against the possibility of losing a frame terminator. On gimlet this causes the UART FIFO to quickly fill up and so when the channel wakes up there are around 16 bytes to drain and things move along. On grapefruit/cosmo, however, there is a 4K FIFO in the FPGA upstream of the SP here so the natural saturation doesn't (yet) occur as we'd like. The extra zero bytes also make tracing the bus harder. Disable them for now.