### PR TITLE
Fix incorrect hash offset

### DIFF
--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -618,9 +618,15 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
             ringbuf_entry!(Trace::HashInitError(e));
             return Err(HfError::HashError.into());
         }
-        let begin = self.flash_addr(addr, len)?.get() as usize;
-        let end = begin + len as usize;
-        self.hash_range_update(self.dev, begin, end)?;
+
+        // Check that the hash range is valid.  We **do not** pass the resulting
+        // value to `hash_range_update`, which expects relative offsets!
+        let _check = self.flash_addr(addr, len)?;
+        self.hash_range_update(
+            self.dev,
+            addr as usize,
+            addr as usize + len as usize,
+        )?;
 
         match self.hash.task.finalize_sha256() {
             Ok(sum) => Ok(sum),

--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -88,9 +88,6 @@ impl FlashAddr {
             None
         }
     }
-    fn get(&self) -> u32 {
-        self.0
-    }
 }
 
 /// Driver for a QSPI NOR flash controlled by an FPGA over FMC


### PR DESCRIPTION
In the current code, both `hash` and `hash_range_update` apply the `flash_addr` correction (going from relative offset to absolute address).

This means that if `Flash1` is selected, `hash` will end up hashing the Bonus Flash range:
- `hash` applies an offset to get an absolute address in `Flash1`
- `hash_range_update` re-applies that offset to an already-absolute address, pushing the address into Bonus Flash

I fixed this by not applying the offset in `hash` (although I still call `flash_addr` to perform address checks).