### PR TITLE
gimlet/cosmo: Put back `U1` in TMP117 refdes

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -884,7 +884,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J44"
+refdes = ["J44", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -896,7 +896,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J45"
+refdes = ["J45", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -908,7 +908,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J46"
+refdes = ["J46", "U1"]
 
 ################################################################################
 
@@ -1130,7 +1130,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J47"
+refdes = ["J47", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1140,7 +1140,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J48"
+refdes = ["J48", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1150,7 +1150,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J49"
+refdes = ["J49", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -434,7 +434,7 @@ name = "Southwest"
 description = "Southwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J194"
+refdes = ["J194", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -444,7 +444,7 @@ name = "South"
 description = "South temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J195"
+refdes = ["J195", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -454,7 +454,7 @@ name = "Southeast"
 description = "Southeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J196"
+refdes = ["J196", "U1"]
 
 [[config.i2c.devices]]
 bus = "front"
@@ -1037,7 +1037,7 @@ name = "Northeast"
 description = "Northeast temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J197"
+refdes = ["J197", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1047,7 +1047,7 @@ name = "North"
 description = "North temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J198"
+refdes = ["J198", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"
@@ -1057,7 +1057,7 @@ name = "Northwest"
 description = "Northwest temperature sensor"
 sensors = { temperature = 1 }
 removable = true
-refdes = "J199"
+refdes = ["J199", "U1"]
 
 [[config.i2c.devices]]
 bus = "rear"

--- a/task/host-sp-comms/src/bsp/cosmo_a.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_a.rs
@@ -430,13 +430,13 @@ impl ServerImpl {
                 })
             }
             37..=42 => {
-                let (name, f, sensors): ([u8; 3], _, _) = match index - 37 {
-                    0 => by_refdes!(J44, tmp117),
-                    1 => by_refdes!(J45, tmp117),
-                    2 => by_refdes!(J46, tmp117),
-                    3 => by_refdes!(J47, tmp117),
-                    4 => by_refdes!(J48, tmp117),
-                    5 => by_refdes!(J49, tmp117),
+                let (name, f, sensors): ([u8; 6], _, _) = match index - 37 {
+                    0 => by_refdes!(J44_U1, tmp117),
+                    1 => by_refdes!(J45_U1, tmp117),
+                    2 => by_refdes!(J46_U1, tmp117),
+                    3 => by_refdes!(J47_U1, tmp117),
+                    4 => by_refdes!(J48_U1, tmp117),
+                    5 => by_refdes!(J49_U1, tmp117),
                     _ => unreachable!(),
                 };
                 let dev = f(I2C.get_task_id());

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -403,13 +403,13 @@ impl ServerImpl {
             }
 
             52..=57 => {
-                let (name, f, sensors): ([u8; 4], _, _) = match index - 52 {
-                    0 => by_refdes!(J194, tmp117),
-                    1 => by_refdes!(J195, tmp117),
-                    2 => by_refdes!(J196, tmp117),
-                    3 => by_refdes!(J197, tmp117),
-                    4 => by_refdes!(J198, tmp117),
-                    5 => by_refdes!(J199, tmp117),
+                let (name, f, sensors): ([u8; 7], _, _) = match index - 52 {
+                    0 => by_refdes!(J194_U1, tmp117),
+                    1 => by_refdes!(J195_U1, tmp117),
+                    2 => by_refdes!(J196_U1, tmp117),
+                    3 => by_refdes!(J197_U1, tmp117),
+                    4 => by_refdes!(J198_U1, tmp117),
+                    5 => by_refdes!(J199_U1, tmp117),
                     _ => unreachable!(),
                 };
                 let dev = f(I2C.get_task_id());


### PR DESCRIPTION
In [this comment][1] on PR #2199, @mkeeter suggested we not add `/U1` to the refdes for TMP117 temperature sensors., and just use the `Jxxx` jack. I followed Matt's advice because I didn't remember why I had added that. It turns out I shouldn't have, because `host-sp-comms` was actually adding it explicitly:
https://github.com/oxidecomputer/hubris/blob/41e43273fcf51634d447265c97d066cf6ad140df/task/host-sp-comms/src/bsp/gimlet_bcde.rs#L408-L424

The presence of the `/U1` is apparently necessary for `fmtopo` to understand the temperature sensors on the host side, and they're not present with it removed (as determined by `diff`ing the `fmtopo -V` output on `master` vs R16). Thus, this branch undoes the consequences of listening to Matt, and puts it back. Now, the temperature sensors once again show up in `fmtopo -V`

[1]: https://github.com/oxidecomputer/hubris/pull/2199#discussion_r2291387093