### PR TITLE
Add Cosmo host flash to inventory

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -4,8 +4,9 @@
 
 use drv_hash_api::SHA256_SZ;
 use drv_hf_api::{
-    HashData, HashState, HfDevSelect, HfError, HfMuxState, HfPersistentData,
-    HfProtectMode, HfRawPersistentData, SlotHash, HF_PERSISTENT_DATA_STRIDE,
+    HashData, HashState, HfChipId, HfDevSelect, HfError, HfMuxState,
+    HfPersistentData, HfProtectMode, HfRawPersistentData, SlotHash,
+    HF_PERSISTENT_DATA_STRIDE,
 };
 use idol_runtime::{
     LeaseBufReader, LeaseBufWriter, Leased, LenLimit, NotificationHandler,
@@ -348,7 +349,7 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
     fn read_id(
         &mut self,
         _: &RecvMessage,
-    ) -> Result<[u8; 20], RequestError<HfError>> {
+    ) -> Result<HfChipId, RequestError<HfError>> {
         self.drv.check_flash_mux_state()?;
         Ok(self.drv.flash_read_id())
     }
@@ -737,7 +738,8 @@ impl NotificationHandler for ServerImpl {
 
 pub mod idl {
     use drv_hf_api::{
-        HfDevSelect, HfError, HfMuxState, HfPersistentData, HfProtectMode,
+        HfChipId, HfDevSelect, HfError, HfMuxState, HfPersistentData,
+        HfProtectMode,
     };
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 }

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -55,9 +55,16 @@ fn main() -> ! {
     };
     drv.flash_set_quad_enable();
 
-    // Check the flash chip's ID against Table 7.3.1 in the datasheet
+    // Check the flash chip's ID against Table 7.3.1 in the W25Q01JV datasheet.
     let id = drv.flash_read_id();
-    if id.mfr_id != 0xef || id.memory_type != 0x40 || id.capacity != 0x21 {
+    const WINBOND_MFR_ID: u8 = 0xef;
+    const EXPECTED_TYPE: u8 = 0x40;
+    const EXPECTED_CAPACITY: u8 = 0x21;
+
+    if id.mfr_id != WINBOND_MFR_ID
+        || id.memory_type != EXPECTED_TYPE
+        || id.capacity != EXPECTED_CAPACITY
+    {
         fail(drv_hf_api::HfError::BadChipId);
     }
 
@@ -112,7 +119,8 @@ mod instr {
 
 impl FlashDriver {
     fn flash_read_id(&mut self) -> drv_hf_api::HfChipId {
-        // Make sure die 0 is selected with a dummy read
+        // Make sure die 0 is selected with a dummy read, because the
+        // READ_UNIQUE_ID command is die-specific.
         let mut buf = [0u8; 4];
         self.flash_read(FlashAddr(0), &mut buf.as_mut_slice())
             .unwrap_lite(); // infallible when given a slice

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -14,7 +14,7 @@
 #![no_main]
 
 use ringbuf::{counted_ringbuf, ringbuf_entry};
-use userlib::{hl::sleep_for, task_slot};
+use userlib::{hl::sleep_for, task_slot, UnwrapLite};
 
 mod hf; // implementation of `HostFlash` API
 
@@ -50,14 +50,14 @@ fn main() -> ! {
     let seq =
         drv_spartan7_loader_api::Spartan7Loader::from(LOADER.get_task_id());
 
-    let drv = FlashDriver {
+    let mut drv = FlashDriver {
         drv: fmc_periph::SpiNor::new(seq.get_token()),
     };
     drv.flash_set_quad_enable();
 
     // Check the flash chip's ID against Table 7.3.1 in the datasheet
     let id = drv.flash_read_id();
-    if id[0..3] != [0xef, 0x40, 0x21] {
+    if id.mfr_id != 0xef || id.memory_type != 0x40 || id.capacity != 0x21 {
         fail(drv_hf_api::HfError::BadChipId);
     }
 
@@ -103,6 +103,7 @@ mod instr {
     pub const FAST_READ_QUAD_OUTPUT_4B: u8 = 0x6c;
     pub const SECTOR_ERASE: u8 = 0x20;
     pub const READ_JEDEC_ID: u8 = 0x9f;
+    pub const READ_UNIQUE_ID: u8 = 0x4b;
     pub const BLOCK_ERASE_64KB: u8 = 0xd8;
     pub const BLOCK_ERASE_64KB_4B: u8 = 0xdc;
     pub const QUAD_INPUT_PAGE_PROGRAM: u8 = 0x32;
@@ -110,21 +111,45 @@ mod instr {
 }
 
 impl FlashDriver {
-    fn flash_read_id(&self) -> [u8; 20] {
+    fn flash_read_id(&mut self) -> drv_hf_api::HfChipId {
+        // Make sure die 0 is selected with a dummy read
+        let mut buf = [0u8; 4];
+        self.flash_read(FlashAddr(0), &mut buf.as_mut_slice())
+            .unwrap_lite();
+
         self.clear_fifos();
-        self.drv.data_bytes.set_count(20);
+        self.drv.data_bytes.set_count(3);
         self.drv.addr.set_addr(0);
         self.drv.dummy_cycles.set_count(0);
         self.drv.instr.set_opcode(instr::READ_JEDEC_ID);
         self.wait_fpga_busy();
-        let mut out = [0u8; 20];
-        for i in 0..out.len() / 4 {
+        let v = self.drv.rx_fifo_rdata.fifo_data();
+        let bytes = v.to_le_bytes();
+        let mfr_id = bytes[0];
+        let memory_type = bytes[1];
+        let capacity = bytes[2];
+
+        // Read the 12-byte unique ID (4 bytes of which are junk)
+        self.drv.data_bytes.set_count(12);
+        self.drv.addr.set_addr(0);
+        self.drv.dummy_cycles.set_count(0);
+        self.drv.instr.set_opcode(instr::READ_UNIQUE_ID);
+        self.wait_fpga_busy();
+        let _v = self.drv.rx_fifo_rdata.fifo_data(); // dummy bytes
+        let mut unique_id = [0u8; 17];
+        for i in 0..2 {
             let v = self.drv.rx_fifo_rdata.fifo_data();
             for (j, byte) in v.to_le_bytes().iter().enumerate() {
-                out[i * 4 + j] = *byte;
+                unique_id[i * 4 + j] = *byte;
             }
         }
-        out
+
+        drv_hf_api::HfChipId {
+            mfr_id,
+            memory_type,
+            capacity,
+            unique_id,
+        }
     }
 
     /// Wait until the FPGA is idle

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -118,18 +118,6 @@ impl FlashDriver {
         self.flash_read(FlashAddr(0), &mut buf.as_mut_slice())
             .unwrap_lite();
 
-        self.clear_fifos();
-        self.drv.data_bytes.set_count(3);
-        self.drv.addr.set_addr(0);
-        self.drv.dummy_cycles.set_count(0);
-        self.drv.instr.set_opcode(instr::READ_JEDEC_ID);
-        self.wait_fpga_busy();
-        let v = self.drv.rx_fifo_rdata.fifo_data();
-        let bytes = v.to_le_bytes();
-        let mfr_id = bytes[0];
-        let memory_type = bytes[1];
-        let capacity = bytes[2];
-
         // Read the 12-byte unique ID (4 bytes of which are junk)
         self.drv.data_bytes.set_count(12);
         self.drv.addr.set_addr(0);
@@ -145,6 +133,18 @@ impl FlashDriver {
                 unique_id[i * 4 + j] = *byte;
             }
         }
+
+        self.clear_fifos();
+        self.drv.data_bytes.set_count(3);
+        self.drv.addr.set_addr(0);
+        self.drv.dummy_cycles.set_count(0);
+        self.drv.instr.set_opcode(instr::READ_JEDEC_ID);
+        self.wait_fpga_busy();
+        let v = self.drv.rx_fifo_rdata.fifo_data();
+        let bytes = v.to_le_bytes();
+        let mfr_id = bytes[0];
+        let memory_type = bytes[1];
+        let capacity = bytes[2];
 
         drv_hf_api::HfChipId {
             mfr_id,

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -115,7 +115,7 @@ impl FlashDriver {
         // Make sure die 0 is selected with a dummy read
         let mut buf = [0u8; 4];
         self.flash_read(FlashAddr(0), &mut buf.as_mut_slice())
-            .unwrap_lite();
+            .unwrap_lite(); // infallible when given a slice
 
         self.clear_fifos();
         self.drv.data_bytes.set_count(3);
@@ -132,7 +132,7 @@ impl FlashDriver {
         // We are running with 3-byte addresses, so we need to skip 4 bytes (32
         // clocks) of dummy data.  The datasheet indicates that the DO line is
         // high-Z when this happens, but experimentally, it's just clocking out
-        // parts of the unique ID.
+        // parts of the unique ID.  Regardless, we'll skip those bytes.
         self.drv.data_bytes.set_count(8);
         self.drv.addr.set_addr(0);
         self.drv.dummy_cycles.set_count(32);

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -28,6 +28,7 @@ enum Trace {
     FpgaBusy,
     SectorEraseBusy,
     WriteBusy,
+    DummyBytes(u32),
 
     HashInitError(drv_hash_api::HashError),
     HashUpdateError(drv_hash_api::HashError),
@@ -135,7 +136,8 @@ impl FlashDriver {
         self.drv.dummy_cycles.set_count(0);
         self.drv.instr.set_opcode(instr::READ_UNIQUE_ID);
         self.wait_fpga_busy();
-        let _v = self.drv.rx_fifo_rdata.fifo_data(); // dummy bytes
+        let v = self.drv.rx_fifo_rdata.fifo_data(); // dummy bytes
+        ringbuf_entry!(Trace::DummyBytes(v));
         let mut unique_id = [0u8; 17];
         for i in 0..2 {
             let v = self.drv.rx_fifo_rdata.fifo_data();

--- a/drv/hf-api/src/lib.rs
+++ b/drv/hf-api/src/lib.rs
@@ -262,4 +262,13 @@ impl SlotHash {
     }
 }
 
+#[derive(Copy, Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct HfChipId {
+    pub mfr_id: u8,
+    pub memory_type: u8,
+    pub capacity: u8,
+    /// Varies depending on chip type
+    pub unique_id: [u8; 17],
+}
+
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/mock-gimlet-hf-server/src/main.rs
+++ b/drv/mock-gimlet-hf-server/src/main.rs
@@ -12,8 +12,8 @@
 
 use drv_hash_api::SHA256_SZ;
 use drv_hf_api::{
-    HfDevSelect, HfError, HfMuxState, HfPersistentData, HfProtectMode,
-    PAGE_SIZE_BYTES,
+    HfChipId, HfDevSelect, HfError, HfMuxState, HfPersistentData,
+    HfProtectMode, PAGE_SIZE_BYTES,
 };
 use idol_runtime::{
     ClientError, Leased, LenLimit, NotificationHandler, RequestError, R, W,
@@ -48,8 +48,13 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
     fn read_id(
         &mut self,
         _: &RecvMessage,
-    ) -> Result<[u8; 20], RequestError<HfError>> {
-        Ok(*b"mockmockmockmockmock")
+    ) -> Result<HfChipId, RequestError<HfError>> {
+        Ok(HfChipId {
+            mfr_id: 0,
+            memory_type: 1,
+            capacity: 2,
+            unique_id: *b"mockmockmockmock!",
+        })
     }
 
     fn capacity(

--- a/drv/mock-gimlet-hf-server/src/main.rs
+++ b/drv/mock-gimlet-hf-server/src/main.rs
@@ -278,7 +278,8 @@ impl NotificationHandler for ServerImpl {
 }
 mod idl {
     use super::{
-        HfDevSelect, HfError, HfMuxState, HfPersistentData, HfProtectMode,
+        HfChipId, HfDevSelect, HfError, HfMuxState, HfPersistentData,
+        HfProtectMode,
     };
 
     include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));

--- a/idl/hf.idol
+++ b/idl/hf.idol
@@ -6,7 +6,7 @@ Interface(
         "read_id": (
             args: {},
             reply: Result(
-                ok: "[u8; 20]",
+                ok: "HfChipId",
                 err: CLike("HfError"),
             ),
         ),

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -509,23 +509,15 @@ pub enum InventoryData {
     },
 
     /// W25Q256JVEIQ flash chip (auxiliary flash on Cosmo, Grapefruit, Sidecar)
-    W25q256jveqi {
-        mfr_id: u8,
-        memory_type: u8,
-        capacity: u8,
-        unique_id: [u8; 8],
-    },
+    W25q256jveqi { unique_id: [u8; 8] },
 
     /// Cosmo host flash
     W25q01jvzeiq {
-        mfr_id: u8,
-        memory_type: u8,
-        capacity: u8,
-
         /// 64-bit unique ID for die 0
-        ///
-        /// Note that each 512M-bit die has a separate ID!
-        unique_id: [u8; 8],
+        die0_unique_id: [u8; 8],
+
+        /// 64-bit unique ID for die 1
+        die1_unique_id: [u8; 8],
     },
 }
 

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -526,7 +526,7 @@ pub enum InventoryData {
         ///
         /// Note that each 512M-bit die has a separate ID!
         unique_id: [u8; 8],
-    }
+    },
 }
 
 #[derive(

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -515,6 +515,18 @@ pub enum InventoryData {
         capacity: u8,
         unique_id: [u8; 8],
     },
+
+    /// Cosmo host flash
+    W25q01jvzeiq {
+        mfr_id: u8,
+        memory_type: u8,
+        capacity: u8,
+
+        /// 64-bit unique ID for die 0
+        ///
+        /// Note that each 512M-bit die has a separate ID!
+        unique_id: [u8; 8],
+    }
 }
 
 #[derive(

--- a/task/hiffy/src/common.rs
+++ b/task/hiffy/src/common.rs
@@ -683,7 +683,10 @@ pub(crate) fn qspi_read_id(
 
     let server = drv_hf_api::HostFlash::from(HF.get_task_id());
     let id = func_err(server.read_id())?;
-    rval[..20].copy_from_slice(&id);
+    rval[0] = id.mfr_id;
+    rval[1] = id.memory_type;
+    rval[2] = id.capacity;
+    rval[3..20].copy_from_slice(&id.unique_id);
     Ok(20)
 }
 

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -548,9 +548,6 @@ impl ServerImpl {
                         .read_id()
                         .map_err(|_| InventoryDataResult::DeviceFailed)?;
                     *self.scratch = InventoryData::W25q256jveqi {
-                        mfr_id: id.mfr_id,
-                        memory_type: id.memory_type,
-                        capacity: id.capacity,
                         unique_id: id.unique_id,
                     };
                     Ok(self.scratch)
@@ -564,10 +561,12 @@ impl ServerImpl {
                         .read_id()
                         .map_err(|_| InventoryDataResult::DeviceFailed)?;
                     *self.scratch = InventoryData::W25q01jvzeiq {
-                        mfr_id: id.mfr_id,
-                        memory_type: id.memory_type,
-                        capacity: id.capacity,
-                        unique_id: id.unique_id[0..8].try_into().unwrap_lite(),
+                        die0_unique_id: id.unique_id[0..8]
+                            .try_into()
+                            .unwrap_lite(),
+                        die1_unique_id: id.unique_id[8..16]
+                            .try_into()
+                            .unwrap_lite(),
                     };
                     Ok(self.scratch)
                 });

--- a/task/host-sp-comms/src/bsp/grapefruit.rs
+++ b/task/host-sp-comms/src/bsp/grapefruit.rs
@@ -95,9 +95,6 @@ impl ServerImpl {
                         .read_id()
                         .map_err(|_| InventoryDataResult::DeviceFailed)?;
                     *self.scratch = InventoryData::W25q256jveqi {
-                        mfr_id: id.mfr_id,
-                        memory_type: id.memory_type,
-                        capacity: id.capacity,
                         unique_id: id.unique_id,
                     };
                     Ok(self.scratch)

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -67,11 +67,11 @@ use tx_buf::TxBuf;
 
 task_slot!(CONTROL_PLANE_AGENT, control_plane_agent);
 task_slot!(CPU_SEQ, cpu_seq);
-task_slot!(HOST_FLASH, hf);
 task_slot!(PACKRAT, packrat);
 task_slot!(NET, net);
 task_slot!(SYS, sys);
 task_slot!(SPROT, sprot);
+task_slot!(pub HOST_FLASH, hf);
 
 // TODO: When rebooting the host, we need to wait for the relevant power rails
 // to decay. We ought to do this properly by monitoring the rails, but for now,


### PR DESCRIPTION
- Add a new `HfChipId` type as a more structured chip ID, then use it in the various host flash drivers
- Add an `InventoryData::W25q01jvzeiq` variant and use it on Cosmo

This needs testing, so I'm opening as a draft for now.