### PR TITLE
Remove old SP sprot configurations

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -1456,10 +1456,6 @@ port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
 
-[config.sprot]
-# ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)
-rot_irq = { port = "F", pin = 2, af = 0} # XXX can we use EXTI now?
-
 [config.auxflash]
 memory-size = 33_554_432 # 256 Mib / 32 MiB
 slot-count = 16 # 2 MiB slots

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -315,6 +315,3 @@ mux = "port_e"
 cs = [{port = "E", pin = 4}]
 clock_divider = "DIV256"
 
-[config.sprot]
-# ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)
-rot_irq = { port = "E", pin = 3, af = 15}

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -1315,6 +1315,3 @@ port = 23547
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 512 }
 
-[config.sprot]
-# ROT_IRQ (af=0 for GPIO, af=15 when EXTI is implemneted)
-rot_irq = { port = "E", pin = 3, af = 0}

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -245,15 +245,6 @@ uses = ["spi3"]
 notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi3.irq" = "spi-irq"}
 
-[config.sprot]
-# TODO: This config is inert. Need to implement STM32 build.rs like the LPC55 has.
-pins = [
-    # ROT_IRQ (af=15 for EXTI)
-    { name = "ROT_IRQ", pin = { port = "D", pin = 0, af = 15, direction = "input"}},
-    # SPI6 CS repurposed for debugging
-    { name = "DEBUG", pin = { port = "G", pin = 8, af = 0, direction = "output"}}
-]
-
 #
 # This device definition is only provided as a way to test this driver absent
 # a larger board that has it; unless your Gimletlet is in a basement known


### PR DESCRIPTION
We now get all sprot pin configuration via the stm32xx-sys library