### PR TITLE
Clear LM5066 faults on `power` startup

### DIFF
--- a/drv/i2c-devices/src/lm5066.rs
+++ b/drv/i2c-devices/src/lm5066.rs
@@ -138,6 +138,10 @@ impl Lm5066 {
         Ok(device_setup)
     }
 
+    pub fn clear_faults(&self) -> Result<(), Error> {
+        pmbus_write!(self.device, CLEAR_FAULTS)
+    }
+
     ///
     /// The coefficients for the LM5066 depend on the value of the current
     /// sense resistor and the sense of the current limit (CL) strap.


### PR DESCRIPTION
The LM5066 has strong opinions on what error flags should be set on startup:

- `STATUS_BYTE` says the VIN fault flag is set by default, no comment about autoclearing; flags should be cleared with `CLEAR_FAULTS`
- `STATUS_WORD` says VIN fault flag is set by default, and is cleared when input voltage > UVLO threshold
- `STATUS_INPUT` says the VIN _warning_ flag is set by default (the VIN fault flag is 0 by default), and is cleared when input voltage > UVLO threshold

In practice, we see the fault flag set in all three of these registers, as well as `!PowerGood`.

This PR adds a `CLEAR_FAULTS` call to the `power` task startup, to persuade the power-good bit to actually reflect reality.  We don't expect the `power` task to restart, so this should be a one-off occurrence (and genuine faults later on will not be affected).