### PR TITLE
Update ahash to fix compilation of xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,13 +21,14 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -4229,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ordered-toml"


### PR DESCRIPTION
For some reason I'm getting this compilation error locally:

```
error[E0635]: unknown feature `stdsimd`
      --> /home/emily/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ahash-0.8.3/src/lib.rs:99:42
       |
    99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
       |                                          ^^^^^^^
```

This is expected, as ahash 0.8.3 had broken feature detection [that got fixed in 0.8.7](https://www.github.com/tkaitchuck/aHash/pull/183). I am so puzzled at why I am seemingly the only one seeing this failure though.