### PR TITLE
Don't get FPGA ID in `cosmo-hf`

### DIFF
--- a/drv/cosmo-hf/build.rs
+++ b/drv/cosmo-hf/build.rs
@@ -26,12 +26,5 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         build_fpga_regmap::fpga_peripheral(node, top, 0x60000000, token)?
     )?;
 
-    let node = Path::new("../spartan7-loader/grapefruit/base_reg_map.json");
-    write!(
-        &mut file,
-        "{}",
-        build_fpga_regmap::fpga_peripheral(node, top, 0x60000000, token)?
-    )?;
-
     Ok(())
 }

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -66,12 +66,6 @@ fn main() -> ! {
     let seq =
         drv_spartan7_loader_api::Spartan7Loader::from(LOADER.get_task_id());
 
-    let base = fmc_periph::Base::new(seq.get_token());
-    let id = base.id.data();
-    if id != 0x1de {
-        fail(drv_hf_api::HfError::FpgaNotConfigured);
-    }
-
     let drv = FlashDriver {
         drv: fmc_periph::SpiNor::new(seq.get_token()),
     };

--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -31,7 +31,6 @@ pub enum HfError {
     Sector0IsReserved,
     NoPersistentData,
     MonotonicCounterOverflow,
-    FpgaNotConfigured,
     BadChipId,
     BadAddress,
 


### PR DESCRIPTION
Eventually, `cosmo-hf` will support both Grapefruit and Cosmo FPGA images.  The upcoming Cosmo image has a different set of base registers, so let's not check them; checking that the FPGA has booted is not really `cosmo-hf`'s job anyways!

(cherry-picked from 73fbbb98f50117f51a2a8cbf6dd5b83f628b805c in the `mkeeter/cosmo-support` branch)