### PR TITLE
Separate device type and chip for power config

### DIFF
--- a/task/power/src/bsp/gimlet_bcdef.rs
+++ b/task/power/src/bsp/gimlet_bcdef.rs
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
-    i2c_config, i2c_config::sensors, Device, DeviceType, PowerControllerConfig,
-    PowerState, SensorId,
+    i2c_config, i2c_config::sensors, Device, PowerControllerConfig, PowerState,
+    SensorId,
 };
 
 use drv_i2c_devices::max5970::*;

--- a/task/power/src/bsp/gimletlet_2.rs
+++ b/task/power/src/bsp/gimletlet_2.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     i2c_config::{self, sensors},
-    DeviceType, Ohms, PowerControllerConfig, PowerState,
+    Ohms, PowerControllerConfig, PowerState,
 };
 
 pub(crate) const CONTROLLER_CONFIG_LEN: usize = 1;

--- a/task/power/src/bsp/psc_bc.rs
+++ b/task/power/src/bsp/psc_bc.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     i2c_config::{self, sensors},
-    DeviceType, PowerControllerConfig, PowerState,
+    PowerControllerConfig, PowerState,
 };
 
 pub(crate) const CONTROLLER_CONFIG_LEN: usize = 12;

--- a/task/power/src/bsp/sidecar_bcd.rs
+++ b/task/power/src/bsp/sidecar_bcd.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     i2c_config::{self, sensors},
-    DeviceType, Ohms, PowerControllerConfig, PowerState,
+    Ohms, PowerControllerConfig, PowerState,
 };
 
 pub(crate) const CONTROLLER_CONFIG_LEN: usize = 16;

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -67,16 +67,30 @@ enum DeviceType {
     Mem,
     MemVpp,
     Sys,
-    HotSwap(Ohms),
-    Fan(Ohms),
-    HotSwapIO(Ohms),
-    HotSwapQSFP(Ohms),
+    HotSwap,
+    Fan,
+    HotSwapIO,
+    HotSwapQSFP,
     PowerShelf,
+}
+
+/// Chip used to talk to the given device
+#[allow(dead_code)]
+enum DeviceChip {
+    Bmr491,
+    Raa229618,
+    Isl68224,
+    Tps546B24A,
+    Adm1272(Ohms),
+    Max5970(Ohms),
+    Mwocp68,
+    Ltc4282(Ohms),
 }
 
 struct PowerControllerConfig {
     state: PowerState,
     device: DeviceType,
+    chip: DeviceChip,
     builder: fn(TaskId) -> (drv_i2c_api::I2cDevice, u8), // device, rail
     voltage: SensorId,
     input_voltage: Option<SensorId>,
@@ -86,6 +100,7 @@ struct PowerControllerConfig {
     phases: Option<&'static [u8]>,
 }
 
+/// Bound device, which exposes sensor functions
 enum Device {
     Bmr491(Bmr491),
     Raa229618(Raa229618),
@@ -227,23 +242,23 @@ impl Device {
 impl PowerControllerConfig {
     fn get_device(&self, task: TaskId) -> Device {
         let (dev, rail) = (self.builder)(task);
-        match &self.device {
-            DeviceType::IBC => Device::Bmr491(Bmr491::new(&dev, rail)),
-            DeviceType::Core | DeviceType::Mem => {
+        match &self.chip {
+            DeviceChip::Bmr491 => Device::Bmr491(Bmr491::new(&dev, rail)),
+            DeviceChip::Raa229618 => {
                 Device::Raa229618(Raa229618::new(&dev, rail))
             }
-            DeviceType::MemVpp | DeviceType::SerDes => {
-                Device::Isl68224(Isl68224::new(&dev, rail))
+            DeviceChip::Isl68224 => Device::Isl68224(Isl68224::new(&dev, rail)),
+            DeviceChip::Tps546B24A => {
+                Device::Tps546B24A(Tps546B24A::new(&dev, rail))
             }
-            DeviceType::Sys => Device::Tps546B24A(Tps546B24A::new(&dev, rail)),
-            DeviceType::HotSwap(sense) | DeviceType::Fan(sense) => {
+            DeviceChip::Adm1272(sense) => {
                 Device::Adm1272(Adm1272::new(&dev, *sense))
             }
-            DeviceType::HotSwapIO(sense) => {
+            DeviceChip::Max5970(sense) => {
                 Device::Max5970(Max5970::new(&dev, rail, *sense))
             }
-            DeviceType::PowerShelf => Device::Mwocp68(Mwocp68::new(&dev, rail)),
-            DeviceType::HotSwapQSFP(sense) => {
+            DeviceChip::Mwocp68 => Device::Mwocp68(Mwocp68::new(&dev, rail)),
+            DeviceChip::Ltc4282(sense) => {
                 Device::Ltc4282(Ltc4282::new(&dev, *sense))
             }
         }
@@ -255,8 +270,9 @@ macro_rules! rail_controller {
     ($which:ident, $dev:ident, $rail:ident, $state:ident) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which,
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::[< $dev:camel >],
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: None,
@@ -276,8 +292,9 @@ macro_rules! rail_controller_notemp {
     ($which:ident, $dev:ident, $rail:ident, $state:ident) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which,
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::[< $dev:camel >],
                 builder:i2c_config::pmbus::$rail,
                 voltage: sensors::[<$dev:upper _ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: None,
@@ -295,8 +312,9 @@ macro_rules! adm1272_controller {
     ($which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which($rsense),
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::Adm1272($rsense),
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<ADM1272_ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: None,
@@ -316,8 +334,9 @@ macro_rules! ltc4282_controller {
     ($which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which($rsense),
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::Ltc4282($rsense),
                 builder: i2c_config::power::$rail,
                 voltage: sensors::[<LTC4282_ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: None,
@@ -335,8 +354,9 @@ macro_rules! max5970_controller {
     ($which:ident, $rail:ident, $state:ident, $rsense:expr) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which($rsense),
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::Max5970($rsense),
                 builder: i2c_config::power::$rail,
                 voltage: sensors::[<MAX5970_ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: None,
@@ -354,8 +374,9 @@ macro_rules! mwocp68_controller {
     ($which:ident, $rail:ident, $state:ident) => {
         paste::paste! {
             PowerControllerConfig {
-                state: PowerState::$state,
-                device: DeviceType::$which,
+                state: $crate::PowerState::$state,
+                device: $crate::DeviceType::$which,
+                chip: $crate::DeviceChip::Mwocp68,
                 builder: i2c_config::pmbus::$rail,
                 voltage: sensors::[<MWOCP68_ $rail:upper _VOLTAGE_SENSOR>],
                 input_voltage: Some(


### PR DESCRIPTION
On Gimlet and Sidecar, the mapping from `DeviceType` (CPU, memory, fans, etc) to chip (RAA229618, MAX5970, etc) was one-to-one.  However, that's going to change for Cosmo (RAA229620A power controller, new hot-swap ICs, etc).

This PR adds a separate `chip: DeviceChip` field to the (static) power controller configuration.  It leaves the previous `DeviceType` field unchanged, although I'm not _totally_ sure if it's still relevant.