### PR TITLE
Split Grapefruit into Ruby vs standalone images

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -239,9 +239,13 @@ jobs:
             app_name: donglet-g031
             app_toml: app/donglet/app-g031.toml
             image: default
-          - build: grapefruit
-            app_name: grapefruit
-            app_toml: app/grapefruit/app.toml
+          - build: grapefruit-ruby
+            app_name: grapefruit-ruby
+            app_toml: app/grapefruit/app-ruby.toml
+            image: default
+          - build: grapefruit-standalone
+            app_name: grapefruit-standalone
+            app_toml: app/grapefruit/app-dev.toml
             image: default
     uses: ./.github/workflows/build-one.yml
     with:

--- a/app/grapefruit/app-dev.toml
+++ b/app/grapefruit/app-dev.toml
@@ -1,0 +1,8 @@
+name = "grapefruit-standalone"
+inherit = "base.toml"
+
+# Host SP comms goes over a UART to J10, using USART8
+[tasks.host_sp_comms]
+features = ["uart8"]
+uses = ["uart8"]
+interrupts = {"uart8.irq" = "usart-irq"}

--- a/app/grapefruit/app-ruby.toml
+++ b/app/grapefruit/app-ruby.toml
@@ -1,0 +1,9 @@
+name = "grapefruit-ruby"
+inherit = "base.toml"
+
+# Host SP comms goes over a UART to the FPGA, which translates to eSPI messages
+# to the Ruby dev board.
+[tasks.host_sp_comms]
+features = ["usart6", "hardware_flow_control"]
+uses = ["usart6"]
+interrupts = {"usart6.irq" = "usart-irq"}

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -1,4 +1,3 @@
-name = "grapefruit"
 board = "grapefruit"
 target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
@@ -223,11 +222,12 @@ max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
+# Note that host_sp_comms does not specify a UART!  It must be fully specified
+# with features + uses + interrupts by manifests inheriting from this file.
 [tasks.host_sp_comms]
 name = "task-host-sp-comms"
-features = ["stm32h753", "usart6", "baud_rate_3M", "hardware_flow_control", "vlan", "grapefruit"]
-uses = ["usart6", "dbgmcu"]
-interrupts = {"usart6.irq" = "usart-irq"}
+features = ["stm32h753", "baud_rate_3M", "vlan", "grapefruit"]
+uses = ["dbgmcu"]
 priority = 8
 max-sizes = {flash = 65536, ram = 65536}
 stacksize = 5080

--- a/task/host-sp-comms/Cargo.toml
+++ b/task/host-sp-comms/Cargo.toml
@@ -57,6 +57,7 @@ stm32h743 = ["drv-stm32h7-usart/h743", "drv-stm32xx-sys-api/h743", "drv-stm32h7-
 stm32h753 = ["drv-stm32h7-usart/h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-dbgmcu/h753"]
 usart6 = []
 uart7 = []
+uart8 = []
 baud_rate_3M = []
 hardware_flow_control = []
 vlan = ["task-net-api/vlan"]

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1547,8 +1547,7 @@ fn configure_uart_device(sys: &sys_api::Sys) -> Usart {
     #[cfg(feature = "baud_rate_3M")]
     const BAUD_RATE: u32 = 3_000_000;
 
-    #[cfg(feature = "hardware_flow_control")]
-    let hardware_flow_control = true;
+    let hardware_flow_control = cfg!(feature = "hardware_flow_control");
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "uart7")] {
@@ -1582,6 +1581,22 @@ fn configure_uart_device(sys: &sys_api::Sys) -> Usart {
             };
             let usart = unsafe { &*device::USART6::ptr() };
             let peripheral = Peripheral::Usart6;
+            let pins = PINS;
+        } else if #[cfg(feature = "uart8")] {
+            const PINS: &[(PinSet, Alternate)] = {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "hardware_flow_control")] {
+                        compile_error!("hardware_flow_control should be disabled");
+                    } else {
+                        &[(
+                            Port::J.pin(8).and_pin(9),
+                            Alternate::AF8
+                        )]
+                    }
+                }
+            };
+            let usart = unsafe { &*device::UART8::ptr() };
+            let peripheral = Peripheral::Uart8;
             let pins = PINS;
         } else {
             compile_error!("no usartX/uartX feature specified");


### PR DESCRIPTION
- Splits Grapefruit into `app-dev.toml` (dev boards only) and `app-ruby.toml` (attached to Ruby)
- Switch `app-dev` to using UART8, which is brought out on a connector

This lets us test IPCC on a desktop, connecting to Grapefruit with a USB-to-serial cable.