### PR TITLE
thermal: remove set_fan_pwm

### DIFF
--- a/idl/thermal.idol
+++ b/idl/thermal.idol
@@ -32,16 +32,6 @@ Interface(
             ),
             encoding: Hubpack
         ),
-        "set_fan_pwm": (
-            args: {
-                "index": "u8",
-                "pwm": "u8",
-            },
-            reply: Result(
-                ok: "()",
-                err: CLike("ThermalError"),
-            ),
-        ),
         "disable_watchdog": (
             args: {},
             reply: Result(

--- a/task/thermal/src/bsp/cosmo_a.rs
+++ b/task/thermal/src/bsp/cosmo_a.rs
@@ -112,7 +112,7 @@ impl Bsp {
         // Awkwardly build the fan array, because there's not a great way to
         // build a fixed-size array from a function
         let mut fans = Fans::new();
-        for i in 0..fans.len() {
+        for i in 0..NUM_FANS {
             fans[i] = Some(sensors::MAX31790_SPEED_SENSORS[i]);
         }
         Ok(fans)

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -161,7 +161,7 @@ impl Bsp {
         // Awkwardly build the fan array, because there's not a great way to
         // build a fixed-size array from a function
         let mut fans = Fans::new();
-        for i in 0..fans.len() {
+        for i in 0..NUM_FANS {
             fans[i] = Some(sensors::MAX31790_SPEED_SENSORS[i]);
         }
         Ok(fans)

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -86,7 +86,7 @@ impl Bsp {
 
     pub fn get_fan_presence(&self) -> Result<Fans<{ NUM_FANS }>, SeqError> {
         let mut fans = Fans::new();
-        for i in 0..fans.len() {
+        for i in 0..NUM_FANS {
             fans[i] = Some(sensors::EMC2305_SPEED_SENSORS[i]);
         }
         Ok(fans)

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -110,6 +110,7 @@ impl Fans<{ bsp::NUM_FANS }> {
     pub fn new() -> Self {
         Self([None; bsp::NUM_FANS])
     }
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -1219,40 +1220,12 @@ impl<'a> ThermalControl<'a> {
         last_err
     }
 
-    /// Sets the PWM for a single fan
-    ///
-    /// If the fan is present, set to `pwm`. if it is not present, set to zero.
-    pub fn set_fan_pwm(
-        &mut self,
-        fan: Fan,
-        pwm: PWMDuty,
-    ) -> Result<(), ThermalError> {
-        let pwm = match self.fans.is_present(fan) {
-            true => pwm,
-            false => PWMDuty(0),
-        };
-        self.bsp
-            .fan_control(fan)?
-            .set_pwm(pwm)
-            .map_err(|_| ThermalError::DeviceError)
-    }
-
     /// Attempts to set the PWM of every fan to whatever the previous value was.
     ///
     /// This is used by ThermalMode::Manual to accomodate the removal and
     /// replacement of fan modules.
     pub fn maintain_pwm(&mut self) -> Result<(), ThermalError> {
         self.set_pwm(self.last_pwm)
-    }
-
-    pub fn fan(&self, index: u8) -> Option<Fan> {
-        let f = &self.fans;
-
-        if (index as usize) < f.len() {
-            Some(Fan(index))
-        } else {
-            None
-        }
     }
 
     pub fn set_watchdog(

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -110,10 +110,6 @@ impl Fans<{ bsp::NUM_FANS }> {
     pub fn new() -> Self {
         Self([None; bsp::NUM_FANS])
     }
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
     pub fn is_present(&self, index: crate::Fan) -> bool {
         self.0[index.0 as usize].is_some()
     }

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -167,27 +167,6 @@ impl<'a> idl::InOrderThermalImpl for ServerImpl<'a> {
         Ok(self.control.get_state())
     }
 
-    fn set_fan_pwm(
-        &mut self,
-        _: &RecvMessage,
-        index: u8,
-        pwm: u8,
-    ) -> Result<(), RequestError<ThermalError>> {
-        if self.mode != ThermalMode::Manual {
-            return Err(ThermalError::NotInManualMode.into());
-        }
-        let pwm =
-            PWMDuty::try_from(pwm).map_err(|_| ThermalError::InvalidPWM)?;
-
-        if let Some(fan) = self.control.fan(index) {
-            self.control
-                .set_fan_pwm(fan, pwm)
-                .map_err(|_| ThermalError::DeviceError.into())
-        } else {
-            Err(ThermalError::InvalidFan.into())
-        }
-    }
-
     fn set_mode_manual(
         &mut self,
         _: &RecvMessage,


### PR DESCRIPTION
I'm removing `set_fan_pwm` from the `thermal` task interface because its existence no longer serves a purpose. Fans can either be in `auto` control mode, where the thermal model decides the PWM, or `manual` control mode, which effectively hardcodes the PWM to the `initial_pwm` argument of `set_mode_manual`. I say "effectively hardcodes" because it calls the [`maintain_pwm`](https://github.com/oxidecomputer/hubris/blob/master/task/thermal/src/main.rs#L333) function each loop iteration. This means that when `set_fan_pwm` was setting the PWM value, it would just be overwritten the next iteration. In addition to that, we just don't control single fans really, so the fact that `set_fan_pwm` required a single fan to be specified just doesn't match reality any more.

An alternative path here would be to remove the `index` argument from `set_fan_pwm` and change its function to update the `last_pwm` value read by `maintain_pwm` each iteration.