### PR TITLE
Bump hiffy text size

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -2,6 +2,7 @@ name = "demo-stm32h743-nucleo"
 target = "thumbv7em-none-eabihf"
 board = "nucleo-h743zi2"
 chip = "../../chips/stm32h7"
+memory = "memory-large.toml"
 stacksize = 896
 
 [kernel]
@@ -122,7 +123,7 @@ notifications = ["socket"]
 name = "task-hiffy"
 features = ["h743", "stm32h7", "i2c", "gpio", "spi", "turbo"]
 priority = 4
-max-sizes = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 65536 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver"]

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -2,6 +2,7 @@ name = "demo-stm32h753-nucleo"
 target = "thumbv7em-none-eabihf"
 board = "nucleo-h753zi"
 chip = "../../chips/stm32h7"
+memory = "memory-large.toml"
 stacksize = 896
 
 [kernel]
@@ -149,7 +150,7 @@ notifications = ["socket"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "turbo"]
 priority = 5
-max-sizes = {flash = 32768, ram = 32768 }
+max-sizes = {flash = 32768, ram = 65536 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -42,7 +42,7 @@ notifications = ["timer"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "gpio", "spi"]
 priority = 3
-max-sizes = {flash = 32768, ram = 16384 }
+max-sizes = {flash = 32768, ram = 65536 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "user_leds"]

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -83,7 +83,7 @@ task-slots = ["sys"]
 name = "task-hiffy"
 features = ["turbo"]
 priority = 7
-max-sizes = {flash = 32768, ram = 32768}
+max-sizes = {flash = 32768, ram = 65536}
 stacksize = 2048
 start = true
 

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -117,7 +117,7 @@ features = ["grapefruit", "boot-kmdb"]
 [tasks.hiffy]
 name = "task-hiffy"
 priority = 7
-max-sizes = {flash = 32768, ram = 32768}
+max-sizes = {flash = 32768, ram = 65536}
 stacksize = 2048
 start = true
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "qspi", "hash", "turbo"]

--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -77,7 +77,7 @@ cfg_if::cfg_if! {
         // go-faster mode
         //
         const HIFFY_DATA_SIZE: usize = 20_480;
-        const HIFFY_TEXT_SIZE: usize = 2048;
+        const HIFFY_TEXT_SIZE: usize = 4096;
         const HIFFY_RSTACK_SIZE: usize = 2048;
 
         /// Number of "scratch" bytes available to Hiffy programs. Humility uses this


### PR DESCRIPTION
Cosmo has Too Many Sensors for `humility` dashboard:
```
c:\oxide\hubris (master -> origin)
λ humility dashboard
humility: attached via ST-Link V3
humility dashboard failed: HIF program cannot be serialized: program length (1067 operations) cannot fit in target program text (2048 bytes); failed after serializing 1024 operations
```

We *could* update Humility to split the program into multiple calls, but it's easier to bump the stack size here.