### PR TITLE
Add support for Bonus Data in Cosmo host flash

### DIFF
--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -4,7 +4,7 @@
 
 //! Minimal driver for FMC-attached NOR flash, implementing the `hf` API
 //!
-//! The NOR flash chip is a W25Q01JVZEIQ, which is a 1 GiB NOR flash.  It is
+//! The NOR flash chip is a W25Q01JVZEIQ, which is a 1 GBit NOR flash.  It is
 //! connected to the FPGA over SPI / QSPI.
 //!
 //! # References

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -502,6 +502,15 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         Ok(())
     }
 
+    fn bonus_page_program(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
+    }
+
     fn read(
         &mut self,
         _: &RecvMessage,
@@ -517,6 +526,15 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         Ok(())
     }
 
+    fn bonus_read(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
+    }
+
     fn sector_erase(
         &mut self,
         _: &RecvMessage,
@@ -524,6 +542,14 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         protect: HfProtectMode,
     ) -> Result<(), RequestError<HfError>> {
         self.sector_erase(addr, protect).map_err(RequestError::from)
+    }
+
+    fn bonus_sector_erase(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
     }
 
     fn get_mux(

--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -33,6 +33,7 @@ pub enum HfError {
     MonotonicCounterOverflow,
     FpgaNotConfigured,
     BadChipId,
+    BadAddress,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/idl/hf.idol
+++ b/idl/hf.idol
@@ -155,5 +155,41 @@ Interface(
                 err: CLike("HfError"),
             ),
         ),
+        "bonus_page_program": (
+            description: "programs a page into the bonus region of host flash",
+            args: {
+                "address": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "bonus_read": (
+            description: "reads from the bonus region of host flash",
+            args: {
+                "address": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", write: true, max_len: Some(256)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
+        "bonus_sector_erase": (
+            description: "erases a 64 KiB sector from the bonus region of host flash",
+            args: {
+                "address": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("HfError"),
+            ),
+        ),
     },
 )


### PR DESCRIPTION
In Cosmo and Grapefruit, we divide a 128 MiB flash chip into two (now three) sections:

- 32 MiB of slot 0 (host boot data)
- 32 MiB of slot 1 (host boot data)
- 64 MiB of Bonus Data (previously unused)

The host boot slots use the lowest 64 KiB for "persistent data", which right now encodes which slot to select at boot time.  This behavior is identical to Gimlet, and is unchanged in the PR.

This PR consists of three standalone commits, which do the following:

- Check flash addresses in the `cosmo-hf` driver, to avoid writing into other sections by accident
- Use a strong type for an absolute address (versus `u32` for a section-relative address)
- Add new Hiffy APIs to read and write the upper 64 MiB of flash
  - These APIs are added to the `HostFlash` interface, so they're also added to Gimlet's host flash driver, which just returns an error if you try to use them.
  - I'm open to naming suggestions here, since `bonus_` is a bit awkward (but "auxiliary" is already in use)

Under the hood, the W25Q01JV uses two 64 MiB dies and exposes manual APIs to select which die is active (e.g. checking BUSY status only reads from the active die).  However, all of the QSPI commands that we use take a 4-byte address and automatically switch between dies, so everything Just Works™ (feel free to double-check this, [here's the docs](https://drive.google.com/file/d/1qcurvqkNYha0cWxEeEhD_J2qGgi_r4AL/))