### PR TITLE
Rename task's name member to bin-crate

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -19,7 +19,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -39,7 +39,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "cosmo", "vlan", "vpd-mac"]
@@ -52,7 +52,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -75,7 +75,7 @@ pin = 2
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ notifications = ["spi-irq"]
 
 # XXX this is only used by cosmo_seq; could we merge it?
 [tasks.spi3_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi3", "h753"]
@@ -100,7 +100,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -120,7 +120,7 @@ notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 stacksize = 1040
 start = true
@@ -130,7 +130,7 @@ features = ["cosmo", "ereport"]
 
 [tasks.rng_driver]
 features = ["h753", "ereport"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -138,7 +138,7 @@ stacksize = 512
 task-slots = ["sys", "packrat"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["cosmo"]
 priority = 8
 max-sizes = {flash = 32768, ram = 8192 }
@@ -148,7 +148,7 @@ task-slots = ["i2c_driver", "sensor", "cosmo_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["cosmo"]
 priority = 8
 max-sizes = {flash = 65536, ram = 16384 }
@@ -158,7 +158,7 @@ task-slots = ["i2c_driver", "sensor", "cosmo_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot", "turbo"]
 priority = 7
 max-sizes = {flash = 32768, ram = 32768 }
@@ -167,7 +167,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.cosmo_seq]
-name = "drv-cosmo-seq-server"
+bin-crate = "drv-cosmo-seq-server"
 features = ["h753"]
 priority = 7
 max-sizes = {flash = 131072, ram = 16384 }
@@ -178,7 +178,7 @@ uses = ["mmio_sequencer", "mmio_info"]
 notifications = ["timer", "vcore"]
 
 [tasks.ignition_flash]
-name = "drv-ignition-flash"
+bin-crate = "drv-ignition-flash"
 priority = 7
 stacksize = 1200
 start = true
@@ -186,7 +186,7 @@ task-slots = ["sys", {spi_front = "spi3_driver"}, "spartan7_loader"]
 uses = ["mmio_sequencer"] # TODO make the mux a separate peripheral
 
 [tasks.spartan7_loader]
-name = "drv-spartan7-loader"
+bin-crate = "drv-spartan7-loader"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -205,7 +205,7 @@ fpga_image = "cosmo-a.bin"
 register_defs = "cosmo-regs-a.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -217,7 +217,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-cosmo-hf"
+bin-crate = "drv-cosmo-hf"
 priority = 6
 start = true
 uses = ["mmio_spi_nor"]
@@ -226,7 +226,7 @@ stacksize = 4000
 notifications = ["timer"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -237,14 +237,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "usart6", "baud_rate_3M", "hardware_flow_control", "vlan", "cosmo"]
 uses = ["usart6", "dbgmcu"]
 interrupts = {"usart6.irq" = "usart-irq"}
@@ -256,7 +256,7 @@ task-slots = ["sys", { cpu_seq = "cosmo_seq" }, "hf", "control_plane_agent", "ne
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -266,7 +266,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -276,7 +276,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 8
 stacksize = 7000
 start = true
@@ -310,7 +310,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -322,7 +322,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi5.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -330,7 +330,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -338,7 +338,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -347,7 +347,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -358,7 +358,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
 priority = 6
@@ -369,7 +369,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.spd]
-name = "task-cosmo-spd"
+bin-crate = "task-cosmo-spd"
 priority = 7
 max-sizes = {flash = 8192, ram = 4096 }
 start = true
@@ -378,7 +378,7 @@ task-slots = ["jefe", "spartan7_loader", "packrat", "sensor"]
 uses = ["mmio_dimms"]
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -390,7 +390,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 15
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/cosmo/dev.toml
+++ b/app/cosmo/dev.toml
@@ -4,7 +4,7 @@
 request_reset = ["udprpc"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -14,7 +14,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.fmc_demo]
-name = "drv-stm32h7-fmc-demo-server"
+bin-crate = "drv-stm32h7-fmc-demo-server"
 features = ["h753"]
 priority = 6
 start = true

--- a/app/demo-stm32f4-discovery/app-f3.toml
+++ b/app/demo-stm32f4-discovery/app-f3.toml
@@ -10,7 +10,7 @@ requires = {flash = 20000, ram = 3072}
 features = ["stm32f3"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -18,7 +18,7 @@ stacksize = 1536
 notifications = ["fault", "timer"]
 
 [tasks.rcc_driver]
-name = "drv-stm32fx-rcc"
+bin-crate = "drv-stm32fx-rcc"
 features = ["f3"]
 priority = 1
 max-sizes = {flash = 8192, ram = 1024}
@@ -26,7 +26,7 @@ uses = ["rcc"]
 start = true
 
 [tasks.usart_driver]
-name = "drv-stm32fx-usart"
+bin-crate = "drv-stm32fx-usart"
 features = ["stm32f3"]
 priority = 2
 max-sizes = {flash = 8192, ram = 1024}
@@ -37,7 +37,7 @@ interrupts = {"usart2.irq" = "usart-irq"}
 task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f3"]
 priority = 2
 max-sizes = {flash = 8192, ram = 1024}
@@ -47,7 +47,7 @@ task-slots = ["rcc_driver"]
 notifications = ["timer"]
 
 [tasks.ping]
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
@@ -56,7 +56,7 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -64,14 +64,14 @@ task-slots = ["user_leds"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 2048
 start = true
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/demo-stm32f4-discovery/app.toml
+++ b/app/demo-stm32f4-discovery/app.toml
@@ -10,7 +10,7 @@ requires = {flash = 20000, ram = 3072}
 features = ["stm32f4"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -18,7 +18,7 @@ stacksize = 1536
 notifications = ["fault", "timer"]
 
 [tasks.rcc_driver]
-name = "drv-stm32fx-rcc"
+bin-crate = "drv-stm32fx-rcc"
 features = ["f4"]
 priority = 1
 max-sizes = {flash = 8192, ram = 1024}
@@ -26,7 +26,7 @@ uses = ["rcc"]
 start = true
 
 [tasks.usart_driver]
-name = "drv-stm32fx-usart"
+bin-crate = "drv-stm32fx-usart"
 features = ["stm32f4"]
 priority = 2
 max-sizes = {flash = 8192, ram = 1024}
@@ -37,7 +37,7 @@ interrupts = {"usart2.irq" = "usart-irq"}
 task-slots = ["rcc_driver"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 max-sizes = {flash = 8192, ram = 1024}
@@ -47,7 +47,7 @@ task-slots = ["rcc_driver"]
 notifications = ["timer"]
 
 [tasks.ping]
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
@@ -56,7 +56,7 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -64,14 +64,14 @@ task-slots = ["user_leds"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 max-sizes = {flash = 16384, ram = 16384 }
 stacksize = 2048
 start = true
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -11,7 +11,7 @@ features = ["g031"]
 stacksize = 640
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -19,7 +19,7 @@ stacksize = 368
 notifications = ["fault", "timer"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio", "system_flash"]
@@ -29,7 +29,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 features = ["no-ipc-counters"]
 priority = 4
 max-sizes = {flash = 1024, ram = 256}
@@ -39,7 +39,7 @@ stacksize = 256
 notifications = ["timer"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0", "no-ipc-counters"]
 priority = 3
 max-sizes = {flash = 2048, ram = 256}
@@ -49,7 +49,7 @@ stacksize = 256
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -58,7 +58,7 @@ stacksize = 912
 features = ["stm32g0", "gpio", "micro", "send"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/demo-stm32g0-nucleo/app-g070-mini.toml
+++ b/app/demo-stm32g0-nucleo/app-g070-mini.toml
@@ -17,7 +17,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -25,7 +25,7 @@ stacksize = 352
 notifications = ["fault", "timer"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -12,7 +12,7 @@ features = ["g070"]
 stacksize = 640
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -20,7 +20,7 @@ stacksize = 352
 notifications = ["fault", "timer"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["g070", "no-ipc-counters"]
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
@@ -30,7 +30,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.usart_driver]
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g070", "no-ipc-counters"]
 priority = 2
 max-sizes = {flash = 4096, ram = 256}
@@ -42,7 +42,7 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0", "no-ipc-counters"]
 priority = 2
 max-sizes = {flash = 2048, ram = 256}
@@ -52,7 +52,7 @@ stacksize = 256
 notifications = ["timer"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 features = ["no-ipc-counters"]
 priority = 3
 max-sizes = {flash = 1024, ram = 256}
@@ -62,7 +62,7 @@ notifications = ["timer"]
 stacksize = 256
 
 [tasks.ping]
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart", "no-ipc-counters"]
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
@@ -71,14 +71,14 @@ start = true
 task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["no-ipc-counters"]
 priority = 3
 max-sizes = {flash = 8192, ram = 8192 }
 start = true
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -11,7 +11,7 @@ requires = {flash = 24736, ram = 5120}
 features = ["h743", "dump"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -25,7 +25,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h743", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -48,7 +48,7 @@ pin = 13
 owner = {name = "user_button", notification = "button"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h743"]
 priority = 2
@@ -68,7 +68,7 @@ notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spi_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi1", "h743"]
@@ -80,7 +80,7 @@ stacksize = 880
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4000
 priority = 2
 max-sizes = {flash = 65536, ram = 8192, sram1_mac = 32768}
@@ -93,7 +93,7 @@ interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}
 task-slots = ["sys", "jefe"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -103,7 +103,7 @@ notifications = ["timer"]
 config = { blink_at_start = [ "Led::Zero" ] }
 
 [tasks.user_button]
-name = "task-nucleo-user-button"
+bin-crate = "task-nucleo-user-button"
 priority = 3
 start = true
 task-slots = ["sys", "user_leds"]
@@ -111,7 +111,7 @@ notifications = ["button"]
 config = { led = 1, edge = "Edge::Rising" }
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -120,7 +120,7 @@ task-slots = ["net"]
 notifications = ["socket"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "i2c", "gpio", "spi", "turbo"]
 priority = 4
 max-sizes = {flash = 32768, ram = 65536 }
@@ -129,7 +129,7 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 6
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
@@ -138,14 +138,14 @@ start = true
 [tasks.rng_driver]
 features = ["h743"]
 priority = 3
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 stacksize = 512
 start = true
 task-slots = ["sys", "user_leds"]
 uses = ["rng"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 features = ["no-rot"]
 priority = 4
 max-sizes = {flash = 32768, ram = 2048 }

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -11,7 +11,7 @@ requires = {flash = 24736, ram = 5120}
 features = ["h753", "dump"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -25,7 +25,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -48,7 +48,7 @@ pin = 13
 owner = {name = "user_button", notification = "button"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -69,14 +69,14 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 2
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
 task-slots = []
 
 [tasks.spi_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi1", "h753"]
@@ -88,7 +88,7 @@ stacksize = 880
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4000
 priority = 2
 max-sizes = {flash = 131072, ram = 16384, sram1_mac = 32768}
@@ -101,7 +101,7 @@ interrupts = {"eth.irq" = "eth-irq", "tim16.irq" = "mdio-timer-irq"}
 task-slots = ["sys", "jefe"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -111,7 +111,7 @@ notifications = ["timer"]
 config = { blink_at_start = [ "Led::Zero" ] }
 
 [tasks.user_button]
-name = "task-nucleo-user-button"
+bin-crate = "task-nucleo-user-button"
 priority = 3
 start = true
 task-slots = ["sys", "user_leds"]
@@ -119,7 +119,7 @@ notifications = ["button"]
 config = { led = 1, edge = "Edge::Rising" }
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -128,7 +128,7 @@ task-slots = ["net"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 3
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -137,7 +137,7 @@ task-slots = ["net", "packrat"]
 notifications = ["socket"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -146,7 +146,7 @@ task-slots = ["net"]
 notifications = ["socket"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 65536 }
@@ -155,7 +155,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 
 [tasks.hf]
-name = "drv-mock-gimlet-hf-server"
+bin-crate = "drv-mock-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
 max-sizes = {flash = 16384, ram = 4096 }
@@ -167,7 +167,7 @@ interrupts = {"quadspi.irq" = "qspi-irq"}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ interrupts = {"hash.irq" = "hash-irq"}
 task-slots = ["sys"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
@@ -188,14 +188,14 @@ start = true
 [tasks.rng_driver]
 features = ["h753"]
 priority = 3
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 stacksize = 512
 start = true
 task-slots = ["sys", "user_leds"]
 uses = ["rng"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 features = ["no-rot"]
 priority = 4
 max-sizes = {flash = 32768, ram = 2048 }

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -11,7 +11,7 @@ features = ["g031"]
 stacksize = 936
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -19,7 +19,7 @@ stacksize = 368
 notifications = ["fault", "timer"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio", "system_flash"]
@@ -29,7 +29,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
 uses = ["i2c1"]
@@ -42,7 +42,7 @@ notifications = ["i2c1-irq"]
 "i2c1.irq" = "i2c1-irq"
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 4
 max-sizes = {flash = 16384, ram = 4096}
 start = true
@@ -51,7 +51,7 @@ stacksize = 912
 features = ["stm32g0", "g031", "i2c", "gpio", "send", "no-ipc-counters"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -11,7 +11,7 @@ features = ["g031"]
 stacksize = 936
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -20,7 +20,7 @@ notifications = ["fault", "timer"]
 features = ["no-panic", "nano"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio", "system_flash"]
@@ -30,7 +30,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["g031", "no-ipc-counters"]
 priority = 2
 uses = ["i2c1"]
@@ -43,7 +43,7 @@ notifications = ["i2c1-irq"]
 "i2c1.irq" = "i2c1-irq"
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -52,7 +52,7 @@ stacksize = 800
 features = ["g031"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -61,7 +61,7 @@ stacksize = 800
 features = ["g031", "tmp117-eeprom", "no-ipc-counters"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -70,7 +70,7 @@ stacksize = 912
 features = ["stm32g0", "g031", "gpio", "micro", "send"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -10,7 +10,7 @@ name = "gemini-bu"
 requires = {flash = 32768, ram = 8192}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -22,7 +22,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti"]
 priority = 1
 max-sizes = {flash = 4096, ram = 2048}
@@ -46,7 +46,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -64,7 +64,7 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 features = ["h753", "spi2"]
@@ -76,7 +76,7 @@ stacksize = 880
 task-slots = ["sys"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 5
 max-sizes = {flash = 2048, ram = 1024}
@@ -85,7 +85,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 8
 max-sizes = {flash = 1024, ram = 1024}
 start = true
@@ -93,7 +93,7 @@ task-slots = ["user_leds"]
 notifications = ["timer"]
 
 [tasks.hf]
-name = "drv-mock-gimlet-hf-server"
+bin-crate = "drv-mock-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096 }
@@ -105,7 +105,7 @@ interrupts = {"quadspi.irq" = "qspi-irq"}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 5
 max-sizes = {flash = 16384, ram=4096 }
@@ -117,7 +117,7 @@ interrupts = {"hash.irq" = "hash-irq"}
 task-slots = ["sys"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 7
 max-sizes = {flash = 32768, ram = 16384 }
@@ -126,7 +126,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver", "sprot", "update_server"]
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 5
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 4096
@@ -138,7 +138,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 max-sizes = {flash = 8192, ram = 4096 }
 stacksize = 1000 
@@ -146,7 +146,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
@@ -154,7 +154,7 @@ start = true
 
 [tasks.rng_driver]
 features = ["h753"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -162,7 +162,7 @@ stacksize = 512
 task-slots = ["sys", "user_leds"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -15,7 +15,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -35,7 +35,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -48,7 +48,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -77,7 +77,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -89,7 +89,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -107,7 +107,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-gimlet-spd"
+bin-crate = "task-gimlet-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -121,7 +121,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 stacksize = 1040
 start = true
@@ -130,7 +130,7 @@ task-slots = []
 features = ["gimlet", "ereport"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -150,7 +150,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -159,7 +159,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -174,7 +174,7 @@ fpga_image = "fpga.bin"
 register_defs = "gimlet-regs.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -184,7 +184,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -197,7 +197,7 @@ notifications = ["hash-irq"]
 
 [tasks.rng_driver]
 features = ["h753", "ereport"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -205,7 +205,7 @@ stacksize = 512
 task-slots = ["sys", "packrat"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 32768, ram = 4096 }
@@ -217,7 +217,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq", "timer"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -228,14 +228,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -247,7 +247,7 @@ task-slots = ["sys", { cpu_seq = "gimlet_seq" }, "hf", "control_plane_agent", "n
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -257,7 +257,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -267,7 +267,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 stacksize = 7000
 start = true
@@ -299,7 +299,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -311,7 +311,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -319,7 +319,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -327,7 +327,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -336,7 +336,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -347,7 +347,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
 priority = 6
@@ -358,7 +358,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -366,7 +366,7 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/gimlet/dev.toml
+++ b/app/gimlet/dev.toml
@@ -4,7 +4,7 @@
 request_reset = ["udprpc"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/app/gimletlet/app-ereportlet.toml
+++ b/app/gimletlet/app-ereportlet.toml
@@ -24,7 +24,7 @@ features = ["h753", "stm32h7", "i2c", "gpio", "spi"]
 task-slots = ["sys", "i2c_driver", "user_leds", "ereportulator"]
 
 [tasks.ereportulator]
-name = "task-ereportulator"
+bin-crate = "task-ereportulator"
 priority = 5
 start = true
 task-slots = ["packrat"]

--- a/app/gimletlet/app-meanwell.toml
+++ b/app/gimletlet/app-meanwell.toml
@@ -9,7 +9,7 @@ task-slots = ["sys", "user_leds"]
 request_reset = ["hiffy"]
 
 [tasks.meanwell]
-name = "drv-meanwell"
+bin-crate = "drv-meanwell"
 features = ["stm32h7"]
 priority = 6
 max-sizes = {flash = 2048, ram = 1024}

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -10,7 +10,7 @@ name = "gimletlet"
 requires = {flash = 32768, ram = 4096}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -22,7 +22,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 2048}
@@ -31,7 +31,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 start = true
@@ -39,7 +39,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "gpio", "spi"]
 priority = 3
 max-sizes = {flash = 32768, ram = 65536 }
@@ -48,7 +48,7 @@ start = true
 task-slots = ["sys", "user_leds"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 3328
 priority = 3
 features = ["mgmt", "h753", "use-spi-core", "spi2"]
@@ -65,7 +65,7 @@ task-slots = ["sys", "user_leds", "jefe"]
 "spi2.irq" = "spi-irq"
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -74,7 +74,7 @@ task-slots = ["net"]
 notifications = ["socket"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/gimletlet/app-sidecar-emulator.toml
+++ b/app/gimletlet/app-sidecar-emulator.toml
@@ -9,7 +9,7 @@ features = ["h753", "stm32h7", "i2c", "gpio", "spi"]
 task-slots = ["sys", "i2c_driver", "user_leds"]
 
 [tasks.fpga]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 2048
@@ -37,7 +37,7 @@ notifications = ["spi-irq"]
 #task-slots = ["sys", {i2c_driver = "i2c_emulator"}, "fpga", "spi_driver"]
 
 [tasks.ignition]
-name = "drv-ignition-server"
+bin-crate = "drv-ignition-server"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -41,7 +41,7 @@ pin = 0
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -50,7 +50,7 @@ stacksize = 1040
 features = ["ereport"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 stacksize = 6256
 start = true
@@ -74,14 +74,14 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 5
 max-sizes = {flash = 16384, ram = 2048 }
 stacksize = 1024
 start = true
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -92,14 +92,14 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.gimlet_seq]
-name = "drv-mock-gimlet-seq-server"
+bin-crate = "drv-mock-gimlet-seq-server"
 priority = 2
 max-sizes = {flash = 2048, ram = 2048 }
 start = true
 task-slots = ["jefe"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["gimlet", "stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -116,7 +116,7 @@ notifications = [
 ]
 
 [tasks.hf]
-name = "drv-mock-gimlet-hf-server"
+bin-crate = "drv-mock-gimlet-hf-server"
 features = ["h753"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096}
@@ -128,7 +128,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -140,7 +140,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 3
 features = ["h753", "vlan", "gimletlet-nic", "use-spi-core", "spi4"]
@@ -157,7 +157,7 @@ notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 "spi4.irq" = "spi-irq"
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -167,7 +167,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -177,7 +177,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -187,7 +187,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
 priority = 4
@@ -259,7 +259,7 @@ tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 35 }
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 5
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -286,7 +286,7 @@ power = { rails = [ "LM5066_EVL_VOUT" ] }
 sensors = { voltage = 1, current = 1, temperature = 1 }
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
 stacksize = 3800

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -12,7 +12,7 @@ name = "gimletlet"
 requires = {flash = 32768, ram = 8192}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -23,7 +23,7 @@ notifications = ["fault", "timer"]
 set_reset_reason = ["sys"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 4096, ram = 2048}
@@ -32,7 +32,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -51,7 +51,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 5
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 8
 max-sizes = {flash = 1024, ram = 1024}
 start = true
@@ -68,7 +68,7 @@ task-slots = ["user_leds"]
 notifications = ["timer"]
 
 [tasks.uartecho]
-name = "task-uartecho"
+bin-crate = "task-uartecho"
 features = ["stm32h753", "usart2", "baud_rate_3M", "hardware_flow_control"]
 uses = ["usart2"]
 notifications = ["usart-irq"]
@@ -80,7 +80,7 @@ start = true
 task-slots = ["sys"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["turbo"]
 priority = 7
 max-sizes = {flash = 32768, ram = 65536}
@@ -88,7 +88,7 @@ stacksize = 2048
 start = true
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 stacksize = 1024
@@ -96,7 +96,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
@@ -104,7 +104,7 @@ start = true
 
 [tasks.rng_driver]
 features = ["h753"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -112,7 +112,7 @@ stacksize = 512
 task-slots = ["sys", "user_leds"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048

--- a/app/grapefruit/app-dev.toml
+++ b/app/grapefruit/app-dev.toml
@@ -13,7 +13,7 @@ stacksize = 1040
 features = ["ereport"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 priority = 4
 stacksize = 1200
 start = true
@@ -23,7 +23,7 @@ notifications = ["socket"]
 
 [tasks.rng_driver]
 features = ["h753", "ereport"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -32,7 +32,7 @@ task-slots = ["sys", "packrat"]
 
 # Demo/test task for ereports
 [tasks.ereportulator]
-name = "task-ereportulator"
+bin-crate = "task-ereportulator"
 priority = 6
 start = true
 task-slots = ["packrat"]

--- a/app/grapefruit/app-ruby.toml
+++ b/app/grapefruit/app-ruby.toml
@@ -9,7 +9,7 @@ uses = ["usart6"]
 interrupts = {"usart6.irq" = "usart-irq"}
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["grapefruit"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -24,7 +24,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -39,7 +39,7 @@ set_state = ["grapefruit_seq"]
 request_reset = ["hiffy", "udprpc", "control_plane_agent"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 # Enable EXTI in the sys task so that we can notify sprot when the RoT
 # raises an IRQ.
 features = ["h753", "exti"]
@@ -65,7 +65,7 @@ pin = 2
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -77,7 +77,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -98,7 +98,7 @@ notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 5
 max-sizes = {flash = 2048, ram = 1024}
@@ -107,7 +107,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -115,7 +115,7 @@ task-slots = []
 features = ["grapefruit", "boot-kmdb"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 7
 max-sizes = {flash = 32768, ram = 65536}
 stacksize = 2048
@@ -124,7 +124,7 @@ features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "qspi", "hash", "turbo"]
 task-slots = ["i2c_driver", "sys", "user_leds", "sprot", "hf", "hash_driver"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 stacksize = 1024
@@ -132,7 +132,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -144,14 +144,14 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -162,7 +162,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 5
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -174,7 +174,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.grapefruit_seq]
-name = "drv-grapefruit-seq-server"
+bin-crate = "drv-grapefruit-seq-server"
 features = ["h753"]
 priority = 5
 max-sizes = {flash = 131072, ram = 16384 }
@@ -184,7 +184,7 @@ task-slots = ["sys", "jefe", "packrat", "spartan7_loader"]
 uses = ["mmio_sgpio"]
 
 [tasks.spartan7_loader]
-name = "drv-spartan7-loader"
+bin-crate = "drv-spartan7-loader"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -199,7 +199,7 @@ config_done = "sys_api::Port::B.pin(4)"
 user_reset_l = "sys_api::Port::I.pin(15)"
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -210,7 +210,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
@@ -219,7 +219,7 @@ start = true
 # Note that host_sp_comms does not specify a UART!  It must be fully specified
 # with features + uses + interrupts by manifests inheriting from this file.
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "baud_rate_3M", "vlan", "grapefruit"]
 uses = ["dbgmcu"]
 priority = 8
@@ -230,7 +230,7 @@ task-slots = ["sys", "hf", "packrat", "control_plane_agent", "net",  { cpu_seq =
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 stacksize = 7000
 start = true
@@ -262,7 +262,7 @@ interrupts = {"usart1.irq" = "usart-irq"}
 
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -274,7 +274,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 3
 features = ["h753", "vlan", "grapefruit"]
@@ -290,7 +290,7 @@ notifications = ["eth-irq", "mdio-timer-irq", "spi-irq", "wake-timer"]
 "tim16.irq" = "mdio-timer-irq"
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -300,7 +300,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -310,7 +310,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -320,7 +320,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.fmc_demo]
-name = "drv-stm32h7-fmc-demo-server"
+bin-crate = "drv-stm32h7-fmc-demo-server"
 features = ["h753"]
 priority = 4
 start = true
@@ -329,7 +329,7 @@ uses = ["mmio_base", "mmio_spi_nor", "mmio_espi", "mmio_sgpio"]
 notifications = ["socket"]
 
 [tasks.hf]
-name = "drv-cosmo-hf"
+bin-crate = "drv-cosmo-hf"
 priority = 5
 start = true
 uses = ["mmio_base", "mmio_spi_nor"]

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -16,7 +16,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -29,7 +29,7 @@ extern-regions = ["sram2"]
 request_reset = ["update_server"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 5
 features = ["lpc55", "gpio"]
 max-sizes = {flash = 32768, ram = 16384 }
@@ -38,14 +38,14 @@ start = true
 task-slots = ["gpio_driver", "update_server"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 256, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.update_server]
-name = "lpc55-update-server"
+bin-crate = "lpc55-update-server"
 priority = 3
 max-sizes = {flash = 26720, ram = 16704}
 stacksize = 8192
@@ -57,7 +57,7 @@ interrupts = {"flash_controller.irq" = "flash-irq", "hash_crypt.irq" = "hashcryp
 task-slots = [{"syscon" = "syscon_driver"}, "jefe"]
 
 [tasks.syscon_driver]
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -66,7 +66,7 @@ stacksize = 1000
 task-slots = ["jefe"]
 
 [tasks.gpio_driver]
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon", "pint", "inputmux"]
@@ -75,7 +75,7 @@ stacksize = 1000
 task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048}
@@ -85,7 +85,7 @@ task-slots = ["gpio_driver"]
 notifications = ["timer"]
 
 [tasks.usart_driver]
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
@@ -102,7 +102,7 @@ pins = [
 ]
 
 [tasks.i2c_driver]
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 4
 uses = ["flexcomm4"]
 start = true
@@ -110,7 +110,7 @@ stacksize = 1000
 task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
@@ -119,7 +119,7 @@ stacksize = 2216
 task-slots = ["syscon_driver"]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 5
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -128,7 +128,7 @@ notifications = ["timer"]
 task-slots = ["user_leds"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 features = ["no-rot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 2272 }
@@ -138,7 +138,7 @@ stacksize = 1536
 extern-regions = ["sram2"]
 
 [tasks.attest]
-name = "task-attest"
+bin-crate = "task-attest"
 priority = 5
 max-sizes = {flash = 35072, ram = 16384}
 stacksize = 12304

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -9,7 +9,7 @@ name = "medusa"
 requires = {flash = 24600, ram = 6256}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -22,7 +22,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash"]
@@ -30,7 +30,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -45,7 +45,7 @@ region = "flash"
 size = 256
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 7
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 2048
@@ -54,7 +54,7 @@ task-slots = ["sys", "i2c_driver"]
 features = ["turbo"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
@@ -74,7 +74,7 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.ecp5_front_io]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["front_io", "use-spi-core", "h753", "spi1"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -86,7 +86,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi1.irq" = "spi-irq"}
 
 [tasks.monorail]
-name = "task-monorail-server"
+bin-crate = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 8192}
 features = ["mgmt", "medusa", "vlan", "use-spi-core", "h753", "spi2"]
@@ -98,7 +98,7 @@ notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "medusa", "vlan", "vpd-mac", "use-spi-core", "spi3"]
@@ -115,7 +115,7 @@ task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 "spi3.irq" = "spi-irq"
 
 [tasks.sequencer]
-name = "drv-medusa-seq-server"
+bin-crate = "drv-medusa-seq-server"
 priority = 4
 stacksize = 4096
 start = true
@@ -128,7 +128,7 @@ task-slots = [
 notifications = ["timer"]
 
 [tasks.transceivers]
-name = "drv-transceivers-server"
+bin-crate = "drv-transceivers-server"
 features = ["vlan"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
@@ -144,7 +144,7 @@ task-slots = [
 notifications = ["socket", "timer"]
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -152,7 +152,7 @@ start = true
 task-slots = []
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -160,7 +160,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 stacksize = 1024
@@ -168,7 +168,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -176,14 +176,14 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -195,7 +195,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -205,7 +205,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096

--- a/app/minibar/app-net.toml
+++ b/app/minibar/app-net.toml
@@ -17,7 +17,7 @@ extern-regions = ["sram1", "sram2", "sram3", "sram4"]
 features = ["mgmt"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 10000
 priority = 5
 features = ["mgmt", "h753", "minibar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
@@ -34,7 +34,7 @@ task-slots = ["sys", "packrat", "jefe"]
 "spi3.irq" = "spi-irq"
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -44,7 +44,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true

--- a/app/minibar/app.toml
+++ b/app/minibar/app.toml
@@ -11,7 +11,7 @@ name = "minibar"
 requires = {flash = 26656, ram = 6256}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -23,7 +23,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy"]
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -31,7 +31,7 @@ start = true
 task-slots = []
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -43,7 +43,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 max-sizes = {flash = 4096, ram = 2048}
@@ -67,7 +67,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.monorail]
-name = "task-monorail-server"
+bin-crate = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 16384}
 features = ["minibar", "vlan", "use-spi-core", "h753", "spi2"]
@@ -79,7 +79,7 @@ notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -99,7 +99,7 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -108,7 +108,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["minibar"]
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
@@ -118,7 +118,7 @@ task-slots = ["i2c_driver", "sensor"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["sidecar"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ task-slots = ["i2c_driver", "sensor"]
 notifications = ["timer"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
@@ -136,7 +136,7 @@ stacksize = 1024
 start = true
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -144,7 +144,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -152,14 +152,14 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -171,7 +171,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.ecp5]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["use-spi-core", "h753", "spi5"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -183,7 +183,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi5.irq" = "spi-irq"}
 
 [tasks.sequencer]
-name = "drv-minibar-seq-server"
+bin-crate = "drv-minibar-seq-server"
 priority = 4
 stacksize = 4096
 start = true
@@ -196,7 +196,7 @@ task-slots = [
 notifications = ["timer"]
 
 [tasks.ignition]
-name = "drv-minibar-ignition-server"
+bin-crate = "drv-minibar-ignition-server"
 priority = 5
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048

--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -10,7 +10,7 @@ requires = {flash = 11680, ram = 1296}
 stacksize = 640
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -19,7 +19,7 @@ stacksize = 368
 notifications = ["fault", "timer"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio", "system_flash"]
@@ -29,7 +29,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0", "no-ipc-counters"]
 priority = 3
 max-sizes = {flash = 2048, ram = 256}
@@ -40,7 +40,7 @@ notifications = ["timer"]
 config = { blink_at_start = [ "Led::Zero" ] }
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 4
 max-sizes = {flash = 8192, ram = 4096}
 start = true
@@ -49,7 +49,7 @@ stacksize = 912
 features = ["stm32g0", "gpio", "i2c", "g030", "micro"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["g030", "no-ipc-counters"]
 priority = 2
 uses = ["i2c1"]
@@ -62,7 +62,7 @@ notifications = ["i2c1-irq"]
 "i2c1.irq" = "i2c1-irq"
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -23,7 +23,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -34,7 +34,7 @@ notifications = ["fault", "timer"]
 request_reset = ["update_server"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 6
 features = ["lpc55", "gpio", "spctrl"]
 max-sizes = {flash = 32768, ram = 16384 }
@@ -43,14 +43,14 @@ start = true
 task-slots = ["gpio_driver", "swd", "update_server"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.update_server]
-name = "lpc55-update-server"
+bin-crate = "lpc55-update-server"
 priority = 3
 stacksize = 8192
 start = true
@@ -61,7 +61,7 @@ interrupts = {"flash_controller.irq" = "flash-irq", "hash_crypt.irq" = "hashcryp
 task-slots = [{"syscon" = "syscon_driver"}, "jefe"]
 
 [tasks.syscon_driver]
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -69,7 +69,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.gpio_driver]
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon", "pint", "inputmux"]
@@ -77,7 +77,7 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.sprot]
-name = "drv-lpc55-sprot-server"
+bin-crate = "drv-lpc55-sprot-server"
 priority = 6
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0", "sp-ctrl"]
@@ -102,7 +102,7 @@ pins = [
 ]
 
 [tasks.swd]
-name = "drv-lpc55-swd"
+bin-crate = "drv-lpc55-swd"
 priority = 4
 uses = ["flexcomm5", "iocon"]
 start = true
@@ -138,7 +138,7 @@ pins = [
 spi_num = 5
 
 [tasks.dumper]
-name = "task-dumper"
+bin-crate = "task-dumper"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
@@ -146,7 +146,7 @@ stacksize = 2600
 task-slots = ["swd"]
 
 [tasks.attest]
-name = "task-attest"
+bin-crate = "task-attest"
 priority = 3
 max-sizes = {flash = 35400, ram = 16384}
 stacksize = 12304

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -20,7 +20,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -31,14 +31,14 @@ notifications = ["fault", "timer"]
 request_reset = ["update_server"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.update_server]
-name = "lpc55-update-server"
+bin-crate = "lpc55-update-server"
 priority = 3
 stacksize = 8192
 start = true
@@ -49,7 +49,7 @@ interrupts = {"flash_controller.irq" = "flash-irq", "hash_crypt.irq" = "hashcryp
 task-slots = [{"syscon" = "syscon_driver"}, "jefe"]
 
 [tasks.syscon_driver]
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -57,7 +57,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.gpio_driver]
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon", "pint", "inputmux"]
@@ -65,7 +65,7 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.sprot]
-name = "drv-lpc55-sprot-server"
+bin-crate = "drv-lpc55-sprot-server"
 priority = 6
 uses = ["flexcomm8", "bootrom"]
 features = ["spi0", "sp-ctrl"]
@@ -90,7 +90,7 @@ pins = [
 ]
 
 [tasks.swd]
-name = "drv-lpc55-swd"
+bin-crate = "drv-lpc55-swd"
 priority = 4
 uses = ["flexcomm5", "iocon"]
 start = true
@@ -125,7 +125,7 @@ pins = [
 spi_num = 5
 
 [tasks.dumper]
-name = "task-dumper"
+bin-crate = "task-dumper"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
@@ -133,7 +133,7 @@ stacksize = 2600
 task-slots = ["swd"]
 
 [tasks.attest]
-name = "task-attest"
+bin-crate = "task-attest"
 priority = 3
 max-sizes = {flash = 35400, ram = 16384}
 stacksize = 12304

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -15,7 +15,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -32,7 +32,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 max-sizes = {flash = 4096, ram = 2048}
@@ -92,7 +92,7 @@ owner = {name = "sequencer", notification = "psu_pwr_ok_6"}
 
 [tasks.rng_driver]
 features = ["h753", "ereport"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -100,7 +100,7 @@ stacksize = 512
 task-slots = ["sys", "packrat"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -116,7 +116,7 @@ notifications = ["i2c2-irq", "i2c3-irq"]
 "i2c3.error" = "i2c3-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 stacksize = 1040
 start = true
@@ -125,7 +125,7 @@ task-slots = []
 features = ["ereport"]
 
 [tasks.sequencer]
-name = "drv-psc-seq-server"
+bin-crate = "drv-psc-seq-server"
 priority = 4
 stacksize = 4096
 start = true
@@ -141,7 +141,7 @@ notifications = [
 ]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -152,7 +152,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768}
@@ -161,7 +161,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -169,7 +169,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 4
 features = ["mgmt", "h753", "psc", "vlan", "vpd-mac", "spi2"]
@@ -190,7 +190,7 @@ task-slots = ["sys", "packrat", "jefe", {spi_driver = "spi2_driver"}]
 "tim16.irq" = "mdio-timer-irq"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 features = ["spi2", "h753"]
 uses = ["spi2"]
@@ -201,7 +201,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 stacksize = 7000
 start = true
@@ -224,7 +224,7 @@ notifications = ["usart-irq", "socket", "timer"]
 # usart-irq is unused but present in the code
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 3
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -236,7 +236,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 5
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -246,7 +246,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 5
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -256,7 +256,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.eeprom]
-name = "drv-eeprom"
+bin-crate = "drv-eeprom"
 priority = 3
 max-sizes = {flash = 2048, ram = 256}
 stacksize = 256
@@ -264,7 +264,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -272,7 +272,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -281,7 +281,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 priority = 4
 max-sizes = {flash = 32768, ram = 4096}
 stacksize = 2504
@@ -291,28 +291,28 @@ features = ["psc"]
 notifications = ["timer"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 3
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.sensor_polling]
-name = "task-sensor-polling"
+bin-crate = "task-sensor-polling"
 priority = 4
 max-sizes = {flash = 16384, ram = 2048 }
 start = true
 task-slots = ["i2c_driver", "sensor"]
 
 [tasks.psu_update]
-name = "drv-psc-psu-update"
+bin-crate = "drv-psc-psu-update"
 priority = 4
 max-sizes = {flash = 65536, ram = 8192 }
 start = true
 task-slots = ["i2c_driver"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -323,7 +323,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
 priority = 5
@@ -334,7 +334,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/psc/dev.toml
+++ b/app/psc/dev.toml
@@ -4,7 +4,7 @@
 request_reset = ["udprpc"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 5
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/app/psc/rev-c-dev.toml
+++ b/app/psc/rev-c-dev.toml
@@ -2,7 +2,7 @@ name = "psc-c-dev"
 inherit = ["rev-c.toml", "dev.toml"]
 
 [tasks.framulator]
-name = "task-framulator"
+bin-crate = "task-framulator"
 priority = 5
 start = true
 task-slots = [{spi_driver = "spi2_driver"}]

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -19,7 +19,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -30,14 +30,14 @@ notifications = ["fault", "timer"]
 request_reset = ["update_server"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.update_server]
-name = "lpc55-update-server"
+bin-crate = "lpc55-update-server"
 priority = 3
 # TODO size this appropriately
 stacksize = 8192
@@ -49,7 +49,7 @@ interrupts = {"flash_controller.irq" = "flash-irq", "hash_crypt.irq" = "hashcryp
 task-slots = [{"syscon" = "syscon_driver"}, "jefe"]
 
 [tasks.syscon_driver]
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -57,7 +57,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.gpio_driver]
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon", "pint", "inputmux"]
@@ -65,7 +65,7 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 6
 max-sizes = {flash = 8192, ram = 1120}
@@ -74,7 +74,7 @@ task-slots = ["gpio_driver"]
 notifications = ["timer"]
 
 [tasks.usart_driver]
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 5
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
@@ -90,7 +90,7 @@ pins = [
 ]
 
 [tasks.rng_driver]
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["rng", "pmc"]
@@ -99,7 +99,7 @@ stacksize = 2216
 task-slots = ["syscon_driver"]
 
 [tasks.sprot]
-name = "drv-lpc55-sprot-server"
+bin-crate = "drv-lpc55-sprot-server"
 priority = 6
 max-sizes = {flash = 54000, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
@@ -127,7 +127,7 @@ pins = [
 ]
 
 [tasks.pong]
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 7
 max-sizes = {flash = 8192, ram = 1056}
 start = true
@@ -135,7 +135,7 @@ task-slots = ["user_leds"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 6
 features = ["lpc55", "gpio", "spi"]
 max-sizes = {flash = 32768, ram = 16384 }
@@ -144,7 +144,7 @@ start = true
 task-slots = ["gpio_driver", "update_server"]
 
 [tasks.attest]
-name = "task-attest"
+bin-crate = "task-attest"
 priority = 5
 max-sizes = {flash = 35072, ram = 16384}
 stacksize = 12304

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -15,7 +15,7 @@ region = "flash"
 size = 256
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -29,7 +29,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 max-sizes = {flash = 4096, ram = 2048}
@@ -54,7 +54,7 @@ owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.rng_driver]
 features = ["h753"]
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
@@ -62,7 +62,7 @@ stacksize = 512
 task-slots = ["sys"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -73,7 +73,7 @@ notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -85,7 +85,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 10000
 priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
@@ -102,7 +102,7 @@ task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 "spi3.irq" = "spi-irq"
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 # This is a big number -- do we need to tune this?
 stacksize = 12000
@@ -133,7 +133,7 @@ notifications = ["socket", "usart-irq", "timer"]
 authorized-keys = "../../support/support_tokens/authorized_keys"
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -145,7 +145,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -155,7 +155,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -165,7 +165,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.monorail]
-name = "task-monorail-server"
+bin-crate = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 16384}
 features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753", "spi2"]
@@ -177,7 +177,7 @@ notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
@@ -197,7 +197,7 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "sprot", "turbo"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -206,7 +206,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
@@ -214,7 +214,7 @@ stacksize = 1024
 start = true
 
 [tasks.ecp5_mainboard]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["mainboard", "use-spi-core", "h753", "spi5"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -226,7 +226,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi5.irq" = "spi-irq"}
 
 [tasks.ecp5_front_io]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["front_io", "use-spi-core", "h753", "spi1"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -238,7 +238,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi1.irq" = "spi-irq"}
 
 [tasks.transceivers]
-name = "drv-transceivers-server"
+bin-crate = "drv-transceivers-server"
 features = ["vlan", "thermal-control"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
@@ -255,7 +255,7 @@ task-slots = [
 notifications = ["socket", "timer"]
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 stacksize = 1040
 start = true
@@ -264,7 +264,7 @@ task-slots = []
 features = ["ereport"]
 
 [tasks.sequencer]
-name = "drv-sidecar-seq-server"
+bin-crate = "drv-sidecar-seq-server"
 priority = 4
 stacksize = 4096
 start = true
@@ -278,7 +278,7 @@ task-slots = [
 notifications = ["timer"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["sidecar"]
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
@@ -288,7 +288,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["sidecar"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -298,7 +298,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 notifications = ["timer"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -306,7 +306,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.ignition]
-name = "drv-ignition-server"
+bin-crate = "drv-ignition-server"
 features = ["sequencer"]
 priority = 5
 max-sizes = {flash = 16384, ram = 8192}
@@ -316,7 +316,7 @@ task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 notifications = ["timer"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -324,7 +324,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -335,7 +335,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.snitch]
-name = "task-snitch"
+bin-crate = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
 priority = 6
@@ -346,7 +346,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/app/sidecar/dev.toml
+++ b/app/sidecar/dev.toml
@@ -3,7 +3,7 @@
 request_reset = ["udprpc"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -313,7 +313,7 @@ pub fn build_notifications() -> Result<()> {
              overlapping with `INTERNAL_TIMER_NOTIFICATION`"
         );
     }
-    if full_task_config.name == "task-jefe"
+    if full_task_config.bin_crate == "task-jefe"
         && full_task_config.notifications.first().cloned()
             != Some("fault".to_string())
     {

--- a/build/xtask/src/clippy.rs
+++ b/build/xtask/src/clippy.rs
@@ -34,7 +34,7 @@ pub fn run(
             "kernel"
         } else {
             let task_toml = &toml.tasks[name];
-            task_toml.name.as_str()
+            task_toml.bin_crate.as_str()
         };
         if tasks.len() > 1 {
             if i > 0 {

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -58,8 +58,10 @@ pub struct MmioData {
     pub register_map: PathBuf,
 }
 
+/// Data structure of an app's `app.toml` file
 #[derive(Clone, Debug)]
 pub struct Config {
+    /// The name of the app, e.g. oxide-rot-1
     pub name: String,
     pub target: String,
     pub board: String,
@@ -73,6 +75,7 @@ pub struct Config {
     pub stacksize: Option<u32>,
     pub kernel: Kernel,
     pub outputs: IndexMap<String, Vec<Output>>,
+    /// Map of tasks, keyed by task name e.g. jefe
     pub tasks: IndexMap<String, Task>,
     pub peripherals: IndexMap<String, Peripheral>,
     pub extratext: IndexMap<String, Peripheral>,
@@ -407,7 +410,7 @@ impl Config {
             .ok_or_else(|| self.task_name_suggestion(task_name))?;
         let mut out = self.common_build_config(
             verbose,
-            &task_toml.name,
+            &task_toml.bin_crate,
             task_toml.no_default_features,
             &task_toml.features,
             sysroot,

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -224,7 +224,7 @@ pub fn list_tasks(app_toml: &Path) -> Result<()> {
     println!("  {:<pad$}  CRATE", "TASK", pad = pad);
     println!("  {:<pad$}  {}", "kernel", toml.kernel.name, pad = pad);
     for (name, task) in toml.tasks {
-        println!("  {:<pad$}  {}", name, task.name, pad = pad);
+        println!("  {:<pad$}  {}", name, task.bin_crate, pad = pad);
     }
     Ok(())
 }
@@ -980,7 +980,7 @@ fn build_archive(
                         let pkg = metadata
                             .packages
                             .iter()
-                            .find(|p| p.name == task.name)
+                            .find(|p| p.name == task.bin_crate)
                             .unwrap();
 
                         let dir = pkg.manifest_path.parent().unwrap();
@@ -1068,12 +1068,12 @@ fn check_rebuild(toml: &Config) -> Result<()> {
             // Well, consider our supervisor:
             //
             // [tasks.jefe]
-            // name = "task-jefe"
+            // bin_crate = "task-jefe"
             //
             // The "name" in the key is `jefe`, but the package (crate)
-            // name is in `tasks.jefe.name`, and that's what we need to
-            // give to `cargo`.
-            names.push(toml.tasks[name].name.as_str());
+            // name is in `tasks.jefe.bin_crate`, and that's what
+            // we need to give to `cargo`.
+            names.push(toml.tasks[name].bin_crate.as_str());
         }
         cargo_clean(&names, &toml.target)?;
     }
@@ -1519,7 +1519,7 @@ fn load_task_flash(
         if flash > *required as usize {
             bail!(
                 "{} has insufficient flash: specified {} bytes, needs {}",
-                task_toml.name,
+                task_toml.bin_crate,
                 required,
                 flash
             );

--- a/build/xtask/src/lsp.rs
+++ b/build/xtask/src/lsp.rs
@@ -230,7 +230,7 @@ fn check_task(
 
     // Check to see if our target package is used in this task (resolved based
     // on per-task features)
-    let dependencies = packages.resolve(&task.name, &task.features);
+    let dependencies = packages.resolve(&task.bin_crate, &task.features);
 
     // Congrats, we've found a task in the given image which uses our
     // desired crate.  Let's do some stuff with it.

--- a/lib/toml-task/src/lib.rs
+++ b/lib/toml-task/src/lib.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Task<T = ordered_toml::Value> {
-    pub name: String,
+    pub bin_crate: String,
     pub priority: u8,
     pub stacksize: Option<u32>,
     #[serde(default)]


### PR DESCRIPTION
This change renames the `name` member of the `Task` struct to `bin-crate` in order to make it more clear to new users that the value refers to an actual crate, and is not the name of the task (which is the key in the map).

(This is admittedly a very silly PR fixing an issue dating back to _2021_ but it did actually trip me up.)

Fixes #196