### PR TITLE
Fix sequencing wait condition

### DIFF
--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -828,7 +828,7 @@ impl<S: SpiServer> ServerImpl<S> {
                     let a0sm = A0SmStatus::try_from(status[0]);
                     ringbuf_entry!(Trace::A0Status(a0sm));
 
-                    if a0sm == Ok(A0SmStatus::Done) {
+                    if a0sm == Ok(A0SmStatus::GroupcPg) {
                         break;
                     }
 


### PR DESCRIPTION
https://github.com/oxidecomputer/hubris/pull/2104 accidentally waited for `Done` instead of `GroupcPg`, so the sequencer would never come up.