### PR TITLE
Introduce cosmo sequencer interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ name = "drv-cosmo-seq-server"
 version = "0.1.0"
 dependencies = [
  "build-fpga-regmap",
+ "build-stm32xx-sys",
  "build-util",
  "cfg-if",
  "counters",

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -74,6 +74,12 @@ port = "F"
 pin = 2
 owner = {name = "sprot", notification = "rot_irq"}
 
+[tasks.sys.config.gpio-irqs.seq_irq]
+# FPGA1_TO_SP_IRQ1_L
+port = "F"
+pin = 5
+owner = {name = "cosmo_seq", notification = "seq_irq"}
+
 [tasks.spi2_driver]
 name = "drv-stm32h7-spi-server"
 priority = 3
@@ -175,7 +181,7 @@ stacksize = 2600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_front = "spi3_driver"}, "jefe", "packrat", "auxflash", "spartan7_loader", "hf"]
 uses = ["mmio_sequencer", "mmio_info"]
-notifications = ["timer", "vcore"]
+notifications = ["timer", "vcore", "seq-irq"]
 
 [tasks.ignition_flash]
 name = "drv-ignition-flash"

--- a/drv/cosmo-seq-server/Cargo.toml
+++ b/drv/cosmo-seq-server/Cargo.toml
@@ -28,6 +28,7 @@ zerocopy-derive = { workspace = true }
 [build-dependencies]
 build-fpga-regmap = { path = "../../build/fpga-regmap" }
 build-util = { path = "../../build/util" }
+build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
 idol = { workspace = true }
 
 [features]

--- a/drv/cosmo-seq-server/build.rs
+++ b/drv/cosmo-seq-server/build.rs
@@ -7,6 +7,7 @@ use std::{fs, io::Write};
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
+    build_stm32xx_sys::build_gpio_irq_pins()?;
 
     let out_dir = build_util::out_dir();
     let out_file = out_dir.join("cosmo_fpga.rs");

--- a/drv/cpu-seq-api/src/lib.rs
+++ b/drv/cpu-seq-api/src/lib.rs
@@ -71,6 +71,12 @@ pub enum StateChangeReason {
     HostReboot,
     /// The system powered off because a component has overheated.
     Overheat,
+    /// A0 MAPO fault from the sequencer
+    A0Mapo,
+    /// System Management Error
+    SmerrAssert,
+    /// The system powered off for reasons we can't explain
+    Unknown,
 }
 
 /// Indicates the result of a power state transition.


### PR DESCRIPTION
Instead of polling for our state changes, rely on the sequencer to deliver interrupts to us