### PR TITLE
Fix version translation for VersionedRotBootInfo

### DIFF
--- a/drv/lpc55-update-api/src/lib.rs
+++ b/drv/lpc55-update-api/src/lib.rs
@@ -161,6 +161,9 @@ pub enum VersionedRotBootInfo {
     V1(RotBootInfo),
     V2(RotBootInfoV2),
 }
+impl VersionedRotBootInfo {
+    pub const HIGHEST_KNOWN_VERSION: u8 = 2;
+}
 
 #[derive(Clone, Copy, Serialize, Deserialize, SerializedSize)]
 pub enum RotPage {


### PR DESCRIPTION
Translate MGS 1-based versions to RoT 0-based versions for the SP/RoT `versioned_rot_boot_info()` call and clamp the version to be the lesser of the MGS's and SP's `RotBootInfo::HIGHEST_KNOWN_VERSION`.

The version argument of the VersionedRotBootInfo message was being used directly for the sprot `versioned_rot_boot_info` call. These are actually two different name spaces. This change helps when an upcoming PR introduces new MGS and RoT varients to support the `BootDecisionLog`.

Without this change, a new MGS and RoT running against an old SP will have some cases where an MGS request is understood by the RoT but the RoT response cannot be deserialized by the SP and results in sending an error to the MGS.

Issue #2185