### PR TITLE
stm32xx-i2c: remove I2cControl function table

### DIFF
--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -1180,11 +1180,11 @@ impl I2cController<'_> {
     }
 }
 
-/// Waits for `notification` or `timeout`, whichever comes first. This is
+/// Waits for `event_mask` or `timeout`, whichever comes first. This is
 /// factored out of `wfi` above for clarity.
 ///
 /// This function, like `userlib::hl`, assumes that notification bit 31 is safe
-/// to use for the timer. If `notification` also has bit 31 set, weird things
+/// to use for the timer. If `event_mask` also has bit 31 set, weird things
 /// will happen, don't do that.
 fn wfi_raw(event_mask: u32, timeout: I2cTimeout) -> I2cControlResult {
     const TIMER_NOTIFICATION: u32 = 1 << 31;

--- a/drv/stm32xx-i2c/src/ltc4306.rs
+++ b/drv/stm32xx-i2c/src/ltc4306.rs
@@ -88,7 +88,6 @@ fn read_reg_u8(
     mux: &I2cMux<'_>,
     controller: &I2cController<'_>,
     reg: u8,
-    ctrl: &I2cControl,
 ) -> Result<u8, ResponseCode> {
     let mut rval = 0u8;
     let wlen = 1;
@@ -102,7 +101,6 @@ fn read_reg_u8(
             rval = byte;
             Some(())
         },
-        ctrl,
     );
     match controller_result {
         Err(code) => Err(mux.error_code(code)),
@@ -115,7 +113,6 @@ fn write_reg_u8(
     controller: &I2cController<'_>,
     reg: u8,
     val: u8,
-    ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
     match controller.write_read(
         mux.address,
@@ -123,7 +120,6 @@ fn write_reg_u8(
         |pos| Some(if pos == 0 { reg } else { val }),
         ReadLength::Fixed(0),
         |_, _| Some(()),
-        ctrl,
     ) {
         Err(code) => Err(mux.error_code(code)),
         _ => Ok(()),
@@ -136,7 +132,6 @@ impl I2cMuxDriver for Ltc4306 {
         mux: &I2cMux<'_>,
         _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -146,7 +141,6 @@ impl I2cMuxDriver for Ltc4306 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         segment: Option<Segment>,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg3 = Register3(0);
 
@@ -170,8 +164,8 @@ impl I2cMuxDriver for Ltc4306 {
             }
         }
 
-        write_reg_u8(mux, controller, 3, reg3.0, ctrl)?;
-        let reg0 = Register0(read_reg_u8(mux, controller, 0, ctrl)?);
+        write_reg_u8(mux, controller, 3, reg3.0)?;
+        let reg0 = Register0(read_reg_u8(mux, controller, 0)?);
 
         if !reg0.not_failed() {
             Err(ResponseCode::SegmentDisconnected)

--- a/drv/stm32xx-i2c/src/max7358.rs
+++ b/drv/stm32xx-i2c/src/max7358.rs
@@ -74,7 +74,6 @@ fn read_regs(
     mux: &I2cMux<'_>,
     controller: &I2cController<'_>,
     rbuf: &mut [u8],
-    ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
     let controller_result = controller.write_read(
         mux.address,
@@ -85,7 +84,6 @@ fn read_regs(
             rbuf[pos] = byte;
             Some(())
         },
-        ctrl,
     );
     match controller_result {
         Err(code) => Err(mux.error_code(code)),
@@ -104,7 +102,6 @@ fn write_reg(
     controller: &I2cController<'_>,
     reg: Register,
     val: u8,
-    ctrl: &I2cControl,
 ) -> Result<(), ResponseCode> {
     let mut wbuf = [0u8; 3];
 
@@ -117,7 +114,7 @@ fn write_reg(
     let index = reg as usize;
 
     if index > 0 {
-        read_regs(mux, controller, &mut wbuf[0..index], ctrl)?;
+        read_regs(mux, controller, &mut wbuf[0..index])?;
     }
 
     ringbuf_entry!(Trace::Write(reg, val));
@@ -130,7 +127,6 @@ fn write_reg(
         |pos| Some(wbuf[pos]),
         ReadLength::Fixed(0),
         |_, _| Some(()),
-        ctrl,
     ) {
         Err(code) => Err(mux.error_code(code)),
         _ => Ok(()),
@@ -143,7 +139,6 @@ impl I2cMuxDriver for Max7358 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         mux.configure(gpio)?;
 
@@ -175,7 +170,7 @@ impl I2cMuxDriver for Max7358 {
         // controller entirely several times over.
         //
         let mut scratch = [0u8; 1];
-        read_regs(mux, controller, &mut scratch[0..1], ctrl)?;
+        read_regs(mux, controller, &mut scratch[0..1])?;
 
         controller.send_konami_code(
             mux.address,
@@ -185,11 +180,10 @@ impl I2cMuxDriver for Max7358 {
                 I2cKonamiCode::Write,
                 I2cKonamiCode::Read,
             ],
-            ctrl,
         )?;
 
         let reg = SwitchControl(0);
-        write_reg(mux, controller, Register::SwitchControl, reg.0, ctrl)
+        write_reg(mux, controller, Register::SwitchControl, reg.0)
     }
 
     fn enable_segment(
@@ -197,7 +191,6 @@ impl I2cMuxDriver for Max7358 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         segment: Option<Segment>,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = SwitchControl(0);
 
@@ -233,7 +226,7 @@ impl I2cMuxDriver for Max7358 {
             }
         }
 
-        write_reg(mux, controller, Register::SwitchControl, reg.0, ctrl)
+        write_reg(mux, controller, Register::SwitchControl, reg.0)
     }
 
     fn reset(

--- a/drv/stm32xx-i2c/src/oximux16.rs
+++ b/drv/stm32xx-i2c/src/oximux16.rs
@@ -40,7 +40,6 @@ impl I2cMuxDriver for Oximux16 {
         mux: &I2cMux<'_>,
         _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -50,7 +49,6 @@ impl I2cMuxDriver for Oximux16 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         segment: Option<Segment>,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = ControlRegister(0);
 
@@ -117,7 +115,6 @@ impl I2cMuxDriver for Oximux16 {
             |i| Some(reg.0.to_le_bytes()[i]),
             ReadLength::Fixed(0),
             |_, _| Some(()),
-            ctrl,
         ) {
             Err(code) => Err(mux.error_code(code)),
             _ => {

--- a/drv/stm32xx-i2c/src/pca9545.rs
+++ b/drv/stm32xx-i2c/src/pca9545.rs
@@ -25,7 +25,6 @@ impl I2cMuxDriver for Pca9545 {
         mux: &I2cMux<'_>,
         _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -35,7 +34,6 @@ impl I2cMuxDriver for Pca9545 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         segment: Option<Segment>,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = ControlRegister(0);
 
@@ -69,7 +67,6 @@ impl I2cMuxDriver for Pca9545 {
             |_| Some(reg.0),
             ReadLength::Fixed(0),
             |_, _| Some(()),
-            ctrl,
         ) {
             Err(code) => Err(mux.error_code(code)),
             _ => Ok(()),

--- a/drv/stm32xx-i2c/src/pca9548.rs
+++ b/drv/stm32xx-i2c/src/pca9548.rs
@@ -29,7 +29,6 @@ impl I2cMuxDriver for Pca9548 {
         mux: &I2cMux<'_>,
         _controller: &I2cController<'_>,
         gpio: &sys_api::Sys,
-        _ctrl: &I2cControl,
     ) -> Result<(), drv_i2c_api::ResponseCode> {
         mux.configure(gpio)
     }
@@ -39,7 +38,6 @@ impl I2cMuxDriver for Pca9548 {
         mux: &I2cMux<'_>,
         controller: &I2cController<'_>,
         segment: Option<Segment>,
-        ctrl: &I2cControl,
     ) -> Result<(), ResponseCode> {
         let mut reg = ControlRegister(0);
 
@@ -85,7 +83,6 @@ impl I2cMuxDriver for Pca9548 {
             |_| Some(reg.0),
             ReadLength::Fixed(0),
             |_, _| Some(()),
-            ctrl,
         ) {
             Err(code) => Err(mux.error_code(code)),
             _ => Ok(()),


### PR DESCRIPTION
It turns out that, in practice, we only ever provide a single function for each of `wfi` and `enable` here. This makes the table itself an unnecessary level of indirection, which has some deleterious effects:

- It opens the possibility for _different_ I2cControl structs containing _different_ function pointers to be passed to each call, complicating analysis. (Searching for this phenomenon was what led me to notice that we only ever use one implementation.)

- It makes it a lot harder to recognize use of syscalls (or misuse of syscalls) in the I2C layer.

- It routes important parts of the I2C stack through indirect function calls, defeating stack analysis.

- It adds a bunch of code that isn't really necessary, as it turns out.

This commit removes the dispatch table, inlining the existing functions into their callsites (and introducing a utility function for the wfi behavior).