### PR TITLE
Tweak cosmo thermal tuning

### DIFF
--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -135,9 +135,9 @@ impl Bsp {
             // Based on experimental tuning!
             pid_config: PidConfig {
                 zero: 35.0,
-                gain_p: 1.75,
+                gain_p: 5.0,
                 gain_i: 0.0135,
-                gain_d: 0.4,
+                gain_d: 5.0,
                 min_output: 0.0,
                 max_output: 100.0,
             },


### PR DESCRIPTION
This aims to address significant overshoot seen in #2280 

Here's the baseline performance when I load the system `svcadm enable cpu-loadgen` (testing on `niles`'s `cosmo-b`):

<img width="1178" height="900" alt="Screenshot 2025-12-10 at 4 51 48 PM" src="https://github.com/user-attachments/assets/40bec732-f9a3-466a-b915-1afba726b678" />

With the new parameters, the overshoot is much more limited:

<img width="1192" height="908" alt="Screenshot 2025-12-10 at 4 51 33 PM" src="https://github.com/user-attachments/assets/ff88236d-5528-49ec-b266-1e88ba593554" />

There's probably more room for improvement, but this should prevent the worst of it.