### PR TITLE
xtask: Override default caboose version from env

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -17,7 +17,6 @@ register-map = "../../drv/spartan7-loader/cosmo-seq/cosmo_seq_top.json"
 tasks = ["control_plane_agent"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -13,7 +13,6 @@ features = ["dump"]
 tasks = ["control_plane_agent"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -125,7 +125,6 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 [caboose]
 region = "flash"
 size = 256
-default = true
 
 [config]
 [[config.i2c.controllers]]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -14,7 +14,6 @@ requires = {flash = 55040, ram = 4096}
 [caboose]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -43,7 +43,6 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 [caboose]
 region = "flash"
 size = 256
-default = true
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -21,7 +21,6 @@ features = ["dice-self"]
 tasks = ["sprot"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -18,7 +18,6 @@ features = ["dice-mfg"]
 tasks = ["sprot"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -13,7 +13,6 @@ features = ["dump"]
 tasks = ["control_plane_agent"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -17,7 +17,6 @@ requires = {flash = 54176, ram = 3876}
 tasks = ["sprot"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -13,7 +13,6 @@ features = ["dump"]
 tasks = ["control_plane_agent"]
 region = "flash"
 size = 256
-default = true
 
 [tasks.jefe]
 name = "task-jefe"

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = { workspace = true }
 atty = { workspace = true }
 cargo_metadata = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["env"] }
 colored = { workspace = true }
 memchr = { workspace = true }
 ordered-toml = { workspace = true }

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -112,10 +112,6 @@ pub struct CabooseConfig {
     /// The system reserves two words (8 bytes) for the size and marker, so the
     /// user-accessible space is 8 bytes less than this value.
     pub size: u32,
-
-    /// If `true`, populates the caboose with default values using `hubtools`
-    #[serde(default)]
-    pub default: bool,
 }
 
 impl Config {

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -244,14 +244,13 @@ pub struct HumilityArgs {
 
 #[derive(Clone, Debug, Parser, Default)]
 struct CabooseArgs {
-    /// Overrides the `VERS` string in the caboose when a default caboose is
-    /// written.
+    /// Overrides the `VERS` string in the caboose.
     ///
     /// This is intended to be used when an engineering image must be
     /// flashed in an environment that expects a particular caboose version.
     ///
-    /// Overriding the default caboose version string is only permitted if
-    /// the app.toml specifies the default caboose.
+    /// This environment variable is, naturally, ignored if the app.toml does
+    /// not have a [caboose] section.
     #[clap(env = "HUBRIS_CABOOSE_VERS")]
     version_override: Option<String>,
 }

--- a/doc/guide/caboose.adoc
+++ b/doc/guide/caboose.adoc
@@ -37,15 +37,46 @@ mapped as an MPU region. Only tasks declared in `caboose.tasks` are allowed to
 read data from the caboose region of flash.  If other tasks attempt to read from
 this memory region, they will experience the typical memory fault.
 
-Hubris does not have strong opinions about the contents of the caboose, other
-than reserving two words.  At build time, the caboose is loaded with the
-following data (shown here as `u32` words):
+The Hubris build system will populate the caboose with start and end words
+(32-bit words) words, and a sequence of 
+https://github.com/oxidecomputer/tlvc[TLV-C] key-value pairs containing image
+metadata:
 
-[cols="1,3"]
+[%header,cols="1,1,4"]
 |===
-| **Start** | `abi::CABOOSE_MAGIC`
-| ...       | _(filled with `0xFFFFFFFF`)_
-| **End**   | Caboose size (little-endian `u32`)
+| Value
+| Type
+| Description
+
+| **Start** 
+| `u32` 
+| `abi::CABOOSE_MAGIC`
+
+| `GITC` tag 
+| TLV-C 
+| The current Git commit hash with an optional trailing "-dirty" if the
+repository contains uncommitted changes.
+
+| `BORD` tag
+| TLV-C
+| The name of the target board, as specified in the image's TOML config.
+
+| `NAME` tag
+| TLV-C
+| The name of the image, as specified in the image's TOML config.
+
+| `VERS` tag
+| TLV-C _(optional)_
+| The value of the `HUBRIS_CABOOSE_VERS` environment variable at build time,
+if it was set.
+
+| ...
+| `u8`
+| _(filled with `0xFF`)_
+
+| **End**   
+| `u32`
+| Caboose size (little-endian `u32`)
 |===
 
 The caboose's length is included in the `total_image_len` field of
@@ -79,20 +110,9 @@ let caboose: Option<&'static [u8]> = drv_caboose_pos::CABOOSE_POS.as_slice();
 (This functionality requires cooperation with the `xtask` build system, as we
 can't know the caboose position until all tasks have been built)
 
-Other than reserving the two words above, the Hubris build system is
-_deliberately agnostic_ to the contents of the caboose; it is left to a separate
-release engineering process to decide what to store there.  The
+Besides the start and end words and the default metadata described above, the
+Hubris build system is agnostic to any further contents of the caboose. A 
+separate release engineering process may decide to store any arbitrary data in
+the remaining space. The 
 https://github.com/oxidecomputer/hubtools[`hubtools` repository] includes a
 library and CLI for modifying the caboose of a Hubris archive.
-
-However, for convenience, it's possible to enable a default caboose:
-```toml
-[caboose]
-region = "flash"
-size = 128
-tasks = ["caboose_reader"]
-default = true
-```
-
-If the `default` parameter is `true`, then Hubris will itself use `hubtools` to
-populate the caboose with default values.


### PR DESCRIPTION
When flashing an engineering Hubris image on an SP that will participate
in a control-plane driven software update, it is necessary to populate
the `VERS` key in the caboose must be present so that the update
machienry doesn't get confused. If it is desirable for the engineering
image to not be overwritten during an update, the verson must also be
set to the version expected by the system. Being able to do this is
useful for testing Hubris changes in integration with the rest of the
system.

Historically, such images have been created by hacking up the `xtask
dist` code to write the desired version string when creating the default
caboose. I thought that this seemed like a common enough thing to want
to do that there should just be a way to ask for it without having to
change the build system. Therefore, this branch adds a
`HUBRIS_CABOOSE_VERS` env var that will override the `VERS` key in the
caboose if building an image that has a default caboose.