### PR TITLE
use and in SVC instruction

### DIFF
--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -862,8 +862,8 @@ cfg_if::cfg_if! {
             SVCall:
                 @ Inspect LR to figure out the caller's mode.
                 mov r0, lr
-                ldr r1, =0xFFFFFFF3
-                bics r0, r0, r1
+                movs r1, #0xC
+                ands r0, r1
                 @ Is the call coming from thread mode + main stack, i.e.
                 @ from the kernel startup routine?
                 cmp r0, #0x8
@@ -939,8 +939,7 @@ cfg_if::cfg_if! {
             SVCall:
                 @ Inspect LR to figure out the caller's mode.
                 mov r0, lr
-                mov r1, #0xFFFFFFF3
-                bic r0, r1
+                and r0, r0, #0xC
                 @ Is the call coming from thread mode + main stack, i.e.
                 @ from the kernel startup routine?
                 cmp r0, #0x8


### PR DESCRIPTION
this PR uses `and` in `SVCall` for ARM instead of `ldr`/`bics` and `mov`/`bic` which should save a few bytes and a cycle for both ARMv6-M and ARMv7/8-M. it should be the same operation for both cases only that we're masking in bits 3:2, not masking out bits 1:0. ARMv7/8-M (or really Thumb-2) supports an immediate with `and` as well