### PR TITLE
chore: Minor QSPI code deduplication

### DIFF
--- a/drv/stm32h7-qspi/src/lib.rs
+++ b/drv/stm32h7-qspi/src/lib.rs
@@ -289,7 +289,7 @@ impl Qspi {
             let fl = self.get_fifo_level()?;
 
             // How much space is in the FIFO?
-            let ffree = FIFO_SIZE - fl;
+            let ffree = FIFO_SIZE.saturating_sub(fl);
             if ffree >= FIFO_THRESH.min(data.len()) {
                 // Calculate the write size. Note that this may be bigger than
                 // the threshold used above above. We'll opportunistically


### PR DESCRIPTION
Since this caught my eye in #2089 and was merged in #2071, I thought I'd put my hands where my mouth is and do the few deduplications that I thought might be considered useful or "pretty".

### Adjacent code error?

In [`drv/auxflash-api/src/lib.rs:191`](https://github.com/oxidecomputer/hubris/blob/master/drv/auxflash-api/src/lib.rs#L191) the call to `self.get_blob_by_tag(tag)` seems to be invalid; that function takes two parameters, `(slot, tag)`. I wonder if this is dead code or what's going on with that?