### PR TITLE
Report power state transitions to MGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,7 +2926,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#3d7f1cb0a84885a91a99860b6db6e5db9dfbd7f8"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#e71c87a6ee63e8f8d6a1940cfeda00e0c312fa19"
 dependencies = [
  "bitflags 2.9.0",
  "hubpack",

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -14,9 +14,9 @@ use gateway_messages::{
     ignition, ComponentAction, ComponentActionResponse, ComponentDetails,
     ComponentUpdatePrepare, DiscoverResponse, DumpSegment, DumpTask,
     IgnitionCommand, IgnitionState, MgsError, MgsRequest, MgsResponse,
-    PowerState, RotBootInfo, RotRequest, RotResponse, SensorRequest,
-    SensorResponse, SpComponent, SpError, SpStateV2, SpUpdatePrepare,
-    UpdateChunk, UpdateId, UpdateStatus,
+    PowerState, PowerStateTransition, RotBootInfo, RotRequest, RotResponse,
+    SensorRequest, SensorResponse, SpComponent, SpError, SpStateV2,
+    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
 };
 use host_sp_messages::HostStartupOptions;
 use idol_runtime::{Leased, RequestError};
@@ -359,7 +359,7 @@ impl SpHandler for MgsHandler {
         &mut self,
         sender: Sender<VLanId>,
         power_state: PowerState,
-    ) -> Result<(), SpError> {
+    ) -> Result<PowerStateTransition, SpError> {
         ringbuf_entry_root!(
             CRITICAL,
             CriticalEvent::SetPowerState {


### PR DESCRIPTION
Basically, this commit glues together the changes from oxidecomputer/hubris#2064 and
oxidecomputer/management-gateway-service#390. The
`SpHandler::set_power_state` implementation for compute sleds in the `control-plane-agent`
task now report the outcome of power state transitions using the new `gateway_messages::PowerStateTransition` type added in oxidecomputer/management-gateway-service#390.

This fixes oxidecomputer/management-gateway-service#270, and closes oxidecomputer/management-gateway-service#271.

We'll need to update MGS proper (in the Omicron repo) to pick up the new `gateway-messages` changes, as well.