### PR TITLE
Use `FailServer` in gimlet host flash

### DIFF
--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -37,6 +37,7 @@ pub enum HfError {
     HashUncalculated,
     RecalculateHash,
     HashInProgress,
+    BadCapacity,
 
     #[idol(server_death)]
     ServerRestarted,


### PR DESCRIPTION
Similar to cosmo, use a fail server to always return an error when the chip ID or capacity is incorrect.