### PR TITLE
Add cosmo dimms to host_sp_comms inventory

### DIFF
--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -295,6 +295,7 @@ impl From<drv_i2c_types::ResponseCode> for InventoryDataResult {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
+#[allow(clippy::large_enum_variant)]
 pub enum InventoryData {
     /// Raw DIMM data
     DimmSpd {
@@ -499,6 +500,12 @@ pub enum InventoryData {
         power_sensor: SensorIndex,
         voltage_sensor: SensorIndex,
         current_sensor: SensorIndex,
+    },
+    /// Raw DIMM data for a DDR5 part
+    DimmDdr5Spd {
+        #[serde(with = "BigArray")]
+        id: [u8; 1024],
+        temp_sensors: [SensorIndex; 2],
     },
 }
 
@@ -1271,7 +1278,7 @@ mod tests {
             sequence: 456,
         };
         let host_to_sp = HostToSp::HostPanic;
-        let data_blob = (0_u32..)
+        let data_blob = (0..)
             .into_iter()
             .map(|x| x as u8)
             .take(MAX_MESSAGE_SIZE)

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -587,65 +587,66 @@ impl ServerImpl {
             name
         };
 
-        const DIMM_SENSORS: [[SensorId; 2]; 12] = [
+        const DIMM_TEMPERATURE_SENSORS: [[SensorId; 2]; 12] = [
             [
-                other_sensors::DIMM_A_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_A_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_A_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_A_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_B_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_B_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_B_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_B_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_C_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_C_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_C_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_C_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_D_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_D_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_D_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_D_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_E_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_E_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_E_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_E_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_F_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_F_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_F_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_F_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_G_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_G_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_G_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_G_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_H_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_H_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_H_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_H_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_I_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_I_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_I_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_I_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_J_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_J_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_J_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_J_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_K_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_K_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_K_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_K_TS1_TEMPERATURE_SENSOR,
             ],
             [
-                other_sensors::DIMM_L_FRONT_TEMPERATURE_SENSOR,
-                other_sensors::DIMM_L_BACK_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_L_TS0_TEMPERATURE_SENSOR,
+                other_sensors::DIMM_L_TS1_TEMPERATURE_SENSOR,
             ],
         ];
 
         let packrat = &self.packrat; // partial borrow
         *self.scratch = InventoryData::DimmDdr5Spd {
             id: [0u8; 1024],
-            temp_sensors: DIMM_SENSORS[usize::from(index)].map(|i| i.into()),
+            temp_sensors: DIMM_TEMPERATURE_SENSORS[usize::from(index)]
+                .map(|i| i.into()),
         };
         self.tx_buf.try_encode_inventory(sequence, &name, || {
             if packrat.get_spd_present(index) {
-                let InventoryData::DimmSpd { id, .. } = self.scratch else {
+                let InventoryData::DimmDdr5Spd { id, .. } = self.scratch else {
                     unreachable!();
                 };
                 packrat.get_full_spd_data(index, id);

--- a/task/host-sp-comms/src/bsp/gimletlet.rs
+++ b/task/host-sp-comms/src/bsp/gimletlet.rs
@@ -35,14 +35,15 @@ impl ServerImpl {
                 let idc = drv_stm32h7_dbgmcu::read_idc();
                 let dbgmcu_rev_id = (idc >> 16) as u16;
                 let dbgmcu_dev_id = (idc & 4095) as u16;
-                let data = InventoryData::Stm32H7 {
+                *self.scratch = InventoryData::Stm32H7 {
                     uid,
                     dbgmcu_rev_id,
                     dbgmcu_dev_id,
                 };
 
-                self.tx_buf
-                    .try_encode_inventory(sequence, b"U12", || Ok(&data));
+                self.tx_buf.try_encode_inventory(sequence, b"U12", || {
+                    Ok(self.scratch)
+                });
             }
 
             // We need to specify INVENTORY_COUNT individually here to trigger

--- a/task/host-sp-comms/src/bsp/grapefruit.rs
+++ b/task/host-sp-comms/src/bsp/grapefruit.rs
@@ -60,7 +60,7 @@ impl ServerImpl {
                 let idc = drv_stm32h7_dbgmcu::read_idc();
                 let dbgmcu_rev_id = (idc >> 16) as u16;
                 let dbgmcu_dev_id = (idc & 4095) as u16;
-                self.scratch = InventoryData::Stm32H7 {
+                *self.scratch = InventoryData::Stm32H7 {
                     uid,
                     dbgmcu_rev_id,
                     dbgmcu_dev_id,

--- a/task/host-sp-comms/src/bsp/grapefruit.rs
+++ b/task/host-sp-comms/src/bsp/grapefruit.rs
@@ -60,28 +60,29 @@ impl ServerImpl {
                 let idc = drv_stm32h7_dbgmcu::read_idc();
                 let dbgmcu_rev_id = (idc >> 16) as u16;
                 let dbgmcu_dev_id = (idc & 4095) as u16;
-                let data = InventoryData::Stm32H7 {
+                self.scratch = InventoryData::Stm32H7 {
                     uid,
                     dbgmcu_rev_id,
                     dbgmcu_dev_id,
                 };
-                self.tx_buf
-                    .try_encode_inventory(sequence, b"U12", || Ok(&data));
+                self.tx_buf.try_encode_inventory(sequence, b"U12", || {
+                    Ok(self.scratch)
+                });
             }
 
             1 => {
                 let spi = drv_spi_api::Spi::from(SPI.get_task_id());
                 let ksz8463_dev = spi.device(drv_spi_api::devices::KSZ8463);
                 let ksz8463 = ksz8463::Ksz8463::new(ksz8463_dev);
-                let mut data = InventoryData::Ksz8463 { cider: 0 };
+                *self.scratch = InventoryData::Ksz8463 { cider: 0 };
                 self.tx_buf.try_encode_inventory(sequence, b"U401", || {
-                    let InventoryData::Ksz8463 { cider } = &mut data else {
+                    let InventoryData::Ksz8463 { cider } = self.scratch else {
                         unreachable!();
                     };
                     *cider = ksz8463
                         .read(ksz8463::Register::CIDER)
                         .map_err(|_| InventoryDataResult::DeviceFailed)?;
-                    Ok(&data)
+                    Ok(self.scratch)
                 });
             }
 

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -262,6 +262,10 @@ struct ServerImpl {
     reboot_state: Option<RebootState>,
     host_kv_storage: HostKeyValueStorage,
     hf_mux_state: Option<HfMuxState>,
+
+    /// Temporary space for inventory data, which is a large `enum`
+    scratch: &'static mut host_sp_messages::InventoryData,
+
     /// Set when the host OS fails to boot or panics, and unset when the system
     /// reboots.
     ///
@@ -290,6 +294,7 @@ impl ServerImpl {
             last_panic: [u8; MAX_HOST_FAIL_MESSAGE_LEN],
             etc_system: [u8; MAX_ETC_SYSTEM_LEN],
             dtrace_conf: [u8; MAX_DTRACE_CONF_LEN],
+            scratch: host_sp_messages::InventoryData,
         }
         let Bufs {
             ref mut tx_buf,
@@ -298,6 +303,7 @@ impl ServerImpl {
             ref mut last_panic,
             ref mut etc_system,
             ref mut dtrace_conf,
+            ref mut scratch,
         } = {
             static BUFS: ClaimOnceCell<Bufs> = ClaimOnceCell::new(Bufs {
                 tx_buf: tx_buf::StaticBufs::new(),
@@ -306,6 +312,12 @@ impl ServerImpl {
                 last_panic: [0; MAX_HOST_FAIL_MESSAGE_LEN],
                 etc_system: [0; MAX_ETC_SYSTEM_LEN],
                 dtrace_conf: [0; MAX_DTRACE_CONF_LEN],
+
+                // Default value for InventoryData
+                scratch: host_sp_messages::InventoryData::DimmSpd {
+                    id: [0u8; 512],
+                    temp_sensor: 0u32,
+                },
             });
             BUFS.claim()
         };
@@ -336,6 +348,7 @@ impl ServerImpl {
             },
             hf_mux_state: None,
             last_power_off: None,
+            scratch,
         }
     }
 


### PR DESCRIPTION
(staged on top of #2094)

This adds DDR5 DIMMS to the `host_sp_comms` inventory reported over IPCC.

I'd like to do some refactoring to reduce stack allocation, because the `enum InventoryData` is now over 1 KiB, but this is reasonable for initial tests.