### PR TITLE
Make `apob_lock` allowed on Gimlet

### DIFF
--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -944,7 +944,12 @@ impl idl::InOrderHostFlashImpl for ServerImpl {
         &mut self,
         _: &RecvMessage,
     ) -> Result<(), RequestError<core::convert::Infallible>> {
-        Ok(()) // tautologically true
+        // `apob_lock` is called by `host_sp_comms` once it receives *any*
+        // message indicating that we've reached a late phase of booting (e.g.
+        // asking the SP for MAC addresses).  The Gimlet has no APOB, so it's
+        // fine to just return `Ok(())` here; this is cleaner than
+        // special-casing `host_sp_comms` to only call `apob_lock` on Cosmo.
+        Ok(())
     }
 
     fn apob_read(


### PR DESCRIPTION
`host-sp-comms` always calls `apob_lock` when it receives a message associated with the later stages of boot (e.g. getting MAC addresses).  Unfortunately, the Gimlet host flash task would kill it for this impertinence.

Fixes #2289 