### PR TITLE
Drop fwid file from packaging

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 memory = "memory-large.toml"
 stacksize = 896
-fwid = true
 
 [kernel]
 name = "cosmo"

--- a/app/gemini-bu/app.toml
+++ b/app/gemini-bu/app.toml
@@ -3,7 +3,6 @@ target = "thumbv7em-none-eabihf"
 board = "gemini-bu-1"
 chip = "../../chips/stm32h7"
 stacksize = 896
-fwid = true
 
 [kernel]
 name = "gemini-bu"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 memory = "memory-large.toml"
 stacksize = 896
-fwid = true
 
 [kernel]
 name = "gimlet"

--- a/app/gimletlet/app-mgmt.toml
+++ b/app/gimletlet/app-mgmt.toml
@@ -3,7 +3,6 @@ target = "thumbv7em-none-eabihf"
 board = "gimletlet-1"
 chip = "../../chips/stm32h7"
 stacksize = 1024
-fwid = true
 
 [kernel]
 name = "gimletlet"

--- a/app/gimletlet/base-gimletlet2.toml
+++ b/app/gimletlet/base-gimletlet2.toml
@@ -5,7 +5,6 @@ memory = "memory-large.toml"
 stacksize = 896
 epoch = 0
 version = 0
-fwid = true
 
 [kernel]
 name = "gimletlet"

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -5,7 +5,6 @@ memory = "memory-large.toml"
 stacksize = 896
 epoch = 0
 version = 0
-fwid = true
 
 [mmio]
 peripheral-region = "fmc_nor_psram_bank_1"

--- a/app/lpc55xpresso/app.toml
+++ b/app/lpc55xpresso/app.toml
@@ -4,7 +4,6 @@ board = "lpcxpresso55s69"
 chip = "../../chips/lpc55"
 stacksize = 1024
 image-names = ["a", "b"]
-fwid = true
 
 [kernel]
 name = "lpc55xpresso"

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 memory = "memory-large.toml"
 stacksize = 896
-fwid = true
 
 [kernel]
 name = "medusa"

--- a/app/minibar/base.toml
+++ b/app/minibar/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 stacksize = 896
 memory = "memory-large.toml"
-fwid = true
 
 [kernel]
 name = "minibar"

--- a/app/oxide-rot-1/app-dev.toml
+++ b/app/oxide-rot-1/app-dev.toml
@@ -10,7 +10,6 @@ stacksize = 1024
 image-names = ["a", "b"]
 epoch = 0
 version = 0
-fwid = true
 
 [kernel]
 name = "oxide-rot-1"

--- a/app/oxide-rot-1/app.toml
+++ b/app/oxide-rot-1/app.toml
@@ -7,7 +7,6 @@ stacksize = 1024
 image-names = ["a", "b"]
 epoch = 0
 version = 0
-fwid = true
 
 [kernel]
 name = "oxide-rot-1"

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 memory = "memory-large.toml"
 stacksize = 896
-fwid = true
 
 [kernel]
 name = "psc"

--- a/app/rot-carrier/app.toml
+++ b/app/rot-carrier/app.toml
@@ -6,7 +6,6 @@ stacksize = 1024
 image-names = ["a", "b"]
 epoch = 0
 version = 0
-fwid = true
 
 [kernel]
 name = "rot-carrier"

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -2,7 +2,6 @@ target = "thumbv7em-none-eabihf"
 chip = "../../chips/stm32h7"
 stacksize = 896
 memory = "memory-large.toml"
-fwid = true
 
 [kernel]
 name = "sidecar"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -28,8 +28,6 @@ struct RawConfig {
     epoch: u32,
     #[serde(default)]
     version: u32,
-    #[serde(default)]
-    fwid: bool,
     memory: Option<String>,
     #[serde(default)]
     image_names: Vec<String>,
@@ -67,7 +65,6 @@ pub struct Config {
     pub epoch: u32,
     pub mmio: Option<MmioData>,
     pub version: u32,
-    pub fwid: bool,
     pub image_names: Vec<String>,
     pub signing: Option<RoTMfgSettings>,
     pub stacksize: Option<u32>,
@@ -262,7 +259,6 @@ impl Config {
             mmio,
             epoch: toml.epoch,
             version: toml.version,
-            fwid: toml.fwid,
             signing: toml.signing,
             stacksize: toml.stacksize,
             kernel: toml.kernel,


### PR DESCRIPTION
The fwid we calculate is always going to be out of date because we will need add the version/signature which will change the fwid. Just remove the file.