### PR TITLE
Introduce `compute-sleds` release target

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -118,7 +118,7 @@ jobs:
       os: ${{ inputs.os }}
 
   build-gimlet:
-    if: ${{ inputs.board-set == 'gimlet' || inputs.board-set == 'all' }}
+    if: ${{ inputs.board-set == 'gimlet' || inputs.board-set == 'all' || inputs.board-set == 'compute-sleds' }}
     name: build-gimlet
     strategy:
       matrix:
@@ -193,7 +193,7 @@ jobs:
       os: ${{ inputs.os }}
 
   build-cosmo:
-    if: ${{ inputs.board-set == 'cosmo' || inputs.board-set == 'all' }}
+    if: ${{ inputs.board-set == 'cosmo' || inputs.board-set == 'all' || inputs.board-set == 'compute-sleds' }}
     name: build-cosmo
     strategy:
       matrix:

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -7,6 +7,7 @@ on:
       - "psc-*"
       - "sidecar-*"
       - "devboards-*"
+      - "compute-sleds-*"
 
 jobs:
   release-rot:
@@ -38,5 +39,11 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       board-set: devboards
+
+  release-compute-sleds:
+    if: startsWith(github.ref, 'refs/heads/compute-sleds')
+    uses: ./.github/workflows/release.yml
+    with:
+      board-set: compute-sleds
 
 


### PR DESCRIPTION
With the addition of `cosmo`, we've switched to the term `compute-sled` to describe gimlet and cosmo together. Add this as a release target. We can keep the old `gimlet` target for backwards compatibility. If we end up really needing a `cosmo` only release we can add that as a target too.