### PR TITLE
`minicbor-lease` adapter for encoding straight into a lease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,6 +3858,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor-lease"
+version = "0.1.0"
+dependencies = [
+ "idol-runtime",
+ "minicbor 0.26.4",
+]
+
+[[package]]
 name = "minicbor-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "minicbor 0.26.4",
+ "minicbor-lease",
  "mutable-statics",
  "num-traits",
  "quote",

--- a/lib/minicbor-lease/Cargo.toml
+++ b/lib/minicbor-lease/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "minicbor-lease"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+minicbor = { workspace = true }
+idol-runtime = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/minicbor-lease/src/lib.rs
+++ b/lib/minicbor-lease/src/lib.rs
@@ -9,33 +9,44 @@
 
 /// An adapter implementing [`minicbor::encode::write::Write`] for
 /// [`idol_runtime::Leased`] byte buffers.
-pub struct LeasedWriter<'lease, A> {
+pub struct LeasedWriter<'lease, A>
+where
+    A: idol_runtime::AttributeWrite,
+{
     lease: &'lease mut idol_runtime::Leased<A, [u8]>,
     pos: usize,
     ran_out_of_space: bool,
 }
 
+/// Errors returned by [`LeasedWriter::check_err`].
 #[derive(Copy, Clone, PartialEq)]
 pub enum Error {
+    /// The other side of the lease has gone away.
     WentAway,
+    /// Data could not be written as there was no room left in the lease.
     EndOfLease,
 }
 
-impl minicbor::encode::write::Write for LeasedWriter<'_, A>
+/// Errors returned by the [`minicbor::encode::write::Write`] implementation for
+/// [`LeasedWriter`].
+#[derive(Copy, Clone, PartialEq)]
+pub struct WriteError(());
+
+impl<A> minicbor::encode::write::Write for LeasedWriter<'_, A>
 where
     A: idol_runtime::AttributeWrite,
 {
-    type Error = Error;
+    type Error = WriteError;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         let end = self.pos + buf.len();
         if end >= self.lease.len() {
             self.ran_out_of_space = true;
-            return Err(Error::EndOfLease);
+            return Err(WriteError(()));
         }
         self.lease
             .write_range(self.pos..end, buf)
-            .map_err(|_| Error::WentAway)?;
+            .map_err(|_| WriteError(()))?;
 
         self.pos += buf.len();
 
@@ -43,22 +54,33 @@ where
     }
 }
 
-impl<A> LeasedWriter<'_, A>
+impl<'lease, A> LeasedWriter<'lease, A>
 where
     A: idol_runtime::AttributeWrite,
 {
     /// Returns a new `LeasedWriter` starting at byte 0 of the lease.
-    pub fn new(lease: &mut idol_runtime::Leased<A, [u8]>) -> Self {
-        Self { lease, pos: 0 }
+    pub fn new(lease: &'lease mut idol_runtime::Leased<A, [u8]>) -> Self {
+        Self {
+            lease,
+            pos: 0,
+            ran_out_of_space: false,
+        }
     }
 
-    /// Returns a new `LeasedWriter` starting at the specified position in the
-    /// lease.
+    /// Returns a new `LeasedWriter` starting at the specified byte position in
+    /// the lease.
     ///
     /// This is intended for cases where some data has already been written to
     /// the lease.
-    pub fn starting_at(lease: &mut idol_runtime::Leased<A, [u8]>) -> Self {
-        Self { lease, pos: 0 }
+    pub fn starting_at(
+        position: usize,
+        lease: &'lease mut idol_runtime::Leased<A, [u8]>,
+    ) -> Self {
+        Self {
+            lease,
+            pos: position,
+            ran_out_of_space: false,
+        }
     }
 
     /// Returns the current byte position within the lease.
@@ -66,8 +88,13 @@ where
         self.pos
     }
 
+    /// Borrows the underlying lease from the writer.
+    pub fn lease(&self) -> &idol_runtime::Leased<A, [u8]> {
+        self.lease
+    }
+
     /// Returns the underlying lease, consuming the writer.
-    pub fn into_inner(self) -> &mut idol_runtime::Leased<A, [u8]> {
+    pub fn into_inner(self) -> &'lease mut idol_runtime::Leased<A, [u8]> {
         self.lease
     }
 
@@ -87,5 +114,40 @@ where
     /// a chunk of bytes that don't fit.
     pub fn ran_out_of_space(&self) -> bool {
         self.ran_out_of_space
+    }
+
+    /// Determine whether an error returned by the [`minicbor::encode::Write`]
+    /// implementation indicates that there was no space left in the lease, or
+    /// that the client went away.
+    ///
+    /// This is an unfortunate workaround for a limitation of the `minicbor`
+    /// API: the errors our `Write` implementation can return are wrapped in an
+    /// `encode::Error`, and we can't actually get our errors *out* of that
+    /// wrapper, so there's no way to tell whether the error was becasue we ran
+    /// out of space in the buffer, or because the lease client went away. So,
+    /// we track it here, so that the caller can just ask us if we didn't have
+    /// space to encode something.
+    ///
+    pub fn check_err(&self, err: minicbor::encode::Error<WriteError>) -> Error {
+        if err.is_write() {
+            if self.ran_out_of_space {
+                Error::EndOfLease
+            } else {
+                Error::WentAway
+            }
+        } else {
+            // This is an encoder error, which we have no good way to
+            // recover from.
+            panic!()
+        }
+    }
+}
+
+impl From<Error> for idol_runtime::ClientError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::EndOfLease => idol_runtime::ClientError::BadLease,
+            Error::WentAway => idol_runtime::ClientError::WentAway,
+        }
     }
 }

