### PR TITLE
Basic crate for accessing task names at build time.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,6 +3129,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hubris-task-names"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+]
+
+[[package]]
 name = "hubtools"
 version = "0.4.6"
 source = "git+https://github.com/oxidecomputer/hubtools#943c4bbe6b50d1ab635d085d6204895fb4154e79"

--- a/sys/task-names/Cargo.toml
+++ b/sys/task-names/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "hubris-task-names"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+
+[features]
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/sys/task-names/build.rs
+++ b/sys/task-names/build.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::fs::File;
+use std::io::Write;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = build_util::out_dir();
+
+    let task_env = build_util::env_var("HUBRIS_TASKS").unwrap_or_else(|_| {
+        panic!("can't build this crate outside of the build system.")
+    });
+
+    let task_names = task_env.split(',').collect::<Vec<_>>();
+    let count = task_names.len();
+
+    let mut task_file = File::create(out.join("tasks.rs")).unwrap();
+    writeln!(task_file, "pub static TASK_NAMES: [&str; {count}] = [").unwrap();
+    for name in &task_names {
+        writeln!(task_file, "    {name:?},").unwrap();
+    }
+    writeln!(task_file, "];").unwrap();
+
+    let longest = task_names.iter().map(|s| s.len()).max().unwrap_or(0);
+    writeln!(task_file, "pub const MAX_TASK_NAME: usize = {longest};").unwrap();
+
+    Ok(())
+}

--- a/sys/task-names/src/lib.rs
+++ b/sys/task-names/src/lib.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Allows compile-time retrieval of task names in the current image.
+//!
+//! The code is generated, but here's what you can expect:
+//!
+//! `TASK_NAMES` is a `static` array of `&str`.
+//!
+//! `MAX_TASK_NAME` is a `const` `usize` giving the number of bytes in the
+//! longest task name. This can be useful for sizing buffers.
+
+#![no_std]
+#![forbid(clippy::wildcard_imports)]
+
+include!(concat!(env!("OUT_DIR"), "/tasks.rs"));


### PR DESCRIPTION
This allows tasks to refer to other tasks by name, which we need _very rarely,_ but has come up for fault reporting.