### PR TITLE
Move `by_refdes` into `pub(crate)` module

### DIFF
--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -5,7 +5,7 @@
 //! SP inventory types and implementation
 //!
 //! This reduces clutter in the main `ServerImpl` implementation
-use super::ServerImpl;
+use super::{inventory::by_refdes, ServerImpl};
 
 use drv_i2c_api::I2cDevice;
 use drv_i2c_api::ResponseCode;
@@ -20,31 +20,6 @@ use host_sp_messages::{InventoryData, InventoryDataResult};
 
 userlib::task_slot!(I2C, i2c_driver);
 userlib::task_slot!(SPI, spi_driver);
-
-/// `const` function to convert a `&'static str` to a fixed-size byte array
-///
-/// This must be called a `const` parameter of `s.len()`
-const fn byteify<const N: usize>(s: &'static [u8]) -> [u8; N] {
-    let mut out = [0u8; N];
-    let mut i = 0;
-    while i < s.len() {
-        out[i] = s[i];
-        i += 1;
-    }
-    out
-}
-macro_rules! by_refdes {
-    ($refdes:ident, $dev:ident) => {
-        paste::paste! {{
-            const BYTE_ARRAY: &'static [u8] = stringify!($refdes).as_bytes();
-            (
-                byteify::<{ BYTE_ARRAY.len() }>(BYTE_ARRAY),
-                i2c_config::devices::[<$dev _ $refdes:lower >] as fn(TaskId) -> I2cDevice,
-                i2c_config::sensors::[<$dev:upper _ $refdes:upper _SENSORS>]
-            )
-        }}
-    };
-}
 
 impl ServerImpl {
     /// Number of devices in our inventory

--- a/task/host-sp-comms/src/inventory.rs
+++ b/task/host-sp-comms/src/inventory.rs
@@ -9,3 +9,39 @@
 
 /// Inventory API version (always 0 for now)
 pub(crate) const INVENTORY_API_VERSION: u32 = 0;
+
+/// `const` function to convert a `&'static str` to a fixed-size byte array
+///
+/// This must be called a `const` parameter of `s.len()`
+#[allow(dead_code)]
+pub(crate) const fn byteify<const N: usize>(s: &'static [u8]) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut i = 0;
+    while i < s.len() {
+        out[i] = s[i];
+        i += 1;
+    }
+    out
+}
+
+#[allow(unused_macros)]
+macro_rules! by_refdes {
+    // Length is found based on refdes
+    ($refdes:ident, $dev:ident) => {
+        by_refdes!($refdes, $dev, stringify!($refdes).as_bytes().len())
+    };
+    // Length is provided, e.g. if it is not consistent between refdes
+    ($refdes:ident, $dev:ident, $n:expr) => {
+        paste::paste! {{
+            const BYTE_ARRAY: &'static [u8] = stringify!($refdes).as_bytes();
+            (
+                $crate::inventory::byteify::<{ $n }>(BYTE_ARRAY),
+                i2c_config::devices::[<$dev _ $refdes:lower >] as fn(TaskId) -> I2cDevice,
+                i2c_config::sensors::[<$dev:upper _ $refdes:upper _SENSORS>]
+            )
+        }}
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use by_refdes;


### PR DESCRIPTION
This is standalone prep for Cosmo, making the macro useable outside of the Gimlet inventory.

In addition, we add a variant to the macro which lets the caller control the array size.  This is needed when there are designators of different lengths in the same inventory slot, e.g. `U123` and `U51`.