### PR TITLE
Bump Cosmo `control-plane-agent` stack size

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -268,7 +268,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 8
-stacksize = 6256
+stacksize = 7000
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -259,7 +259,7 @@ notifications = ["socket"]
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-stacksize = 6256
+stacksize = 7000
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -232,7 +232,7 @@ notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 7
-stacksize = 6256
+stacksize = 7000
 start = true
 uses = ["usart1"]
 task-slots = [

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -191,11 +191,10 @@ stacksize = 872
 task-slots = ["sys"]
 notifications = ["spi-irq"]
 
-
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
 priority = 6
-stacksize = 6256
+stacksize = 7000
 start = true
 uses = []
 task-slots = [


### PR DESCRIPTION
This isn't detected by the stack size check because `serde` has recursive calls.

```
humility: attached to dump
system time = 123546
ID TASK                       GEN PRI STATE
20 control_plane_agent          0   8 FAULT: stack overflow; sp=0x2402ffd8 (was: ready)
   could not read registers: read of 32 bytes from invalid address: 0x2402ffd8
   guessing at stack trace using saved frame pointer
   |
   +--->  0x24031870 0x08054b98 <hubpack::de::SeqAccess as serde::de::SeqAccess>::next_element_seed
                     @ /crates.io/hubpack-0.1.2/src/de.rs:280
```

Marking it as a draft, pending testing on hardware (as part of #2158)