### PR TITLE
Correct cosmo sharkfin refdes

### DIFF
--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -111,14 +111,14 @@ impl ServerImpl {
             4..=13 => {
                 let (designator, f): ([u8; 4], _) =
                     Self::get_sharkfin_vpd(index as usize - 4);
-                let mut name = *b"____/U7/ID";
+                let mut name = *b"____/U2/ID";
                 name[0..4].copy_from_slice(&designator);
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             14..=23 => {
                 let (designator, f): ([u8; 4], _) =
                     Self::get_sharkfin_vpd(index as usize - 14);
-                let mut name = *b"____/U7";
+                let mut name = *b"____/U2";
                 name[0..4].copy_from_slice(&designator);
                 let mut data = InventoryData::At24csw08xSerial([0u8; 16]);
                 self.read_at24csw080_id(sequence, &name, f, &mut data)


### PR DESCRIPTION
The BSP identities for the sharkfin refdes were using the Gimlet sharkfin refdes as opposed to the Cosmo ones as the board ended up changing across this. I still will need to test this with some sharkfins present and will not merge until I can confirm that I have data. But I do note that we are now using the correct key when missing sharkfins:

```
BRM13250010 # /usr/platform/oxide/bin/ipcc inventory 4
metadata:
    version: 0x0
    entries: 0x3b
J200/U2/ID (4) -- Result: 2 [I/O error -- device gone?]
BRM13250010 # /usr/platform/oxide/bin/ipcc inventory 14
metadata:
    version: 0x0
    entries: 0x3b
J200/U2 (14) -- Result: 2 [I/O error -- device gone?]
```