### PR TITLE
Add `LastPostCode` component details to SP5 host CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#6bd2660d651332f38949cdfd3d23d751ca54b120"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#a8e4c63e04e3453fe7d95bd3b071e3701ca9e137"
 dependencies = [
  "bitflags 2.9.4",
  "hubpack",

--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -181,7 +181,7 @@ max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 2600
 start = true
 task-slots = ["sys", "i2c_driver", {spi_front = "spi3_driver"}, "jefe", "packrat", "auxflash", "spartan7_loader", "hf"]
-uses = ["mmio_sequencer", "mmio_info"]
+uses = ["mmio_sequencer", "mmio_info", "mmio_espi"]
 notifications = ["timer", "vcore", "seq-irq"]
 
 [tasks.ignition_flash]

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -181,7 +181,7 @@ max-sizes = {flash = 131072, ram = 16384 }
 stacksize = 2600
 start = true
 task-slots = ["sys", "jefe", "packrat", "spartan7_loader"]
-uses = ["mmio_sgpio"]
+uses = ["mmio_sgpio", "mmio_espi"]
 
 [tasks.spartan7_loader]
 name = "drv-spartan7-loader"

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -449,6 +449,7 @@ pub fn build_peripheral(
             else {
                 panic!("nodes within register must be fields, not {c:?}");
             };
+            let desc = Some(desc.as_str()).filter(|s| !s.is_empty());
             let msb = u32::try_from(*msb).unwrap();
             let lsb = u32::try_from(*lsb).unwrap();
             let setter: syn::Ident =
@@ -458,9 +459,10 @@ pub fn build_peripheral(
                 syn::parse_str(&inst_name.to_snake_case()).unwrap();
             if lsb == msb {
                 if sw_access.is_write() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #setter(&self, t: bool) {
                             let mut d = self.get_raw();
                             if t {
@@ -473,9 +475,10 @@ pub fn build_peripheral(
                     });
                 }
                 if sw_access.is_read() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #getter(&self) -> bool {
                             let d = self.get_raw();
                             (d & (1 << #msb)) != 0
@@ -535,9 +538,10 @@ pub fn build_peripheral(
                     }
                 });
                 if sw_access.is_write() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #setter(&self, t: #ty) {
                             let mut d = self.get_raw();
                             d &= !(#mask << #lsb);
@@ -547,9 +551,10 @@ pub fn build_peripheral(
                     });
                 }
                 if sw_access.is_read() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #getter(&self) -> Result<#ty, #raw_ty> {
                             let d = self.get_raw();
                             let t = ((d >> #lsb) & #mask) as #raw_ty;
@@ -576,9 +581,10 @@ pub fn build_peripheral(
                 };
                 let ty: syn::Ident = syn::parse_str(ty).unwrap();
                 if sw_access.is_write() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #setter(&self, t: #ty) {
                             let mut d = self.get_raw();
                             d &= !(#mask << #lsb);
@@ -588,9 +594,10 @@ pub fn build_peripheral(
                     });
                 }
                 if sw_access.is_read() {
+                    let doc = desc.into_iter();
                     struct_fns.push(quote! {
                         #[inline]
-                        #[doc = #desc]
+                        #(#[doc = #doc])*
                         pub fn #getter(&self) -> #ty {
                             let d = self.get_raw();
                             ((d >> #lsb) & #mask) as #ty

--- a/drv/cosmo-seq-server/build.rs
+++ b/drv/cosmo-seq-server/build.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         idol::server::ServerStyle::InOrder,
     )?;
 
-    let out_file = out_dir.join("fmc_sequencer.rs");
+    let out_file = out_dir.join("fmc_periph.rs");
     let mut file = std::fs::File::create(out_file)?;
-    for periph in ["sequencer", "info"] {
+    for periph in ["sequencer", "info", "espi"] {
         write!(
             &mut file,
-            "{}",
+            "pub mod {periph} {{\n{}\n}}",
             build_fpga_regmap::fpga_peripheral(
                 periph,
                 "drv_spartan7_loader_api::Spartan7Token"

--- a/drv/cosmo-seq-server/src/main.rs
+++ b/drv/cosmo-seq-server/src/main.rs
@@ -52,17 +52,17 @@ enum Trace {
     Programmed,
 
     Startup {
-        early_power_rdbks: fmc_periph::EarlyPowerRdbksView,
+        early_power_rdbks: fmc_sequencer::EarlyPowerRdbksView,
     },
     RegStateValues {
-        seq_api_status: fmc_periph::SeqApiStatusView,
-        seq_raw_status: fmc_periph::SeqRawStatusView,
-        nic_api_status: fmc_periph::NicApiStatusView,
-        nic_raw_status: fmc_periph::NicRawStatusView,
+        seq_api_status: fmc_sequencer::SeqApiStatusView,
+        seq_raw_status: fmc_sequencer::SeqRawStatusView,
+        nic_api_status: fmc_sequencer::NicApiStatusView,
+        nic_raw_status: fmc_sequencer::NicRawStatusView,
     },
     RegPgValues {
-        rail_pgs: fmc_periph::RailPgsView,
-        rail_pgs_max_hold: fmc_periph::RailPgsMaxHoldView,
+        rail_pgs: fmc_sequencer::RailPgsView,
+        rail_pgs_max_hold: fmc_sequencer::RailPgsMaxHoldView,
     },
     SetState {
         prev: Option<PowerState>,
@@ -73,12 +73,12 @@ enum Trace {
     },
     UnexpectedPowerOff {
         our_state: PowerState,
-        seq_state: Result<fmc_periph::A0Sm, u8>,
+        seq_state: Result<fmc_sequencer::A0Sm, u8>,
     },
     SequencerInterrupt {
         our_state: PowerState,
-        seq_state: Result<fmc_periph::A0Sm, u8>,
-        ifr: fmc_periph::IfrView,
+        seq_state: Result<fmc_sequencer::A0Sm, u8>,
+        ifr: fmc_sequencer::IfrView,
     },
     PowerDownError(drv_cpu_seq_api::SeqError),
     Coretype {
@@ -155,8 +155,8 @@ use gpio_irq_pins::SEQ_IRQ;
 
 /// Helper type which includes both sequencer and NIC state machine states
 struct StateMachineStates {
-    seq: Result<fmc_periph::A0Sm, u8>,
-    nic: Result<fmc_periph::NicSm, u8>,
+    seq: Result<fmc_sequencer::A0Sm, u8>,
+    nic: Result<fmc_sequencer::NicSm, u8>,
 }
 
 #[export_name = "main"]
@@ -260,7 +260,7 @@ fn init(packrat: Packrat) -> Result<ServerImpl, SeqError> {
 
     // Set up the checksum registers for the Spartan7 FPGA
     let token = loader.get_token();
-    let info = fmc_periph::Info::new(token);
+    let info = fmc_periph::info::Info::new(token);
     let short_checksum = gen::SPARTAN7_FPGA_BITSTREAM_CHECKSUM[..4]
         .try_into()
         .unwrap();
@@ -298,8 +298,7 @@ fn init(packrat: Packrat) -> Result<ServerImpl, SeqError> {
     // Turn on the chassis LED!
     sys.gpio_set(SP_CHASSIS_STATUS_LED);
 
-    let token = loader.get_token();
-    Ok(ServerImpl::new(token, packrat))
+    Ok(ServerImpl::new(loader, packrat))
 }
 
 /// Configures the front FPGA pins and holds it in reset
@@ -376,7 +375,8 @@ struct ServerImpl {
     jefe: Jefe,
     sys: Sys,
     hf: HostFlash,
-    seq: fmc_periph::Sequencer,
+    seq: fmc_sequencer::Sequencer,
+    espi: fmc_periph::espi::Espi,
     vcore: VCore,
     /// Static buffer for encoding ereports. This is a static so that we don't
     /// have it on the stack when encoding ereports.
@@ -387,11 +387,14 @@ const EREPORT_BUF_LEN: usize = 256;
 
 impl ServerImpl {
     fn new(
-        token: drv_spartan7_loader_api::Spartan7Token,
+        loader: drv_spartan7_loader_api::Spartan7Loader,
         packrat: Packrat,
     ) -> Self {
         let now = sys_get_timer().now;
-        let seq = fmc_periph::Sequencer::new(token);
+
+        let seq = fmc_sequencer::Sequencer::new(loader.get_token());
+        let espi = fmc_periph::espi::Espi::new(loader.get_token());
+
         ringbuf_entry!(Trace::Startup {
             early_power_rdbks: (&seq.early_power_rdbks).into(),
         });
@@ -417,6 +420,7 @@ impl ServerImpl {
             sys: Sys::from(SYS.get_task_id()),
             hf: HostFlash::from(HF.get_task_id()),
             seq,
+            espi,
             vcore: VCore::new(I2C.get_task_id(), packrat),
             ereport_buf,
         }
@@ -464,7 +468,7 @@ impl ServerImpl {
             now,
         });
 
-        use fmc_periph::A0Sm;
+        use fmc_sequencer::A0Sm;
         match (self.get_state_impl(), state) {
             (PowerState::A2, PowerState::A0) => {
                 // Reset edge counters in the sequencer
@@ -881,6 +885,13 @@ impl idl::InOrderSequencerImpl for ServerImpl {
             idol_runtime::ClientError::BadMessageContents,
         ))
     }
+
+    fn last_post_code(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Ok(self.espi.last_post_code.payload())
+    }
 }
 
 impl NotificationHandler for ServerImpl {
@@ -897,7 +908,7 @@ impl NotificationHandler for ServerImpl {
             return;
         }
         let state = self.log_state_registers();
-        use fmc_periph::{A0Sm, NicSm};
+        use fmc_sequencer::{A0Sm, NicSm};
 
         // Detect when the NIC comes online
         // TODO: should we handle the NIC powering down while the main CPU
@@ -940,8 +951,9 @@ mod gen {
 }
 
 mod fmc_periph {
-    include!(concat!(env!("OUT_DIR"), "/fmc_sequencer.rs"));
+    include!(concat!(env!("OUT_DIR"), "/fmc_periph.rs"));
 }
+use fmc_periph::sequencer as fmc_sequencer;
 
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
 include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -1135,6 +1135,15 @@ impl<S: SpiServer> idl::InOrderSequencerImpl for ServerImpl<S> {
 
         Ok(buf)
     }
+
+    fn last_post_code(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
 }
 
 fn read_spd_data_and_load_packrat(

--- a/drv/grapefruit-seq-server/build.rs
+++ b/drv/grapefruit-seq-server/build.rs
@@ -12,16 +12,18 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     )?;
 
     let out_dir = build_util::out_dir();
-    let out_file = out_dir.join("fmc_sgpio.rs");
+    let out_file = out_dir.join("fmc_periph.rs");
     let mut file = std::fs::File::create(out_file)?;
-    write!(
-        &mut file,
-        "{}",
-        build_fpga_regmap::fpga_peripheral(
-            "sgpio",
-            "drv_spartan7_loader_api::Spartan7Token"
-        )?
-    )?;
+    for p in ["sgpio", "espi"] {
+        write!(
+            &mut file,
+            "pub mod {p} {{\n{}\n}}",
+            build_fpga_regmap::fpga_peripheral(
+                p,
+                "drv_spartan7_loader_api::Spartan7Token"
+            )?
+        )?;
+    }
 
     Ok(())
 }

--- a/drv/grapefruit-seq-server/src/main.rs
+++ b/drv/grapefruit-seq-server/src/main.rs
@@ -75,7 +75,8 @@ fn main() -> ! {
 #[allow(unused)]
 struct ServerImpl {
     jefe: Jefe,
-    sgpio: fmc_periph::Sgpio,
+    sgpio: fmc_periph::sgpio::Sgpio,
+    espi: fmc_periph::espi::Espi,
 }
 
 impl ServerImpl {
@@ -96,7 +97,8 @@ impl ServerImpl {
 
         let server = Self {
             jefe: Jefe::from(JEFE.get_task_id()),
-            sgpio: fmc_periph::Sgpio::new(loader.get_token()),
+            sgpio: fmc_periph::sgpio::Sgpio::new(loader.get_token()),
+            espi: fmc_periph::espi::Espi::new(loader.get_token()),
         };
 
         // Note that we don't use `Self::set_state_impl` here, as that will
@@ -184,6 +186,13 @@ impl idl::InOrderSequencerImpl for ServerImpl {
     ) -> Result<[u8; 64], RequestError<core::convert::Infallible>> {
         Ok([0; 64])
     }
+
+    fn last_post_code(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Ok(self.espi.last_post_code.payload())
+    }
 }
 
 impl NotificationHandler for ServerImpl {
@@ -202,5 +211,5 @@ mod idl {
 }
 
 mod fmc_periph {
-    include!(concat!(env!("OUT_DIR"), "/fmc_sgpio.rs"));
+    include!(concat!(env!("OUT_DIR"), "/fmc_periph.rs"));
 }

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -103,6 +103,15 @@ impl idl::InOrderSequencerImpl for ServerImpl {
     ) -> Result<[u8; 64], RequestError<core::convert::Infallible>> {
         Ok([0; 64])
     }
+
+    fn last_post_code(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
 }
 
 impl NotificationHandler for ServerImpl {

--- a/idl/cpu-seq.idol
+++ b/idl/cpu-seq.idol
@@ -57,9 +57,15 @@ Interface(
             ),
         ),
         "read_fpga_regs": (
-            doc: "Raw read of the FPGA registers",
+            doc: "Raw read of the FPGA registers (Gimlet only)",
             args: {},
             reply: Simple("[u8; 64]"),
+            idempotent: true,
+        ),
+        "last_post_code": (
+            doc: "Read the last POST code seen by the sequencer FPGA (Cosmo only)",
+            args: {},
+            reply: Simple("u32"),
             idempotent: true,
         ),
     },

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -42,27 +42,39 @@ impl Inventory {
         component: &SpComponent,
     ) -> Result<u32, SpError> {
         match Index::try_from(component)? {
-            Index::OurDevice(_) => Ok(0),
+            Index::OurDevice(d) => {
+                match OUR_DEVICES[d].component {
+                    // The SP5 CPU can report a POST code
+                    SpComponent::SP5_HOST_CPU => Ok(1),
+                    _ => Ok(0),
+                }
+            }
             Index::ValidateDevice(i) => {
                 Ok(VALIDATE_DEVICES[i].sensors.len() as u32)
             }
         }
     }
 
-    pub(crate) fn component_details(
+    pub(crate) fn component_details<F>(
         &self,
         component: &SpComponent,
         component_index: BoundsChecked,
-    ) -> ComponentDetails {
+        our_device_lookup: F,
+    ) -> ComponentDetails
+    where
+        F: Fn(&DeviceDescription<'static>, BoundsChecked) -> ComponentDetails,
+    {
         // `component_index` is guaranteed to be in the range
-        // `0..num_component_details(component)`, and we only return a value
-        // greater than 0 from that method for indices in the VALIDATE_DEVICES
-        // range. We'll map the component back to an index back here and panic
-        // for the unreachable branches (an out of range index or an index in
-        // the `OurDevice(_)` subrange).
+        // `0..num_component_details(component)`. We'll map the component back
+        // to an index back here, panicking for an out-of-range index; the
+        // `our_device_lookup` closure is also expected to panic if given an
+        // out-of-range index
         let val_device_index = match Index::try_from(component) {
             Ok(Index::ValidateDevice(i)) => i,
-            Ok(Index::OurDevice(_)) | Err(_) => panic!(),
+            Ok(Index::OurDevice(i)) => {
+                return our_device_lookup(&OUR_DEVICES[i], component_index)
+            }
+            Err(_) => panic!(),
         };
 
         let sensor_description = &VALIDATE_DEVICES[val_device_index].sensors

--- a/task/control-plane-agent/src/mgs_compute_sled.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled.rs
@@ -17,11 +17,12 @@ use gateway_messages::sp_impl::{
 use gateway_messages::{
     ignition, ComponentAction, ComponentActionResponse, ComponentDetails,
     ComponentUpdatePrepare, DiscoverResponse, DumpSegment, DumpTask, Header,
-    IgnitionCommand, IgnitionState, Message, MessageKind, MgsError, MgsRequest,
-    MgsResponse, PowerState, PowerStateTransition, RotBootInfo, RotRequest,
-    RotResponse, SensorRequest, SensorResponse, SpComponent, SpError,
-    SpPort as GwSpPort, SpRequest, SpStateV2, SpUpdatePrepare, UpdateChunk,
-    UpdateId, UpdateStatus, SERIAL_CONSOLE_IDLE_TIMEOUT,
+    IgnitionCommand, IgnitionState, LastPostCode, Message, MessageKind,
+    MgsError, MgsRequest, MgsResponse, PowerState, PowerStateTransition,
+    RotBootInfo, RotRequest, RotResponse, SensorRequest, SensorResponse,
+    SpComponent, SpError, SpPort as GwSpPort, SpRequest, SpStateV2,
+    SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    SERIAL_CONSOLE_IDLE_TIMEOUT,
 };
 use heapless::{Deque, Vec};
 use host_sp_messages::HostStartupOptions;
@@ -914,7 +915,24 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         index: BoundsChecked,
     ) -> ComponentDetails {
-        self.common.inventory().component_details(&component, index)
+        self.common.inventory().component_details(
+            &component,
+            index,
+            |dev, index| {
+                match dev.component {
+                    SpComponent::SP5_HOST_CPU => {
+                        // Only one component detail for now
+                        assert_eq!(index.0, 0);
+                        ComponentDetails::LastPostCode(LastPostCode(
+                            self.sequencer.last_post_code(),
+                        ))
+                    }
+                    _ => {
+                        panic!("no other devices have component details");
+                    }
+                }
+            },
+        )
     }
 
     fn component_get_active_slot(

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -452,7 +452,13 @@ impl SpHandler for MgsHandler {
         component: SpComponent,
         index: BoundsChecked,
     ) -> ComponentDetails {
-        self.common.inventory().component_details(&component, index)
+        self.common
+            .inventory()
+            .component_details(&component, index, |_, _| {
+                // This should never be called, because num_component_details
+                // never returns > 0 for devices in the OUR_DEVICES array
+                panic!("no custom devices")
+            })
     }
 
     fn component_get_active_slot(

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -928,7 +928,13 @@ impl SpHandler for MgsHandler {
             SpComponent::MONORAIL => ComponentDetails::PortStatus(
                 monorail_port_status::port_status(&self.monorail, index),
             ),
-            _ => self.common.inventory().component_details(&component, index),
+            _ => self.common.inventory().component_details(
+                &component,
+                index,
+                // This should never be called, because num_component_details
+                // never returns > 0 for devices in the OUR_DEVICES array
+                |_, _| panic!("no custom devices"),
+            ),
         }
     }
 


### PR DESCRIPTION
Fixes #2244 

We would like to be able to read the `LAST_POST_CODE` register from the FPGA.  This PR adds it as a `ComponentDetail` to the `SP5_HOST_CPU` component.

The MGS side is https://github.com/oxidecomputer/management-gateway-service/pull/451, so this is marked as a draft (but can still be reviewed).

There are two interesting changes:
- `Inventory::num_component_details` now returns 1 for the `SP5_HOST_CPU` component
- `Inventory::component_details` now accepts a closure to handle any components in `OUR_DEVICES`

The rest of the PR is mostly plumbing, e.g. adding modules to the generated FMC code (because otherwise we have name collisions between `espi` and `sequencer` registers).

I tested this on the bench with a Grapefruit, and it "works":
```
➜  management-gateway-service jj:(zq) cargo run -pfaux-mgs -- --interface=en10 component-details sp5-host-cpu
   Compiling gateway-messages v0.1.0 (/Users/mjk/oxide/management-gateway-service/gateway-messages)
   Compiling gateway-sp-comms v0.1.1 (/Users/mjk/oxide/management-gateway-service/gateway-sp-comms)
   Compiling faux-mgs v0.1.1 (/Users/mjk/oxide/management-gateway-service/faux-mgs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.01s
     Running `target/debug/faux-mgs --interface=en10 component-details sp5-host-cpu`
Sep 25 15:41:12.950 INFO creating SP handle on interface en10, component: faux-mgs
Sep 25 15:41:12.954 INFO initial discovery complete, addr: [fe80::c1d:8cff:fec0:e208%26]:11111, interface: en10, socket: control-plane-agent, component: faux-mgs
LastPostCode(LastPostCode(0))
```

I've also tested the `Sequencer.last_post_code` function on a Cosmo through `humility hiffy`.  I would like to do an end-to-end test, but Cosmos with network connectivity are in high demand (see https://github.com/oxidecomputer/meta/issues/761)