### PR TITLE
lpc55xpresso: Add `dice-mfg` feature

### DIFF
--- a/app/lpc55xpresso/Cargo.toml
+++ b/app/lpc55xpresso/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [features]
 dump = ["kern/dump"]
+dice-mfg= ["lpc55-rot-startup/dice-mfg"]
 dice-self = ["lpc55-rot-startup/dice-self"]
 locked = ["lpc55-rot-startup/locked"]
 


### PR DESCRIPTION
This is useful for testing our mfg tools on an lpc55xpresso board