### PR TITLE
i2c: optionally generate refdes string constants

### DIFF
--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -11,6 +11,10 @@ counters = { path = "../../lib/counters" }
 drv-i2c-types.path = "../i2c-types"
 userlib.path = "../../sys/userlib"
 
+
+[features]
+refdes = []
+
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.
 [lib]

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -38,6 +38,8 @@ pub struct I2cDevice {
     pub port: PortIndex,
     pub segment: Option<(Mux, Segment)>,
     pub address: u8,
+    #[cfg(feature = "refdes")]
+    pub refdes: Option<&'static str>,
 }
 
 type I2cMessage = (u8, Controller, PortIndex, Option<(Mux, Segment)>);
@@ -120,7 +122,22 @@ impl I2cDevice {
             port,
             segment,
             address,
+            #[cfg(feature = "refdes")]
+            refdes: None,
         }
+    }
+
+    #[cfg(feature = "refdes")]
+    pub fn with_refdes(mut self, refdes: &'static str) -> Self {
+        Self {
+            refdes: Some(refdes),
+            ..self
+        }
+    }
+
+    #[cfg(feature = "refdes")]
+    pub fn refdes(&self) -> Option<&'static str> {
+        self.refdes
     }
 }
 


### PR DESCRIPTION
When generating ereports that refer to errors observed by a particular
hardware component, we would like to be able to include the [reference
designator][1] (or _refdes_) of the component, to uniquely identify
which component the ereport pertains to.

Presently, I<sup>2</sup>C devices in Hubris app config TOML files have
an optional field for specifying the refdes on the board for that
device. The `build-i2c` codegen can be configured to use this field to
generate functions for looking up devices by their refdes.  This is used
by `host-sp-comms` for reporting inventory to the host. However, there
isn't presently a way to take a handle to an `I2cDevice` and get the
refdes _back_. When we report an error from a device, we typically have
the `I2cDevice` for the device in question, but don't know the refdes.
In many cases, we are only talking to a single device,[^1] we _could_
just hard-code the refdes string in the ereport, but this feels less
than ideal: since we already have a more authoritative source, I'd
rather use that, instead of creating an opportunity to typo it. And, if
we can just get the `app.toml` refdes *from* the device, it's much
easier to reuse code across multiple boards.

Thus, this branch adds an option to the `build-i2c` crate to generate a
`&'static str` constant for the refdes, and include it in the
`I2cDevice` struct, provided a "refdes" feature flag is enabled on the
`drv_i2c_api` crate. I thought it best to feature flag this, as
otherwise, a bunch of strings would be unconditionally added to the
binary, which seems sad to do when a task doesn't actually need them.
Ideally, we could just rely on these all getting dead-code eliminated if
they're not needed, but since they go in a struct field, I don't think
we can rely on that.

[1]: https://en.wikipedia.org/wiki/Reference_designator
[^2]: For example, in `drv_gimlet_seq_server::vcore`, we are interacting
    exclusively with the RAA229618 regulator on the VDD_VCORE rail,
    which we know has refdes `U350` on Gimlet.