### PR TITLE
Make RAM non-executable on STM32Fx parts

### DIFF
--- a/chips/stm32f3/memory.toml
+++ b/chips/stm32f3/memory.toml
@@ -9,4 +9,4 @@ address = 0x20000000
 size = 40960
 read = true
 write = true
-execute = true
+execute = false

--- a/chips/stm32f4/memory.toml
+++ b/chips/stm32f4/memory.toml
@@ -9,5 +9,4 @@ address = 0x20000000
 size = 114688
 read = true
 write = true
-execute = true
-
+execute = false


### PR DESCRIPTION
This fixes a failing test (`execdata`) in the kernel test suite on the STM32F3 Discovery Board.