### PR TITLE
Add macOS as a first-tier platform including CI support

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -77,7 +77,19 @@ jobs:
         run: |
           rustup show active-toolchain || rustup toolchain install
           rustup show
-          rustup component add clippy
+          # Add clippy to the active toolchain
+          TOOLCHAIN=$(rustup show active-toolchain | cut -d' ' -f1)
+          rustup component add --toolchain "$TOOLCHAIN" clippy
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install libusb libftdi
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libftdi1-dev 
 
       - name: Cache build output
         uses: Swatinem/rust-cache@v2
@@ -106,15 +118,21 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Fetch Humility
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
-          curl -fLo target/release/humility https://github.com/oxidecomputer/humility/releases/download/nightly/humility
-          chmod +x target/release/humility
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            # Build from source on macOS until pre-built binaries are available
+            cargo install --git https://github.com/oxidecomputer/humility.git --locked humility-bin
+            mkdir -p target/release
+            cp ~/.cargo/bin/humility target/release
+          else
+            curl -fLo target/release/humility https://github.com/oxidecomputer/humility/releases/download/nightly/humility
+            chmod +x target/release/humility
+          fi
 
       - name: Test Humility manifest
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
-          sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libftdi1-dev
           for image in ${images}; do
               mv "target/${name}/dist/${image}/build-${name}-image-${image}.zip" "target/${name}/dist/";
               target/release/humility -a "target/${name}/dist/build-${name}-image-${image}.zip" manifest;
@@ -124,7 +142,7 @@ jobs:
           images: ${{ matrix.image }}
 
       - name: Clippy
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           cargo xtask clippy ${{ matrix.app_toml }} -- --deny warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             name: Linux
           - os: windows-latest
             name: Windows
+          - os: macos-latest
+            name: macOS
     uses: ./.github/workflows/build-boards.yml
     with:
       os: ${{ matrix.os }}

--- a/README.mkdn
+++ b/README.mkdn
@@ -57,10 +57,9 @@ The repo is laid out as follows.
 
 # Developing
 
-We currently support Linux and Windows as first-tier platforms. macOS is also
-used on a daily basis by Oxide employees, but is not tested in CI.  The build
-probably also works on Illumos; if anyone would like to step up to maintain
-support and a continuous build for Illumos or macOS, we'd love the help.
+We currently support Linux, Windows, and macOS as first-tier platforms with continuous integration testing.
+The build probably also works on Illumos; if anyone would like to step up to maintain
+support and a continuous build for Illumos, we'd love the help.
 
 To submit changes for review, push them to a branch in a fork and submit a pull
 request to merge that branch into `master`. For details, see
@@ -92,6 +91,35 @@ You will need:
   verbatim to install Humility, do so from a different directory:
   - `cargo install --git https://github.com/oxidecomputer/humility.git --locked humility-bin`
     - Requires `cargo-readme` as a dependency: `cargo install cargo-readme`
+
+### macOS
+
+Install dependencies using Homebrew:
+
+```console
+$ brew install libusb libftdi
+```
+
+If you will be running GDB, you can install ARM GDB tools:
+
+```console
+$ brew install arm-none-eabi-gdb
+```
+
+Note: The `gcc-arm-embedded` cask may have checksum mismatches. If you encounter issues, `arm-none-eabi-gdb` is a reliable alternative.
+
+To install Humility:
+
+```console
+$ cargo install cargo-readme
+$ cargo install --git https://github.com/oxidecomputer/humility.git --locked humility-bin
+```
+
+Note: When building Hubris, rustup will automatically install the required nightly toolchain. You'll also need to add clippy to that toolchain:
+
+```console
+$ rustup component add clippy
+```
 
 ### Windows
 


### PR DESCRIPTION
## Summary:
This commit adds macOS to the CI build matrix including all needed infrastructure to support macOS builds in CI.

## Changes:
- Add macOS to the CI matrix in ci.yml
- Install libftdi and libusb dependencies using Homebrew on macOS runner
- Relocate Linux dependency installation to separate step for clarity
- Build Humility from source on macOS in the absence of pre-built binaries
- Enable Humility manifest tests on macOS
- Enable clippy checking on macOS
- Fix clippy install by explicitly specifying active toolchain
- Update README documenting macOS as first-tier platform
- Add macOS prerequisites section including Homebrew setup instructions

## Testing:
Verified on macOS 15.6.1 (Intel x86_64):
- Built demo-stm32f4-discovery and demo-stm32h7-nucleo
- Passing all tests (cargo test --verbose --workspace)
- Passing all format checks (cargo fmt --all --check)
- Clippy checks are passing with no warnings

## Related:
This addresses the request in README.mkdn for help maintaining macOS support and continuous builds.