### PR TITLE
Update to enable stable toolchain

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
 
-[build]
-# The purpose of this flag is to block crates using version_detect from "detecting"
-# features that are no longer supported by the toolchain, because despite its name,
-# version_detect is basically "if nightly { return true; }". This setting gets
-# overridden within xtask for Hubris programs, so this only affects host tools like
-# xtask.
-rustflags = ["-Zallow-features=proc_macro_diagnostic,used_with_arg"]
-
 [unstable]
 bindeps = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,13 +21,14 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -963,7 +964,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "syn 1.0.94",
 ]
 
@@ -1620,7 +1621,6 @@ dependencies = [
  "drv-lpc55-spi",
  "drv-lpc55-syscon-api",
  "drv-sp-ctrl-api",
- "endoscope",
  "endoscope-abi",
  "goblin",
  "idol",
@@ -3152,7 +3152,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "serde",
  "spin 0.9.4",
  "stable_deref_trait",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ordered-toml"
@@ -4562,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.13",
 ]
@@ -6928,6 +6928,7 @@ dependencies = [
  "regex",
  "ron",
  "rustc-demangle",
+ "rustc_version 0.4.1",
  "scroll",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 ]
 default-members = []
 resolver = "2"
+rust-version = "1.89.0"
 
 [profile.release]
 codegen-units = 1 # better optimizations
@@ -111,6 +112,7 @@ rangemap = { version = "1.3", default-features = false }
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode-perl"] }
 ron = { version = "0.8", default-features = false }
 rustc-demangle = { version = "0.1.24", default-features = false }
+rustc_version = { version = "0.4.1" }
 scroll = { version = "0.10", default-features = false }
 serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.4", default-features = false }

--- a/FAQ.mkdn
+++ b/FAQ.mkdn
@@ -129,28 +129,16 @@ try to keep things working on Mac and Illumos.
 
 ### What Rust toolchain versions do you support?
 
-Because of our reliance on nightly toolchain features, we support exactly one
-version of the toolchain -- the one listed in our `rust-toolchain.toml` file at
-the top of the repo.
+Hubris can be built using the stable toolchain (see [Cargo.toml](Cargo.toml) for
+the MSRV). This should suffice for development uses and production builds.
 
-### Why does Hubris require the nightly Rust toolchain?
+There is one feature that requires nightly: build-time task [stack overflow
+checking]. Using this check requires [emit-stack-sizes], for which there is
+no stable workaround or equivalent. In order to enable this check, pass the
+flag `+nightly-2025-07-20` to cargo (i.e. `cargo +nightly... xtask ...`).
 
-Mostly because we need some assembly language, and we'd like to write that in
-Rust functions instead of separate files, which means we need the unstable `asm`
-feature. To do context switching, specifically, we need to be able to write a
-function that contains _only_ assembly instructions without additional
-preamble/epilogue code. For this, we need the unstable `naked_fn` feature.
-
-At the time of this writing, portions of `asm` are on track to stabilizing, but
-unfortunately not the portions we use.
-
-Unfortunately, Hubris's use of the nightly toolchain more or less requires any
-applications of Hubris to also use the nightly toolchain.
-
-Just because we're on nightly doesn't mean we can use any unstable feature --
-we're trying hard _not_ to use any additional unstable features, in the hopes of
-eventually being able to use stable.
-
+[stack overflow checking]: https://github.com/oxidecomputer/hubris/pull/1890
+[emit-stack-sizes]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/emit-stack-sizes.html
 
 ## Hardware support
 

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }
 rustc-demangle = { workspace = true }
+rustc_version = { workspace = true }
 tlvc = { workspace = true }
 tlvc-text = { workspace = true }
 toml = { workspace = true }

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -797,20 +797,6 @@ impl BuildConfig<'_> {
             None => PathBuf::from("cargo"),
         });
 
