### PR TITLE
Use refdes-based component IDs in control-plane-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,6 +6069,7 @@ dependencies = [
 name = "task-validate-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "build-i2c",
  "counters",
  "derive-idol-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,6 +6074,7 @@ dependencies = [
  "counters",
  "derive-idol-err",
  "drv-i2c-api",
+ "gateway-messages",
  "hubpack",
  "idol",
  "idol-runtime",

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -519,7 +519,7 @@ description = "U.2 Sharkfin A hot swap controller"
 power = { rails = [ "V12_U2A_A0", "V3P3_U2A_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_a_hsc"
-refdes = ["J200", "U1A"]
+refdes = ["J200", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -556,7 +556,7 @@ description = "U.2 Sharkfin B hot swap controller"
 power = { rails = [ "V12_U2B_A0", "V3P3_U2B_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_b_hsc"
-refdes = ["J201", "U1A"]
+refdes = ["J201", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -593,7 +593,7 @@ description = "U.2 Sharkfin C hot swap controller"
 power = { rails = [ "V12_U2C_A0", "V3P3_U2C_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_c_hsc"
-refdes = ["J202", "U1A"]
+refdes = ["J202", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -630,7 +630,7 @@ description = "U.2 Sharkfin D hot swap controller"
 power = { rails = [ "V12_U2D_A0", "V3P3_U2D_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_d_hsc"
-refdes = ["J203", "U1A"]
+refdes = ["J203", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -667,7 +667,7 @@ description = "U.2 Sharkfin E hot swap controller"
 power = { rails = [ "V12_U2E_A0", "V3P3_U2E_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_e_hsc"
-refdes = ["J204", "U1A"]
+refdes = ["J204", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -704,7 +704,7 @@ description = "U.2 Sharkfin F hot swap controller"
 power = { rails = [ "V12_U2F_A0", "V3P3_U2F_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_f_hsc"
-refdes = ["J205", "U1A"]
+refdes = ["J205", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -744,7 +744,7 @@ description = "U.2 Sharkfin G hot swap controller"
 power = { rails = [ "V12_U2G_A0", "V3P3_U2G_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_g_hsc"
-refdes = ["J206", "U1A"]
+refdes = ["J206", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -783,7 +783,7 @@ description = "U.2 Sharkfin H hot swap controller"
 power = { rails = [ "V12_U2H_A0", "V3P3_U2H_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_h_hsc"
-refdes = ["J207", "U1A"]
+refdes = ["J207", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -820,7 +820,7 @@ description = "U.2 Sharkfin I hot swap controller"
 power = { rails = [ "V12_U2I_A0", "V3P3_U2I_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_i_hsc"
-refdes = ["J208", "U1A"]
+refdes = ["J208", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -857,7 +857,7 @@ description = "U.2 Sharkfin J hot swap controller"
 power = { rails = [ "V12_U2J_A0", "V3P3_U2J_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_j_hsc"
-refdes = ["J209", "U1A"]
+refdes = ["J209", "U1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -957,7 +957,7 @@ address = 0x3c
 device = "sbrmi"
 name = "RMI"
 description = "CPU via SB-RMI"
-refdes = ["U1U", "SBRMI"]
+refdes = ["U1", "SBRMI"]
 
 [[config.i2c.devices]]
 bus = "main"
@@ -968,7 +968,7 @@ device = "sbtsi"
 name = "CPU"
 description = "CPU temperature sensor"
 sensors = { temperature = 1 }
-refdes = ["U1U", "SBTSI"]
+refdes = ["U1", "SBTSI"]
 
 # Segment 5 is SEC_SP5_TO_FPGA1
 # Segment 6 is unused

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -500,8 +500,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin A VPD"
 name = "sharkfin_a_vpd"
-refdes = "J200"
-refdes-suffix = "U2"
+refdes = ["J200", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -514,8 +513,7 @@ description = "U.2 Sharkfin A hot swap controller"
 power = { rails = [ "V12_U2A_A0", "V3P3_U2A_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_a_hsc"
-refdes = "J200"
-refdes-suffix = "U1A"
+refdes = ["J200", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -527,8 +525,7 @@ device = "nvme_bmc"
 description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
-refdes = "J200"
-refdes-suffix = "J2"
+refdes = ["J200", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMB
@@ -540,8 +537,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin B VPD"
 name = "sharkfin_b_vpd"
-refdes = "J201"
-refdes-suffix = "U2"
+refdes = ["J201", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -554,8 +550,7 @@ description = "U.2 Sharkfin B hot swap controller"
 power = { rails = [ "V12_U2B_A0", "V3P3_U2B_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_b_hsc"
-refdes = "J201"
-refdes-suffix = "U1A"
+refdes = ["J201", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -567,8 +562,7 @@ device = "nvme_bmc"
 description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
-refdes = "J201"
-refdes-suffix = "J2"
+refdes = ["J201", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMC
@@ -580,8 +574,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin C VPD"
 name = "sharkfin_c_vpd"
-refdes = "J202"
-refdes-suffix = "U2"
+refdes = ["J202", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -594,8 +587,7 @@ description = "U.2 Sharkfin C hot swap controller"
 power = { rails = [ "V12_U2C_A0", "V3P3_U2C_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_c_hsc"
-refdes = "J202"
-refdes-suffix = "U1A"
+refdes = ["J202", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -607,8 +599,7 @@ device = "nvme_bmc"
 description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
-refdes = "J202"
-refdes-suffix = "J2"
+refdes = ["J202", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMD
@@ -620,8 +611,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin D VPD"
 name = "sharkfin_d_vpd"
-refdes = "J203"
-refdes-suffix = "U2"
+refdes = ["J203", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -634,8 +624,7 @@ description = "U.2 Sharkfin D hot swap controller"
 power = { rails = [ "V12_U2D_A0", "V3P3_U2D_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_d_hsc"
-refdes = "J203"
-refdes-suffix = "U1A"
+refdes = ["J203", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -647,8 +636,7 @@ device = "nvme_bmc"
 description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
-refdes = "J203"
-refdes-suffix = "J2"
+refdes = ["J203", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEME
@@ -660,8 +648,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin E VPD"
 name = "sharkfin_e_vpd"
-refdes = "J204"
-refdes-suffix = "U2"
+refdes = ["J204", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -674,8 +661,7 @@ description = "U.2 Sharkfin E hot swap controller"
 power = { rails = [ "V12_U2E_A0", "V3P3_U2E_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_e_hsc"
-refdes = "J204"
-refdes-suffix = "U1A"
+refdes = ["J204", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -687,8 +673,7 @@ device = "nvme_bmc"
 description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
-refdes = "J204"
-refdes-suffix = "J2"
+refdes = ["J204", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMF
@@ -700,8 +685,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin F VPD"
 name = "sharkfin_f_vpd"
-refdes = "J205"
-refdes-suffix = "U2"
+refdes = ["J205", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -714,8 +698,7 @@ description = "U.2 Sharkfin F hot swap controller"
 power = { rails = [ "V12_U2F_A0", "V3P3_U2F_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_f_hsc"
-refdes = "J205"
-refdes-suffix = "U1A"
+refdes = ["J205", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -727,8 +710,7 @@ device = "nvme_bmc"
 description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
-refdes = "J205"
-refdes-suffix = "J2"
+refdes = ["J205", "J2"]
 removable = true
 
 # Note that we skip segments 7 and 8, which are
@@ -743,8 +725,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin G VPD"
 name = "sharkfin_g_vpd"
-refdes = "J206"
-refdes-suffix = "U2"
+refdes = ["J206", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -757,8 +738,7 @@ description = "U.2 Sharkfin G hot swap controller"
 power = { rails = [ "V12_U2G_A0", "V3P3_U2G_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_g_hsc"
-refdes = "J206"
-refdes-suffix = "U1A"
+refdes = ["J206", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -770,8 +750,7 @@ device = "nvme_bmc"
 description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
-refdes = "J206"
-refdes-suffix = "J2"
+refdes = ["J206", "J2"]
 removable = true
 
 
@@ -785,8 +764,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin H VPD"
 name = "sharkfin_h_vpd"
-refdes = "J207"
-refdes-suffix = "U2"
+refdes = ["J207", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -799,8 +777,7 @@ description = "U.2 Sharkfin H hot swap controller"
 power = { rails = [ "V12_U2H_A0", "V3P3_U2H_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_h_hsc"
-refdes = "J207"
-refdes-suffix = "U1A"
+refdes = ["J207", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -812,8 +789,7 @@ device = "nvme_bmc"
 description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
-refdes = "J207"
-refdes-suffix = "J2"
+refdes = ["J207", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMI
@@ -825,8 +801,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin I VPD"
 name = "sharkfin_i_vpd"
-refdes = "J208"
-refdes-suffix = "U2"
+refdes = ["J208", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -839,8 +814,7 @@ description = "U.2 Sharkfin I hot swap controller"
 power = { rails = [ "V12_U2I_A0", "V3P3_U2I_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_i_hsc"
-refdes = "J208"
-refdes-suffix = "U1A"
+refdes = ["J208", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -852,8 +826,7 @@ device = "nvme_bmc"
 description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
-refdes = "J208"
-refdes-suffix = "J2"
+refdes = ["J208", "J2"]
 removable = true
 
 # SMBUS_FPGA2_TO_CEMJ
@@ -865,8 +838,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin J VPD"
 name = "sharkfin_j_vpd"
-refdes = "J209"
-refdes-suffix = "U2"
+refdes = ["J209", "U2"]
 removable = true
 
 [[config.i2c.devices]]
@@ -879,8 +851,7 @@ description = "U.2 Sharkfin J hot swap controller"
 power = { rails = [ "V12_U2J_A0", "V3P3_U2J_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_j_hsc"
-refdes = "J209"
-refdes-suffix = "U1A"
+refdes = ["J209", "U1A"]
 removable = true
 
 [[config.i2c.devices]]
@@ -892,8 +863,7 @@ device = "nvme_bmc"
 description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
-refdes = "J209"
-refdes-suffix = "J2"
+refdes = ["J209", "J2"]
 removable = true
 # you are now leaving the sharkfin zone
 
@@ -908,8 +878,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J44"
-refdes-suffix = "U1"
+refdes = ["J44", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -921,8 +890,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J45"
-refdes-suffix = "U1"
+refdes = ["J45", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -934,8 +902,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J46"
-refdes-suffix = "U1"
+refdes = ["J46", "U1"]
 
 ################################################################################
 
@@ -984,8 +951,7 @@ address = 0x3c
 device = "sbrmi"
 name = "RMI"
 description = "CPU via SB-RMI"
-refdes = "U1U"
-refdes-suffix = "SBRMI"
+refdes = ["U1U", "SBRMI"]
 
 [[config.i2c.devices]]
 bus = "main"
@@ -996,8 +962,7 @@ device = "sbtsi"
 name = "CPU"
 description = "CPU temperature sensor"
 sensors = { temperature = 1 }
-refdes = "U1U"
-refdes-suffix = "SBTSI"
+refdes = ["U1U", "SBTSI"]
 
 # Segment 5 is SEC_SP5_TO_FPGA1
 # Segment 6 is unused
@@ -1159,8 +1124,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J47"
-refdes-suffix = "U1"
+refdes = ["J47", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1170,8 +1134,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J48"
-refdes-suffix = "U1"
+refdes = ["J48", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1181,8 +1144,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J49"
-refdes-suffix = "U1"
+refdes = ["J49", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -501,6 +501,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin A VPD"
 name = "sharkfin_a_vpd"
 refdes = "J200"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -514,6 +515,7 @@ power = { rails = [ "V12_U2A_A0", "V3P3_U2A_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_a_hsc"
 refdes = "J200"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -526,6 +528,7 @@ description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
 refdes = "J200"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMB
@@ -538,6 +541,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin B VPD"
 name = "sharkfin_b_vpd"
 refdes = "J201"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -551,6 +555,7 @@ power = { rails = [ "V12_U2B_A0", "V3P3_U2B_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_b_hsc"
 refdes = "J201"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -563,6 +568,7 @@ description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
 refdes = "J201"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMC
@@ -575,6 +581,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin C VPD"
 name = "sharkfin_c_vpd"
 refdes = "J202"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -588,6 +595,7 @@ power = { rails = [ "V12_U2C_A0", "V3P3_U2C_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_c_hsc"
 refdes = "J202"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -600,6 +608,7 @@ description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
 refdes = "J202"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMD
@@ -612,6 +621,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin D VPD"
 name = "sharkfin_d_vpd"
 refdes = "J203"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -625,6 +635,7 @@ power = { rails = [ "V12_U2D_A0", "V3P3_U2D_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_d_hsc"
 refdes = "J203"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -637,6 +648,7 @@ description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
 refdes = "J203"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEME
@@ -649,6 +661,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin E VPD"
 name = "sharkfin_e_vpd"
 refdes = "J204"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -662,6 +675,7 @@ power = { rails = [ "V12_U2E_A0", "V3P3_U2E_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_e_hsc"
 refdes = "J204"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -674,6 +688,7 @@ description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
 refdes = "J204"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMF
@@ -686,6 +701,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin F VPD"
 name = "sharkfin_f_vpd"
 refdes = "J205"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -699,6 +715,7 @@ power = { rails = [ "V12_U2F_A0", "V3P3_U2F_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_f_hsc"
 refdes = "J205"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -711,6 +728,7 @@ description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
 refdes = "J205"
+refdes-suffix = "J2"
 removable = true
 
 # Note that we skip segments 7 and 8, which are
@@ -726,6 +744,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin G VPD"
 name = "sharkfin_g_vpd"
 refdes = "J206"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -739,6 +758,7 @@ power = { rails = [ "V12_U2G_A0", "V3P3_U2G_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_g_hsc"
 refdes = "J206"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -751,6 +771,7 @@ description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
 refdes = "J206"
+refdes-suffix = "J2"
 removable = true
 
 
@@ -765,6 +786,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin H VPD"
 name = "sharkfin_h_vpd"
 refdes = "J207"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -778,6 +800,7 @@ power = { rails = [ "V12_U2H_A0", "V3P3_U2H_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_h_hsc"
 refdes = "J207"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -790,6 +813,7 @@ description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
 refdes = "J207"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMI
@@ -802,6 +826,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin I VPD"
 name = "sharkfin_i_vpd"
 refdes = "J208"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -815,6 +840,7 @@ power = { rails = [ "V12_U2I_A0", "V3P3_U2I_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_i_hsc"
 refdes = "J208"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -827,6 +853,7 @@ description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
 refdes = "J208"
+refdes-suffix = "J2"
 removable = true
 
 # SMBUS_FPGA2_TO_CEMJ
@@ -839,6 +866,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin J VPD"
 name = "sharkfin_j_vpd"
 refdes = "J209"
+refdes-suffix = "U2"
 removable = true
 
 [[config.i2c.devices]]
@@ -852,6 +880,7 @@ power = { rails = [ "V12_U2J_A0", "V3P3_U2J_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_j_hsc"
 refdes = "J209"
+refdes-suffix = "U1A"
 removable = true
 
 [[config.i2c.devices]]
@@ -864,6 +893,7 @@ description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
 refdes = "J209"
+refdes-suffix = "J2"
 removable = true
 # you are now leaving the sharkfin zone
 
@@ -879,6 +909,7 @@ description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J44"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -891,6 +922,7 @@ description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J45"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -903,6 +935,7 @@ description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J46"
+refdes-suffix = "U1"
 
 ################################################################################
 
@@ -926,6 +959,7 @@ description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J210"
 
 # SMBUS_FPGA1_TO_M2B
 [[config.i2c.devices]]
@@ -938,6 +972,7 @@ description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J211"
 
 # Segment 3 is unused
 
@@ -949,6 +984,8 @@ address = 0x3c
 device = "sbrmi"
 name = "RMI"
 description = "CPU via SB-RMI"
+refdes = "U1U"
+refdes-suffix = "SBRMI"
 
 [[config.i2c.devices]]
 bus = "main"
@@ -959,6 +996,8 @@ device = "sbtsi"
 name = "CPU"
 description = "CPU temperature sensor"
 sensors = { temperature = 1 }
+refdes = "U1U"
+refdes-suffix = "SBTSI"
 
 # Segment 5 is SEC_SP5_TO_FPGA1
 # Segment 6 is unused
@@ -1121,6 +1160,7 @@ description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J47"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1131,6 +1171,7 @@ description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J48"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1141,6 +1182,7 @@ description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J49"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -494,7 +494,7 @@ bus = "front"
 address = 0x70
 device = "oximux16"
 description = "Front FPGA virtual mux"
-refdes = "U31_1"
+refdes = ["U31"]
 
 # Welcome to the sharkfin zone
 # SMBUS_FPGA2_TO_CEMA
@@ -884,7 +884,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J44", "U1"]
+refdes = "J44"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -896,7 +896,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J45", "U1"]
+refdes = "J45"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -908,7 +908,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J46", "U1"]
+refdes = "J46"
 
 ################################################################################
 
@@ -919,7 +919,7 @@ bus = "main"
 address = 0x70
 device = "oximux16"
 description = "Main FPGA virtual mux"
-refdes = "U27_1"
+refdes = ["U27", "MUX"]
 
 # SMBUS_FPGA1_TO_M2A
 [[config.i2c.devices]]
@@ -1130,7 +1130,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J47", "U1"]
+refdes = "J47"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1140,7 +1140,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J48", "U1"]
+refdes = "J48"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1150,7 +1150,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J49", "U1"]
+refdes = "J49"
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -101,7 +101,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Sharkfin VPD"
 removable = true
-refdes = ["J3", "J3"]
+refdes = ["J3", "J3", "U7"]
 
 [[config.i2c.devices]]
 controller = 1
@@ -111,7 +111,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Gimlet Fan VPD"
 removable = true
-refdes = ["J3", "J5"]
+refdes = ["J3", "J5", "U1"]
 
 [[config.i2c.devices]]
 controller = 1
@@ -121,7 +121,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Sidecar Fan VPD"
 removable = true
-refdes = ["J3", "J4"]
+refdes = ["J3", "J4", "U1"]
 
 [[config.i2c.devices]]
 controller = 1

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -124,7 +124,7 @@ device = "at24csw080"
 description = "Sidecar Fan VPD"
 removable = true
 refdes = "J3"
-refdes-suffix = "J5"
+refdes-suffix = "J4"
 
 [[config.i2c.devices]]
 controller = 1

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -101,8 +101,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Sharkfin VPD"
 removable = true
-refdes = "J3"
-refdes-suffix = "J3"
+refdes = ["J3", "J3"]
 
 [[config.i2c.devices]]
 controller = 1
@@ -112,8 +111,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Gimlet Fan VPD"
 removable = true
-refdes = "J3"
-refdes-suffix = "J5"
+refdes = ["J3", "J5"]
 
 [[config.i2c.devices]]
 controller = 1
@@ -123,8 +121,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Sidecar Fan VPD"
 removable = true
-refdes = "J3"
-refdes-suffix = "J4"
+refdes = ["J3", "J4"]
 
 [[config.i2c.devices]]
 controller = 1
@@ -135,5 +132,4 @@ device = "tmp117"
 description = "TempSense"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J3"
-refdes-suffix = "J2"
+refdes = ["J3", "J2"]

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -96,11 +96,13 @@ address = 0x73
 [[config.i2c.devices]]
 controller = 1
 mux = 1
-segment = 1 
+segment = 1
 address = 0b1010_000
 device = "at24csw080"
 description = "Sharkfin VPD"
 removable = true
+refdes = "J3"
+refdes-suffix = "J3"
 
 [[config.i2c.devices]]
 controller = 1
@@ -110,6 +112,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Gimlet Fan VPD"
 removable = true
+refdes = "J3"
+refdes-suffix = "J5"
 
 [[config.i2c.devices]]
 controller = 1
@@ -119,6 +123,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Sidecar Fan VPD"
 removable = true
+refdes = "J3"
+refdes-suffix = "J5"
 
 [[config.i2c.devices]]
 controller = 1
@@ -129,3 +135,5 @@ device = "tmp117"
 description = "TempSense"
 sensors = { temperature = 1 }
 removable = true
+refdes = "J3"
+refdes-suffix = "J2"

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -141,7 +141,7 @@ interrupts = {"spi4.irq" = "spi-irq"}
 name = "task-validate"
 priority = 3
 max-sizes = {flash = 8192, ram = 4096 }
-stacksize = 1000 
+stacksize = 1000
 start = true
 task-slots = ["i2c_driver"]
 
@@ -227,24 +227,28 @@ device = "max31790"
 bus = "onboard"
 address = 0x20
 description = "Fan controller"
+refdes = "U701"
 
 [[config.i2c.devices]]
 device = "pca9555"
 bus = "onboard"
 address = 0x21
 description = "GPIO expander"
+refdes = "U1501"
 
 [[config.i2c.devices]]
 device = "ina219"
 bus = "onboard"
 address = 0x40
 description = "Current sensor"
+refdes = "U602"
 
 [[config.i2c.devices]]
 device = "ina219"
 bus = "onboard"
 address = 0x41
 description = "Current sensor"
+refdes = "U603"
 
 [[config.i2c.devices]]
 device = "ltc4306"
@@ -252,6 +256,7 @@ controller = 4
 port = "F"
 address = 0x44
 description = "Multiplexer"
+refdes = "U501"
 
 #
 # The following are devices for which Gemini BU has been or can be used as
@@ -266,6 +271,7 @@ segment = 1
 address = 0x10
 description = "ADM1272 evaluation board"
 power = { rails = [ "ADM_EVL_VOUT" ] }
+refdes = "J501"
 
 [[config.i2c.devices]]
 device = "isl68224"
@@ -276,6 +282,7 @@ segment = 3
 address = 0x60
 description = "ISL68224 evaluation board"
 power = { rails = [ "ISL_EVL_VOUT0", "ISL_EVL_VOUT1", "ISL_EVL_VOUT2" ] }
+refdes = "J503"
 
 [[config.i2c.devices]]
 device = "tps546b24a"
@@ -286,6 +293,7 @@ segment = 4
 address = 0x24
 description = "TPS546B24A evaluation board"
 power = { rails = [ "TPS_EVL_VOUT" ] }
+refdes = "J504"
 
 [config.spi.spi2]
 controller = 2
@@ -314,4 +322,3 @@ input = {port = "E", pin = 5, af = 5}
 mux = "port_e"
 cs = [{port = "E", pin = 4}]
 clock_divider = "DIV256"
-

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -488,6 +488,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin A VPD"
 name = "sharkfin_a_vpd"
 refdes = "J206"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -501,6 +502,7 @@ power = { rails = [ "V12_U2A_A0", "V3P3_U2A_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_a_hsc"
 refdes = "J206"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -513,6 +515,7 @@ description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
 refdes = "J206"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -524,6 +527,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin B VPD"
 name = "sharkfin_b_vpd"
 refdes = "J207"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -537,6 +541,7 @@ power = { rails = [ "V12_U2B_A0", "V3P3_U2B_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_b_hsc"
 refdes = "J207"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -549,6 +554,7 @@ description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
 refdes = "J207"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -560,6 +566,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin C VPD"
 name = "sharkfin_c_vpd"
 refdes = "J208"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -573,6 +580,7 @@ power = { rails = [ "V12_U2C_A0", "V3P3_U2C_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_c_hsc"
 refdes = "J208"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -585,6 +593,7 @@ description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
 refdes = "J208"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -596,6 +605,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin D VPD"
 name = "sharkfin_d_vpd"
 refdes = "J209"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -609,6 +619,7 @@ power = { rails = [ "V12_U2D_A0", "V3P3_U2D_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_d_hsc"
 refdes = "J209"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -621,6 +632,7 @@ description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
 refdes = "J209"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -632,6 +644,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin E VPD"
 name = "sharkfin_e_vpd"
 refdes = "J210"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -645,6 +658,7 @@ power = { rails = [ "V12_U2E_A0", "V3P3_U2E_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_e_hsc"
 refdes = "J210"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -657,6 +671,7 @@ description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
 refdes = "J210"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -668,6 +683,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin F VPD"
 name = "sharkfin_f_vpd"
 refdes = "J211"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -681,6 +697,7 @@ power = { rails = [ "V12_U2F_A0", "V3P3_U2F_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_f_hsc"
 refdes = "J211"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -693,6 +710,7 @@ description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
 refdes = "J211"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -704,6 +722,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin G VPD"
 name = "sharkfin_g_vpd"
 refdes = "J212"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -717,6 +736,7 @@ power = { rails = [ "V12_U2G_A0", "V3P3_U2G_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_g_hsc"
 refdes = "J212"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -729,6 +749,7 @@ description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
 refdes = "J212"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -740,6 +761,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin H VPD"
 name = "sharkfin_h_vpd"
 refdes = "J213"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -753,6 +775,7 @@ power = { rails = [ "V12_U2H_A0", "V3P3_U2H_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_h_hsc"
 refdes = "J213"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -765,6 +788,7 @@ description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
 refdes = "J213"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -776,6 +800,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin I VPD"
 name = "sharkfin_i_vpd"
 refdes = "J214"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -789,6 +814,7 @@ power = { rails = [ "V12_U2I_A0", "V3P3_U2I_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_i_hsc"
 refdes = "J214"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -801,6 +827,7 @@ description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
 refdes = "J214"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -812,6 +839,7 @@ device = "at24csw080"
 description = "U.2 Sharkfin J VPD"
 name = "sharkfin_j_vpd"
 refdes = "J215"
+refdes-suffix = "U7"
 removable = true
 
 [[config.i2c.devices]]
@@ -825,6 +853,7 @@ power = { rails = [ "V12_U2J_A0", "V3P3_U2J_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_j_hsc"
 refdes = "J215"
+refdes-suffix = "U8"
 removable = true
 
 [[config.i2c.devices]]
@@ -837,6 +866,7 @@ description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
 refdes = "J215"
+refdes-suffix = "J1"
 removable = true
 
 [[config.i2c.devices]]
@@ -943,6 +973,8 @@ address = 0x3c
 device = "sbrmi"
 name = "RMI"
 description = "CPU via SB-RMI"
+refdes = "P0"
+refdes-suffix = "SBRMI"
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -951,6 +983,8 @@ device = "sbtsi"
 name = "CPU"
 description = "CPU temperature sensor"
 sensors = { temperature = 1 }
+refdes = "P0"
+refdes-suffix = "SBTSI"
 
 [[config.i2c.devices]]
 bus = "mid"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -434,8 +434,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J194"
-refdes-suffix = "U1"
+refdes = ["J194", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -445,8 +444,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J195"
-refdes-suffix = "U1"
+refdes = ["J195", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -456,8 +454,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J196"
-refdes-suffix = "U1"
+refdes = ["J196", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -490,8 +487,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin A VPD"
 name = "sharkfin_a_vpd"
-refdes = "J206"
-refdes-suffix = "U7"
+refdes = ["J206", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -504,8 +500,7 @@ description = "U.2 Sharkfin A hot swap controller"
 power = { rails = [ "V12_U2A_A0", "V3P3_U2A_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_a_hsc"
-refdes = "J206"
-refdes-suffix = "U8"
+refdes = ["J206", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -517,8 +512,7 @@ device = "nvme_bmc"
 description = "U.2 A NVMe Basic Management Command"
 sensors = { temperature = 1 }
 name = "U2_N0"
-refdes = "J206"
-refdes-suffix = "J1"
+refdes = ["J206", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -529,8 +523,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin B VPD"
 name = "sharkfin_b_vpd"
-refdes = "J207"
-refdes-suffix = "U7"
+refdes = ["J207", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -543,8 +536,7 @@ description = "U.2 Sharkfin B hot swap controller"
 power = { rails = [ "V12_U2B_A0", "V3P3_U2B_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_b_hsc"
-refdes = "J207"
-refdes-suffix = "U8"
+refdes = ["J207", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -556,8 +548,7 @@ device = "nvme_bmc"
 description = "U.2 B NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N1"
-refdes = "J207"
-refdes-suffix = "J1"
+refdes = ["J207", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -568,8 +559,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin C VPD"
 name = "sharkfin_c_vpd"
-refdes = "J208"
-refdes-suffix = "U7"
+refdes = ["J208", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -582,8 +572,7 @@ description = "U.2 Sharkfin C hot swap controller"
 power = { rails = [ "V12_U2C_A0", "V3P3_U2C_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_c_hsc"
-refdes = "J208"
-refdes-suffix = "U8"
+refdes = ["J208", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -595,8 +584,7 @@ device = "nvme_bmc"
 description = "U.2 C NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N2"
-refdes = "J208"
-refdes-suffix = "J1"
+refdes = ["J208", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -607,8 +595,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin D VPD"
 name = "sharkfin_d_vpd"
-refdes = "J209"
-refdes-suffix = "U7"
+refdes = ["J209", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -621,8 +608,7 @@ description = "U.2 Sharkfin D hot swap controller"
 power = { rails = [ "V12_U2D_A0", "V3P3_U2D_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_d_hsc"
-refdes = "J209"
-refdes-suffix = "U8"
+refdes = ["J209", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -634,8 +620,7 @@ device = "nvme_bmc"
 description = "U.2 D NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N3"
-refdes = "J209"
-refdes-suffix = "J1"
+refdes = ["J209", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -646,8 +631,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin E VPD"
 name = "sharkfin_e_vpd"
-refdes = "J210"
-refdes-suffix = "U7"
+refdes = ["J210", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -660,8 +644,7 @@ description = "U.2 Sharkfin E hot swap controller"
 power = { rails = [ "V12_U2E_A0", "V3P3_U2E_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_e_hsc"
-refdes = "J210"
-refdes-suffix = "U8"
+refdes = ["J210", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -673,8 +656,7 @@ device = "nvme_bmc"
 description = "U.2 E NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N4"
-refdes = "J210"
-refdes-suffix = "J1"
+refdes = ["J210", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -685,8 +667,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin F VPD"
 name = "sharkfin_f_vpd"
-refdes = "J211"
-refdes-suffix = "U7"
+refdes = ["J211", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -699,8 +680,7 @@ description = "U.2 Sharkfin F hot swap controller"
 power = { rails = [ "V12_U2F_A0", "V3P3_U2F_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_f_hsc"
-refdes = "J211"
-refdes-suffix = "U8"
+refdes = ["J211", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -712,8 +692,7 @@ device = "nvme_bmc"
 description = "U.2 F NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N5"
-refdes = "J211"
-refdes-suffix = "J1"
+refdes = ["J211", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -724,8 +703,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin G VPD"
 name = "sharkfin_g_vpd"
-refdes = "J212"
-refdes-suffix = "U7"
+refdes = ["J212", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -738,8 +716,7 @@ description = "U.2 Sharkfin G hot swap controller"
 power = { rails = [ "V12_U2G_A0", "V3P3_U2G_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_g_hsc"
-refdes = "J212"
-refdes-suffix = "U8"
+refdes = ["J212", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -751,8 +728,7 @@ device = "nvme_bmc"
 description = "U.2 G NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N6"
-refdes = "J212"
-refdes-suffix = "J1"
+refdes = ["J212", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -763,8 +739,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin H VPD"
 name = "sharkfin_h_vpd"
-refdes = "J213"
-refdes-suffix = "U7"
+refdes = ["J213", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -777,8 +752,7 @@ description = "U.2 Sharkfin H hot swap controller"
 power = { rails = [ "V12_U2H_A0", "V3P3_U2H_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_h_hsc"
-refdes = "J213"
-refdes-suffix = "U8"
+refdes = ["J213", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -790,8 +764,7 @@ device = "nvme_bmc"
 description = "U.2 H NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N7"
-refdes = "J213"
-refdes-suffix = "J1"
+refdes = ["J213", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -802,8 +775,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin I VPD"
 name = "sharkfin_i_vpd"
-refdes = "J214"
-refdes-suffix = "U7"
+refdes = ["J214", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -816,8 +788,7 @@ description = "U.2 Sharkfin I hot swap controller"
 power = { rails = [ "V12_U2I_A0", "V3P3_U2I_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_i_hsc"
-refdes = "J214"
-refdes-suffix = "U8"
+refdes = ["J214", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -829,8 +800,7 @@ device = "nvme_bmc"
 description = "U.2 I NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N8"
-refdes = "J214"
-refdes-suffix = "J1"
+refdes = ["J214", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -841,8 +811,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "U.2 Sharkfin J VPD"
 name = "sharkfin_j_vpd"
-refdes = "J215"
-refdes-suffix = "U7"
+refdes = ["J215", "U7"]
 removable = true
 
 [[config.i2c.devices]]
@@ -855,8 +824,7 @@ description = "U.2 Sharkfin J hot swap controller"
 power = { rails = [ "V12_U2J_A0", "V3P3_U2J_A0" ], pmbus = false }
 sensors = { voltage = 2, current = 2 }
 name = "sharkfin_j_hsc"
-refdes = "J215"
-refdes-suffix = "U8"
+refdes = ["J215", "U8"]
 removable = true
 
 [[config.i2c.devices]]
@@ -868,8 +836,7 @@ device = "nvme_bmc"
 description = "U.2 J NVMe Basic Management Control"
 sensors = { temperature = 1 }
 name = "U2_N9"
-refdes = "J215"
-refdes-suffix = "J1"
+refdes = ["J215", "J1"]
 removable = true
 
 [[config.i2c.devices]]
@@ -976,8 +943,7 @@ address = 0x3c
 device = "sbrmi"
 name = "RMI"
 description = "CPU via SB-RMI"
-refdes = "P0"
-refdes-suffix = "SBRMI"
+refdes = ["P0", "SBRMI"]
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -986,8 +952,7 @@ device = "sbtsi"
 name = "CPU"
 description = "CPU temperature sensor"
 sensors = { temperature = 1 }
-refdes = "P0"
-refdes-suffix = "SBTSI"
+refdes = ["P0", "SBTSI"]
 
 [[config.i2c.devices]]
 bus = "mid"
@@ -1072,8 +1037,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J197"
-refdes-suffix = "U1"
+refdes = ["J197", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1083,8 +1047,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J198"
-refdes-suffix = "U1"
+refdes = ["J198", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1094,8 +1057,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J199"
-refdes-suffix = "U1"
+refdes = ["J199", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -435,6 +435,7 @@ description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J194"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -445,6 +446,7 @@ description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J195"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -455,6 +457,7 @@ description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J196"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -1070,6 +1073,7 @@ description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J197"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1080,6 +1084,7 @@ description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J198"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1090,6 +1095,7 @@ description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
 refdes = "J199"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -434,7 +434,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J194", "U1"]
+refdes = "J194"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -444,7 +444,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J195", "U1"]
+refdes = "J195"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -454,7 +454,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J196", "U1"]
+refdes = "J196"
 
 [[config.i2c.devices]]
 bus = "front"
@@ -1037,7 +1037,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J197", "U1"]
+refdes = "J197"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1047,7 +1047,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J198", "U1"]
+refdes = "J198"
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1057,7 +1057,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = ["J199", "U1"]
+refdes = "J199"
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/gimlet/rev-b.toml
+++ b/app/gimlet/rev-b.toml
@@ -57,6 +57,7 @@ address = 0b110_1010
 device = "m2_hp_only"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
+refdes = "P1"
 sensors = { temperature = 1 }
 removable = true
 
@@ -68,5 +69,6 @@ address = 0b110_1010
 device = "m2_hp_only"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
+refdes = "P2"
 sensors = { temperature = 1 }
 removable = true

--- a/app/gimlet/rev-d.toml
+++ b/app/gimlet/rev-d.toml
@@ -66,6 +66,7 @@ address = 0b110_1010
 device = "nvme_bmc"
 description = "M.2 A NVMe Basic Management Command"
 name = "M2_A"
+refdes = "P1"
 sensors = { temperature = 1 }
 removable = true
 
@@ -77,5 +78,6 @@ address = 0b110_1010
 device = "nvme_bmc"
 description = "M.2 B NVMe Basic Management Command"
 name = "M2_B"
+refdes = "P2"
 sensors = { temperature = 1 }
 removable = true

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -284,6 +284,7 @@ address = 0x16
 description = "LM5066 evaluation board"
 power = { rails = [ "LM5066_EVL_VOUT" ] }
 sensors = { voltage = 1, current = 1, temperature = 1 }
+refdes = "LOL"
 
 [tasks.power]
 name = "task-power"

--- a/app/grapefruit/app-ruby.toml
+++ b/app/grapefruit/app-ruby.toml
@@ -66,6 +66,7 @@ address = 0b100_1101
 device = "emc2305"
 sensors = { speed = 4, names = [ "fan1", "fan2", "fan3", "fan4" ] }
 description = "fan controller"
+refdes = "U92"
 
 [[config.i2c.devices]]
 bus = "temp"

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -360,8 +360,10 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Front IO board FRUID"
 removable = true
-refdes = "J2" # on front IO board
-refdes-suffix = "U3"
+refdes = [
+    "J2", # on front IO board
+    "U3",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -369,8 +371,10 @@ address = 0b1110_011
 device = "pca9538"
 description = "Front IO GPIO expander"
 removable = true
-refdes = "J2" # on front IO board
-refdes-suffix = "U4"
+refdes = [
+    "J2", # on front IO board
+    "U4",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -379,8 +383,10 @@ device = "pca9956b"
 name = "front_leds_left"
 description = "Front IO LED driver (left)"
 removable = true
-refdes = "J2" # on front IO board
-refdes-suffix = "U5"
+refdes = [
+    "J2", # on front IO board
+    "U5",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -389,8 +395,10 @@ device = "pca9956b"
 name = "front_leds_right"
 description = "Front IO LED driver (right)"
 removable = true
-refdes = "J2" # on front IO board
-refdes-suffix = "U6"
+refdes = [
+    "J2", # on front IO board
+    "U6",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -400,8 +408,10 @@ description = "Front IO V3P3_SYS_A2 rail"
 removable = true
 power = {rails = ["V3P3_SYS_A2"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J2" # on front IO board
-refdes-suffix = "U7"
+refdes = [
+    "J2", # on front IO board
+    "U7",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -411,8 +421,10 @@ description = "Front IO V3P3_QSFP0_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP0_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J2" # on front IO board
-refdes-suffix = "U15"
+refdes = [
+    "J2", # on front IO board
+    "U15",
+]
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -422,8 +434,8 @@ description = "Front IO V3P3_QSFP1_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP1_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J2" # on front IO board
-refdes-suffix = "U18"
+refdes = [
+        "J2", "U18"]
 
 #
 # I2C3: Front I/O 1

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -435,7 +435,9 @@ removable = true
 power = {rails = ["V3P3_QSFP1_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = [
-        "J2", "U18"]
+    "J2", # on front IO board
+    "U18",
+]
 
 #
 # I2C3: Front I/O 1

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -360,6 +360,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Front IO board FRUID"
 removable = true
+refdes = "J2" # on front IO board
+refdes-suffix = "U3"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -367,6 +369,8 @@ address = 0b1110_011
 device = "pca9538"
 description = "Front IO GPIO expander"
 removable = true
+refdes = "J2" # on front IO board
+refdes-suffix = "U4"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -375,7 +379,8 @@ device = "pca9956b"
 name = "front_leds_left"
 description = "Front IO LED driver (left)"
 removable = true
-refdes = "U5"
+refdes = "J2" # on front IO board
+refdes-suffix = "U5"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -384,7 +389,8 @@ device = "pca9956b"
 name = "front_leds_right"
 description = "Front IO LED driver (right)"
 removable = true
-refdes = "U6"
+refdes = "J2" # on front IO board
+refdes-suffix = "U6"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -394,7 +400,8 @@ description = "Front IO V3P3_SYS_A2 rail"
 removable = true
 power = {rails = ["V3P3_SYS_A2"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U7" # on front IO board
+refdes = "J2" # on front IO board
+refdes-suffix = "U7"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -404,7 +411,8 @@ description = "Front IO V3P3_QSFP0_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP0_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U15" # on front IO board
+refdes = "J2" # on front IO board
+refdes-suffix = "U15"
 
 [[config.i2c.devices]]
 bus = "front_io0"
@@ -414,7 +422,8 @@ description = "Front IO V3P3_QSFP1_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP1_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U18" # on front IO board
+refdes = "J2" # on front IO board
+refdes-suffix = "U18"
 
 #
 # I2C3: Front I/O 1

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -398,8 +398,7 @@ name = "psu0eeprom"
 address = 0b1010_000
 device = "m24c02"
 description = "PSU 0 EEPROM"
-refdes = "PSU0"
-refdes-suffix = "ID"
+refdes = ["PSU0", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -417,8 +416,7 @@ name = "psu1eeprom"
 address = 0b1010_001
 device = "m24c02"
 description = "PSU 1 EEPROM"
-refdes = "PSU1"
-refdes-suffix = "ID"
+refdes = ["PSU1", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -436,8 +434,7 @@ name = "psu2eeprom"
 address = 0b1010_010
 device = "m24c02"
 description = "PSU 2 EEPROM"
-refdes = "PSU2"
-refdes-suffix = "ID"
+refdes = ["PSU2", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -455,8 +452,7 @@ name = "psu3eeprom"
 address = 0b1010_011
 device = "m24c02"
 description = "PSU 3 EEPROM"
-refdes = "PSU3"
-refdes-suffix = "ID"
+refdes = ["PSU3", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -474,8 +470,7 @@ name = "psu4eeprom"
 address = 0b1010_100
 device = "m24c02"
 description = "PSU 4 EEPROM"
-refdes = "PSU4"
-refdes-suffix = "ID"
+refdes = ["PSU4", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -493,8 +488,7 @@ name = "psu5eeprom"
 address = 0b1010_101
 device = "m24c02"
 description = "PSU 5 EEPROM"
-refdes = "PSU5"
-refdes-suffix = "ID"
+refdes = ["PSU5", "ID"]
 
 [[config.i2c.devices]]
 bus = "backplane"

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -398,6 +398,8 @@ name = "psu0eeprom"
 address = 0b1010_000
 device = "m24c02"
 description = "PSU 0 EEPROM"
+refdes = "PSU0"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -407,6 +409,7 @@ device = "mwocp68"
 description = "PSU 0 MCU"
 power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU0"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -414,6 +417,8 @@ name = "psu1eeprom"
 address = 0b1010_001
 device = "m24c02"
 description = "PSU 1 EEPROM"
+refdes = "PSU1"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -423,6 +428,7 @@ device = "mwocp68"
 description = "PSU 1 MCU"
 power = { rails = [ "V54_PSU1", "V12_PSU1" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU1"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -430,6 +436,8 @@ name = "psu2eeprom"
 address = 0b1010_010
 device = "m24c02"
 description = "PSU 2 EEPROM"
+refdes = "PSU2"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -439,6 +447,7 @@ device = "mwocp68"
 description = "PSU 2 MCU"
 power = { rails = [ "V54_PSU2", "V12_PSU2" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU2"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -446,6 +455,8 @@ name = "psu3eeprom"
 address = 0b1010_011
 device = "m24c02"
 description = "PSU 3 EEPROM"
+refdes = "PSU3"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -455,6 +466,7 @@ device = "mwocp68"
 description = "PSU 3 MCU"
 power = { rails = [ "V54_PSU3", "V12_PSU3" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU3"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -462,6 +474,8 @@ name = "psu4eeprom"
 address = 0b1010_100
 device = "m24c02"
 description = "PSU 4 EEPROM"
+refdes = "PSU4"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -471,6 +485,7 @@ device = "mwocp68"
 description = "PSU 4 MCU"
 power = { rails = [ "V54_PSU4", "V12_PSU4" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU4"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -478,6 +493,8 @@ name = "psu5eeprom"
 address = 0b1010_101
 device = "m24c02"
 description = "PSU 5 EEPROM"
+refdes = "PSU5"
+refdes-suffix = "ID"
 
 [[config.i2c.devices]]
 bus = "backplane"
@@ -487,6 +504,7 @@ device = "mwocp68"
 description = "PSU 5 MCU"
 power = { rails = [ "V54_PSU5", "V12_PSU5" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
 sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 3, speed = 2 }
+refdes = "PSU5"
 
 [config.spi.spi2]
 controller = 2

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -755,8 +755,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 0 FRUID"
 removable = true
-refdes = "J75"
-refdes-suffix = "U1"
+refdes = ["J75", "U1"]
 
 [[config.i2c.devices]]
 bus = "northeast0"
@@ -766,8 +765,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 1 FRUID"
 removable = true
-refdes = "J74"
-refdes-suffix = "U1"
+refdes = ["J74", "U1"]
 
 [[config.i2c.devices]]
 bus = "northwest1"
@@ -777,8 +775,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 2 FRUID"
 removable = true
-refdes = "J77"
-refdes-suffix = "U1"
+refdes = ["J77", "U1"]
 
 [[config.i2c.devices]]
 bus = "northwest1"
@@ -788,8 +785,7 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 3 FRUID"
 removable = true
-refdes = "J76"
-refdes-suffix = "U1"
+refdes = ["J76", "U1"]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -797,8 +793,10 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Front IO board FRUID"
 removable = true
-refdes = "J61" # on front IO board
-refdes-suffix = "U3"
+refdes = [
+    "J61",  # on front IO board
+    "U3",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -806,8 +804,10 @@ address = 0b1110_011
 device = "pca9538"
 description = "Front IO GPIO expander"
 removable = true
-refdes = "J61" # on front IO board
-refdes-suffix = "U4"
+refdes = [
+    "J61",  # on front IO board
+    "U4",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -816,8 +816,10 @@ device = "pca9956b"
 name = "front_leds_left"
 description = "Front IO LED driver (left)"
 removable = true
-refdes = "J61" # on front IO board
-refdes-suffix = "U5"
+refdes = [
+    "J61",  # on front IO board
+    "U5",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -826,8 +828,10 @@ device = "pca9956b"
 name = "front_leds_right"
 description = "Front IO LED driver (right)"
 removable = true
-refdes = "J61" # on front IO board
-refdes-suffix = "U6"
+refdes = [
+    "J61",  # on front IO board
+    "U6",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -837,8 +841,10 @@ description = "Front IO V3P3_SYS_A2 rail"
 removable = true
 power = {rails = ["V3P3_SYS_A2"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61" # on front IO board
-refdes-suffix = "U7"
+refdes = [
+    "J61",  # on front IO board
+    "U7",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -848,8 +854,10 @@ description = "Front IO V3P3_QSFP0_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP0_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61" # on front IO board
-refdes-suffix = "U15"
+refdes = [
+    "J61",  # on front IO board
+    "U15",
+]
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -859,8 +867,7 @@ description = "Front IO V3P3_QSFP1_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP1_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61" # on front IO board
-refdes-suffix = "U18"
+refdes = ["J61", "U18"]
 
 [[config.sensor.devices]]
 name = "xcvr0"

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -755,6 +755,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 0 FRUID"
 removable = true
+refdes = "J75"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "northeast0"
@@ -764,6 +766,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 1 FRUID"
 removable = true
+refdes = "J74"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "northwest1"
@@ -773,6 +777,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 2 FRUID"
 removable = true
+refdes = "J77"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "northwest1"
@@ -782,6 +788,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Fan 3 FRUID"
 removable = true
+refdes = "J76"
+refdes-suffix = "U1"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -789,6 +797,8 @@ address = 0b1010_000
 device = "at24csw080"
 description = "Front IO board FRUID"
 removable = true
+refdes = "J61" # on front IO board
+refdes-suffix = "U3"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -796,6 +806,8 @@ address = 0b1110_011
 device = "pca9538"
 description = "Front IO GPIO expander"
 removable = true
+refdes = "J61" # on front IO board
+refdes-suffix = "U4"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -804,7 +816,8 @@ device = "pca9956b"
 name = "front_leds_left"
 description = "Front IO LED driver (left)"
 removable = true
-refdes = "U5"
+refdes = "J61" # on front IO board
+refdes-suffix = "U5"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -813,7 +826,8 @@ device = "pca9956b"
 name = "front_leds_right"
 description = "Front IO LED driver (right)"
 removable = true
-refdes = "U6"
+refdes = "J61" # on front IO board
+refdes-suffix = "U6"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -823,7 +837,8 @@ description = "Front IO V3P3_SYS_A2 rail"
 removable = true
 power = {rails = ["V3P3_SYS_A2"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U7" # on front IO board
+refdes = "J61" # on front IO board
+refdes-suffix = "U7"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -833,7 +848,8 @@ description = "Front IO V3P3_QSFP0_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP0_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U15" # on front IO board
+refdes = "J61" # on front IO board
+refdes-suffix = "U15"
 
 [[config.i2c.devices]]
 bus = "front_io"
@@ -843,7 +859,8 @@ description = "Front IO V3P3_QSFP1_A0 rail"
 removable = true
 power = {rails = ["V3P3_QSFP1_A0"] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
-refdes = "J61_U18" # on front IO board
+refdes = "J61" # on front IO board
+refdes-suffix = "U18"
 
 [[config.sensor.devices]]
 name = "xcvr0"

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -1848,7 +1848,7 @@ impl Refdes {
             }
             Self::Path(parts) => {
                 let len = parts.iter().map(String::len).sum::<usize>()
-                    + (parts.len() - 1);
+                    + (parts.len() - 1) * sep.len();
                 let mut s = String::with_capacity(len);
                 let mut parts = parts.iter();
                 if let Some(first) = parts.next() {

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -1742,6 +1742,8 @@ pub struct I2cDeviceDescription {
     pub device: String,
     pub description: String,
     pub sensors: Vec<DeviceSensor>,
+    pub refdes: Option<String>,
+    pub name: Option<String>,
 }
 
 ///
@@ -1763,6 +1765,8 @@ pub fn device_descriptions() -> impl Iterator<Item = I2cDeviceDescription> {
             device: device.device,
             description: device.description,
             sensors,
+            refdes: device.refdes,
+            name: device.name,
         },
     )
 }

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -958,7 +958,7 @@ impl ConfigGenerator {
         let refdes_part = if self.include_refdes {
             d.device_id()
                 .map(|id| format!(".with_refdes({id:?})"))
-                .unwrap_or(String::new())
+                .unwrap_or_default()
         } else {
             String::new()
         };
@@ -1171,8 +1171,7 @@ impl ConfigGenerator {
         for ((device, name, suffix), d) in &all {
             let name = name.to_lowercase();
             let suffix_sep = if suffix.is_some() { "_" } else { "" };
-            let suffix =
-                suffix.map(|s| s.to_lowercase()).unwrap_or_else(String::new);
+            let suffix = suffix.map(|s| s.to_lowercase()).unwrap_or_default();
             write!(
                 &mut self.output,
                 r##"
@@ -1660,7 +1659,7 @@ impl ConfigGenerator {
                 .suffix
                 .as_ref()
                 .map(|s| s.to_uppercase())
-                .unwrap_or_else(String::new);
+                .unwrap_or_default();
             let label = format!("{refdes}{suffix_sep}{suffix}_{}", k.kind);
             self.emit_sensor(&k.device, &label, ids)?;
         }

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -953,10 +953,14 @@ impl ConfigGenerator {
 
         let indent = format!("{:indent$}", "", indent = indent);
 
-        let refdes_part = match (self.include_refdes, d.refdes.as_deref()) {
-            (true, Some(refdes)) => format!(".with_refdes(\"{refdes}\")"),
-            _ => String::new(),
+        let refdes_part = if self.include_refdes {
+            d.device_id()
+                .map(|id| format!(".with_refdes({id:?})"))
+                .unwrap_or(String::new())
+        } else {
+            String::new()
         };
+
         format!(
             r##"
 {indent}// {description}

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -13,7 +13,7 @@ userlib.path = "../../sys/userlib"
 
 
 [features]
-component-id = [] # adds a `component_id` field to the `I2cDevice`
+refdes = [] # adds a `refdes` field to the `I2cDevice`
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/i2c-api/Cargo.toml
+++ b/drv/i2c-api/Cargo.toml
@@ -13,7 +13,7 @@ userlib.path = "../../sys/userlib"
 
 
 [features]
-refdes = [] # adds a `refdes` field to the `I2cDevice`
+component-id = [] # adds a `component_id` field to the `I2cDevice`
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -38,8 +38,8 @@ pub struct I2cDevice {
     pub port: PortIndex,
     pub segment: Option<(Mux, Segment)>,
     pub address: u8,
-    #[cfg(feature = "component-id")]
-    pub component_id: &'static str,
+    #[cfg(feature = "refdes")]
+    pub refdes: Option<&'static str>,
 }
 
 type I2cMessage = (u8, Controller, PortIndex, Option<(Mux, Segment)>);
@@ -115,7 +115,6 @@ impl I2cDevice {
         port: PortIndex,
         segment: Option<(Mux, Segment)>,
         address: u8,
-        #[cfg(feature = "component-id")] component_id: &'static str,
     ) -> Self {
         Self {
             task,
@@ -123,14 +122,22 @@ impl I2cDevice {
             port,
             segment,
             address,
-            #[cfg(feature = "component-id")]
-            component_id,
+            #[cfg(feature = "refdes")]
+            refdes: None,
         }
     }
 
-    #[cfg(feature = "component-id")]
-    pub fn component_id(&self) -> &'static str {
-        self.component_id
+    #[cfg(feature = "refdes")]
+    pub fn with_refdes(self, refdes: &'static str) -> Self {
+        Self {
+            refdes: Some(refdes),
+            ..self
+        }
+    }
+
+    #[cfg(feature = "refdes")]
+    pub fn refdes(&self) -> Option<&'static str> {
+        self.refdes
     }
 }
 

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -38,8 +38,8 @@ pub struct I2cDevice {
     pub port: PortIndex,
     pub segment: Option<(Mux, Segment)>,
     pub address: u8,
-    #[cfg(feature = "refdes")]
-    pub refdes: Option<&'static str>,
+    #[cfg(feature = "component-id")]
+    pub component_id: &'static str,
 }
 
 type I2cMessage = (u8, Controller, PortIndex, Option<(Mux, Segment)>);
@@ -115,6 +115,7 @@ impl I2cDevice {
         port: PortIndex,
         segment: Option<(Mux, Segment)>,
         address: u8,
+        #[cfg(feature = "component-id")] component_id: &'static str,
     ) -> Self {
         Self {
             task,
@@ -122,22 +123,14 @@ impl I2cDevice {
             port,
             segment,
             address,
-            #[cfg(feature = "refdes")]
-            refdes: None,
+            #[cfg(feature = "component-id")]
+            component_id,
         }
     }
 
-    #[cfg(feature = "refdes")]
-    pub fn with_refdes(self, refdes: &'static str) -> Self {
-        Self {
-            refdes: Some(refdes),
-            ..self
-        }
-    }
-
-    #[cfg(feature = "refdes")]
-    pub fn refdes(&self) -> Option<&'static str> {
-        self.refdes
+    #[cfg(feature = "component-id")]
+    pub fn component_id(&self) -> &'static str {
+        self.component_id
     }
 }
 

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -163,10 +163,10 @@ impl TryFrom<&'_ SpComponent> for Index {
     type Error = SpError;
 
     fn try_from(component: &'_ SpComponent) -> Result<Self, Self::Error> {
-        if let Ok(entry_idx) = task_validate_api::DEVICE_INDICES_BY_ID
+        if let Ok(entry_idx) = task_validate_api::DEVICE_INDICES_BY_SORTED_ID
             .binary_search_by_key(&component.id, |&(id, _)| id)
         {
-            let &(_, index) = task_validate_api::DEVICE_INDICES_BY_ID
+            let &(_, index) = task_validate_api::DEVICE_INDICES_BY_SORTED_ID
                 .get(entry_idx)
                 .unwrap_lite();
             return Ok(Self::ValidateDevice(index));

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -494,8 +494,8 @@ impl ServerImpl {
                     7 => by_refdes!(J207_U1, max5970),
                     8 => by_refdes!(J208_U1, max5970),
                     9 => by_refdes!(J209_U1, max5970),
-                    10 => by_refdes!(U15, max5970, 8),
-                    11 => by_refdes!(U54, max5970, 8),
+                    10 => by_refdes!(U15, max5970, 7),
+                    11 => by_refdes!(U54, max5970, 7),
                     _ => panic!(),
                 };
                 *self.scratch = InventoryData::Max5970 {

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -430,13 +430,13 @@ impl ServerImpl {
                 })
             }
             37..=42 => {
-                let (name, f, sensors): ([u8; 6], _, _) = match index - 37 {
-                    0 => by_refdes!(J44_U1, tmp117),
-                    1 => by_refdes!(J45_U1, tmp117),
-                    2 => by_refdes!(J46_U1, tmp117),
-                    3 => by_refdes!(J47_U1, tmp117),
-                    4 => by_refdes!(J48_U1, tmp117),
-                    5 => by_refdes!(J49_U1, tmp117),
+                let (name, f, sensors): ([u8; 3], _, _) = match index - 37 {
+                    0 => by_refdes!(J44, tmp117),
+                    1 => by_refdes!(J45, tmp117),
+                    2 => by_refdes!(J46, tmp117),
+                    3 => by_refdes!(J47, tmp117),
+                    4 => by_refdes!(J48, tmp117),
+                    5 => by_refdes!(J49, tmp117),
                     _ => unreachable!(),
                 };
                 let dev = f(I2C.get_task_id());

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -109,7 +109,7 @@ impl ServerImpl {
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             14..=23 => {
-                let (mut name, f): ([u8; 7], _) =
+                let (name, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 14);
                 self.read_at24csw080_id(sequence, &name, f)
             }
@@ -430,7 +430,7 @@ impl ServerImpl {
                 })
             }
             37..=42 => {
-                let (mut name, f, sensors): ([u8; 6], _, _) = match index - 37 {
+                let (name, f, sensors): ([u8; 6], _, _) = match index - 37 {
                     0 => by_refdes!(J44_U1, tmp117),
                     1 => by_refdes!(J45_U1, tmp117),
                     2 => by_refdes!(J46_U1, tmp117),
@@ -483,7 +483,7 @@ impl ServerImpl {
             }
             44..=55 => {
                 let i = index - 44;
-                let (mut name, _f, sensors) = match i {
+                let (name, _f, sensors) = match i {
                     0 => by_refdes!(J200_U1, max5970),
                     1 => by_refdes!(J201_U1, max5970),
                     2 => by_refdes!(J202_U1, max5970),

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -105,7 +105,7 @@ impl ServerImpl {
                 let (designator, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 4);
                 let mut name = *b"____/U2/ID";
-                name[0..4].copy_from_slice(&designator);
+                name[0..4].copy_from_slice(&designator[0..4]);
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             14..=23 => {

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -104,14 +104,13 @@ impl ServerImpl {
             4..=13 => {
                 let (designator, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 4);
-                let mut name = *b"____/U2/ID";
-                name[0..4].copy_from_slice(&designator[0..4]);
+                let mut name = *b"_______/ID";
+                name[0..7].copy_from_slice(&designator);
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             14..=23 => {
                 let (mut name, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 14);
-                name[4] = b'/';
                 self.read_at24csw080_id(sequence, &name, f)
             }
             24 => {
@@ -442,12 +441,6 @@ impl ServerImpl {
                 };
                 let dev = f(I2C.get_task_id());
 
-                // Convert the name from Jxxx (in the TOML file) -> Jxxx/U1
-                // All connector names should have length 3; that's checked by
-                // the type in the tuple assignment above.
-                // TODO(eliza): get this from codegen...
-                name[4] = b'/';
-
                 *self.scratch = InventoryData::Tmp117 {
                     id: 0,
                     eeprom1: 0,
@@ -505,11 +498,6 @@ impl ServerImpl {
                     11 => by_refdes!(U54, max5970, 8),
                     _ => panic!(),
                 };
-                // Convert `Jxxx_U1` to `Jxxx/U1`.
-                // TODO(eliza): get this from the device...
-                if name[0] == b'J' {
-                    name[4] = b'/';
-                }
                 *self.scratch = InventoryData::Max5970 {
                     voltage_sensors: SensorId::into_u32_array(sensors.voltage),
                     current_sensors: SensorId::into_u32_array(sensors.current),

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -491,21 +491,21 @@ impl ServerImpl {
             44..=55 => {
                 let i = index - 44;
                 let (mut name, _f, sensors) = match i {
-                    0 => by_refdes!(J200_U1A, max5970),
-                    1 => by_refdes!(J201_U1A, max5970),
-                    2 => by_refdes!(J202_U1A, max5970),
-                    3 => by_refdes!(J203_U1A, max5970),
-                    4 => by_refdes!(J204_U1A, max5970),
-                    5 => by_refdes!(J205_U1A, max5970),
-                    6 => by_refdes!(J206_U1A, max5970),
-                    7 => by_refdes!(J207_U1A, max5970),
-                    8 => by_refdes!(J208_U1A, max5970),
-                    9 => by_refdes!(J209_U1A, max5970),
+                    0 => by_refdes!(J200_U1, max5970),
+                    1 => by_refdes!(J201_U1, max5970),
+                    2 => by_refdes!(J202_U1, max5970),
+                    3 => by_refdes!(J203_U1, max5970),
+                    4 => by_refdes!(J204_U1, max5970),
+                    5 => by_refdes!(J205_U1, max5970),
+                    6 => by_refdes!(J206_U1, max5970),
+                    7 => by_refdes!(J207_U1, max5970),
+                    8 => by_refdes!(J208_U1, max5970),
+                    9 => by_refdes!(J209_U1, max5970),
                     10 => by_refdes!(U15, max5970, 8),
                     11 => by_refdes!(U54, max5970, 8),
                     _ => panic!(),
                 };
-                // Convert `Jxxx_U1A` to `Jxxx/U1A`.
+                // Convert `Jxxx_U1` to `Jxxx/U1`.
                 // TODO(eliza): get this from the device...
                 if name[0] == b'J' {
                     name[4] = b'/';

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -403,13 +403,13 @@ impl ServerImpl {
             }
 
             52..=57 => {
-                let (name, f, sensors): ([u8; 7], _, _) = match index - 52 {
-                    0 => by_refdes!(J194_U1, tmp117),
-                    1 => by_refdes!(J195_U1, tmp117),
-                    2 => by_refdes!(J196_U1, tmp117),
-                    3 => by_refdes!(J197_U1, tmp117),
-                    4 => by_refdes!(J198_U1, tmp117),
-                    5 => by_refdes!(J199_U1, tmp117),
+                let (name, f, sensors): ([u8; 4], _, _) = match index - 52 {
+                    0 => by_refdes!(J194, tmp117),
+                    1 => by_refdes!(J195, tmp117),
+                    2 => by_refdes!(J196, tmp117),
+                    3 => by_refdes!(J197, tmp117),
+                    4 => by_refdes!(J198, tmp117),
+                    5 => by_refdes!(J199, tmp117),
                     _ => unreachable!(),
                 };
                 let dev = f(I2C.get_task_id());

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -107,7 +107,7 @@ impl ServerImpl {
                 let (designator, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 20);
                 let mut name = *b"____/U7/ID";
-                name[0..4].copy_from_slice(&designator);
+                name[0..4].copy_from_slice(&designator[0..4]);
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             30..=39 => {

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -104,18 +104,17 @@ impl ServerImpl {
             //
             // Sharkfin connectors start at J206 and are numbered sequentially
             20..=29 => {
-                let (designator, f): ([u8; 4], _) =
+                let (designator, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 20);
                 let mut name = *b"____/U7/ID";
                 name[0..4].copy_from_slice(&designator);
                 self.read_eeprom_barcode(sequence, &name, f)
             }
             30..=39 => {
-                let (designator, f): ([u8; 4], _) =
+                let (mut designator, f): ([u8; 7], _) =
                     Self::get_sharkfin_vpd(index as usize - 30);
-                let mut name = *b"____/U7";
-                name[0..4].copy_from_slice(&designator);
-                self.read_at24csw080_id(sequence, &name, f)
+                designator[4] = b'/';
+                self.read_at24csw080_id(sequence, &designator, f)
             }
             40 => {
                 // U12: the service processor itself
@@ -405,23 +404,21 @@ impl ServerImpl {
             }
 
             52..=57 => {
-                let (connector_name, f, sensors): ([u8; 4], _, _) =
-                    match index - 52 {
-                        0 => by_refdes!(J194, tmp117),
-                        1 => by_refdes!(J195, tmp117),
-                        2 => by_refdes!(J196, tmp117),
-                        3 => by_refdes!(J197, tmp117),
-                        4 => by_refdes!(J198, tmp117),
-                        5 => by_refdes!(J199, tmp117),
-                        _ => unreachable!(),
-                    };
+                let (mut name, f, sensors): ([u8; 7], _, _) = match index - 52 {
+                    0 => by_refdes!(J194_U1, tmp117),
+                    1 => by_refdes!(J195_U1, tmp117),
+                    2 => by_refdes!(J196_U1, tmp117),
+                    3 => by_refdes!(J197_U1, tmp117),
+                    4 => by_refdes!(J198_U1, tmp117),
+                    5 => by_refdes!(J199_U1, tmp117),
+                    _ => unreachable!(),
+                };
                 let dev = f(I2C.get_task_id());
 
-                // Convert the name from Jxxx (in the TOML file) -> Jxxx/U1
-                let mut name = *b"Jxxx/U1";
-                // All connector names should have length 4; that's checked by
-                // the type in the tuple assignment above.
-                name[..4].copy_from_slice(&connector_name);
+                // Convert the name from Jxxx_U1 (in the TOML file) -> Jxxx/U1
+                // TODO(eliza): let's just get this from the include_refdes i2c
+                // codegen...
+                name[4] = b'/';
 
                 *self.scratch = InventoryData::Tmp117 {
                     id: 0,
@@ -516,16 +513,16 @@ impl ServerImpl {
             60..=70 => {
                 let i = index - 60;
                 let (name, _f, sensors) = match i {
-                    0 => by_refdes!(J206, max5970),
-                    1 => by_refdes!(J207, max5970),
-                    2 => by_refdes!(J208, max5970),
-                    3 => by_refdes!(J209, max5970),
-                    4 => by_refdes!(J210, max5970),
-                    5 => by_refdes!(J211, max5970),
-                    6 => by_refdes!(J212, max5970),
-                    7 => by_refdes!(J213, max5970),
-                    8 => by_refdes!(J214, max5970),
-                    9 => by_refdes!(J215, max5970),
+                    0 => by_refdes!(J206_U8, max5970, 4),
+                    1 => by_refdes!(J207_U8, max5970, 4),
+                    2 => by_refdes!(J208_U8, max5970, 4),
+                    3 => by_refdes!(J209_U8, max5970, 4),
+                    4 => by_refdes!(J210_U8, max5970, 4),
+                    5 => by_refdes!(J211_U8, max5970, 4),
+                    6 => by_refdes!(J212_U8, max5970, 4),
+                    7 => by_refdes!(J213_U8, max5970, 4),
+                    8 => by_refdes!(J214_U8, max5970, 4),
+                    9 => by_refdes!(J215_U8, max5970, 4),
                     10 => by_refdes!(U275, max5970),
                     _ => panic!(),
                 };
@@ -557,19 +554,19 @@ impl ServerImpl {
 
     /// Looks up a Sharkfin VPD EEPROM by sharkfin index (0-9)
     ///
-    /// Returns a designator (e.g. J206) and constructor function
-    fn get_sharkfin_vpd(i: usize) -> ([u8; 4], fn(TaskId) -> I2cDevice) {
+    /// Returns a designator (e.g. J206_U7) and constructor function
+    fn get_sharkfin_vpd(i: usize) -> ([u8; 7], fn(TaskId) -> I2cDevice) {
         let (name, f, _sensors) = match i {
-            0 => by_refdes!(J206, at24csw080),
-            1 => by_refdes!(J207, at24csw080),
-            2 => by_refdes!(J208, at24csw080),
-            3 => by_refdes!(J209, at24csw080),
-            4 => by_refdes!(J210, at24csw080),
-            5 => by_refdes!(J211, at24csw080),
-            6 => by_refdes!(J212, at24csw080),
-            7 => by_refdes!(J213, at24csw080),
-            8 => by_refdes!(J214, at24csw080),
-            9 => by_refdes!(J215, at24csw080),
+            0 => by_refdes!(J206_U7, at24csw080),
+            1 => by_refdes!(J207_U7, at24csw080),
+            2 => by_refdes!(J208_U7, at24csw080),
+            3 => by_refdes!(J209_U7, at24csw080),
+            4 => by_refdes!(J210_U7, at24csw080),
+            5 => by_refdes!(J211_U7, at24csw080),
+            6 => by_refdes!(J212_U7, at24csw080),
+            7 => by_refdes!(J213_U7, at24csw080),
+            8 => by_refdes!(J214_U7, at24csw080),
+            9 => by_refdes!(J215_U7, at24csw080),
             _ => panic!("bad VPD index"),
         };
         (name, f)

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -512,20 +512,25 @@ impl ServerImpl {
             }
             60..=70 => {
                 let i = index - 60;
-                let (name, _f, sensors) = match i {
-                    0 => by_refdes!(J206_U8, max5970, 4),
-                    1 => by_refdes!(J207_U8, max5970, 4),
-                    2 => by_refdes!(J208_U8, max5970, 4),
-                    3 => by_refdes!(J209_U8, max5970, 4),
-                    4 => by_refdes!(J210_U8, max5970, 4),
-                    5 => by_refdes!(J211_U8, max5970, 4),
-                    6 => by_refdes!(J212_U8, max5970, 4),
-                    7 => by_refdes!(J213_U8, max5970, 4),
-                    8 => by_refdes!(J214_U8, max5970, 4),
-                    9 => by_refdes!(J215_U8, max5970, 4),
-                    10 => by_refdes!(U275, max5970),
+                let (mut name, _f, sensors) = match i {
+                    0 => by_refdes!(J206_U8, max5970),
+                    1 => by_refdes!(J207_U8, max5970),
+                    2 => by_refdes!(J208_U8, max5970),
+                    3 => by_refdes!(J209_U8, max5970),
+                    4 => by_refdes!(J210_U8, max5970),
+                    5 => by_refdes!(J211_U8, max5970),
+                    6 => by_refdes!(J212_U8, max5970),
+                    7 => by_refdes!(J213_U8, max5970),
+                    8 => by_refdes!(J214_U8, max5970),
+                    9 => by_refdes!(J215_U8, max5970),
+                    10 => by_refdes!(U275, max5970, 7),
                     _ => panic!(),
                 };
+                // Transform Jxxx_U8 -> `Jxxx/U8`
+                // TOD(eliza): get this from i2c device codegen
+                if name[0] == b'J' {
+                    name[4] = b'/';
+                }
                 *self.scratch = InventoryData::Max5970 {
                     voltage_sensors: SensorId::into_u32_array(sensors.voltage),
                     current_sensors: SensorId::into_u32_array(sensors.current),

--- a/task/host-sp-comms/src/inventory.rs
+++ b/task/host-sp-comms/src/inventory.rs
@@ -18,7 +18,7 @@ pub(crate) const fn byteify<const N: usize>(s: &'static [u8]) -> [u8; N] {
     let mut out = [0u8; N];
     let mut i = 0;
     while i < s.len() {
-        out[i] = s[i];
+        out[i] = if s[i] == b'_' { b'/' } else { s[i] };
         i += 1;
     }
     out

--- a/task/validate-api/Cargo.toml
+++ b/task/validate-api/Cargo.toml
@@ -30,6 +30,7 @@ bench = false
 [build-dependencies]
 build-i2c = { path = "../../build/i2c" }
 idol.workspace = true
+anyhow.workspace = true
 
 [lints]
 workspace = true

--- a/task/validate-api/Cargo.toml
+++ b/task/validate-api/Cargo.toml
@@ -29,6 +29,7 @@ bench = false
 
 [build-dependencies]
 build-i2c = { path = "../../build/i2c" }
+gateway-messages.workspace = true
 idol.workspace = true
 anyhow.workspace = true
 

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -14,8 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn write_pub_device_descriptions(
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn write_pub_device_descriptions() -> anyhow::Result<()> {
     let devices = build_i2c::device_descriptions().collect::<Vec<_>>();
 
     let out_dir = std::env::var("OUT_DIR")?;
@@ -30,10 +29,27 @@ fn write_pub_device_descriptions(
         devices.len()
     )?;
 
-    for dev in devices {
+    let mut missing_ids = 0;
+    let mut duplicate_ids = 0;
+    let mut id2idx = std::collections::BTreeMap::new();
+
+    for (idx, dev) in devices.into_iter().enumerate() {
         writeln!(file, "    DeviceDescription {{")?;
         writeln!(file, "        device: {:?},", dev.device)?;
         writeln!(file, "        description: {:?},", dev.description)?;
+        if let Some(id) = dev.refdes.or_else(|| dev.name) {
+            writeln!(file, "        id: {id:?},")?;
+            if id2idx.insert(id.clone(), idx).is_some() {
+                println!("cargo::error=duplicate device id {id:?}",);
+                duplicate_ids += 1;
+            }
+        } else {
+            println!(
+                "cargo::error=device {:?} ({:?}) missing both name and refdes",
+                dev.device, dev.description
+            );
+            missing_ids += 1;
+        };
         writeln!(file, "        sensors: &[")?;
         for s in dev.sensors {
             writeln!(file, "            SensorDescription {{")?;
@@ -53,7 +69,27 @@ fn write_pub_device_descriptions(
         "pub static DEVICES: [DeviceDescription; DEVICES_CONST.len()] = DEVICES_CONST;"
     )?;
 
+    writeln!(
+        file,
+        "pub static DEVICE_INDICES_BY_ID: [(&'static str, usize); {}] = [",
+        id2idx.len()
+    )?;
+    for (id, idx) in id2idx {
+        writeln!(file, "    ({id:?}, {idx}")?;
+    }
+    writeln!(file, "];")?;
+
     file.flush()?;
+
+    anyhow::ensure!(
+        missing_ids == 0,
+        "{missing_ids} devices had neither name nor refdes"
+    );
+
+    anyhow::ensure!(
+        duplicate_ids == 0,
+        "{duplicate_ids} duplicate device IDs!"
+    );
 
     Ok(())
 }

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -50,7 +50,12 @@ fn write_pub_device_descriptions() -> anyhow::Result<()> {
     let mut missing_ids = 0;
     let mut duplicate_ids = 0;
     let mut ids_too_long = 0;
-    // We use a BTreeMap here so that the list is ordered by device ID. When generating the array, we want to ensure it's
+    //
+    // The DEVICE_INDICES_BY_SORTED_ID array is used to look up indices by ID
+    // using a binary search, so it must be sorted by ID. This map is used to
+    // generate that array, so we use a BTreeMap here to ensure it's sorted by
+    // key.
+    //
     let mut id2idx = std::collections::BTreeMap::new();
 
     for (idx, dev) in devices.into_iter().enumerate() {

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -50,6 +50,7 @@ fn write_pub_device_descriptions() -> anyhow::Result<()> {
     let mut missing_ids = 0;
     let mut duplicate_ids = 0;
     let mut ids_too_long = 0;
+    // We use a BTreeMap here so that the list is ordered by device ID. When generating the array, we want to ensure it's
     let mut id2idx = std::collections::BTreeMap::new();
 
     for (idx, dev) in devices.into_iter().enumerate() {
@@ -98,18 +99,13 @@ fn write_pub_device_descriptions() -> anyhow::Result<()> {
 
     writeln!(
         file,
-        "pub const DEVICE_INDICES_BY_ID_CONST: [([u8; MAX_ID_LENGTH], usize); {}] = [",
+        "pub static DEVICE_INDICES_BY_SORTED_ID: [([u8; MAX_ID_LENGTH], usize); {}] = [",
         id2idx.len()
     )?;
     for (id, idx) in id2idx {
         writeln!(file, "    ({id:?}, {idx}),")?;
     }
     writeln!(file, "];")?;
-    writeln!(
-        file,
-        "pub static DEVICE_INDICES_BY_ID: [([u8; MAX_ID_LENGTH], usize); \
-         DEVICE_INDICES_BY_ID_CONST.len()] = DEVICE_INDICES_BY_ID_CONST;"
-    )?;
 
     file.flush()?;
 

--- a/task/validate-api/build.rs
+++ b/task/validate-api/build.rs
@@ -36,6 +36,17 @@ fn write_pub_device_descriptions() -> anyhow::Result<()> {
         devices.len()
     )?;
 
+    //
+    // If a device in the TOML has no refdes, has the same refdes and suffix as
+    // another device, or produces a refdes-and-suffix string that is longer
+    // than the max component ID length, we will generate code that will not
+    // compile, so these errors are all fatal. However, as we loop over devices,
+    // we'll just log them and keep going, so that we can tell the user about
+    // *all* the bad devices in the config file, rather than bailing out at the
+    // first one. At the end, we return an error if there were any bad devices.
+    // This way, you don't have to fix one issue and recompile in order to
+    // discover the next error.
+    //
     let mut missing_ids = 0;
     let mut duplicate_ids = 0;
     let mut ids_too_long = 0;

--- a/task/validate-api/src/lib.rs
+++ b/task/validate-api/src/lib.rs
@@ -74,6 +74,7 @@ pub struct DeviceDescription {
     pub device: &'static str,
     pub description: &'static str,
     pub sensors: &'static [SensorDescription],
+    pub id: &'static str,
 }
 
 include!(concat!(env!("OUT_DIR"), "/device_descriptions.rs"));

--- a/task/validate-api/src/lib.rs
+++ b/task/validate-api/src/lib.rs
@@ -74,7 +74,7 @@ pub struct DeviceDescription {
     pub device: &'static str,
     pub description: &'static str,
     pub sensors: &'static [SensorDescription],
-    pub id: &'static str,
+    pub id: [u8; MAX_ID_LENGTH],
 }
 
 include!(concat!(env!("OUT_DIR"), "/device_descriptions.rs"));


### PR DESCRIPTION
In the `gateway-sp-comms` protocol, hardware devices known to the SP are uniquely identified by _component IDs_. These IDs are generated by the SP and are given to the control plane when reporting inventory. The control plane may then request details about a particular hardware component using the ID received from the inventory.

Presently, these IDs use what I've been referring to as the "dev-NN scheme".  In this scheme, each component is identified by a string consisting of `"dev-` followed by a two digit number, which is generated by the `control-plane-agent` task from that device's position in an array of devices generated at build time. While @jgallagher  will claim that this is just a bad design driven entirely by expedience, it does have some redeeming qualities: the SP can look up devices very efficiently by parsing the `NN` part as an integer and using it to index the array, and all the identifiers are a fixed, short number of bytes. However, it also has some disadvantages:

- The identifiers are not semantically meaningful
- A given device's identifier may change across firmware versions if new devices are added to the `app.toml` or the ordering of devices changes
- The identifiers are known only to the `control-plane-agent` task, and cannot easily be accessed by other tasks.

That last point is particularly problematic for the fault management subsystem: we would like a variety of tasks to be able to generate ereports relating to particular hardware components. When producing such an ereport, we would like to be able to include an identifier for that device that the control plane may then use to request additional information about that device from the SP. These identifiers should also be able to be used by the control plane to look up that device in its own cached understanding of the SP's inventory, and for querying metrics collected from the SP about that component. Since the `dev-nn` component IDs are known only to the `control-plane-agent` task, other Hubris tasks cannot easily include them in ereports. This is discussed at length in #2197.

In that issue, we [decided][1] to solve this problem by changing the `control-plane-agent` task from identifying components using the `dev-NN` scheme to a new scheme based on reference designators (refdes). Since a device's refdes is set in the `app.toml` for the board, it can be accessed by any number of tasks if we include it in generated code for the I<sup>2</sup>C (and, eventually, SPI) APIs. We started on this in #2189. Using refdes as the identifiers for hardware components has a number of other advantages:

- In `host-sp-comms`, we report inventory to the host OS using refdes as the unique ID for devices, so this makes the MGS API consistent with the IPCC API.
- Refdes is a fixed property of the _board_, rather than a property of the particular layout of items in a TOML file. This means that it should not change across Hubris versions (barring a bug or incorrect refdes in an app config).
- The refdes indicates semantically meaningful information; it can be used to find a given component in the board's schematic.
- Refdes are also pretty short strings

This PR changes `control-plane-agent` to use the device's refdes as the component ID, rather than the `dev-nn` identifier. When looking up a device, we use an array mapping refdes strings to indices in the devices array, which is generated at build time. We perform a binary search over this array to find the index and then access the device by index.

Certain devices (typically, those with updateable firmware) use hard-coded component ID strings. On Gimlets, for example, these are `sp`, `sp3-host-cpu`, `host-boot-flash`, and `system-led`.  I left these alone and didn't mess with them.

In a handful of cases, multiple devices have the same refdes in `app.toml`. Typically, this is when a removable subassembly is on the "other side" of a connector --- for example, a sharkfin has a VPD EEPROM, a MAX5970 hotswap controller,  and the U.2 device's NVMe Basic Management Command, and these all have refdes like `J206`, for the CEM slot that the sharkfin occupies. In this case, the `host-sp-comms` task uses a scheme like `{connector_refdes}/{refdes_on_subassembly}`, so (for example) sharkfin A's VPD EEPROM is `J206/U7` and its HSC is `J206/U8`. Currently, this is all just hardcoded in `host-sp-comms`. In order to use this scheme in `control-plane-agent` as well, I've changed the toml format to accept refdes either as a string _or_ an array of strings, which are joined together at codegen-time with `/` when forming the device IDs, or `_`s when generating Rust identifiers. There were some preexisting cases of refdes strings like `Jxxx_Uxx` in some app.tomls; I've changed these to use the new format.

Finally, there were a handful of boards which lacked refdes for some or all of their devices. After this change, these boards no longer build, so I've gone and updated them.

Fixes #2197

[1]: https://github.com/oxidecomputer/hubris/issues/2197#issuecomment-3192600805