### PR TITLE
.gitignore: additional editor ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ itm.txt
 !.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/extensions.json
+
+.zed/
+.helix/


### PR DESCRIPTION
`.gitignore` ignores most VSCode customizations,
but we could also ignore .zed/ and .helix/.