### PR TITLE
Add RAA229620A rail driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,8 +3910,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pmbus"
-version = "0.1.4"
-source = "git+https://github.com/oxidecomputer/pmbus#44568ce7eb86fe0b03dd088a75ad76ea0d8529bb"
+version = "0.1.5"
+source = "git+https://github.com/oxidecomputer/pmbus#e1c123745f712174f6e027d7eef491b723e7352f"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -27,6 +27,7 @@
 //! - [`pca9956b`]: PCA9956B LED driver
 //! - [`pct2075`]: PCT2075 temperature sensor
 //! - [`raa229618`]: RAA229618 power controller
+//! - [`raa229620a`]: RAA229620A power controller
 //! - [`sbrmi`]: AMD SB-RMI driver
 //! - [`sbtsi`]: AMD SB-TSI temperature sensor
 //! - [`tmp116`]: TMP116 temperature sensor
@@ -250,6 +251,7 @@ pub mod pca9538;
 pub mod pca9956b;
 pub mod pct2075;
 pub mod raa229618;
+pub mod raa229620a;
 pub mod sbrmi;
 pub mod sbtsi;
 pub mod tmp117;

--- a/drv/i2c-devices/src/raa229620a.rs
+++ b/drv/i2c-devices/src/raa229620a.rs
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::cell::Cell;
+
+use crate::{
+    pmbus_validate, BadValidation, CurrentSensor, TempSensor, Validate,
+    VoltageSensor,
+};
+use drv_i2c_api::*;
+use pmbus::commands::raa229620a::*;
+use pmbus::commands::CommandCode;
+use pmbus::*;
+use userlib::units::*;
+
+//
+// This is a special rail value that is issued as a PAGE command to enable
+// reading phase current via PHASE + PHASE_CURRENT
+//
+const PHASE_RAIL: u8 = 0x80;
+
+pub struct Raa229620A {
+    device: I2cDevice,
+    rail: u8,
+    mode: Cell<Option<pmbus::VOutModeCommandData>>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Error {
+    BadRead { cmd: u8, code: ResponseCode },
+    BadWrite { cmd: u8, code: ResponseCode },
+    BadData { cmd: u8 },
+    BadValidation { cmd: u8, code: ResponseCode },
+    InvalidData { err: pmbus::Error },
+}
+
+impl From<BadValidation> for Error {
+    fn from(value: BadValidation) -> Self {
+        Self::BadValidation {
+            cmd: value.cmd,
+            code: value.code,
+        }
+    }
+}
+
+impl From<Error> for ResponseCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::BadRead { code, .. } => code,
+            Error::BadWrite { code, .. } => code,
+            Error::BadValidation { code, .. } => code,
+            _ => panic!(),
+        }
+    }
+}
+
+impl From<pmbus::Error> for Error {
+    fn from(err: pmbus::Error) -> Self {
+        Error::InvalidData { err }
+    }
+}
+
+impl Raa229620A {
+    pub fn new(device: &I2cDevice, rail: u8) -> Self {
+        Raa229620A {
+            device: *device,
+            rail,
+            mode: Cell::new(None),
+        }
+    }
+
+    pub fn read_mode(&self) -> Result<pmbus::VOutModeCommandData, Error> {
+        Ok(match self.mode.get() {
+            None => {
+                let mode = pmbus_rail_read!(
+                    self.device,
+                    self.rail,
+                    commands::VOUT_MODE
+                )?;
+                self.mode.set(Some(mode));
+                mode
+            }
+            Some(mode) => mode,
+        })
+    }
+
+    pub fn turn_off(&mut self) -> Result<(), Error> {
+        let mut op = pmbus_rail_read!(self.device, self.rail, OPERATION)?;
+        op.set_on_off_state(OPERATION::OnOffState::Off);
+        pmbus_rail_write!(self.device, self.rail, OPERATION, op)
+    }
+
+    pub fn turn_on(&mut self) -> Result<(), Error> {
+        let mut op = pmbus_rail_read!(self.device, self.rail, OPERATION)?;
+        op.set_on_off_state(OPERATION::OnOffState::On);
+        pmbus_rail_write!(self.device, self.rail, OPERATION, op)
+    }
+
+    pub fn set_vout(&mut self, value: Volts) -> Result<(), Error> {
+        if value > Volts(3.050) {
+            Err(Error::InvalidData {
+                err: pmbus::Error::ValueOutOfRange,
+            })
+        } else {
+            let mut vout = VOUT_COMMAND::CommandData(0);
+            vout.set(self.read_mode()?, pmbus::units::Volts(value.0))?;
+            pmbus_rail_write!(self.device, self.rail, VOUT_COMMAND, vout)
+        }
+    }
+
+    pub fn clear_faults(&self) -> Result<(), Error> {
+        pmbus_write!(self.device, CLEAR_FAULTS)
+    }
+
+    pub fn set_vin_uv_warn_limit(&self, value: Volts) -> Result<(), Error> {
+        let mut vin = VIN_UV_WARN_LIMIT::CommandData(0);
+        vin.set(pmbus::units::Volts(value.0))?;
+        pmbus_rail_write!(self.device, self.rail, VIN_UV_WARN_LIMIT, vin)
+    }
+
+    pub fn read_vin(&self) -> Result<Volts, Error> {
+        let vin = pmbus_rail_read!(self.device, self.rail, READ_VIN)?;
+        Ok(Volts(vin.get()?.0))
+    }
+
+    pub fn read_phase_current(&self, phase: Phase) -> Result<Amperes, Error> {
+        let iout = pmbus_rail_phase_read!(
+            self.device,
+            PHASE_RAIL,
+            phase.0,
+            PHASE_CURRENT
+        )?;
+        Ok(Amperes(iout.get()?.0))
+    }
+
+    pub fn i2c_device(&self) -> &I2cDevice {
+        &self.device
+    }
+}
+
+impl Validate<Error> for Raa229620A {
+    fn validate(device: &I2cDevice) -> Result<bool, Error> {
+        let expected = &[0x00, 0x9B, 0xd2, 0x49];
+        pmbus_validate(device, CommandCode::IC_DEVICE_ID, expected)
+            .map_err(Into::into)
+    }
+}
+
+impl VoltageSensor<Error> for Raa229620A {
+    fn read_vout(&self) -> Result<Volts, Error> {
+        let vout = pmbus_rail_read!(self.device, self.rail, READ_VOUT)?;
+        Ok(Volts(vout.get(self.read_mode()?)?.0))
+    }
+}
+
+impl TempSensor<Error> for Raa229620A {
+    fn read_temperature(&self) -> Result<Celsius, Error> {
+        let t = pmbus_rail_read!(self.device, self.rail, READ_TEMPERATURE_1)?;
+        Ok(Celsius(t.get()?.0))
+    }
+}
+
+impl CurrentSensor<Error> for Raa229620A {
+    fn read_iout(&self) -> Result<Amperes, Error> {
+        let iout = pmbus_rail_read!(self.device, self.rail, READ_IOUT)?;
+        Ok(Amperes(iout.get()?.0))
+    }
+}

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -17,6 +17,7 @@ use drv_i2c_devices::ltc4282::*;
 use drv_i2c_devices::max5970::*;
 use drv_i2c_devices::mwocp68::*;
 use drv_i2c_devices::raa229618::*;
