### PR TITLE
Speed up FPGA loading on Cosmo / Grapefruit

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -387,7 +387,7 @@ uses = ["mmio_dimms"]
 name = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
-features = ["h753", "gotta-go-fast"]
+features = ["h753", "fast-qspi"]
 uses = ["quadspi"]
 start = true
 notifications = ["qspi-irq"]

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -387,7 +387,7 @@ uses = ["mmio_dimms"]
 name = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
-features = ["h753"]
+features = ["h753", "gotta-go-fast"]
 uses = ["quadspi"]
 start = true
 notifications = ["qspi-irq"]
@@ -1388,6 +1388,7 @@ input = {port = "B", pin = 14, af = 5}
 [config.spi.spi2.devices.spartan7_fpga]
 mux = "port_b"
 cs = []
+clock_divider = "DIV8" # 12.5 MHz
 # no CS pin; we're using the SPI peripheral to send synchronized CLK + DATA
 
 # SPI_SP_TO_KSZ8463_SCK

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -265,7 +265,7 @@ interrupts = {"usart1.irq" = "usart-irq"}
 name = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
-features = ["h753"]
+features = ["h753", "gotta-go-fast"]
 uses = ["quadspi"]
 start = true
 notifications = ["qspi-irq"]

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -265,7 +265,7 @@ interrupts = {"usart1.irq" = "usart-irq"}
 name = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
-features = ["h753", "gotta-go-fast"]
+features = ["h753", "fast-qspi"]
 uses = ["quadspi"]
 start = true
 notifications = ["qspi-irq"]

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -428,6 +428,7 @@ input = {port = "B", pin = 14, af = 5} # not actually used in FPGA config
 [config.spi.spi2.devices.spartan7_fpga]
 mux = "port_b"
 cs = []
+clock_divider = "DIV8" # 12.5 MHz
 # no CS pin; we're using the SPI peripheral to send synchronized CLK + DATA
 
 [config.spi.spi4]

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -22,6 +22,9 @@ build-util = {path = "../../build/util"}
 idol.workspace = true
 serde.workspace = true
 
+[features]
+gotta-go-fast = []
+
 [lib]
 test = false
 doctest = false

--- a/drv/auxflash-api/Cargo.toml
+++ b/drv/auxflash-api/Cargo.toml
@@ -22,9 +22,6 @@ build-util = {path = "../../build/util"}
 idol.workspace = true
 serde.workspace = true
 
-[features]
-gotta-go-fast = []
-
 [lib]
 test = false
 doctest = false

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -25,7 +25,7 @@ idol = { workspace = true }
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]
 no-ipc-counters = ["idol/no-counters"]
-gotta-go-fast = [] # runs in quad mode + 66 MHz, instead of single + 40 MHz
+fast-qspi = [] # runs in quad mode + 66 MHz, instead of single + 40 MHz
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/auxflash-server/Cargo.toml
+++ b/drv/auxflash-server/Cargo.toml
@@ -25,6 +25,7 @@ idol = { workspace = true }
 [features]
 h753 = ["stm32h7/stm32h753", "drv-stm32xx-sys-api/h753", "drv-stm32h7-qspi/h753"]
 no-ipc-counters = ["idol/no-counters"]
+gotta-go-fast = [] # runs in quad mode + 66 MHz, instead of single + 40 MHz
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -71,10 +71,21 @@ fn main() -> ! {
     sys.leave_reset(sys_api::Peripheral::QuadSpi);
 
     let reg = unsafe { &*device::QUADSPI::ptr() };
-    let qspi =
-        Qspi::new(reg, notifications::QSPI_IRQ_MASK, ReadSetting::Single);
+    let qspi = Qspi::new(
+        reg,
+        notifications::QSPI_IRQ_MASK,
+        if cfg!(feature = "gotta-go-fast") {
+            ReadSetting::Quad
+        } else {
+            ReadSetting::Single
+        },
+    );
 
-    let clock = 5; // 200MHz kernel / 5 = 40MHz clock
+    let clock = if cfg!(feature = "gotta-go-fast") {
+        3 // 200MHz kernel / 3 = 66MHz clock
+    } else {
+        5 // 200MHz kernel / 5 = 40MHz clock
+    };
     const MEMORY_SIZE: usize = SLOT_COUNT as usize * SLOT_SIZE;
     assert!(MEMORY_SIZE.is_power_of_two());
     let memory_size_log2 = MEMORY_SIZE.trailing_zeros().try_into().unwrap();

--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -74,14 +74,14 @@ fn main() -> ! {
     let qspi = Qspi::new(
         reg,
         notifications::QSPI_IRQ_MASK,
-        if cfg!(feature = "gotta-go-fast") {
+        if cfg!(feature = "fast-qspi") {
             ReadSetting::Quad
         } else {
             ReadSetting::Single
         },
     );
 
-    let clock = if cfg!(feature = "gotta-go-fast") {
+    let clock = if cfg!(feature = "fast-qspi") {
         3 // 200MHz kernel / 3 = 66MHz clock
     } else {
         5 // 200MHz kernel / 5 = 40MHz clock


### PR DESCRIPTION
On Cosmo and Grapefruit, it takes ~10 seconds to load the sequencer FPGA, which is a very human-noticeable delay.

According to https://github.com/oxidecomputer/hubris/issues/2088 , 4-bit QSPI works on Cosmo at 66 MHz, so this PR adds a new `fast-qspi` feature to use those settings.  The feature is enabled for Cosmo and Grapefruit.  It is not enabled for Sidecar because that hasn't been validated, and Sidecar load times have been less annoying.

In addition, the PR bumps our FPGA SPI clock divider from `DIV64` (1.5625 MHz) to `DIV8` (12.5 MHz).  This is well below the FPGA's limit of 100 MHz, but any faster and we hit https://github.com/oxidecomputer/hubris/issues/2133

Together, this bring the FPGA load time down to about 4 seconds.

I tested this on `cosmo-hubris-sp` and confirmed that the host boots up to `bldb`, which is a strong indicator that everything is working.