--- a/lib/minicbor-lease/src/lib.rs
+++ b/lib/minicbor-lease/src/lib.rs
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! An adapter implementing [`minicbor::encode::write::Write`] for
+//! [`idol_runtime::Leased`] byte buffers.
+
+#![no_std]
+
+/// An adapter implementing [`minicbor::encode::write::Write`] for
+/// [`idol_runtime::Leased`] byte buffers.
+pub struct LeasedWriter<A> {
+    lease: idol_runtime::Leased<A, [u8]>,
+    pos: usize,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum Error {
+    WentAway,
+    EndOfLease,
+}
+
+impl minicbor::encode::write::Write for LeasedWriter<A>
+where
+    A: idol_runtime::AttributeWrite,
+{
+    type Error = Error;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        let end = self.pos + buf.len();
+        if end >= self.lease.len() {
+            return Error::EndOfLease;
+        }
+        self.lease
+            .write_range(self.pos..end, buf)
+            .map_err(|_| Error::WentAway)?;
+
+        self.pos += buf.len();
+
+        Ok(())
+    }
+}
+
+impl<A> LeasedWriter<A>
+where
+    A: idol_runtime::AttributeWrite,
+{
+    /// Returns a new `LeasedWriter` starting at byte 0 of the lease.
+    pub fn new(lease: idol_runtime::Leased<A, [u8]>) -> Self {
+        Self { lease, pos: 0 }
+    }
+
+    /// Returns a new `LeasedWriter` starting at the specified position in the
+    /// lease.
+    ///
+    /// This is intended for cases where some data has already been written to
+    /// the lease.
+    pub fn starting_at(lease: idol_runtime::Leased<A, [u8]>) -> Self {
+        Self { lease, pos: 0 }
+    }
+
+    /// Returns the current byte position within the lease.
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    /// Returns the underlying lease, consuming the writer.
+    pub fn into_inner(self) -> idol_runtime::Leased<A, [u8]> {
+        self.lease
+    }
+}