+use drv_i2c_devices::raa229620a::*;
 use drv_i2c_devices::tps546b24a::*;
 use pmbus::Phase;
 use ringbuf::*;
@@ -79,6 +80,7 @@ enum DeviceType {
 enum DeviceChip {
     Bmr491,
     Raa229618,
+    Raa229620A,
     Isl68224,
     Tps546B24A,
     Adm1272(Ohms),
@@ -104,6 +106,7 @@ struct PowerControllerConfig {
 enum Device {
     Bmr491(Bmr491),
     Raa229618(Raa229618),
+    Raa229620A(Raa229620A),
     Isl68224(Isl68224),
     Tps546B24A(Tps546B24A),
     Adm1272(Adm1272),
@@ -117,6 +120,7 @@ impl Device {
         let r = match &self {
             Device::Bmr491(dev) => dev.read_temperature()?,
             Device::Raa229618(dev) => dev.read_temperature()?,
+            Device::Raa229620A(dev) => dev.read_temperature()?,
             Device::Isl68224(dev) => dev.read_temperature()?,
             Device::Tps546B24A(dev) => dev.read_temperature()?,
             Device::Adm1272(dev) => dev.read_temperature()?,
@@ -137,6 +141,7 @@ impl Device {
         let r = match &self {
             Device::Bmr491(dev) => dev.read_iout()?,
             Device::Raa229618(dev) => dev.read_iout()?,
+            Device::Raa229620A(dev) => dev.read_iout()?,
             Device::Isl68224(dev) => dev.read_iout()?,
             Device::Tps546B24A(dev) => dev.read_iout()?,
             Device::Adm1272(dev) => dev.read_iout()?,
@@ -151,6 +156,7 @@ impl Device {
         let r = match &self {
             Device::Bmr491(dev) => dev.read_vout()?,
             Device::Raa229618(dev) => dev.read_vout()?,
+            Device::Raa229620A(dev) => dev.read_vout()?,
             Device::Isl68224(dev) => dev.read_vout()?,
             Device::Tps546B24A(dev) => dev.read_vout()?,
             Device::Adm1272(dev) => dev.read_vout()?,
@@ -200,6 +206,7 @@ impl Device {
             Device::Mwocp68(dev) => dev.pmbus_read(op)?,
             Device::Bmr491(_)
             | Device::Raa229618(_)
+            | Device::Raa229620A(_)
             | Device::Isl68224(_)
             | Device::Tps546B24A(_)
             | Device::Adm1272(_)
@@ -216,6 +223,7 @@ impl Device {
             Device::Mwocp68(dev) => dev.read_mode()?,
             Device::Bmr491(dev) => dev.read_mode()?,
             Device::Raa229618(dev) => dev.read_mode()?,
+            Device::Raa229620A(dev) => dev.read_mode()?,
             Device::Isl68224(dev) => dev.read_mode()?,
             Device::Tps546B24A(dev) => dev.read_mode()?,
             Device::Adm1272(..) | Device::Ltc4282(..) | Device::Max5970(..) => {
@@ -230,6 +238,7 @@ impl Device {
             Device::Mwocp68(dev) => dev.i2c_device(),
             Device::Bmr491(dev) => dev.i2c_device(),
             Device::Raa229618(dev) => dev.i2c_device(),
+            Device::Raa229620A(dev) => dev.i2c_device(),
             Device::Isl68224(dev) => dev.i2c_device(),
             Device::Tps546B24A(dev) => dev.i2c_device(),
             Device::Adm1272(dev) => dev.i2c_device(),
@@ -246,6 +255,9 @@ impl PowerControllerConfig {
             DeviceChip::Bmr491 => Device::Bmr491(Bmr491::new(&dev, rail)),
             DeviceChip::Raa229618 => {
                 Device::Raa229618(Raa229618::new(&dev, rail))
+            }
+            DeviceChip::Raa229620A => {
+                Device::Raa229620A(Raa229620A::new(&dev, rail))
             }
             DeviceChip::Isl68224 => Device::Isl68224(Isl68224::new(&dev, rail)),
             DeviceChip::Tps546B24A => {


### PR DESCRIPTION
Another standalone building block for Cosmo.

The RAA229620A is identical to the RAA229618 (for our purposes), other than its device ID code.