### PR TITLE
cpu_seq: standardize ereport naming

### DIFF
--- a/drv/cosmo-seq-server/src/vcore.rs
+++ b/drv/cosmo-seq-server/src/vcore.rs
@@ -377,11 +377,7 @@ impl VCore {
         };
 
         let ereport = Ereport {
-            k: if !power_good {
-                "hw.pwr_good.bad"
-            } else {
-                "hw.pmbus.alert"
-            },
+            k: "hw.pwr.pmbus.alert",
             v: 0,
             rail,
             refdes: device.i2c_device().component_id(),
@@ -401,6 +397,8 @@ impl VCore {
                 ringbuf_entry!(Trace::EreportTooBig(rail))
             }
         }
+        // TODO(eliza): if POWER_GOOD has been deasserted, we should produce a
+        // subsequent ereport for that.
 
         RegulatorState {
             faulted,

--- a/drv/cosmo-seq-server/src/vcore.rs
+++ b/drv/cosmo-seq-server/src/vcore.rs
@@ -366,7 +366,7 @@ impl VCore {
         .map(|s| s.0);
         ringbuf_entry!(Trace::StatusMfrSpecific(rail, status_mfr));
 
-        let status = PmbusStatus {
+        let pmbus_status = PmbusStatus {
             word: status_word.map(|s| s.0).ok(),
             input: status_input.ok(),
             vout: status_vout.ok(),
@@ -377,12 +377,16 @@ impl VCore {
         };
 
         let ereport = Ereport {
-            k: "pmbus.alert",
+            k: if !power_good {
+                "hw.pwr_good.bad"
+            } else {
+                "hw.pmbus.alert"
+            },
             v: 0,
             rail,
-            dev_id: device.i2c_device().component_id(),
+            refdes: device.i2c_device().component_id(),
             time: now,
-            status,
+            pmbus_status,
             pwr_good: power_good,
         };
         match self.packrat.serialize_ereport(&ereport, ereport_buf) {
@@ -409,11 +413,11 @@ impl VCore {
 struct Ereport {
     k: &'static str,
     v: usize,
-    dev_id: &'static str,
+    refdes: &'static str,
     rail: Rail,
     time: u64,
     pwr_good: Option<bool>,
-    status: PmbusStatus,
+    pmbus_status: PmbusStatus,
 }
 
 #[derive(Copy, Clone, Default, Serialize)]

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -207,7 +207,7 @@ struct ServerImpl<S: SpiServer> {
 }
 
 const TIMER_INTERVAL: u32 = 10;
-const EREPORT_BUF_LEN: usize = 128;
+const EREPORT_BUF_LEN: usize = 256;
 
 impl<S: SpiServer + Clone> ServerImpl<S> {
     fn init(

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -267,13 +267,17 @@ impl VCore {
             mfr: status_mfr_specific.ok(),
         };
         let ereport = Ereport {
-            k: "pmbus.alert",
+            k: if !power_good {
+                "hw.pwr_good.bad"
+            } else {
+                "hw.pmbus.alert"
+            },
             v: 0,
-            dev_id: self.device.i2c_device().component_id(),
+            refdes: self.device.i2c_device().component_id(),
             rail: "VDD_VCORE",
             time: now,
             pwr_good,
-            status,
+            pmbus_status: status,
         };
         match self
             .packrat
@@ -339,9 +343,9 @@ struct PmbusStatus {
 struct Ereport {
     k: &'static str,
     v: usize,
-    dev_id: &'static str,
+    refdes: &'static str,
     rail: &'static str,
     time: u64,
     pwr_good: Option<bool>,
-    status: PmbusStatus,
+    pmbus_status: PmbusStatus,
 }

--- a/drv/gimlet-seq-server/src/vcore.rs
+++ b/drv/gimlet-seq-server/src/vcore.rs
@@ -267,11 +267,7 @@ impl VCore {
             mfr: status_mfr_specific.ok(),
         };
         let ereport = Ereport {
-            k: if !power_good {
-                "hw.pwr_good.bad"
-            } else {
-                "hw.pmbus.alert"
-            },
+            k: "hw.pwr.pmbus.alert",
             v: 0,
             refdes: self.device.i2c_device().component_id(),
             rail: "VDD_VCORE",
@@ -294,6 +290,8 @@ impl VCore {
                 ringbuf_entry!(Trace::EreportTooBig)
             }
         }
+        // TODO(eliza): if POWER_GOOD has been deasserted, we should produce a
+        // subsequent ereport for that.
 
         // If the `INPUT_FAULT` bit in `STATUS_WORD` is set, or any bit is hot
         // in `STATUS_INPUT`, sample Vin in order to record the voltage dip in


### PR DESCRIPTION
This commit tweaks the field and class naming in the CPU sequencer ereports for VRM PMbus alerts (added in #2184) based on a discussion with @rmustacc on standardizing ereport naming and class hierarchy. In particular, we namespace all "hardware" events under "hw", and emit a different class name string when the POWER_GOOD state has changed. Additionally, we've rename the "status" field for PMBus status registers to "pmbus_status" for clarity, and the "dev_id" to "refdes" --- the idea is that "dev_id" will be used when we want to indicate that the `control-plane-agent` device ID is _different_ from the refdes, but all `hw.` ereports will include a "refdes".