### PR TITLE
Fixup `mock-gimlet-hf-server` and switch to it for gimletlet

### DIFF
--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -119,9 +119,9 @@ notifications = [
 ]
 
 [tasks.hf]
-# If you do not have a gimletlet qspi-let adapter but want to test the hf API
-# (e.g., from control-plane-agent / MGS), switch to `drv-mock-gimlet-hf-server`.
-name = "drv-gimlet-hf-server"
+# This now uses the `drv-mock-gimlet-hf-server` task by default. If you
+# actually want to run with a qspi-let adapter switch to `drv-gimlet-hf-server`
+name = "drv-mock-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096}

--- a/drv/mock-gimlet-hf-server/src/main.rs
+++ b/drv/mock-gimlet-hf-server/src/main.rs
@@ -174,6 +174,32 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
     ) -> Result<HfPersistentData, RequestError<HfError>> {
         Err(HfError::HashNotConfigured.into())
     }
+
+    fn bonus_page_program(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _data: LenLimit<Leased<R, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
+    }
+
+    fn bonus_read(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+        _dest: LenLimit<Leased<W, [u8]>, PAGE_SIZE_BYTES>,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
+    }
+
+    fn bonus_sector_erase(
+        &mut self,
+        _: &RecvMessage,
+        _addr: u32,
+    ) -> Result<(), RequestError<HfError>> {
+        Err(HfError::BadAddress.into())
+    }
 }
 
 impl NotificationHandler for ServerImpl {


### PR DESCRIPTION
We have more boards available with actual host flash, just use the mock server by default.