### PR TITLE
Update lockfile from #2250

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4327,7 +4327,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.7"
-source = "git+https://github.com/oxidecomputer/pmbus?branch=aaron%2Fadm1273-support#a029ad704f1be0ffa8030f252776ca4576fa69b0"
+source = "git+https://github.com/oxidecomputer/pmbus#631358a97cf9775c825a2cf726d51f0f243b91a4"
 dependencies = [
  "anyhow",
  "convert_case",


### PR DESCRIPTION
It looks like PR #2250 forgot to remove an updated lockfile after a Git dep on
a development branch was removed. The `Cargo.toml` is pointed at the correct
Git rev, but the lockfile doesn't realize that. This means that any time 
rust-analyzer (or Cargo) runs, it will immediately generate this diff:

```patch
diff --git a/Cargo.lock b/Cargo.lock
index 08fb860d..6fac3b3e 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4327,7 +4327,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.7"
-source = "git+https://github.com/oxidecomputer/pmbus?branch=aaron%2Fadm1273-support#a029ad704f1be0ffa8030f252776ca4576fa69b0"
+source = "git+https://github.com/oxidecomputer/pmbus#631358a97cf9775c825a2cf726d51f0f243b91a4"
 dependencies = [
  "anyhow",
  "convert_case",
```

This makes it difficult to switch branches from one's editor, since now there
are unstaged changes, and as soon as you undo them, rust-analyzer will
"helpfully" fix the lockfile again. So you can't switch branches without killing
rust-analyzer. Whoopsie. Anyway this commit fixes it.