### PR TITLE
Return `HashInProgress` error for `hash_significant_bits`

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -620,7 +620,9 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         }
 
         match self.hash.state {
-            HashState::Hashing { .. } => return Err(HfError::HashError.into()),
+            HashState::Hashing { .. } => {
+                return Err(HfError::HashInProgress.into())
+            }
             _ => (),
         }
 

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -758,7 +758,9 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             return Err(HfError::HashError.into());
         }
         match self.hash.state {
-            HashState::Hashing { .. } => return Err(HfError::HashError.into()),
+            HashState::Hashing { .. } => {
+                return Err(HfError::HashInProgress.into())
+            }
             _ => (),
         }
         let begin = addr as usize;


### PR DESCRIPTION
This is more specific than `HashError`