### PR TITLE
README: change CI platform language

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -57,10 +57,12 @@ The repo is laid out as follows.
 
 # Developing
 
-We currently support Linux and Windows as first-tier platforms. macOS is also
-used on a daily basis by Oxide employees, but is not tested in CI.  The build
-probably also works on Illumos; if anyone would like to step up to maintain
-support and a continuous build for Illumos or macOS, we'd love the help.
+We currently support Linux and Windows as first-tier platforms. Because of some
+inconsistency in linker behavior across platforms, images may not match across
+platforms, so we recommend choosing one as your "official" build platform for
+producing blessed images. macOS and Illumos are both used as informal build
+platforms by Oxide employees, though they are not currently tested in CI. (Oxide
+blessed images are produced on Linux.)
 
 To submit changes for review, push them to a branch in a fork and submit a pull
 request to merge that branch into `master`. For details, see


### PR DESCRIPTION
I realized that this section of the README was sounding like an invitation for potential starter projects, without giving people full context on what the "maintain" part of maintaining a tier-one platform would involve (long term commitment from an experienced engineer). In practice, macOS seems to be the main "other" platform that folks are interested in, but it's also the only one that those of us without Apple hardware can't test locally -- every other OS permits virtualization, which makes macOS a uniquely high support burden.

To avoid misleading people, I've adjusted the language to remove the suggestion that we're looking for maintainers. It's not that we _aren't_ looking for maintainers, but more that maintaining a platform will be a longer discussion and not merely a PR.