### PR TITLE
adjust settings for donglet

### DIFF
--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -15,7 +15,7 @@ name = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
-stacksize = 192
+stacksize = 256
 notifications = ["fault", "timer"]
 features = ["no-panic", "nano"]
 
@@ -130,20 +130,20 @@ description = "TempSense"
 sensors = { temperature = 1 }
 removable = true
 
-# [[config.i2c.devices]]
-# controller = 1
-# mux = 1
-# segment = 5
-# address = 0b1010_000
-# device = "at24csw080"
-# description = "Cosmo Sharkfin VPD"
-# removable = true
-# 
-# [[config.i2c.devices]]
-# controller = 1
-# mux = 1
-# segment = 6
-# address = 0b1010_000
-# device = "at24csw080"
-# description = "Cosmo Fan VPD"
-# removable = true
+[[config.i2c.devices]]
+controller = 1
+mux = 1
+segment = 5
+address = 0b1010_000
+device = "at24csw080"
+description = "Cosmo Sharkfin VPD"
+removable = true
+
+[[config.i2c.devices]]
+controller = 1
+mux = 1
+segment = 6
+address = 0b1010_000
+device = "at24csw080"
+description = "Cosmo Fan VPD"
+removable = true

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -129,21 +129,3 @@ device = "tmp117"
 description = "TempSense"
 sensors = { temperature = 1 }
 removable = true
-
-[[config.i2c.devices]]
-controller = 1
-mux = 1
-segment = 5
-address = 0b1010_000
-device = "at24csw080"
-description = "Cosmo Sharkfin VPD"
-removable = true
-
-[[config.i2c.devices]]
-controller = 1
-mux = 1
-segment = 6
-address = 0b1010_000
-device = "at24csw080"
-description = "Cosmo Fan VPD"
-removable = true

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -129,3 +129,21 @@ device = "tmp117"
 description = "TempSense"
 sensors = { temperature = 1 }
 removable = true
+
+# [[config.i2c.devices]]
+# controller = 1
+# mux = 1
+# segment = 5
+# address = 0b1010_000
+# device = "at24csw080"
+# description = "Cosmo Sharkfin VPD"
+# removable = true
+# 
+# [[config.i2c.devices]]
+# controller = 1
+# mux = 1
+# segment = 6
+# address = 0b1010_000
+# device = "at24csw080"
+# description = "Cosmo Fan VPD"
+# removable = true

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -119,27 +119,27 @@ static mut HIFFY_RSTACK: [u8; HIFFY_RSTACK_SIZE] = [0; HIFFY_RSTACK_SIZE];
 static HIFFY_SCRATCH: StaticCell<[u8; HIFFY_SCRATCH_SIZE]> =
     StaticCell::new([0; HIFFY_SCRATCH_SIZE]);
 
-#[no_mangle]
+#[used]
 static HIFFY_REQUESTS: AtomicU32 = AtomicU32::new(0);
-#[no_mangle]
+#[used]
 static HIFFY_ERRORS: AtomicU32 = AtomicU32::new(0);
-#[no_mangle]
+#[used]
 static HIFFY_KICK: AtomicU32 = AtomicU32::new(0);
-#[no_mangle]
+#[used]
 static HIFFY_READY: AtomicU32 = AtomicU32::new(0);
 
-#[no_mangle]
+#[used]
 static mut HIFFY_FAILURE: Option<Failure> = None;
 
 ///
 /// We deliberately export the HIF version numbers to allow Humility to
 /// fail cleanly if its HIF version does not match our own.
 ///
-#[no_mangle]
+#[used]
 static HIFFY_VERSION_MAJOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MAJOR);
-#[no_mangle]
+#[used]
 static HIFFY_VERSION_MINOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MINOR);
-#[no_mangle]
+#[used]
 static HIFFY_VERSION_PATCH: AtomicU32 = AtomicU32::new(HIF_VERSION_PATCH);
 
 #[export_name = "main"]

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -119,27 +119,27 @@ static mut HIFFY_RSTACK: [u8; HIFFY_RSTACK_SIZE] = [0; HIFFY_RSTACK_SIZE];
 static HIFFY_SCRATCH: StaticCell<[u8; HIFFY_SCRATCH_SIZE]> =
     StaticCell::new([0; HIFFY_SCRATCH_SIZE]);
 
-#[used]
+#[no_mangle]
 static HIFFY_REQUESTS: AtomicU32 = AtomicU32::new(0);
-#[used]
+#[no_mangle]
 static HIFFY_ERRORS: AtomicU32 = AtomicU32::new(0);
-#[used]
+#[no_mangle]
 static HIFFY_KICK: AtomicU32 = AtomicU32::new(0);
-#[used]
+#[no_mangle]
 static HIFFY_READY: AtomicU32 = AtomicU32::new(0);
 
-#[used]
+#[no_mangle]
 static mut HIFFY_FAILURE: Option<Failure> = None;
 
 ///
 /// We deliberately export the HIF version numbers to allow Humility to
 /// fail cleanly if its HIF version does not match our own.
 ///
-#[used]
+#[no_mangle]
 static HIFFY_VERSION_MAJOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MAJOR);
-#[used]
+#[no_mangle]
 static HIFFY_VERSION_MINOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MINOR);
-#[used]
+#[no_mangle]
 static HIFFY_VERSION_PATCH: AtomicU32 = AtomicU32::new(HIF_VERSION_PATCH);
 
 #[export_name = "main"]

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -119,9 +119,13 @@ static mut HIFFY_RSTACK: [u8; HIFFY_RSTACK_SIZE] = [0; HIFFY_RSTACK_SIZE];
 static HIFFY_SCRATCH: StaticCell<[u8; HIFFY_SCRATCH_SIZE]> =
     StaticCell::new([0; HIFFY_SCRATCH_SIZE]);
 
+#[used]
 static HIFFY_REQUESTS: AtomicU32 = AtomicU32::new(0);
+#[used]
 static HIFFY_ERRORS: AtomicU32 = AtomicU32::new(0);
+#[used]
 static HIFFY_KICK: AtomicU32 = AtomicU32::new(0);
+#[used]
 static HIFFY_READY: AtomicU32 = AtomicU32::new(0);
 
 #[used]
@@ -131,8 +135,11 @@ static mut HIFFY_FAILURE: Option<Failure> = None;
 /// We deliberately export the HIF version numbers to allow Humility to
 /// fail cleanly if its HIF version does not match our own.
 ///
+#[used]
 static HIFFY_VERSION_MAJOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MAJOR);
+#[used]
 static HIFFY_VERSION_MINOR: AtomicU32 = AtomicU32::new(HIF_VERSION_MINOR);
+#[used]
 static HIFFY_VERSION_PATCH: AtomicU32 = AtomicU32::new(HIF_VERSION_PATCH);
 
 #[export_name = "main"]


### PR DESCRIPTION
The compiler was getting rid of some HIFFY symbols we actually needed, so we try to ask it to keep them.

Bump stack size to keep `jefe` from faulting.