### PR TITLE
Standalone spartan-7 loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
  "build-util",
  "cortex-m",
  "counters",
- "drv-cpu-seq-api",
  "drv-hash-api",
  "drv-hf-api",
+ "drv-spartan7-loader-api",
  "hubpack",
  "idol",
  "idol-runtime",
@@ -1218,10 +1218,8 @@ dependencies = [
  "drv-auxflash-api",
  "drv-cpu-power-state",
  "drv-cpu-seq-api",
- "drv-spartan7-spi-program",
- "drv-spi-api",
+ "drv-spartan7-loader-api",
  "drv-stm32xx-sys-api",
- "gnarle",
  "idol",
  "idol-runtime",
  "num-traits",
@@ -1959,6 +1957,38 @@ version = "0.1.0"
 dependencies = [
  "counters",
  "derive-idol-err",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "userlib",
+ "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "drv-spartan7-loader"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cfg-if",
+ "counters",
+ "drv-auxflash-api",
+ "drv-spartan7-spi-program",
+ "drv-spi-api",
+ "drv-stm32h7-spi-server-core",
+ "drv-stm32xx-sys-api",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "ringbuf",
+ "userlib",
+ "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "drv-spartan7-loader-api"
+version = "0.1.0"
+dependencies = [
+ "counters",
  "idol",
  "idol-runtime",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "ringbuf",
+ "task-config",
  "userlib",
  "zerocopy 0.6.6",
 ]

--- a/app/grapefruit/app.toml
+++ b/app/grapefruit/app.toml
@@ -182,12 +182,18 @@ uses = ["fmc_nor_psram_bank_1"]
 
 [tasks.spartan7_loader]
 name = "drv-spartan7-loader"
-features = ["h753", "grapefruit"]
+features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 2600
 start = true
 task-slots = ["sys", {spi = "spi2_driver"}, "auxflash"]
+
+[tasks.spartan7_loader.config]
+program_l = "sys_api::Port::B.pin(6)"
+init_l = "sys_api::Port::B.pin(5)"
+config_done = "sys_api::Port::B.pin(4)"
+user_reset_l = "sys_api::Port::I.pin(15)"
 
 [tasks.thermal]
 name = "task-thermal"

--- a/app/grapefruit/app.toml
+++ b/app/grapefruit/app.toml
@@ -173,12 +173,21 @@ interrupts = {"spi4.irq" = "spi-irq"}
 [tasks.grapefruit_seq]
 name = "drv-grapefruit-seq-server"
 features = ["h753"]
+priority = 5
+max-sizes = {flash = 131072, ram = 16384 }
+stacksize = 2600
+start = true
+task-slots = ["sys", "jefe", "packrat", "spartan7_loader"]
+uses = ["fmc_nor_psram_bank_1"]
+
+[tasks.spartan7_loader]
+name = "drv-spartan7-loader"
+features = ["h753", "grapefruit"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 2600
 start = true
-task-slots = ["sys", {spi = "spi2_driver"}, "auxflash", "jefe", "packrat"]
-uses = ["fmc_nor_psram_bank_1"]
+task-slots = ["sys", {spi = "spi2_driver"}, "auxflash"]
 
 [tasks.thermal]
 name = "task-thermal"
@@ -326,7 +335,7 @@ name = "drv-cosmo-hf"
 priority = 5
 start = true
 uses = ["fmc_nor_psram_bank_1"]
-task-slots = ["hash_driver", "grapefruit_seq"]
+task-slots = ["hash_driver", "spartan7_loader"]
 stacksize = 4000
 
 [config.net]
@@ -551,7 +560,7 @@ outputs = [
 ]
 input = {port = "B", pin = 14, af = 5} # not actually used in FPGA config
 
-[config.spi.spi2.devices.fpga]
+[config.spi.spi2.devices.spartan7_fpga]
 mux = "port_b"
 cs = []
 # no CS pin; we're using the SPI peripheral to send synchronized CLK + DATA
@@ -580,4 +589,4 @@ slot-count = 16 # 2 MiB slots
 file = "drv/grapefruit-seq-server/grapefruit.bz2"
 unzip = "bz2"
 compress = true
-tag = "FPGA"
+tag = "SPA7" # used by drv-spartan7-loader

--- a/drv/cosmo-hf/Cargo.toml
+++ b/drv/cosmo-hf/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 counters = { path = "../../lib/counters" }
-drv-cpu-seq-api = { path = "../cpu-seq-api" }
 drv-hash-api = { path = "../hash-api" }
 drv-hf-api = { path = "../hf-api" }
+drv-spartan7-loader-api = { path = "../spartan7-loader-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -18,7 +18,7 @@ use userlib::{hl::sleep_for, task_slot};
 
 mod hf; // implementation of `HostFlash` API
 
-task_slot!(SEQ, grapefruit_seq);
+task_slot!(LOADER, spartan7_loader);
 
 #[derive(Debug, Clone, Copy, PartialEq, counters::Count)]
 enum Trace {
@@ -65,8 +65,9 @@ pub const FLASH_SIZE_BYTES: u32 = 128 * 1024 * 1024;
 fn main() -> ! {
     // Wait for the FPGA to be configured; the sequencer task only starts its
     // Idol loop after the FPGA has been brought up.
-    let seq = drv_cpu_seq_api::Sequencer::from(SEQ.get_task_id());
-    let _ = seq.get_state();
+    let seq =
+        drv_spartan7_loader_api::Spartan7Loader::from(LOADER.get_task_id());
+    seq.ping();
 
     let id = unsafe { reg::BASE.read_volatile() };
     if id != 0x1de {

--- a/drv/grapefruit-seq-server/Cargo.toml
+++ b/drv/grapefruit-seq-server/Cargo.toml
@@ -8,10 +8,8 @@ counters = { path = "../../lib/counters" }
 drv-auxflash-api = { path = "../auxflash-api" }
 drv-cpu-power-state = { path = "../cpu-power-state" }
 drv-cpu-seq-api = { path = "../cpu-seq-api" }
-drv-spartan7-spi-program = { path = "../spartan7-spi-program" }
-drv-spi-api = { path = "../spi-api" }
+drv-spartan7-loader-api = { path = "../spartan7-loader-api" }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
-gnarle = { path = "../../lib/gnarle" }
 task-packrat-api = { path = "../../task/packrat-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }

--- a/drv/spartan7-loader-api/Cargo.toml
+++ b/drv/spartan7-loader-api/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "drv-spartan7-loader-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+idol-runtime = { workspace = true }
+num-traits.workspace = true
+zerocopy.workspace = true
+
+counters = { path = "../../lib/counters", features = ["derive"] }
+userlib = { path = "../../sys/userlib" }
+
+[build-dependencies]
+idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/drv/spartan7-loader-api/build.rs
+++ b/drv/spartan7-loader-api/build.rs
@@ -3,12 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    build_util::expose_target_board();
-    idol::Generator::new().build_server_support(
-        "../../idl/cpu-seq.idol",
-        "server_stub.rs",
-        idol::server::ServerStyle::InOrder,
-    )?;
-
+    idol::Generator::new()
+        .with_counters(idol::CounterSettings::default())
+        .build_client_stub(
+            "../../idl/spartan7-loader.idol",
+            "client_stub.rs",
+        )?;
     Ok(())
 }

--- a/drv/spartan7-loader-api/src/lib.rs
+++ b/drv/spartan7-loader-api/src/lib.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API crate for the Spartan7 loader.
+
+#![no_std]
+
+use userlib::sys_send;
+
+/// Token that indicates that the Spartan-7 is running
+///
+/// This token can be passed to peripheral constructors.
+pub struct Spartan7Token(core::marker::PhantomData<()>);
+
+impl Spartan7Loader {
+    /// Gets a token proving that the Spartan-7 is running
+    pub fn get_token(&self) -> Spartan7Token {
+        self.ping();
+        Spartan7Token(core::marker::PhantomData)
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/spartan7-loader-api/src/lib.rs
+++ b/drv/spartan7-loader-api/src/lib.rs
@@ -11,13 +11,13 @@ use userlib::sys_send;
 /// Token that indicates that the Spartan-7 is running
 ///
 /// This token can be passed to peripheral constructors.
-pub struct Spartan7Token(core::marker::PhantomData<()>);
+pub struct Spartan7Token(());
 
 impl Spartan7Loader {
     /// Gets a token proving that the Spartan-7 is running
     pub fn get_token(&self) -> Spartan7Token {
         self.ping();
-        Spartan7Token(core::marker::PhantomData)
+        Spartan7Token(())
     }
 }
 

--- a/drv/spartan7-loader/Cargo.toml
+++ b/drv/spartan7-loader/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "drv-spartan7-loader"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+drv-auxflash-api = { path = "../auxflash-api" }
+drv-spartan7-spi-program = { path = "../spartan7-spi-program" }
+drv-spi-api = { path = "../spi-api" }
+drv-stm32h7-spi-server-core = { path = "../../drv/stm32h7-spi-server-core", optional = true }
+drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
+counters = { path = "../../lib/counters" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+
+cfg-if = { workspace = true }
+idol-runtime.workspace = true
+num-traits = { workspace = true }
+zerocopy = { workspace = true }
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
+
+[features]
+h753 = ["drv-stm32xx-sys-api/h753"]
+use-spi-core = ["drv-stm32h7-spi-server-core"]
+spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
+spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
+spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
+spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
+spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
+spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+
+# enable one of these features to select FPGA pins
+grapefruit = [] 
+
+[[bin]]
+name = "drv-spartan7-loader"
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/drv/spartan7-loader/Cargo.toml
+++ b/drv/spartan7-loader/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2021"
 [dependencies]
 drv-auxflash-api = { path = "../auxflash-api" }
 drv-spartan7-spi-program = { path = "../spartan7-spi-program" }
+counters = { path = "../../lib/counters" }
 drv-spi-api = { path = "../spi-api" }
 drv-stm32h7-spi-server-core = { path = "../../drv/stm32h7-spi-server-core", optional = true }
 drv-stm32xx-sys-api = { path = "../stm32xx-sys-api" }
-counters = { path = "../../lib/counters" }
 ringbuf = { path = "../../lib/ringbuf" }
+task-config = {  path = "../../lib/task-config"  }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
 cfg-if = { workspace = true }
@@ -31,9 +32,6 @@ spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
 spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
 spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
 spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
-
-# enable one of these features to select FPGA pins
-grapefruit = [] 
 
 [[bin]]
 name = "drv-spartan7-loader"

--- a/drv/spartan7-loader/build.rs
+++ b/drv/spartan7-loader/build.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::{fs, io::Write};
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_util::expose_target_board();
+
+    let out_dir = build_util::out_dir();
+    let out_file = out_dir.join("spartan7_fpga.rs");
+    let mut file = fs::File::create(out_file)?;
+
+    // Check that a valid bitstream is available for this board.
+    let board = build_util::env_var("HUBRIS_BOARD")?;
+    if board != "grapefruit" {
+        panic!("unknown target board");
+    }
+
+    // Pull the bitstream checksum from an environment variable
+    // (injected by `xtask` itself as part of auxiliary flash packing)
+    let checksum =
+        build_util::env_var("HUBRIS_AUXFLASH_CHECKSUM_SPA7").unwrap();
+    writeln!(
+        &mut file,
+        "\npub const SPARTAN7_FPGA_BITSTREAM_CHECKSUM: [u8; 32] = {};",
+        checksum,
+    )?;
+
+    idol::Generator::new().build_server_support(
+        "../../idl/spartan7-loader.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    Ok(())
+}

--- a/drv/spartan7-loader/src/main.rs
+++ b/drv/spartan7-loader/src/main.rs
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Dedicated task for loading the Spartan-7 FPGA bitstream
+//!
+//! This FPGA is used as a memory-mapped peripheral.  Once it's loaded, other
+//! tasks interact with it by writing directly to memory addresses, so it's
+//! important that it remains running without interruption.  As such, this task
+//! is infallible once it enters the Idol runtime loop.
+
+#![no_std]
+#![no_main]
+
+use core::num::NonZeroUsize;
+use drv_spartan7_spi_program::{BitstreamLoader, Spartan7Error};
+use drv_spi_api::{SpiDevice, SpiServer};
+use drv_stm32xx_sys_api as sys_api;
+use idol_runtime::{NotificationHandler, RequestError};
+use userlib::{hl, sys_recv_notification, task_slot, RecvMessage, UnwrapLite};
+
+use ringbuf::{counted_ringbuf, ringbuf_entry, Count};
+
+////////////////////////////////////////////////////////////////////////////////
+// Select local vs server SPI communication
+
+/// Claims the SPI core.
+///
+/// This function can only be called once, and will panic otherwise!
+#[cfg(feature = "use-spi-core")]
+pub fn claim_spi(
+    sys: &sys_api::Sys,
+) -> drv_stm32h7_spi_server_core::SpiServerCore {
+    drv_stm32h7_spi_server_core::declare_spi_core!(
+        sys.clone(),
+        notifications::SPI_IRQ_MASK
+    )
+}
+
+#[cfg(not(feature = "use-spi-core"))]
+pub fn claim_spi(_sys: &sys_api::Sys) -> drv_spi_api::Spi {
+    task_slot!(SPI, spi);
+    drv_spi_api::Spi::from(SPI.get_task_id())
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Copy, Clone, PartialEq, Count)]
+enum Trace {
+    FpgaInit,
+    FpgaInitFailed(#[count(children)] Spartan7Error),
+    StartFailed(#[count(children)] SeqError),
+    ContinueBitstreamLoad(usize),
+    WaitForDone,
+    Programmed,
+
+    #[count(skip)]
+    None,
+}
+
+#[derive(Copy, Clone, PartialEq, Count)]
+enum SeqError {
+    AuxFlashError(#[count(children)] drv_auxflash_api::AuxFlashError),
+    SpartanError(#[count(children)] Spartan7Error),
+    AuxChecksumMismatch,
+}
+
+impl From<drv_auxflash_api::AuxFlashError> for SeqError {
+    fn from(v: drv_auxflash_api::AuxFlashError) -> Self {
+        SeqError::AuxFlashError(v)
+    }
+}
+
+impl From<Spartan7Error> for SeqError {
+    fn from(v: Spartan7Error) -> Self {
+        SeqError::SpartanError(v)
+    }
+}
+
+counted_ringbuf!(Trace, 128, Trace::None);
+
+task_slot!(SYS, sys);
+task_slot!(AUXFLASH, auxflash);
+
+#[export_name = "main"]
+fn main() -> ! {
+    match init() {
+        // Set up everything nicely, time to start serving incoming messages.
+        Ok(()) => {
+            let mut server = ServerImpl;
+            let mut buffer = [0; idl::INCOMING_SIZE];
+            loop {
+                idol_runtime::dispatch(&mut buffer, &mut server);
+            }
+        }
+
+        // Initializing the sequencer failed.
+        Err(e) => {
+            // Log that something's broken
+            //
+            // The main sequencer task has ownership over the fault pin and is
+            // responsible for leaving it held low until the FPGA boots, so it
+            // will be stuck low here.
+            ringbuf_entry!(Trace::StartFailed(e));
+
+            // All these moments will be lost in time, like tears in rain...
+            // Time to die.
+            loop {
+                // Sleeping with all bits in the notification mask clear means
+                // we should never be notified --- and if one never wakes up,
+                // the difference between sleeping and dying seems kind of
+                // irrelevant. But, `rustc` doesn't realize that this should
+                // never return, we'll stick it in a `loop` anyway so the main
+                // function can return `!`
+                sys_recv_notification(0);
+            }
+        }
+    }
+}
+
+fn init() -> Result<(), SeqError> {
+    let sys = sys_api::Sys::from(SYS.get_task_id());
+    let dev = claim_spi(&sys).device(drv_spi_api::devices::SPARTAN7_FPGA);
+    let aux = drv_auxflash_api::AuxFlash::from(AUXFLASH.get_task_id());
+
+    init_spartan7_fpga(&sys, &dev, &aux)?;
+
+    Ok(())
+}
+
+struct ServerImpl;
+
+/// Initialize the Spartan-7 FPGA
+fn init_spartan7_fpga<S: SpiServer>(
+    sys: &sys_api::Sys,
+    seq: &SpiDevice<S>,
+    aux: &drv_auxflash_api::AuxFlash,
+) -> Result<(), SeqError> {
+    #[cfg(feature = "grapefruit")]
+    let pin_cfg = drv_spartan7_spi_program::Config {
+        program_l: sys_api::Port::B.pin(6),
+        init_l: sys_api::Port::B.pin(5),
+        config_done: sys_api::Port::B.pin(4),
+        user_reset_l: sys_api::Port::I.pin(15),
+    };
+
+    ringbuf_entry!(Trace::FpgaInit);
+    // On initial power up, the FPGA may not be listening right away, so
+    // retry for 500 ms.
+    let loader = retry_spartan7_init(
+        sys,
+        &pin_cfg,
+        seq,
+        NonZeroUsize::new(10).unwrap_lite(),
+        50,
+    )?;
+
+    let sha_out = aux.get_compressed_blob_streaming(
+        *b"SPA7",
+        |chunk| -> Result<(), SeqError> {
+            loader.continue_bitstream_load(chunk)?;
+            ringbuf_entry!(Trace::ContinueBitstreamLoad(chunk.len()));
+            Ok(())
+        },
+    )?;
+
+    if sha_out != gen::SPARTAN7_FPGA_BITSTREAM_CHECKSUM {
+        // Reset the FPGA to clear the invalid bitstream
+        sys.gpio_reset(pin_cfg.program_l);
+        hl::sleep_for(1);
+        sys.gpio_set(pin_cfg.program_l);
+
+        return Err(SeqError::AuxChecksumMismatch);
+    }
+
+    ringbuf_entry!(Trace::WaitForDone);
+    loader.finish_bitstream_load()?;
+
+    ringbuf_entry!(Trace::Programmed);
+
+    Ok(())
+}
+
+fn retry_spartan7_init<'a, S: SpiServer>(
+    sys: &'a sys_api::Sys,
+    pin_cfg: &'a drv_spartan7_spi_program::Config,
+    seq: &'a SpiDevice<S>,
+    count: NonZeroUsize,
+    delay_ms: u64,
+) -> Result<BitstreamLoader<'a, S>, Spartan7Error> {
+    let mut last_err = None;
+    for _ in 0..count.get() {
+        match BitstreamLoader::begin_bitstream_load(sys, pin_cfg, seq, true) {
+            Ok(loader) => return Ok(loader),
+            Err(e) => {
+                ringbuf_entry!(Trace::FpgaInitFailed(e));
+                last_err = Some(e);
+                hl::sleep_for(delay_ms);
+            }
+        }
+    }
+    Err(last_err.unwrap_lite())
+}
+
+impl idl::InOrderSpartan7LoaderImpl for ServerImpl {
+    fn ping(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<core::convert::Infallible>> {
+        Ok(())
+    }
+}
+
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: u32) {
+        unreachable!()
+    }
+}
+
+mod idl {
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}
+
+mod gen {
+    include!(concat!(env!("OUT_DIR"), "/spartan7_fpga.rs"));
+}

--- a/drv/spartan7-loader/src/main.rs
+++ b/drv/spartan7-loader/src/main.rs
@@ -120,17 +120,24 @@ fn main() -> ! {
 
 struct ServerImpl;
 
+task_config::task_config! {
+    program_l: sys_api::PinSet,
+    init_l: sys_api::PinSet,
+    config_done: sys_api::PinSet,
+    user_reset_l: sys_api::PinSet,
+}
+
 fn init() -> Result<(), LoaderError> {
     let sys = sys_api::Sys::from(SYS.get_task_id());
     let dev = claim_spi(&sys).device(drv_spi_api::devices::SPARTAN7_FPGA);
     let aux = drv_auxflash_api::AuxFlash::from(AUXFLASH.get_task_id());
 
-    #[cfg(feature = "grapefruit")]
+    // Translate from our magical task config to our desired type
     let pin_cfg = drv_spartan7_spi_program::Config {
-        program_l: sys_api::Port::B.pin(6),
-        init_l: sys_api::Port::B.pin(5),
-        config_done: sys_api::Port::B.pin(4),
-        user_reset_l: sys_api::Port::I.pin(15),
+        program_l: TASK_CONFIG.program_l,
+        init_l: TASK_CONFIG.init_l,
+        config_done: TASK_CONFIG.config_done,
+        user_reset_l: TASK_CONFIG.user_reset_l,
     };
 
     ringbuf_entry!(Trace::FpgaInit);

--- a/idl/spartan7-loader.idol
+++ b/idl/spartan7-loader.idol
@@ -1,0 +1,13 @@
+// Interface to Spartan-7 FPGA loader.
+
+Interface(
+    name: "Spartan7Loader",
+    ops: {
+        "ping": (
+            doc: "returns once the loader is complete",
+            args: {},
+            reply: Simple("()"),
+            idempotent: true,
+        ),
+    }
+)


### PR DESCRIPTION
For Grapefruit and Cosmo, the Spartan-7 FPGA is used as a memory-mapped peripheral once its bitstream is loaded.  It's important that it not die or be reset, because that will be Very Confusing for any tasks writing directly into its memory space.

This PR moves loading that FPGA into a standalone task, separate from `grapefruit-seq` (and the eventual `cosmo-seq`).  The new task is infallible once it enters the Idol runtime loop, and can provide unforgeable tokens that prove the FPGA was loaded; eventually, I'd like for FPGA-based peripherals to take those tokens in their constructors.

The code changes in this PR are mostly reorganization and boilerplate, pulling stuff from `grapefruit-seq` into `drv-spartan7-loader` and writing `drv-spartan7-loader-api` / Idol files.

Tested on Grapefruit (standalone).