### PR TITLE
Make more ringbufs zero-initialized, saving flash

### DIFF
--- a/app/cosmo/src/tracing.rs
+++ b/app/cosmo/src/tracing.rs
@@ -27,8 +27,8 @@ enum Event {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    Event(Event),
     None,
+    Event(Event),
 }
 
 ringbuf!(Trace, 128, Trace::None);

--- a/app/gimlet/src/tracing.rs
+++ b/app/gimlet/src/tracing.rs
@@ -27,8 +27,8 @@ enum Event {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    Event(Event),
     None,
+    Event(Event),
 }
 
 ringbuf!(Trace, 128, Trace::None);

--- a/drv/cosmo-seq-server/src/main.rs
+++ b/drv/cosmo-seq-server/src/main.rs
@@ -38,6 +38,8 @@ task_slot!(PACKRAT, packrat);
 
 #[derive(Copy, Clone, PartialEq, Count)]
 enum Trace {
+    #[count(skip)]
+    None,
     FpgaInit,
     StartFailed(#[count(children)] SeqError),
     ContinueBitstreamLoad(usize),
@@ -78,8 +80,6 @@ enum Trace {
         sp5r3: bool,
         sp5r4: bool,
     },
-    #[count(skip)]
-    None,
 }
 counted_ringbuf!(Trace, 128, Trace::None);
 

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -67,6 +67,8 @@ enum I2cTxn {
 
 #[derive(Copy, Clone, PartialEq, Count)]
 enum Trace {
+    #[count(skip)]
+    None,
     Ice40Rails(bool, bool),
     IdentValid(#[count(children)] bool),
     ChecksumValid(#[count(children)] bool),
@@ -150,8 +152,6 @@ enum Trace {
         retries_remaining: u8,
     },
     StartFailed(#[count(children)] SeqError),
-    #[count(skip)]
-    None,
 }
 
 counted_ringbuf!(Trace, 128, Trace::None);

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -41,6 +41,7 @@ pub struct VCore {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Initializing,
     Initialized,
     LimitLoaded,
@@ -49,7 +50,6 @@ enum Trace {
     Fault,
     Reading { timestamp: u64, volts: units::Volts },
     Error(ResponseCode),
-    None,
 }
 
 ringbuf!(Trace, 120, Trace::None);

--- a/drv/grapefruit-seq-server/src/main.rs
+++ b/drv/grapefruit-seq-server/src/main.rs
@@ -22,11 +22,11 @@ task_slot!(LOADER, spartan7_loader);
 
 #[derive(Copy, Clone, PartialEq, Count)]
 enum Trace {
-    MacsAlreadySet(MacAddressBlock),
-    IdentityAlreadySet(VpdIdentity),
-
     #[count(skip)]
     None,
+
+    MacsAlreadySet(MacAddressBlock),
+    IdentityAlreadySet(VpdIdentity),
 }
 
 counted_ringbuf!(Trace, 128, Trace::None);

--- a/drv/i2c-devices/src/adm1272.rs
+++ b/drv/i2c-devices/src/adm1272.rs
@@ -81,10 +81,10 @@ impl core::fmt::Display for Adm1272 {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Coefficients(pmbus::Coefficients),
     Config(adm1272::PMON_CONFIG::CommandData),
     WriteConfig(adm1272::PMON_CONFIG::CommandData),
-    None,
 }
 
 ringbuf!(Trace, 8, Trace::None);

--- a/drv/i2c-devices/src/ds2482.rs
+++ b/drv/i2c-devices/src/ds2482.rs
@@ -67,11 +67,11 @@ pub enum Error {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Read(Register, u8),
     ReadError(Register, ResponseCode),
     Command(Command),
     CommandError(Command, ResponseCode),
-    None,
 }
 
 ringbuf!(Trace, 196, Trace::None);

--- a/drv/i2c-devices/src/emc2305.rs
+++ b/drv/i2c-devices/src/emc2305.rs
@@ -216,10 +216,10 @@ fn write_reg16(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     ZeroTach(Fan),
     TachOverflow(u32),
     BadFanCount(u8),
-    None,
 }
 
 ringbuf!(Trace, 6, Trace::None);

--- a/drv/i2c-devices/src/lm5066.rs
+++ b/drv/i2c-devices/src/lm5066.rs
@@ -101,10 +101,10 @@ impl core::fmt::Display for Lm5066 {
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Trace {
+    None,
     CurrentCoefficients(pmbus::Coefficients),
     PowerCoefficients(pmbus::Coefficients),
     DeviceSetup(lm5066::DEVICE_SETUP::CommandData),
-    None,
 }
 
 ringbuf!(Trace, 8, Trace::None);

--- a/drv/i2c-devices/src/lm5066i.rs
+++ b/drv/i2c-devices/src/lm5066i.rs
@@ -23,10 +23,10 @@ pub use crate::lm5066::{CurrentLimitStrap, Error};
 
 #[derive(Copy, Clone, PartialEq)]
 pub(crate) enum Trace {
+    None,
     CurrentCoefficients(pmbus::Coefficients),
     PowerCoefficients(pmbus::Coefficients),
     DeviceSetup(lm5066i::DEVICE_SETUP::CommandData),
-    None,
 }
 
 pub struct Lm5066I {

--- a/drv/i2c-devices/src/max31790.rs
+++ b/drv/i2c-devices/src/max31790.rs
@@ -254,8 +254,8 @@ fn write_reg16(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
-    ZeroTach(Fan),
     None,
+    ZeroTach(Fan),
 }
 
 ringbuf!(Trace, 6, Trace::None);

--- a/drv/lpc55-spi-server/src/main.rs
+++ b/drv/lpc55-spi-server/src/main.rs
@@ -19,10 +19,10 @@ task_slot!(GPIO, gpio_driver);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Irq,
     Tx(u8),
     Rx(u8),
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/drv/lpc55-swd/src/main.rs
+++ b/drv/lpc55-swd/src/main.rs
@@ -112,12 +112,12 @@ use zerocopy::IntoBytes;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Idcode(u32),
     Idr(u32),
     MemVal(u32),
     ReadCmd,
     WriteCmd,
-    None,
     AckErr(Ack),
     DongleDetected,
     Dhcsr(Dhcsr),

--- a/drv/oxide-vpd/src/lib.rs
+++ b/drv/oxide-vpd/src/lib.rs
@@ -36,9 +36,9 @@ struct EepromReader<'a> {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     EepromError(drv_i2c_devices::at24csw080::Error),
     Error(VpdError),
-    None,
 }
 
 ringbuf!(Trace, 4, Trace::None);

--- a/drv/spartan7-loader/src/main.rs
+++ b/drv/spartan7-loader/src/main.rs
@@ -47,15 +47,14 @@ pub fn claim_spi(_sys: &sys_api::Sys) -> drv_spi_api::Spi {
 
 #[derive(Copy, Clone, PartialEq, Count)]
 enum Trace {
+    #[count(skip)]
+    None,
     FpgaInit,
     FpgaInitFailed(#[count(children)] Spartan7Error),
     StartFailed(#[count(children)] LoaderError),
     ContinueBitstreamLoad(usize),
     WaitForDone,
     Programmed,
-
-    #[count(skip)]
-    None,
 }
 
 #[derive(Copy, Clone, PartialEq, Count)]

--- a/drv/stm32h7-spi-server-core/src/lib.rs
+++ b/drv/stm32h7-spi-server-core/src/lib.rs
@@ -64,12 +64,12 @@ pub struct SpiServerCore {
 
 #[derive(Copy, Clone, PartialEq, counters::Count)]
 enum Trace {
+    #[count(skip)]
+    None,
     Start(#[count(children)] SpiOperation, (u16, u16)),
     Tx(u8),
     Rx(u8),
     WaitISR(u32),
-    #[count(skip)]
-    None,
 }
 
 counted_ringbuf!(Trace, 64, Trace::None);

--- a/drv/stm32h7-update-server/src/main.rs
+++ b/drv/stm32h7-update-server/src/main.rs
@@ -47,6 +47,7 @@ extern "C" {
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     EraseStart,
     EraseEnd,
     WriteStart,
@@ -54,7 +55,6 @@ enum Trace {
     FinishStart,
     FinishEnd,
     WriteBlock(usize),
-    None,
 }
 
 enum UpdateState {

--- a/drv/stm32xx-i2c-server/src/main.rs
+++ b/drv/stm32xx-i2c-server/src/main.rs
@@ -226,6 +226,7 @@ fn configure_mux(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     SegmentOnError((Mux, Segment)),
     Error(u8, ResponseCodeU8),
     MuxError(ResponseCodeU8),
@@ -237,7 +238,6 @@ enum Trace {
     SegmentFailed(ResponseCodeU8),
     ConfigureFailed(ResponseCodeU8),
     Wiggles(u8),
-    None,
 }
 
 ringbuf!(Trace, 160, Trace::None);

--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -171,6 +171,8 @@ enum Register {
 
 #[derive(Copy, Clone, Eq, PartialEq, counters::Count)]
 enum Trace {
+    #[count(skip)]
+    None,
     Wait(Register, u32),
     Write(Register, u32),
     WriteWait(Register, u32),
@@ -205,8 +207,6 @@ enum Trace {
         enabled: bool,
         posted: bool,
     },
-    #[count(skip)]
-    None,
 }
 
 counted_ringbuf!(Trace, 48, Trace::None);

--- a/drv/stm32xx-i2c/src/max7358.rs
+++ b/drv/stm32xx-i2c/src/max7358.rs
@@ -63,9 +63,9 @@ bitfield! {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum Trace {
+    None,
     Read(Register, u8),
     Write(Register, u8),
-    None,
 }
 
 ringbuf!(Trace, 32, Trace::None);

--- a/task/attest/src/main.rs
+++ b/task/attest/src/main.rs
@@ -40,6 +40,7 @@ use build::{ALIAS_DATA, CERT_DATA, PERMIT_LOG_RESET};
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Cert,
     CertChainLen(u32),
     CertLen(usize),
@@ -58,7 +59,6 @@ enum Trace {
     ClientError(ClientError),
     StartAttest,
     FinishAttest,
-    None,
 }
 
 ringbuf!(Trace, 16, Trace::None);

--- a/task/dump-agent/src/main.rs
+++ b/task/dump-agent/src/main.rs
@@ -34,9 +34,9 @@ struct ServerImpl {
 #[cfg(not(feature = "no-rot"))]
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     SpRotDump,
     SpRotDumpResult(Result<(), DumpAgentError>),
-    None,
 }
 
 #[cfg(not(feature = "no-rot"))]

--- a/task/dumper/src/main.rs
+++ b/task/dumper/src/main.rs
@@ -16,6 +16,7 @@ use zerocopy::FromBytes;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     DumpInitiated(u32),
     SetupFailed(SpCtrlError),
     DumpHeader([u8; 4]),
@@ -33,7 +34,6 @@ enum Trace {
     ReinitFailed,
     ReinitSucceededButResumeFailed,
     ReinitResumed,
-    None,
 }
 
 task_slot!(SP_CTRL, swd);

--- a/task/gimlet-spd/src/main.rs
+++ b/task/gimlet-spd/src/main.rs
@@ -62,6 +62,7 @@ const LTC4306_ADDRESS: u8 = 0b1001_010;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Ready,
     Initiate(u8, bool),
     Rx(u8, u8),
@@ -69,7 +70,6 @@ enum Trace {
     MemInitiate(u8),
     MemSetOffset(usize, u8),
     MuxState(ltc4306::State, ltc4306::State),
-    None,
 }
 
 ringbuf!(Trace, 16, Trace::None);

--- a/task/hiffy/src/lpc55.rs
+++ b/task/hiffy/src/lpc55.rs
@@ -18,10 +18,10 @@ task_slot!(SP_CTRL, swd);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Execute((usize, hif::Op)),
     Failure(Failure),
     Success,
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/task/hiffy/src/stm32h7.rs
+++ b/task/hiffy/src/stm32h7.rs
@@ -27,6 +27,7 @@ task_slot!(SYS, sys);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Execute((usize, Op)),
     Failure(Failure),
     #[cfg(feature = "gpio")]
@@ -42,7 +43,6 @@ enum Trace {
     #[cfg(feature = "gpio")]
     GpioInput(drv_stm32xx_sys_api::Port),
     Success,
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/task/hiffy/src/tests.rs
+++ b/task/hiffy/src/tests.rs
@@ -81,11 +81,11 @@ pub(crate) fn run_a_test(
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Execute((usize, hif::Op)),
     Failure(Failure),
     Success,
     RunTest(u32),
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/task/power/src/bsp/cosmo_a.rs
+++ b/task/power/src/bsp/cosmo_a.rs
@@ -129,6 +129,7 @@ const TRACE_DEPTH: usize = 52;
 /// Tooling can then collect this ringbuf periodically and get recent events.
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     /// Configuration of the MAX5970 failed
     Max5970ConfigFailed {
         u2_index: usize,
@@ -177,7 +178,6 @@ enum Trace {
         crossbounce_min_vout: f32,
         crossbounce_max_vout: f32,
     },
-    None,
 }
 
 ringbuf!(Trace, TRACE_DEPTH, Trace::None);

--- a/task/power/src/bsp/gimlet_bcdef.rs
+++ b/task/power/src/bsp/gimlet_bcdef.rs
@@ -104,6 +104,7 @@ const TRACE_DEPTH: usize = 52;
 /// Tooling can then collect this ringbuf periodically and get recent events.
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     /// Written before trace records; the `u32` is the number of times the task
     /// has woken up to process its timer. This is not exactly equivalent to
     /// seconds because of the way the timer is maintained, but is approximately
@@ -134,7 +135,6 @@ enum Trace {
         crossbounce_min_vout: f32,
         crossbounce_max_vout: f32,
     },
-    None,
 }
 
 ringbuf!(Trace, TRACE_DEPTH, Trace::None);

--- a/task/power/src/main.rs
+++ b/task/power/src/main.rs
@@ -39,9 +39,9 @@ use drv_i2c_devices::{
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     GotVersion(u32),
     GotAddr(u32),
-    None,
 }
 
 ringbuf!(Trace, 2, Trace::None);

--- a/task/sp_measure/src/main.rs
+++ b/task/sp_measure/src/main.rs
@@ -18,11 +18,11 @@ task_slot!(SP_CTRL, swd);
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Start(u64),
     End(u64),
     ShaGood,
     ShaBad,
-    None,
 }
 
 ringbuf!(Trace, 16, Trace::None);

--- a/task/validate/src/main.rs
+++ b/task/validate/src/main.rs
@@ -18,9 +18,9 @@ struct ServerImpl;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Validate(usize),
     ValidateFailure(drv_i2c_api::ResponseCode),
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -62,13 +62,13 @@ const TEST_TASK: usize = 1;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     Notification,
     TestComplete(TaskId),
     TestResult(TaskId),
     SoftIrq(TaskId, u32),
     AutoRestart(bool),
     RestartingTask(usize),
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -35,9 +35,9 @@ use zerocopy::IntoBytes;
 
 #[derive(Copy, Clone, PartialEq)]
 enum Trace {
+    None,
     TestStart,
     TestFinish,
-    None,
 }
 
 ringbuf!(Trace, 64, Trace::None);


### PR DESCRIPTION
To simplify its implementation, ringbuf currently requires every ringbuf to be declared with an initialization element. It creates a static array containing that element.

If that element is represented as zero, that goes in BSS and is zero-initialized with the rest of BSS.

If that element is represented as anything other than zero, the compiler creates a full-sized "initialization image" copy of the ringbuf _in flash_ that it can then memcpy into RAM on startup.

Using the default Rust enum representation, the easiest way to get a ringbuf initialized to non-zero bytes is to put its initialization sentinel value (e.g. None) as the last variant in the enum. Unfortunately, this is super common.

This commit moves all the ones I could find, which should reduce flash usage in a bunch of cases.