-        let mut nightly_features = vec![];
-        // nightly features that we use:
-        nightly_features.extend(["emit_stack_sizes", "used_with_arg"]);
-        // nightly features that our dependencies use:
-        nightly_features.extend([
-            "backtrace",
-            "error_generic_member_access",
-            "proc_macro_span",
-            "proc_macro_span_shrink",
-            "provide_any",
-        ]);
-
-        cmd.arg(format!("-Zallow-features={}", nightly_features.join(",")));
-
         cmd.arg(subcommand);
         cmd.arg("-p").arg(&self.crate_name);
         for a in &self.args {

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -376,7 +376,7 @@ pub fn package(
     // build changed.
     for name in cfg.toml.tasks.keys() {
         // Magic for lpc55-swd to be able to include endoscope, until artifact
-        // dependencies are available on stable. See build_endoscope's commend for
+        // dependencies are available on stable. See build_endoscope's comment for
         // more.
         if cfg.toml.tasks[name.as_str()].name == "drv-lpc55-swd" {
             build_endoscope()?;

--- a/drv/lpc55-swd/Cargo.toml
+++ b/drv/lpc55-swd/Cargo.toml
@@ -30,7 +30,11 @@ build-lpc55pins = { path = "../../build/lpc55pins" }
 build-util = { path = "../../build/util" }
 call_rustfmt = { path = "../../build/call_rustfmt" }
 endoscope-abi = { path = "../../lib/endoscope-abi" }
-endoscope = { path = "../../lib/endoscope", artifact="bin:endoscope", target = "thumbv7em-none-eabihf", features = ["soc_stm32h753"]}
+# "artifact dependencies" (i.e. `artifact="bin:endoscope"` et al.) are not supported in stable. As
+# such, building endoscope is done directly by the `dist` xtask when building this crate. See the
+# `build_endoscope` function in `build/xtask/src/dist.rs`.
+# For more, see https://github.com/rust-lang/cargo/issues/9096
+# endoscope = { path = "../../lib/endoscope", artifact="bin:endoscope", target = "thumbv7em-none-eabihf", features = ["soc_stm32h753"]}
 goblin = { workspace = true }
 idol = { workspace = true }
 quote = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-07-20"
+channel = "stable"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "rustfmt" ]

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -17,7 +17,7 @@
 //! hard time moving values into registers r6, r7, and r11. Because (for better
 //! or worse) the syscall ABI uses these registers, we have to take extra steps.
 //!
-//! The `stub` function contains the actual `asm!` call sequence. It is `naked`,
+//! The `stub` function contains the actual `naked_asm!` call sequence. It is `naked`,
 //! meaning the compiler will *not* attempt to do any framepointer/basepointer
 //! nonsense, and we can thus reason about the assignment and availability of
 //! all registers.
@@ -1066,7 +1066,8 @@ unsafe extern "C" fn sys_panic_stub(_msg: *const u8, _len: usize) -> ! {
 
                 @ To the kernel!
                 svc #0
-                @ noreturn generates a udf to trap us if it returns.
+                @ if the handler ever returns, trap
+                udf 0xde
                 ",
                 sysnum = const Sysnum::Panic as u32,
             )
@@ -1085,7 +1086,8 @@ unsafe extern "C" fn sys_panic_stub(_msg: *const u8, _len: usize) -> ! {
 
                 @ To the kernel!
                 svc #0
-                @ noreturn generates a udf to trap us if it returns.
+                @ if the handler ever returns, trap
+                udf 0xde
                 ",
                 sysnum = const Sysnum::Panic as u32,
             )
@@ -1268,9 +1270,9 @@ pub unsafe extern "C" fn _start() -> ! {
                 @ a sym operand because it's a Rust func and may be mangled.
                 bl {main}
 
-                @ The noreturn option below will automatically generate an
-                @ undefined instruction trap past this point, should main
+                @ Add an undefined instruction to trap past this point, should main
                 @ return.
+                udf 0xde
                 ",
                 main = sym main,
             )
@@ -1325,9 +1327,9 @@ pub unsafe extern "C" fn _start() -> ! {
                 @ a sym operand because it's a Rust func and may be mangled.
                 bl {main}
 
-                @ The noreturn option below will automatically generate an
-                @ undefined instruction trap past this point, should main
+                @ Add an undefined instruction to trap past this point, should main
                 @ return.
+                udf 0xde
                 ",
                 main = sym main,
             )

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1349,7 +1349,6 @@ impl ServerImpl {
                             // space we have for our response, then statically
                             // guarantee we have sufficient space in `buf` for
                             // longest possible DTRACE_CONF blob.
-                            #[allow(dead_code)] // suppress warning in nightly
                             const SP_TO_HOST_FILL_DATA_LEN: usize =
                                 MIN_SP_TO_HOST_FILL_DATA_LEN
                                     + SpToHost::MAX_SIZE

--- a/test/test-suite/src/main.rs
+++ b/test/test-suite/src/main.rs
@@ -18,7 +18,6 @@
 //!
 //! The Idol server, `test-idol-server`, tests Idol-mediated IPC.  It must be
 //! included in the image with the name `idol`, but its ID is immaterial.
-#![feature(used_with_arg)]
 #![no_std]
 #![no_main]
 #![forbid(clippy::wildcard_imports)]
@@ -49,12 +48,12 @@ const BAD_ADDRESS: u32 = 0x0;
 
 /// Helper macro for building a list of functions with their names.
 /// We use the humility debug processing to get the name of each
-/// test case and the total number of tests. The #[used(linker)]
-/// is to ensure that this actually gets emitted as a symbol.
+/// test case and the total number of tests. The #[used] is to ensure
+/// that this actually gets emitted as a symbol.
 macro_rules! test_cases {
     ($($(#[$attr:meta])* $name:path,)*) => {
         #[no_mangle]
-        #[used(linker)]
+        #[used]
         static TESTS: &[(&str, &(dyn Fn() + Send + Sync))] = &[
             $(
                 $(#[$attr])*


### PR DESCRIPTION
# PR content

This commit makes a small number of updates necessary to adopt the stable toolchain:
* Sets the stable toolchain as the default by config. Invoking nightly will require using `+nightly-2025-07-20` per #2169.
* Removes references to nightly requirements in the FAQ, and adds a note about enabling stack size checking being the only thing that requires nightly.
* Removes code that passes the `-Z` flag to cargo to enable nightly features.
* Updates `#[naked]` and `asm!` usage to stable convention, which is `#[unsafe(naked)]` and `naked_asm!`. Any affected assembly sections are expected to diverge (which was previously handled by `options(noreturn)`) or end with a trap (in the case of `_start`).
* Replaces `used(linker)` with `used`, which is [equivalent].
* Adds a code path in the `dist` build task to build endoscope if the task being built has a name `drv_lpc55_swd`, upon which it depends. This is because [artifact dependencies] are not stable, but `lcp55-swd` depends on having the endoscope binary available to its build script.
* Gates stack size emission and check behind a `rustc_version` channel check. Passing `+nightly-2025-07-20` to `cargo` (when invoking xtask) will enable the check.

[equivalent]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/attrs/data_structures/enum.UsedBy.html
[artifact dependencies]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies

Fixes #1927 

# Open questions

* [ ] This PR implicitly declares a MSRV of 1.89.0, but no MSRV policy, which requires the input of the maintainers.
* [ ] Excepting the FAQ, the preferred nightly version is not actually encoded anywhere. You just have to kind of already know that `2025-07-20` is the blessed nightly version.
* [ ] I have not run this on production hardware.
* [ ] Checking task stack sizes is something that should be done in CI, but that requires tooling changes.