### PR TITLE
build-fpga-regmap: namespace generated enum types

### DIFF
--- a/drv/cosmo-seq-server/src/main.rs
+++ b/drv/cosmo-seq-server/src/main.rs
@@ -16,6 +16,7 @@ use drv_spartan7_loader_api::Spartan7Loader;
 use drv_spi_api::{SpiDevice, SpiServer};
 use drv_stm32xx_sys_api::{self as sys_api, Sys};
 use fixedstr::FixedStr;
+use fmc_sequencer::{nic_api_status, seq_api_status};
 use idol_runtime::{NotificationHandler, RequestError};
 use task_jefe_api::Jefe;
 use userlib::{
@@ -74,11 +75,11 @@ enum Trace {
     },
     UnexpectedPowerOff {
         our_state: PowerState,
-        seq_state: Result<fmc_sequencer::A0Sm, u8>,
+        seq_state: Result<seq_api_status::A0Sm, u8>,
     },
     SequencerInterrupt {
         our_state: PowerState,
-        seq_state: Result<fmc_sequencer::A0Sm, u8>,
+        seq_state: Result<seq_api_status::A0Sm, u8>,
         ifr: fmc_sequencer::IfrView,
     },
     PowerDownError(drv_cpu_seq_api::SeqError),
@@ -160,8 +161,8 @@ use gpio_irq_pins::SEQ_IRQ;
 
 /// Helper type which includes both sequencer and NIC state machine states
 struct StateMachineStates {
-    seq: Result<fmc_sequencer::A0Sm, u8>,
-    nic: Result<fmc_sequencer::NicSm, u8>,
+    seq: Result<seq_api_status::A0Sm, u8>,
+    nic: Result<nic_api_status::NicSm, u8>,
 }
 
 const EREPORT_BUF_LEN: usize = microcbor::max_cbor_len_for!(
@@ -556,7 +557,7 @@ impl ServerImpl {
             now,
         });
 
-        use fmc_sequencer::A0Sm;
+        use seq_api_status::A0Sm;
         match (self.get_state_impl(), state) {
             (PowerState::A2, PowerState::A0) => {
                 // Reset edge counters in the sequencer
@@ -1031,7 +1032,7 @@ impl NotificationHandler for ServerImpl {
             return;
         }
         let state = self.log_state_registers();
-        use fmc_sequencer::{A0Sm, NicSm};
+        use fmc_sequencer::{nic_api_status::NicSm, seq_api_status::A0Sm};
 
         // Detect when the NIC comes online
         // TODO: should we handle the NIC powering down while the main CPU


### PR DESCRIPTION
When the `build-fpga-regmap` code generation emits a Rust enum type for enum fields in FPGA registers, the generated Rust type is named after the name of the register field (after being converted to CamelCase), and emitted in the same top-level generated code module as the register view types.This is all well and good until two different FPGA registers want to have enum fields with the same name, which seems like a fairly reasonable thing for the hardware folks to want to do. When there are two or more enum fields in different registers sharing the same name, the generated Rust types collide and the code no longer compiles.

For instance, the FPGA changes @nathanaelhuffman pushed in 26f4837cd070c12082f694647d86fca6b07b8ea7 added a second enum field named `hw_sm`, in the `nic_raw_status` register. This results in generating a type that collides with the `seq_raw_status[hw_sm]` field. Rather than making Nathanael go back and rename all his register fields, the codegen should properly handle this.

Thus, this commit changes the code generation a bit so that enum field types generated by `build-fpga-regmap` are now emitted in submodules named after the register containing that field. So, rather than having `fmc_sequencer::HwSm` as the enum that represents the `seq_raw_status[hw_sm]` field, we now produce `fmc_sequencer::seq_raw_status::HwSm`, allowing it to coexist with the new `nic_raw_status[hw_sm]` field's enum, which lands in `fmc_sequencer::nic_raw_status::HwSm`.

This requires a small change to `cosmo_seq` to get the enum types from the correct places. Thus far, I think the `cosmo_seq` task is the only Hubris task that touches FPGA registers with enums.

This is required for #2390 