### PR TITLE
Update sparse registry hash for new toolchain

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -197,7 +197,7 @@ impl PackageConfig {
             let cargo_sparse_registry = cargo_home
                 .join("registry")
                 .join("src")
-                .join("index.crates.io-6f17d22bba15001f");
+                .join("index.crates.io-1949cf8c6b5b557f");
             remap_paths.insert(cargo_sparse_registry, "/crates.io");
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,8 @@
 [toolchain]
+# If you change the toolchain version, check that the cargo registry hash has
+# not changed (look at `remap_paths` in `xtask/src/dist.rs`).  This remapping
+# strips local paths from panic messages, because they're bad for both
+# reproducibility and binary size.
 channel = "nightly-2025-07-20"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"


### PR DESCRIPTION
When we bumped the toolchain, this changed as well.

Keeping the hash correct reduces the length of panic strings.