### PR TITLE
website: update the kernel bug page, which has been lagging

### DIFF
--- a/website/bugs/index.html
+++ b/website/bugs/index.html
@@ -52,6 +52,8 @@ hr {
 
 <script>
 const bugs = [
+    ["commit/3f93005b33a94", "2024-12-25T04:40Z", "MPU attribute misconfiguration on ARMv8M"],
+    ["commit/88617a279efdcc", "2024-12-18T18:19Z", "Client-controlled kernel panic in kipc"],
     ["issues/1943", "2024-12-10T19:39Z", "Kernel refuses to start if initial stack frame spans regions"],
     ["issues/1928", "2024-11-22T19:25Z", "ARMv6M still attributes faulting SVC to wrong task"],
     ["issues/1876", "2024-09-20T13:54Z", "Stack scribbling does not work for tasks with pow2 stack"],


### PR DESCRIPTION
This includes the bugs I've found recently, all of which have merged fixes.