### PR TITLE
Fix Cosmo flash capacity

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -249,11 +249,16 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         Ok(self.drv.flash_read_id())
     }
 
+    /// Returns the capacity of each host flash slot
+    ///
+    /// Note that this **is not** the total flash capacity; it's part of the
+    /// `HostFlash` API, so we're pretending to be two distinct flash chips,
+    /// each with a capacity of 32 MiB.
     fn capacity(
         &mut self,
         _: &RecvMessage,
     ) -> Result<usize, RequestError<HfError>> {
-        Ok(0x8000000) // 1 GBit = 128 MiB
+        Ok(0x2000000) // 32 MiB
     }
 
     /// Reads the STATUS_1 register from the SPI flash


### PR DESCRIPTION
@rmustacc noticed that updating host flash didn't work over the management network on Cosmo.  I reproduced this locally on a Grapefruit; this PR is the fix.

The issue was that MGS uses `HostFlash::capacity` to decide how many sectors to erase.  On Gimlet, this is the true capacity of a physical flash chip, of which there are two.  On Cosmo, we instead split a single 1 GiB flash into 2× 32 MiB + 1× 64 MiB virtual devices.

We were returning the full 1 GiB flash size, so MGS tried to erase outside the range of the 32 MiB virtual slot.  On the bright side, Hubris correctly detects this and returned an `HfError::BadAddress`.

The fix is to return a capacity of 32 MiB, because that's the capacity that MGS needs to know about.