### PR TITLE
Differentiate SWD fault codes

### DIFF
--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -141,7 +141,6 @@ spi_num = 5
 [tasks.dumper]
 name = "task-dumper"
 priority = 5
-max-sizes = {flash = 16384, ram = 4096}
 start = true
 stacksize = 2600
 task-slots = ["swd"]

--- a/drv/sp-ctrl-api/src/lib.rs
+++ b/drv/sp-ctrl-api/src/lib.rs
@@ -22,6 +22,24 @@ pub enum SpCtrlError {
     #[idol(server_death)]
     ServerRestarted,
     Timeout,
+
+    SwdFault0,
+    SwdFault1,
+    SwdFault2,
+    SwdFault3,
+    SwdFault4,
+    SwdFault5,
+    SwdFault6,
+    SwdFault7,
+    SwdFault8,
+    SwdFault9,
+    SwdFault10,
+    SwdFault11,
+    SwdFault12,
+    SwdFault13,
+    SwdFault14,
+    SwdFault15,
+    SwdFault16,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));


### PR DESCRIPTION
Each SWD use of Ack::Fault or SpCtrlError::Fault is changed to a unique value to help debugging. No logic changes are made.