### PR TITLE
Fix `spare_macs` calculation if VPD is unprogrammed

### DIFF
--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -572,7 +572,8 @@ where
             spare_macs: MacAddressBlock {
                 base_mac: mac,
                 count: U16::new(
-                    mac_address_block.count.get() - VLanId::LENGTH as u16,
+                    mac_address_block.count.get()
+                        - generated::PORT_COUNT as u16,
                 ),
                 stride: mac_address_block.stride,
             },


### PR DESCRIPTION
Ever since #1835, the number of ports (needing unique MAC addresses) and VLANs are not necessarily the same.  Computing `spare_macs.count` has been broken since then, but triggering the issue requires (1) a board with more VLANs than ports (i.e. only Sidecar) and (2) an unprogrammed VPD (i.e. none of our actual units)

The stars aligned yesterday when @lzrd updated the SP image on a Sidecar with an unprogrammed VPD, and the `net` task promptly panicked:
```
stoltz@lurch ~ $ pfexec humility -p usb-4 --archive build-sidecar-b-lab-image-default.zip tasks -v net
humility: attached via ST-Link V3
system time = 380145
ID TASK                       GEN PRI STATE
 5 net                       1145   5 FAULT: panicked at task/net/src/server.rs:575:21:
attempt to subtract with overflow (was: ready)
```

When the VPD is unprogrammed, we allocate `PORT_COUNT` MAC addresses based on a hash of the chip's unique ID.  However, the computation of `spare_macs.count` subtracts `VLanId::LENGTH`, which underflows if there are more VLANs than ports.  The fix is easy: just subtract `PORT_COUNT` instead.