### PR TITLE
ringbuf: Remove unused `#[used]` we weren't using

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -381,7 +381,6 @@ macro_rules! counted_ringbuf {
 #[macro_export]
 macro_rules! counted_ringbuf {
     ($name:ident, $t:ident, $n:expr, $init:expr, no_dedup) => {
-        #[used]
         static $name: $crate::CountedRingbuf<$t, (), $n> =
             $crate::CountedRingbuf {
                 counters: <$t as $crate::Count>::NEW_COUNTERS,
@@ -389,7 +388,6 @@ macro_rules! counted_ringbuf {
             };
     };
     ($name:ident, $t:ident, $n:expr, $init:expr) => {
-        #[used]
         static $name: $crate::CountedRingbuf<$t, u16, $n> =
             $crate::CountedRingbuf {
                 counters: <$t as $crate::Count>::NEW_COUNTERS,


### PR DESCRIPTION
This commit removes one more instance of the `#[used]` attribute in `ringbuf` that we don't actually need --- in the macro that generates `counted_ringbuf!`s when counters are enabled but the actual ringbuf isn't. I had somehow forgotten this in #2167, my bad!