### PR TITLE
net-api: change TryFrom<IpAddress> to just From

### DIFF
--- a/task/net-api/src/lib.rs
+++ b/task/net-api/src/lib.rs
@@ -250,14 +250,12 @@ impl From<Address> for smoltcp::wire::IpAddress {
 }
 
 #[cfg(feature = "use-smoltcp")]
-impl TryFrom<smoltcp::wire::IpAddress> for Address {
-    type Error = AddressUnspecified;
-
-    fn try_from(a: smoltcp::wire::IpAddress) -> Result<Self, Self::Error> {
+impl From<smoltcp::wire::IpAddress> for Address {
+    fn from(a: smoltcp::wire::IpAddress) -> Self {
         use smoltcp::wire::IpAddress;
 
         match a {
-            IpAddress::Ipv6(a) => Ok(Self::Ipv6(a.into())),
+            IpAddress::Ipv6(a) => Self::Ipv6(a.into()),
         }
     }
 }

--- a/task/net/src/server.rs
+++ b/task/net/src/server.rs
@@ -718,7 +718,7 @@ where
                         return Ok(vlan.device.make_meta(
                             endp.port,
                             body_len,
-                            endp.addr.try_into().map_err(|_| ()).unwrap(),
+                            endp.addr.into(),
                         ));
                     }
                     Err(udp::RecvError::Exhausted) => {


### PR DESCRIPTION
It turns out, the TryFrom impl for smoltcp's IpAddress can't fail. This changed in 2023 with the upgrade to smoltcp 0.9, which made the shape of IpAddress depend on which protocol features we'd selected, removing the "unreachable" variants.

This commit converts the impl to From, making it clear that it can't fail and eliminating an unwrap at its (apparently single) use site.