### PR TITLE
Flash padding byte is 0xff for correct SP FWID.

### DIFF
--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -387,10 +387,10 @@ impl idl::InOrderUpdateImpl for ServerImpl<'_> {
                 .read_range(0..len, flash_bytes)
                 .map_err(|_| RequestError::Fail(ClientError::WentAway))?;
 
-            // If there is a write less than the block size zero out the
-            // trailing bytes
+            // If there is a write less than the block size fill out the
+            // trailing bytes with 0xff.
             if len < BLOCK_SIZE_BYTES {
-                flash_bytes[len..].fill(0);
+                flash_bytes[len..].fill(0xff);
             }
         }
 


### PR DESCRIPTION
It was incorrectly set to 0x00.

Measurement of an installed SP image will not be correct without this change.

Using `humility readmem ...` we can see the effect of this change.

Incorrect padding of an SP image with 0x00.
See caboose offset at 0x00083afc (0x00000100) with 0x00 padding to the end of 256-byte flash block.
```
00083a60  f7 c4 84 3c 67 72 61 70  65 66 72 75 69 74 00 00  |...<grapefruit..|
00083a70  f8 11 f5 08 ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00083a80  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00083af0  ff ff ff ff ff ff ff ff  ff ff ff ff 00 01 00 00  |................|
00083b00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00083c00  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00100000
```

Fixed padding of an SP image with 0xff.
See caboose offset at 0x00083afc (0x00000100) with 0xff padding to the end of the 256-byte flash block.
```
00083a60  f7 c4 84 3c 67 72 61 70  65 66 72 75 69 74 00 00  |...<grapefruit..|
00083a70  f8 11 f5 08 ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00083a80  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00083af0  ff ff ff ff ff ff ff ff  ff ff ff ff 00 01 00 00  |................|
00083b00
```