### PR TITLE
stm32xx-i2c: flush txdr on NACK

### DIFF
--- a/drv/stm32xx-i2c/src/lib.rs
+++ b/drv/stm32xx-i2c/src/lib.rs
@@ -549,6 +549,8 @@ impl I2cController<'_> {
 
                     if isr.nackf().is_nack() {
                         i2c.icr.write(|w| w.nackcf().set_bit());
+                        // Setting ISR.TXE to 1 flushes anything pending there.
+                        i2c.isr.write(|w| w.txe().set_bit());
                         return Err(drv_i2c_api::ResponseCode::NoDevice);
                     }
 
@@ -579,6 +581,8 @@ impl I2cController<'_> {
 
                 if isr.nackf().is_nack() {
                     i2c.icr.write(|w| w.nackcf().set_bit());
+                    // Setting ISR.TXE to 1 flushes anything pending there.
+                    i2c.isr.write(|w| w.txe().set_bit());
                     return Err(drv_i2c_api::ResponseCode::NoRegister);
                 }
 
@@ -644,6 +648,9 @@ impl I2cController<'_> {
 
                     if isr.nackf().is_nack() {
                         i2c.icr.write(|w| w.nackcf().set_bit());
+                        // Since we're reading, and not transmitting, we don't
+                        // need to do anything special to flush TXDR here --
+                        // unlike the write case.
                         return Err(drv_i2c_api::ResponseCode::NoDevice);
                     }
 
@@ -760,6 +767,9 @@ impl I2cController<'_> {
 
                 if isr.nackf().is_nack() {
                     i2c.icr.write(|w| w.nackcf().set_bit());
+                    // Even when we're writing, the "konami code" sends no data,
+                    // so we haven't loaded TXDR, so we don't need to flush it
+                    // on nack.
                     return Err(drv_i2c_api::ResponseCode::NoRegister);
                 }
 


### PR DESCRIPTION
During the write phase of an operation when acting as bus initiator, the ST I2C block is slightly pipelined: software loads one byte _ahead_ of what is actually being transmitted.

This means that byte N+1 is loaded before we're certain that byte N got ack'd.

It turns out that a premature abort to the write, due to a NACK received from the target device, does _not_ automatically flush the contents of the outgoing transmit data register TXDR. It hangs around, leaving ISR.TXE=1, until it's needed next. In particular, it will persist through arbitrarily many read operations, until it _quietly provides the first byte of the next write._

This behavior is not described in the reference manual, but it is hinted at, obliquely. The I2C chapter in the reference manual is generally really, really bad at describing error responses -- the many flowcharts for different transmit/receive operations ignore errors completely. I figured the behavior out when I instrumented a reliable bus hang and discovered that the driver was spinning because it thought there was one byte left to send, but the hardware had set TC (transfer complete) rather than TXIS (byte needed to transmit). Sure enough, logging the ISR value at the start of the write, before anything happened, showed TXE=1 already and transmission starting.

Other codebases have discovered this through the years. In particular, the stm32h7xx-hal crate contains code to flush txdr on NACK.

As of this commit, so does this driver.

In our case, most other error cases that might cause an abort during a write don't require flushing txdr, because it's implied by toggling PE to turn the peripheral off and back on again. We do this more than we need to, most likely, but it does prevent this specific error.