### PR TITLE
Tweak polling timeout in `cosmo-hf`

### DIFF
--- a/drv/cosmo-hf/src/main.rs
+++ b/drv/cosmo-hf/src/main.rs
@@ -216,7 +216,11 @@ impl FlashDriver {
         // desired status transition occurs in less than 1ms, avoiding a 1-2ms
         // sleep and round-trip through the scheduler. status transitions
         // quickly.
-        const MAX_BUSY_POLLS: u32 = 32;
+        //
+        // Initial tests show that waiting on the FPGA takes ~50 polls when
+        // page programming. Waiting even 1 tick is still more costly than
+        // just waiting for the poll to finish.
+        const MAX_BUSY_POLLS: u32 = 100;
 
         let mut busy_polls = 0;
         while !poll(self) {


### PR DESCRIPTION
The existing polling number will result in us always hitting the sleep case when waiting for the FPGA to go idle when programming a page. It turns out sleeping for even one tick will take up much more time than waiting for the poll to complete. Up our timeout to something sufficiently large we are unlikely to hit it on common cases.

`faux-mgs update host-flash` before

```
real	6m46.185s
user	0m4.559s
sys	0m3.476s
```

after

```
real	3m31.962s
user	0m4.325s
sys	0m3.188s
```