### PR TITLE
FMC-attached peripherals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6564,6 +6564,7 @@ dependencies = [
  "abi",
  "anyhow",
  "atty",
+ "build-fpga-regmap",
  "build-kconfig",
  "byteorder",
  "bzip2-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ stm32f4 = { version = "0.13.0", default-features = false }
 stm32h7 = { version = "0.14", default-features = false }
 stm32g0 = { version = "0.15.1", default-features = false }
 strsim = { version = "0.10.0", default-features = false }
-syn = { version = "2", default-features = false, features = ["derive", "parsing", "proc-macro", "extra-traits", "full"] }
+syn = { version = "2", default-features = false, features = ["derive", "parsing", "proc-macro", "extra-traits", "full", "printing"] }
 toml = { version = "0.7", default-features = false, features = ["parse", "display"] }
 toml_edit = { version = "0.19", default-features = false }
 vcell = { version = "0.1.2", default-features = false }

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -7,6 +7,10 @@ epoch = 0
 version = 0
 fwid = true
 
+[mmio]
+peripheral-region = "fmc_nor_psram_bank_1"
+register-map = "../../drv/spartan7-loader/grapefruit/gfruit_top_map.json"
+
 [kernel]
 name = "grapefruit"
 requires = {flash = 32768, ram = 8192}
@@ -177,7 +181,7 @@ max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 2600
 start = true
 task-slots = ["sys", "jefe", "packrat", "spartan7_loader"]
-uses = ["fmc_nor_psram_bank_1"]
+uses = ["mmio_sgpio"]
 
 [tasks.spartan7_loader]
 name = "drv-spartan7-loader"
@@ -333,14 +337,14 @@ features = ["h753"]
 priority = 4
 start = true
 task-slots = ["sys", "net"]
-uses = ["fmc_nor_psram_bank_1"]
+uses = ["mmio_base", "mmio_spi_nor", "mmio_espi", "mmio_sgpio"]
 notifications = ["socket"]
 
 [tasks.hf]
 name = "drv-cosmo-hf"
 priority = 5
 start = true
-uses = ["fmc_nor_psram_bank_1"]
+uses = ["mmio_base", "mmio_spi_nor"]
 task-slots = ["hash_driver", "spartan7_loader"]
 stacksize = 4000
 

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -46,6 +46,7 @@ zip = { workspace = true }
 
 gnarle = { path = "../../lib/gnarle", features = ["std"] }
 abi.path = "../../sys/abi"
+build-fpga-regmap.path = "../../build/fpga-regmap"
 build-kconfig.path = "../kconfig"
 lpc55-rom-data.path = "../../lib/lpc55-rom-data"
 toml-task.path = "../../lib/toml-task"

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -843,9 +843,16 @@ fn build_archive(
     archive.text("app.toml", &cfg.toml.app_config)?;
 
     let chip_dir = cfg.app_src_dir.join(cfg.toml.chip.clone());
-    let chip_file = chip_dir.join("chip.toml");
-    let chip_filename = chip_file.file_name().unwrap();
-    archive.copy(&chip_file, chip_filename)?;
+
+    // Generate a synthetic `chip.toml` by serializing our peripheral map,
+    // because we may have added addition FMC peripherals.
+    archive
+        .text(
+            "chip.toml",
+            toml::to_string(&cfg.toml.peripherals)
+                .context("could not serialize chip.toml")?,
+        )
+        .context("could not write chip.toml")?;
 
     archive
         .text(

--- a/chips/stm32h7/chip.toml
+++ b/chips/stm32h7/chip.toml
@@ -151,16 +151,18 @@ size = 128 # 96 bytes of actual data, rounding up to a power of two
 address = 0x52004000
 size = 0x1000
 
-# NOTE: this is the correct thing to depend on if you want to use the PSRAM
-# interface as a memory mapped peripheral, like we do with certain FPGAs. This
-# is NOT the right way to use it as RAM! For that you probably want an
-# extern-region instead.
+# NOTE: this defines the chunk of memory used for memory-mapped peripherals,
+# like we do for certain FPGAs.  You should not use it directly; instead, use an
+# `[fmc]` configuration block in your manifest to generate fine-grained memory
+# regions for each memory-mapped peripheral, based on the FPGA's top-level
+# peripheral map.
 #
-# Why, you ask? Because this is a peripheral mapping, and will set up this
-# section of the address space as bypassing the cache, not coalescing stores,
-# and so forth. This is what you want for memory mapped registers; it is _not_
-# what you want for RAM, at least if you want performance to be halfway
-# reasonable.
+# This is also NOT the right way to use FMC-attached devices as RAM! For that
+# you probably want an extern-region instead. Why, you ask? Because this is a
+# peripheral mapping, and will set up this section of the address space as
+# bypassing the cache, not coalescing stores, and so forth. This is what you
+# want for memory mapped registers; it is _not_ what you want for RAM, at least
+# if you want performance to be halfway reasonable.
 [fmc_nor_psram_bank_1]
 address = 0x60000000
 size = 0x10000000


### PR DESCRIPTION
This lets us specify a set of FMC-attached **virtual peripherals**, which are implemented in an FPGA.

A manifest may specify an `[fmc]` configuration object, with a base address and register map (which is a JSON file).  If present, `xtask` parses the JSON file and adds its peripherals to the `chip.toml`'s peripheral list, prefixed with `fmc_`.  Tasks can include these peripherals in their `uses = [...]` list.

Instead of copying `chip.toml` into the output archive, we re-serialize the `peripherals` map, so that it includes these virtual peripherals.  This means that `humility map` works fine:

```
DESC       LOW          HIGH          SIZE ATTR   ID TASK
...elided...
0x08005820 0x60000000 - 0x600000ff     256 rw-d-- 24 [fmc_base] fmc_demo, hf
0x0800585c 0x60000100 - 0x600001ff     256 rw-d-- 24 [fmc_spi_nor] fmc_demo, hf
0x08005834 0x60000200 - 0x600002ff     256 rw-d-- 24 [fmc_espi] fmc_demo
0x08005848 0x60000300 - 0x600003ff     256 rw-d-- 12 [fmc_sgpio] grapefruit_seq, fmc_demo
```

(it does lose the comments in the original `chip.toml`; raise an objection if you think that's a big deal)

I've removed the `fmc_nor_psram_bank_1` peripheral, because Humility doesn't play nice with multiple regions at the same start address.  Instead, `drv-stm32h7-fmc-demo-server` is configured to use each of the FPGA's peripherals.  If we are still using this demo task with > 8 peripherals, then we can reconsider.