### PR TITLE
Add LM5066I driver; use it on Cosmo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,8 +4192,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pmbus"
-version = "0.1.5"
-source = "git+https://github.com/oxidecomputer/pmbus#e1c123745f712174f6e027d7eef491b723e7352f"
+version = "0.1.7"
+source = "git+https://github.com/oxidecomputer/pmbus#1eb632c84bd62b939880192d23cef09ea5a76c66"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -1207,7 +1207,7 @@ refdes = "U32"
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x11
-device = "lm5066"
+device = "lm5066i"
 description = "Fan hot swap controller (east)"
 power = { rails = [ "V54P5_FAN_EAST" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
@@ -1218,7 +1218,7 @@ refdes = "U71"
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x12
-device = "lm5066"
+device = "lm5066i"
 description = "Fan hot swap controller (central)"
 power = { rails = [ "V54P5_FAN_CENTRAL" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
@@ -1229,7 +1229,7 @@ refdes = "U72"
 [[config.i2c.devices]]
 bus = "rear"
 address = 0x13
-device = "lm5066"
+device = "lm5066i"
 description = "Fan hot swap controller (west)"
 power = { rails = [ "V54P5_FAN_WEST" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }

--- a/drv/i2c-devices/src/lib.rs
+++ b/drv/i2c-devices/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`emc2305`]: EMC2305 fan driver
 //! - [`isl68224`]: ISL68224 power controller
 //! - [`lm5066`]: LM5066 hot swap controller
+//! - [`lm5066i`]: LM5066I hot swap controller
 //! - [`ltc4282`]: LTC4282 high current hot swap controller
 //! - [`m24c02`]: M24C02 EEPROM, used in MWOCP68 power shelf
 //! - [`m2_hp_only`]: M.2 drive; identical to `nvme_bmc`, with the limitation
@@ -240,6 +241,7 @@ pub mod ds2482;
 pub mod emc2305;
 pub mod isl68224;
 pub mod lm5066;
+pub mod lm5066i;
 pub mod ltc4282;
 pub mod m24c02;
 pub mod m2_hp_only;

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -486,8 +486,8 @@ pub enum InventoryData {
         current_sensor: SensorIndex,
     },
 
-    /// LM5066 hot-swap controller
-    Lm5066 {
+    /// LM5066I hot-swap controller
+    Lm5066I {
         /// MFR_ID (PMBus operation 0x99)
         mfr_id: [u8; 3],
         /// MFR_MODEL (PMBus operation 0x9A)

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -402,13 +402,13 @@ impl ServerImpl {
             }
             34..=36 => {
                 let (name, f, sensors) = match index - 34 {
-                    0 => by_refdes!(U71, lm5066),
-                    1 => by_refdes!(U72, lm5066),
-                    2 => by_refdes!(U73, lm5066),
+                    0 => by_refdes!(U71, lm5066i),
+                    1 => by_refdes!(U72, lm5066i),
+                    2 => by_refdes!(U73, lm5066i),
                     _ => unreachable!(),
                 };
                 let dev = f(I2C.get_task_id());
-                let mut data = InventoryData::Lm5066 {
+                let mut data = InventoryData::Lm5066I {
                     mfr_id: [0u8; 3],
                     mfr_model: [0u8; 8],
                     mfr_revision: [0u8; 2],
@@ -419,8 +419,8 @@ impl ServerImpl {
                     current_sensor: sensors.current.into(),
                 };
                 self.tx_buf.try_encode_inventory(sequence, &name, || {
-                    use pmbus::commands::lm5066::CommandCode;
-                    let InventoryData::Lm5066 {
+                    use pmbus::commands::lm5066i::CommandCode;
+                    let InventoryData::Lm5066I {
                         mfr_id,
                         mfr_model,
                         mfr_revision,


### PR DESCRIPTION
(Staged on top of #2073)

The LM5066I has different coefficients and a different validation serial name.  This PR makes a new driver for it (which uses a bunch of types from LM5066, and is _mostly_ copy-pasted).  This new part is used on Cosmo.

