### PR TITLE
Removed unneeded used_with_arg

### DIFF
--- a/test/tests-lpc55xpresso/src/main.rs
+++ b/test/tests-lpc55xpresso/src/main.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![feature(used_with_arg)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
I'm actually not 100% sure this isn't needed here, but it appears vestigial, so let's give it a CI run.