### PR TITLE
"humility qspi -D" is sluggish on...everything else

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -149,7 +149,7 @@ notifications = ["timer"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
+features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot", "turbo"]
 priority = 7
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1200
@@ -387,7 +387,7 @@ af = 4
 # The front FPGA has five virtual muxes, which pretend to be PCA9545s.
 # We only use the lower 3 channels on each mux (which is normally 4-channel)
 [[config.i2c.controllers.ports.B.muxes]]
-driver = "pca9545" 
+driver = "pca9545"
 address = 0x70
 
 [[config.i2c.controllers.ports.B.muxes]]
@@ -425,7 +425,7 @@ af = 4
 
 # The main FPGA has two virtual muxes, which pretend to be PCA9545s.
 [[config.i2c.controllers.ports.F.muxes]]
-driver = "pca9545" 
+driver = "pca9545"
 address = 0x70
 
 [[config.i2c.controllers.ports.F.muxes]]

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -120,7 +120,7 @@ notifications = ["socket"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h743", "stm32h7", "i2c", "gpio", "spi"]
+features = ["h743", "stm32h7", "i2c", "gpio", "spi", "turbo"]
 priority = 4
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -147,7 +147,7 @@ notifications = ["socket"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash"]
+features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 2048

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -151,7 +151,7 @@ notifications = ["timer"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
+features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1200

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -81,6 +81,7 @@ task-slots = ["sys"]
 
 [tasks.hiffy]
 name = "task-hiffy"
+features = ["turbo"]
 priority = 7
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -120,7 +120,7 @@ priority = 7
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
-features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "qspi", "hash"]
+features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "qspi", "hash", "turbo"]
 task-slots = ["i2c_driver", "sys", "user_leds", "sprot", "hf", "hash_driver"]
 
 [tasks.validate]

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -58,6 +58,7 @@ max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver"]
+features = ["turbo"]
 
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"

--- a/app/minibar/app.toml
+++ b/app/minibar/app.toml
@@ -100,7 +100,7 @@ task-slots = ["sys"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "sprot"]
+features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1200

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -145,7 +145,7 @@ notifications = ["flash-irq"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "sprot"]
+features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
 stacksize = 1200

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -147,7 +147,7 @@ notifications = ["flash-irq"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
-max-sizes = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768}
 stacksize = 1200
 start = true
 task-slots = ["sys", "i2c_driver", "sprot"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -200,7 +200,7 @@ task-slots = ["sys"]
 
 [tasks.hiffy]
 name = "task-hiffy"
-features = ["h753", "stm32h7", "i2c", "gpio", "sprot"]
+features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
 stacksize = 1200

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -55,7 +55,11 @@ h753 = ["stm32h7", "drv-stm32xx-i2c/h753", "build-i2c/h753"]
 g031 = ["stm32g0", "drv-stm32xx-i2c/g031", "build-i2c/g031"]
 g030 = ["stm32g0", "drv-stm32xx-i2c/g030", "build-i2c/g030"]
 micro = ["no-ipc-counters"]
-# enables large memory buffer to make hiffy not slow
+# enables large memory buffer to make data transfers through through hiffy (e.g.
+# `humility qspi` and such) not slow. this conflicts with the "micro" feature,
+# which makes the buffer smaller for memory constrained-targets, and is off by
+# default, because it makes the buffer much larger, and you may not need that if
+# you're not using `humility qspi` etc.
 turbo = []
 panic-messages = ["userlib/panic-messages"]
 spctrl = ["drv-sp-ctrl-api"]

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -55,6 +55,8 @@ h753 = ["stm32h7", "drv-stm32xx-i2c/h753", "build-i2c/h753"]
 g031 = ["stm32g0", "drv-stm32xx-i2c/g031", "build-i2c/g031"]
 g030 = ["stm32g0", "drv-stm32xx-i2c/g030", "build-i2c/g030"]
 micro = ["no-ipc-counters"]
+# enables large memory buffer to make hiffy not slow
+turbo = []
 panic-messages = ["userlib/panic-messages"]
 spctrl = ["drv-sp-ctrl-api"]
 

--- a/task/hiffy/Cargo.toml
+++ b/task/hiffy/Cargo.toml
@@ -55,7 +55,7 @@ h753 = ["stm32h7", "drv-stm32xx-i2c/h753", "build-i2c/h753"]
 g031 = ["stm32g0", "drv-stm32xx-i2c/g031", "build-i2c/g031"]
 g030 = ["stm32g0", "drv-stm32xx-i2c/g030", "build-i2c/g030"]
 micro = ["no-ipc-counters"]
-# enables large memory buffer to make data transfers through through hiffy (e.g.
+# enables large memory buffer to make data transfers through hiffy (e.g.
 # `humility qspi` and such) not slow. this conflicts with the "micro" feature,
 # which makes the buffer smaller for memory constrained-targets, and is off by
 # default, because it makes the buffer much larger, and you may not need that if

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -52,6 +52,12 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(all(feature = "turbo", feature = "micro"))]
+compile_error!(
+    "enabling the 'micro' feature takes precedent over the 'turbo' feature,
+     as both control memory buffer size"
+);
+
 cfg_if::cfg_if! {
     //
     // The "micro" feature denotes a minimal RAM footprint.  Note that this
@@ -65,18 +71,10 @@ cfg_if::cfg_if! {
         const HIFFY_DATA_SIZE: usize = 256;
         const HIFFY_TEXT_SIZE: usize = 256;
         const HIFFY_RSTACK_SIZE: usize = 64;
-    } else if #[cfg(any(
-        target_board = "gimlet-b",
-        target_board = "gimlet-c",
-        target_board = "gimlet-d",
-        target_board = "gimlet-e",
-        target_board = "gimlet-f",
-        target_board = "sidecar-b",
-        target_board = "gimletlet-2",
-        target_board = "nucleo-h743zi2",
-        target_board = "nucleo-h753zi",
-        target_board = "grapefruit",
-    ))] {
+    } else if #[cfg(feature = "turbo")] {
+        //
+        // go-faster mode
+        //
         const HIFFY_DATA_SIZE: usize = 20_480;
         const HIFFY_TEXT_SIZE: usize = 2048;
         const HIFFY_RSTACK_SIZE: usize = 2048;


### PR DESCRIPTION
_No description provided._

So, `humility qspi` and auxflash commands are Really Slow on Cosmo. It turns out that this is because Hiffy has a magical list of boards that are allowed to go fast, and we never put Cosmo on it. Boards on the go-faster list are allowed to use a much larger buffer for data transferred through Hiffy than boards not on the go faster list. 

Controlling this based on `target_board` seems quite unfortunate. Subsequent revisions of the same board need to be added to the list, and it's easy to forget to do that when there's a new board revision and regress hiffy performance again (c.f. #1498). Instead, let's control this via a Cargo feature, which can at least be set in the `base.toml` for a board and inherited by every subsequent revision of the board without having to remember to do that.

I had wanted to just always enable go-faster mode on STM32H7 but I let @cbiffle talk me out of it.