--- a/task/packrat/Cargo.toml
+++ b/task/packrat/Cargo.toml
@@ -23,6 +23,7 @@ task-packrat-api = { path = "../packrat-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 snitch-core = { version = "0.1.0", path = "../../lib/snitch-core", optional = true, features = ["counters"] }
 minicbor = { workspace = true,  optional = true }
+minicbor-lease = { path = "../../lib/minicbor-lease", optional = true }
 
 [build-dependencies]
 anyhow.workspace = true
@@ -37,7 +38,7 @@ gimlet = ["drv-cpu-seq-api"]
 grapefruit = []
 boot-kmdb = []
 no-ipc-counters = ["idol/no-counters"]
-ereport = ["dep:drv-rng-api", "dep:snitch-core", "dep:minicbor", "dep:quote"]
+ereport = ["dep:drv-rng-api", "dep:snitch-core", "dep:minicbor", "dep:minicbor-lease", "dep:quote"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/packrat/src/ereport.rs
+++ b/task/packrat/src/ereport.rs
@@ -17,7 +17,7 @@ use super::ereport_messages;
 use core::convert::Infallible;
 use idol_runtime::{ClientError, Leased, LenLimit, RequestError};
 use minicbor::CborLen;
-use minicbor_lease::LeaseWriter;
+use minicbor_lease::LeasedWriter;
 use ringbuf::{counted_ringbuf, ringbuf_entry};
 use task_packrat_api::{EreportReadError, VpdIdentity};
 use userlib::{kipc, sys_get_timer, RecvMessage, TaskId};
@@ -79,7 +79,6 @@ enum Trace {
 
 #[derive(Copy, Clone, PartialEq, Eq, counters::Count)]
 enum MetadataError {
-    TooLong,
     PartNumberNotUtf8,
     SerialNumberNotUtf8,
 }
@@ -87,7 +86,6 @@ enum MetadataError {
 #[derive(Copy, Clone, PartialEq, Eq, counters::Count)]
 enum EreportError {
     TaskIdOutOfRange,
-    TooLong,
 }
 
 counted_ringbuf!(Trace, 16, Trace::None);
@@ -144,45 +142,54 @@ impl EreportStore {
         begin_ena: ereport_messages::Ena,
         limit: u8,
         committed_ena: ereport_messages::Ena,
-        data: Leased<idol_runtime::W, [u8]>,
+        mut data: Leased<idol_runtime::W, [u8]>,
         vpd: Option<&VpdIdentity>,
     ) -> Result<usize, RequestError<EreportReadError>> {
         ringbuf_entry!(Trace::ReadRequest {
             restart_id: restart_id.into()
         });
 
-        // XXX(eliza): in theory it might be nicer to use
-        // `minicbor::data::Token::{BeginArray, BeginMap, Break}` for these, but
-        // it's way more annoying in practice, because you need to have an
-        // `Encoder` and can't just put it in the buffer.
-        /// Byte indicating the beginning of an indeterminate-length CBOR
-        /// array.
-        const CBOR_BEGIN_ARRAY: u8 = 0x9f;
-        /// Byte indicating the beginning of an indeterminate-length CBOR map.
-        const CBOR_BEGIN_MAP: u8 = 0xbf;
-        /// Byte indicating the end of an indeterminate-length CBOR array or
-        /// map.
-        const CBOR_BREAK: u8 = 0xff;
-
         let current_restart_id =
             self.restart_id.ok_or(EreportReadError::RestartIdNotSet)?;
         // Skip over a header-sized initial chunk.
         let first_data_byte = size_of::<ereport_messages::ResponseHeader>();
-
-        let mut position = first_data_byte;
         let mut first_written_ena = None;
+
+        let mut encoder = minicbor::Encoder::new(LeasedWriter::starting_at(
+            first_data_byte,
+            &mut data,
+        ));
+
+        fn check_err(
+            encoder: &minicbor::Encoder<LeasedWriter<'_, idol_runtime::W>>,
+            err: minicbor::encode::Error<minicbor_lease::WriteError>,
+        ) -> RequestError<EreportReadError> {
+            match encoder.writer().check_err(err) {
+                minicbor_lease::Error::WentAway => ClientError::WentAway.fail(),
+                minicbor_lease::Error::EndOfLease => {
+                    ClientError::BadLease.fail()
+                }
+            }
+        }
 
         // Start the metadata map.
         //
         // MGS expects us to always include this, and to just have it be
         // empty if we didn't send any metadata.
-        let mut e = minicbor::Encoder::new(LeasedWriter::starting_at(
-            position, &mut data,
-        ));
-        e.begin_map().map_err(|_| ClientError::WentAway.fail())?;
-        data.write_at(position, CBOR_BEGIN_MAP)
-            .map_err(|_| ClientError::WentAway.fail())?;
-        position += 1;
+        encoder
+            .begin_map()
+            // This pattern (which will occur every time we handle an encoder
+            // error in this function) is goofy, but is necessary to placate the
+            // borrow checker: the function passed to `map_err` must borrow the
+            // encoder so that it can check whether the error indicates that we
+            // ran out of space in the lease, or if the client disappeared.
+            // However, because `minicbor::Encoder`'s methods return a mutable
+            // borrow of the encoder, we must drop it first before borrowing it
+            // into the `map_err` closure. Thus, every `map_err` must be
+            // preceded by a `map` with a toilet closure that drops the mutable
+            // borrow. Yuck.
+            .map(|_| ())
+            .map_err(|e| check_err(&encoder, e))?;
 
         // If the requested restart ID matches the current restart ID, then read
         // from the requested ENA. If not, start at ENA 0.
@@ -209,50 +216,33 @@ impl EreportStore {
             // ensures that MGS will continue asking for metadata on subsequent
             // requests.
             if let Some(vpd) = vpd {
-                // Encode the metadata map into our buffer.
-                match self.encode_metadata(vpd) {
-                    Ok(encoded) => {
-                        data.write_range(
-                            position..position + encoded.len(),
-                            encoded,
-                        )
-                        .map_err(|_| ClientError::WentAway.fail())?;
-
-                        position += encoded.len();
-
-                        ringbuf_entry!(Trace::MetadataEncoded {
-                            len: encoded.len() as u32
-                        });
-                    }
-                    Err(err) => {
-                        // Encoded VPD metadata was too long, or couldn't be
-                        // represented as a CBOR string.
-                        ringbuf_entry!(Trace::MetadataError(err));
-                    }
-                }
+                // Encode the metadata map.
+                self.encode_metadata(&mut encoder, vpd)
+                    .map(|_| ())
+                    .map_err(|e| check_err(&encoder, e))?;
+                ringbuf_entry!(Trace::MetadataEncoded {
+                    len: encoder
+                        .writer()
+                        .position()
+                        .saturating_sub(first_data_byte)
+                        as u32,
+                });
             }
             // Begin at ENA 0
             0
         };
 
         // End metadata map.
-        data.write_at(position, CBOR_BREAK)
-            .map_err(|_| ClientError::WentAway.fail())?;
-        position += 1;
+        encoder
+            .end()
+            .map(|_| ())
+            .map_err(|e| check_err(&encoder, e))?;
 
         let mut reports = 0;
         // Beginning with the first
         for r in self.storage.read_from(begin_ena) {
             if reports >= limit {
                 break;
-            }
-
-            if first_written_ena.is_none() {
-                first_written_ena = Some(r.ena);
-                // Start the ereport array
-                data.write_at(position, CBOR_BEGIN_ARRAY)
-                    .map_err(|_| ClientError::WentAway.fail())?;
-                position += 1;
             }
 
             let tid = TaskId(r.tid);
@@ -277,41 +267,47 @@ impl EreportStore {
                 r.timestamp,
                 ByteGather(r.slices.0, r.slices.1),
             );
-            let mut c =
-                minicbor::encode::write::Cursor::new(&mut self.recv[..]);
-            match minicbor::encode(&entry, &mut c) {
-                Ok(()) => {
-                    let size = c.position();
-                    // If there's no room left for this one in the lease, we're
-                    // done here. Note that the use of `>=` rather than `>` is
-                    // intentional, as we want to ensure that there's room for
-                    // the final `CBOR_BREAK` byte that ends the CBOR array.
-                    if position + size >= data.len() {
-                        break;
-                    }
-                    data.write_range(
-                        position..position + size,
-                        &self.recv[..size],
-                    )
-                    .map_err(|_| ClientError::WentAway.fail())?;
-                    position += size;
-                    reports += 1;
-                }
-                Err(_end) => {
-                    // This is an odd one; we've admitted a record into our
-                    // queue that won't fit in our buffer. This can happen
-                    // because of the encoding overhead, in theory, but should
-                    // be prevented.
-                    ringbuf_entry!(Trace::EreportError(EreportError::TooLong));
-                }
+
+            // If there's no room left for this one in the lease, we're
+            // done here. Note that the use of `>=` rather than `>` is
+            // intentional, as we want to ensure that there's room for
+            // the final `CBOR_BREAK` byte that ends the CBOR array.
+            //
+            // N.B.: saturating_add is used to avoid panic sites --- if this
+            // adds up to `u32::MAX` it *definitely* won't fit :)
+            let len_needed = encoder
+                .writer()
+                .position()
+                // Of course, we need enough space for the ereport itself...
+                .saturating_add(minicbor::len(&entry))
+                // In addition, if we haven't yet started the CBOR array of
+                // ereports, we need a byte for that too.
+                .saturating_add(first_written_ena.is_none() as usize);
+            if len_needed >= encoder.writer().lease().len() {
+                break;
             }
+
+            if first_written_ena.is_none() {
+                first_written_ena = Some(r.ena);
+                // Start the ereport array
+                encoder
+                    .begin_array()
+                    .map(|_| ())
+                    .map_err(|e| check_err(&encoder, e))?;
+            }
+            encoder
+                .encode(&entry)
+                .map(|_| ())
+                .map_err(|e| check_err(&encoder, e))?;
+            reports += 1;
         }
 
         if let Some(start_ena) = first_written_ena {
             // End CBOR array, if we wrote anything.
-            data.write_at(position, CBOR_BREAK)
-                .map_err(|_| ClientError::WentAway.fail())?;
-            position += 1;
+            encoder
+                .end()
+                .map(|_| ())
+                .map_err(|e| check_err(&encoder, e))?;
 
             ringbuf_entry!(Trace::Reported {
                 start_ena,
@@ -320,6 +316,8 @@ impl EreportStore {
             });
         }
 
+        // Release the mutable borrow on the lease so we can write the header.
+        let end = encoder.into_writer().position();
         let first_ena = first_written_ena.unwrap_or(0);
         let header = ereport_messages::ResponseHeader::V0(
             ereport_messages::ResponseHeaderV0 {
@@ -330,18 +328,14 @@ impl EreportStore {
         );
         data.write_range(0..size_of_val(&header), header.as_bytes())
             .map_err(|_| ClientError::WentAway.fail())?;
-        Ok(position)
+        Ok(end)
     }
 
-    fn encode_metadata(
-        &mut self,
+    fn encode_metadata<'lease>(
+        &self,
+        encoder: &mut minicbor::Encoder<LeasedWriter<'lease, idol_runtime::W>>,
         vpd: &VpdIdentity,
-    ) -> Result<&[u8], MetadataError> {
-        let c = minicbor::encode::write::Cursor::new(&mut self.recv[..]);
-        let mut encoder = minicbor::Encoder::new(c);
-        // TODO(eliza): presently, this code bails out if the metadata map gets
-        // longer than our buffer. It would be nice to have a way to keep the
-        // encoded metadata up to the last complete key-value pair...
+    ) -> Result<(), minicbor::encode::Error<minicbor_lease::WriteError>> {
         encoder
             .str("hubris_archive_id")?
             .bytes(&self.image_id[..])?;
@@ -362,8 +356,7 @@ impl EreportStore {
             )),
         }
         encoder.str("rev")?.u32(vpd.revision)?;
-        let size = encoder.into_writer().position();
-        Ok(&self.recv[..size])
+        Ok(())
     }
 }
 
@@ -399,16 +392,6 @@ impl<C> CborLen<C> for ByteGather<'_, '_> {
     fn cbor_len(&self, ctx: &mut C) -> usize {
         let n = self.0.len().wrapping_add(self.1.len());
         n.cbor_len(ctx).wrapping_add(n)
-    }
-}
-
-impl From<minicbor::encode::Error<minicbor::encode::write::EndOfSlice>>
-    for MetadataError
-{
-    fn from(
-        _: minicbor::encode::Error<minicbor::encode::write::EndOfSlice>,
-    ) -> MetadataError {
-        MetadataError::TooLong
     }
 }
 


### PR DESCRIPTION
Based on [a suggestion][1] from @mkeeter, this branch adds an adapter that implements `minicbor::encode::write::Write` for a cursor into a writable lease. This lets us avoid double-buffering in the `read_ereports` path, where we would previously encode each ereport into the receive buffer, and then copy the contents of that into the lease if there is space for it. The new approach avoids the memcpy, and also doesn't encode the ereport in the case where there isn't space left for it.

I implemented the lease-writer adapter thing in a separate `minicbor-lease` crate, as I was hoping it would be useful elsewhere...but I'm not actually sure if it will be, now that I think of it: the IPC for delivering an ereport to packrat leases the data _from_ the caller, so callers will just encode into a normal buffer they own. Ah well.

[1]: https://github.com/oxidecomputer/hubris/pull/2126#discussion_r2198529251