### PR TITLE
Remove extra `[caboose]` from `gimletlet.toml`

### DIFF
--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -48,9 +48,6 @@ start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
 task-slots = []
 
-[caboose]
-tasks = ["control_plane_agent"]
-
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7


### PR DESCRIPTION
The caboose region is defined in the `base-gimletlet2.toml` file