### PR TITLE
Support Cosmo CPUs in SBRMI validation

### DIFF
--- a/drv/i2c-devices/src/sbrmi.rs
+++ b/drv/i2c-devices/src/sbrmi.rs
@@ -343,7 +343,8 @@ impl Validate<Error> for Sbrmi {
         let sbrmi = Sbrmi::new(device);
         let rev = sbrmi.read_reg(Register::Revision)?;
 
-        // Support either Gimlet or Cosmo CPUs
+        // Support either Gimlet or Cosmo CPUs, documented in the AMD PPR docs
+        // (e.g. "PPR Vol 5 for AMD Family 1Ah Model 02h C1", which lists 0x21)
         Ok(rev == 0x10 || rev == 0x21)
     }
 }


### PR DESCRIPTION
This should fix racktest failures of the form
```
component U1/SBRMI (CPU via SB-RMI) is "failed", not "present"
```

(reported in https://github.com/oxidecomputer/mfg-troubleshooting/issues/171#issuecomment-3606985546)

Tested on `cosmo-os`; after this change, we are currently clean on ~opsec~ `humility validate`