### PR TITLE
thermal: *actually* only poll Cosmo T6 temperatures in A0+HP

### DIFF
--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -66,8 +66,10 @@ bitflags::bitflags! {
         // in A2; you probably want to use `A0_OR_A2` instead.
         const A2 = 0b00000001;
         const A0 = 0b00000010;
-        // A0+HP: T6 is also active, in addition to all A0 devices.
-        const A0_PLUS_HP = Self::A0.bits() | 0b00000100;
+        // A0+HP: T6 power is enabled by the host processor, in addition to
+        // all A0 devices.
+        const T6 = 0b00000100;
+        const A0_PLUS_HP = Self::A0.bits() | Self::T6.bits();
     }
 }
 
@@ -236,7 +238,9 @@ const INPUTS: [InputChannel; NUM_TEMPERATURE_INPUTS] = [
             sensors::TMP451_T6_TEMPERATURE_SENSOR,
         ),
         T6_THERMALS,
-        PowerBitmask::A0_PLUS_HP,
+        // Enabled only if we are in the A0+HP power state, as T6 power is
+        // controlled by the host OS.
+        PowerBitmask::T6,
         ChannelType::MustBePresent,
     ),
     // U.2 drives


### PR DESCRIPTION
I made the mistake of blindly applying feedback from https://github.com/oxidecomputer/hubris/pull/2391#discussion_r2818677621 on PR #2391 after I had tested it, and in doing so, inadvertently broke the intended behavior. As I described  in https://github.com/oxidecomputer/hubris/pull/2391#discussion_r2834509368, there _needs_ to be a separate bitflag constant that includes ONLY the bit that is set only in the A0+HP state, and _not_ the bit which is also set in A0, so that it can be used as the bitmask for determining whether the T6 is enabled. Changing the T6 `InputChannel` to use both the `HP` bit and the `A0` bit as its `PowerBitmask` undid the intended change of only looking at the T6 temperature while in A0+HP and *not* in A0 only.

This is because the thermal loop checks if an input is enabled using `PowerBitmask::intersects`:
https://github.com/oxidecomputer/hubris/blob/a26ae8e34576fbab24423dbfb0561804cdb01ef3/task/thermal/src/control.rs#L1137

The [`Flags::intersects` method](https://docs.rs/bitflags/latest/bitflags/trait.Flags.html#method.intersects) generated by `bitflags` returns true if _any_ bits in `self` are set in `Other`. So, I broke it, and should have left things the way they were before the review. Whoops.

This commit changes it back to the way it was before, although now we call the bit flag that's only set in A0+HP `T6` rather than `HP`. Hopefully that reduces the confusion around how this works for future readers?