### PR TITLE
Control plane agent for Nucleo boards

### DIFF
--- a/app/demo-stm32h7-nucleo/README.md
+++ b/app/demo-stm32h7-nucleo/README.md
@@ -1,1 +1,129 @@
-# STM32H7 demo application
+# STM32H7 Nucleo-144 Demo Application
+
+Hubris application configurations for the STM32H7 Nucleo-144
+development boards:
+
+- `app-h743.toml` -- NUCLEO-H743ZI (order code NUCLEO-H743ZI2)
+- `app-h753.toml` -- NUCLEO-H753ZI
+
+The Nucleo boards are readily available development boards for general
+Hubris development. Although they are not part of any Oxide Computer
+product, they are configured to work with the Management Gateway Service
+to allow over-the-network update and testing.
+
+## Board differences
+
+Both boards use the same Nucleo-144 form factor and share identical
+pin assignments. The STM32H753 includes a hardware hash accelerator
+supported by Hubris that the STM32H743 lacks.
+
+## VLAN
+
+Unlike Oxide designed boards, the Nucleo boards do not have a KSZ8463
+Ethernet switch chip and have no need for 802.1q VLAN tags.  The `vlan`
+feature is omitted through conditional compilation, i.e. `#[cfg(feature =
+"vlan")]` and does not affect production code.
+
+## Pin assignments
+
+[Reference: UM2407 Rev 2, "STM32H7 Nucleo-144 boards (MB1364)"](https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf)):
+
+### Ethernet (RMII, active)
+
+| Pin  | Function        | Connector        |
+|------|-----------------|------------------|
+| PA1  | RMII Ref Clock  | --               |
+| PA2  | RMII MDIO       | --               |
+| PA7  | RMII RX DV      | --               |
+| PC1  | RMII MDC        | --               |
+| PC4  | RMII RXD0       | --               |
+| PC5  | RMII RXD1       | --               |
+| PG11 | RMII TX Enable  | --               |
+| PG13 | RMII TXD0       | --               |
+| PB13 | RMII TXD1       | CN7 pin 5 (Zio) |
+
+### SPI3 -- SP-to-RoT connection (active, no peer)
+
+In the past, developers have connected an NXP LPC55S69 xPresso board to
+emulate an RoT. We do not make any effort to support this configuration.
+It is more complicated to get it right than just using jumper wires.
+
+We still reserve the pins to make sure that we can run the CPA and its
+required `sprot` task without modifications or interfering with other
+signals. In this configuration, the non-existent "RoT" just won't respond.
+
+
+| Pin  | Function  | AF | Connector                  |
+|------|-----------|----|----------------------------|
+| PC10 | SPI3_SCK  | 6  | CN11 pin 1, CN8 pin 6      |
+| PC11 | SPI3_MISO | 6  | CN11 pin 2, CN8 pin 8      |
+| PC12 | SPI3_MOSI | 6  | CN11 pin 3, CN8 pin 10     |
+| PA15 | SPI3_NSS  | -- | CN11 pin 17, CN7 pin 9     |
+
+The Zio connector labels these as SDMMC_D2/D3/CK (CN8).  SDMMC is
+not used.  The SPI3 alternate function is selected in firmware.
+
+### GPIO -- RoT signals
+
+| Pin  | Function    | Direction | Connector   |
+|------|-------------|-----------|-------------|
+| PD0  | rot_irq     | Input     | CN11 pin 57 |
+| PE6  | sprot debug | Output    | CN11 pin 62 |
+
+PD0 is labeled CAN_RX on the Zio connector (CN9 pin 25); CAN is not
+used.  PE6 is labeled SAI_A_SD (CN9 pin 20); SAI is not used.
+
+### SPI1 -- General purpose header
+
+| Pin  | Function   | AF | H743         | H753         |
+|------|------------|----|--------------|--------------|
+| PA5  | SPI1_SCK   | 5  | Used         | --           |
+| PA3  | SPI1_SCK   | 5  | --           | Used         |
+| PB5  | SPI1_MOSI  | 5  | Used         | Used         |
+| PA6  | SPI1_MISO  | 5  | Used         | Used         |
+| PD14 | SPI1_CS    | -- | Used         | Used         |
+
+### I2C2
+
+| Pin | Function  | AF |
+|-----|-----------|----|
+| PF1 | I2C2_SCL  | 4  |
+| PF0 | I2C2_SDA  | 4  |
+
+### USART1 -- Host UART (active, no peer)
+
+| Pin  | Function   | Connector   |
+|------|------------|-------------|
+| PA9  | USART1_TX  | CN11 pin 21 |
+| PA10 | USART1_RX  | CN11 pin 33 |
+
+Reserved by CPA for host-SP communication.  No host CPU on the
+Nucleo; the UART is idle.
+
+### On-board hardware (do not reassign)
+
+| Pin  | Function                | Notes                   |
+|------|-------------------------|-------------------------|
+| PC13 | User button B1          | GPIO IRQ                |
+| PB0  | User LED LD1 (green)    | Default SB39/SB47 config|
+| PE1  | User LED LD2 (yellow)   | --                      |
+| PB14 | User LED LD3 (red)      | --                      |
+| PA13 | ST-Link SWDIO           | Do not use as GPIO      |
+| PA14 | ST-Link SWCLK           | Do not use as GPIO      |
+| PD8  | USART3 TX (VCP default) | ST-Link virtual COM     |
+| PD9  | USART3 RX (VCP default) | ST-Link virtual COM     |
+
+## Connecting an LPC55S69-EVK as RoT
+
+The sprot SPI3 pins and GPIO signals are accessible on the ST morpho
+connector CN11.  To connect an LPC55S69-EVK board:
+
+| Nucleo (CN11)     | Signal    | LPC55S69-EVK       |
+|-------------------|-----------|---------------------|
+| Pin 1 (PC10)      | SPI_SCK   | SPI CS/SCK pin      |
+| Pin 2 (PC11)      | SPI_MISO  | SPI MISO pin        |
+| Pin 3 (PC12)      | SPI_MOSI  | SPI MOSI pin        |
+| Pin 17 (PA15)     | SPI_CS    | SPI CS pin          |
+| Pin 57 (PD0)      | ROT_IRQ   | GPIO IRQ output     |
+| Pin 19/GND        | GND       | GND                 |
+

--- a/app/demo-stm32h7-nucleo/app-h743.toml
+++ b/app/demo-stm32h7-nucleo/app-h743.toml
@@ -10,10 +10,14 @@ name = "demo-stm32h7-nucleo"
 requires = {flash = 24736, ram = 5120}
 features = ["h743", "dump"]
 
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
+
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["dump"]
 stacksize = 2000
@@ -22,7 +26,7 @@ extern-regions = [ "sram1", "sram2", "sram3", "sram4" ]
 
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy"]
+request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -47,6 +51,11 @@ port = "C"
 pin = 13
 owner = {name = "user_button", notification = "button"}
 
+[tasks.sys.config.gpio-irqs.rot_irq]
+port = "D"
+pin = 0
+owner = {name = "sprot", notification = "rot_irq"}
+
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
 stacksize = 1048
@@ -67,10 +76,16 @@ notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.event" = "i2c4-irq"
 "i2c4.error" = "i2c4-irq"
 
+[tasks.packrat]
+name = "task-packrat"
+priority = 2
+start = true
+# task-slots is explicitly empty: packrat should not send IPCs!
+task-slots = []
+
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 features = ["spi1", "h743"]
 uses = ["spi1"]
 start = true
@@ -83,7 +98,7 @@ task-slots = ["sys"]
 name = "task-net"
 stacksize = 4000
 priority = 2
-max-sizes = {flash = 65536, ram = 8192, sram1_mac = 32768}
+max-sizes = {flash = 131072, ram = 32768, sram1_mac = 32768}
 features = ["h743"]
 sections = {eth_bulk = "sram1_mac"}
 uses = ["eth", "tim16"]
@@ -96,7 +111,6 @@ task-slots = ["sys", "jefe"]
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 notifications = ["timer"]
@@ -113,7 +127,22 @@ config = { led = 1, edge = "Edge::Rising" }
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 3
-max-sizes = {flash = 16384, ram = 8192}
+stacksize = 4096
+start = true
+task-slots = ["net"]
+notifications = ["socket"]
+
+[tasks.udpbroadcast]
+name = "task-udpbroadcast"
+priority = 3
+stacksize = 4096
+start = true
+task-slots = ["net", "packrat"]
+notifications = ["socket"]
+
+[tasks.udprpc]
+name = "task-udprpc"
+priority = 3
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -122,17 +151,91 @@ notifications = ["socket"]
 [tasks.hiffy]
 name = "task-hiffy"
 features = ["h743", "stm32h7", "i2c", "gpio", "spi", "turbo"]
-priority = 4
-max-sizes = {flash = 32768, ram = 65536 }
+priority = 5
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver"]
 notifications = ["timer"]
 
+[tasks.hf]
+name = "drv-mock-gimlet-hf-server"
+features = ["h743"]
+priority = 4
+stacksize = 2048
+start = true
+uses = ["quadspi"]
+notifications = ["qspi-irq"]
+interrupts = {"quadspi.irq" = "qspi-irq"}
+task-slots = ["sys"]
+
+[tasks.gimlet_seq]
+name = "drv-mock-gimlet-seq-server"
+priority = 2
+start = true
+task-slots = ["jefe"]
+
+[tasks.update_server]
+name = "stm32h7-update-server"
+priority = 3
+stacksize = 2048
+start = true
+uses = ["flash_controller"]
+extern-regions = ["bank2"]
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
+
+[tasks.validate]
+name = "task-validate"
+priority = 3
+stacksize = 1024
+start = true
+task-slots = ["i2c_driver"]
+
+[tasks.sensor]
+name = "task-sensor"
+priority = 5
+stacksize = 1024
+start = true
+
+[tasks.sprot]
+name = "drv-stm32h7-sprot-server"
+priority = 5
+stacksize = 16384
+start = true
+task-slots = ["sys"]
+features = ["sink_test", "use-spi-core", "h743", "spi3"]
+uses = ["spi3"]
+notifications = ["spi-irq", "rot-irq", "timer"]
+interrupts = {"spi3.irq" = "spi-irq"}
+
+[tasks.control_plane_agent]
+name = "task-control-plane-agent"
+priority = 7
+stacksize = 6256
+start = true
+uses = ["usart1"]
+task-slots = [
+    "jefe",
+    "net",
+    "dump_agent",
+    "update_server",
+    "sys",
+    "hf",
+    { cpu_seq = "gimlet_seq" },
+    "validate",
+    "sensor",
+    "sprot",
+    "i2c_driver",
+    "packrat",
+    "user_leds",
+]
+features = ["gimlet", "usart1-gimletlet", "baud_rate_3M"]
+notifications = ["usart-irq", "socket", "timer"]
+interrupts = {"usart1.irq" = "usart-irq"}
+
 [tasks.idle]
 name = "task-idle"
-priority = 6
-max-sizes = {flash = 128, ram = 256}
+priority = 9
 stacksize = 256
 start = true
 
@@ -149,7 +252,6 @@ uses = ["rng"]
 name = "task-dump-agent"
 features = ["no-rot"]
 priority = 4
-max-sizes = {flash = 32768, ram = 4096 }
 start = true
 task-slots = ["jefe"]
 stacksize = 1328
@@ -188,6 +290,19 @@ mux = "cn7_arduino"
 cs = [{port = "D", pin = 14}]
 clock_divider = "DIV16"
 
+[config.spi.spi3]
+controller = 3
+
+[config.spi.spi3.mux_options.port_c]
+outputs = [
+    {port = "C", pins = [10, 12], af = 6},
+]
+input = {port = "C", pin = 11, af = 6}
+
+[config.spi.spi3.devices.spi3_header]
+mux = "port_c"
+cs = [{port = "A", pin = 15}]
+clock_divider = "DIV256"
 
 [config.net]
 # UDP ports in sockets below are assigned in oxidecomputer/oana
@@ -198,3 +313,24 @@ owner = {name = "udpecho", notification = "socket"}
 port = 7
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.broadcast]
+kind = "udp"
+owner = {name = "udpbroadcast", notification = "socket"}
+port = 997
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.rpc]
+kind = "udp"
+owner = {name = "udprpc", notification = "socket"}
+port = 998
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.control_plane_agent]
+kind = "udp"
+owner = {name = "control_plane_agent", notification = "socket"}
+port = 11111
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }

--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -7,22 +7,29 @@ stacksize = 896
 
 [kernel]
 name = "demo-stm32h7-nucleo"
-requires = {flash = 24736, ram = 5120}
+requires = {flash = 24736, ram = 5632}
 features = ["h753", "dump"]
+
+[caboose]
+tasks = ["control_plane_agent"]
+region = "flash"
+size = 256
 
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 16384, ram = 4096}
 start = true
-features = ["dump"]
+features = ["dump", "fault-notification"]
 stacksize = 2000
 notifications = ["fault", "timer"]
 extern-regions = [ "sram1", "sram2", "sram3", "sram4" ]
 
+[tasks.jefe.config.on-task-fault]
+packrat = "task-faulted"
+
 [tasks.jefe.config.allowed-callers]
 set_reset_reason = ["sys"]
-request_reset = ["hiffy"]
+request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"
@@ -47,12 +54,16 @@ port = "C"
 pin = 13
 owner = {name = "user_button", notification = "button"}
 
+[tasks.sys.config.gpio-irqs.rot_irq]
+port = "D"
+pin = 0
+owner = {name = "sprot", notification = "rot_irq"}
+
 [tasks.i2c_driver]
 name = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 uses = ["i2c1", "i2c2", "i2c3", "i2c4"]
 notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 start = true
@@ -71,14 +82,15 @@ task-slots = ["sys"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 2
+stacksize = 1616
 start = true
-# task-slots is explicitly empty: packrat should not send IPCs!
-task-slots = []
+task-slots = ["jefe"]
+features = ["ereport"]
+notifications = ["task-faulted"]
 
 [tasks.spi_driver]
 name = "drv-stm32h7-spi-server"
 priority = 2
-max-sizes = {flash = 16384, ram = 4096}
 features = ["spi1", "h753"]
 uses = ["spi1"]
 start = true
@@ -91,7 +103,7 @@ task-slots = ["sys"]
 name = "task-net"
 stacksize = 4000
 priority = 2
-max-sizes = {flash = 131072, ram = 16384, sram1_mac = 32768}
+max-sizes = {flash = 131072, ram = 32768, sram1_mac = 32768}
 features = ["h753"]
 sections = {eth_bulk = "sram1_mac"}
 uses = ["eth", "tim16"]
@@ -104,7 +116,6 @@ task-slots = ["sys", "jefe"]
 name = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
-max-sizes = {flash = 2048, ram = 1024}
 start = true
 task-slots = ["sys"]
 notifications = ["timer"]
@@ -121,7 +132,6 @@ config = { led = 1, edge = "Edge::Rising" }
 [tasks.udpecho]
 name = "task-udpecho"
 priority = 3
-max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -130,7 +140,6 @@ notifications = ["socket"]
 [tasks.udpbroadcast]
 name = "task-udpbroadcast"
 priority = 3
-max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net", "packrat"]
@@ -139,7 +148,6 @@ notifications = ["socket"]
 [tasks.udprpc]
 name = "task-udprpc"
 priority = 3
-max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true
 task-slots = ["net"]
@@ -149,7 +157,6 @@ notifications = ["socket"]
 name = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "turbo"]
 priority = 5
-max-sizes = {flash = 32768, ram = 65536 }
 stacksize = 2048
 start = true
 task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
@@ -159,7 +166,6 @@ notifications = ["timer"]
 name = "drv-mock-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
-max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 2048
 start = true
 uses = ["quadspi"]
@@ -171,7 +177,6 @@ task-slots = ["sys", "hash_driver"]
 name = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
-max-sizes = {flash = 16384, ram=4096 }
 stacksize = 2048
 start = true
 uses = ["hash"]
@@ -179,20 +184,84 @@ notifications = ["hash-irq"]
 interrupts = {"hash.irq" = "hash-irq"}
 task-slots = ["sys"]
 
+[tasks.gimlet_seq]
+name = "drv-mock-gimlet-seq-server"
+priority = 2
+start = true
+task-slots = ["jefe"]
+
+[tasks.update_server]
+name = "stm32h7-update-server"
+priority = 3
+stacksize = 2048
+start = true
+uses = ["flash_controller"]
+extern-regions = ["bank2"]
+notifications = ["flash-irq"]
+interrupts = {"flash_controller.irq" = "flash-irq"}
+
+[tasks.validate]
+name = "task-validate"
+priority = 3
+stacksize = 1024
+start = true
+task-slots = ["i2c_driver"]
+
+[tasks.sensor]
+name = "task-sensor"
+priority = 5
+stacksize = 1024
+start = true
+
+[tasks.sprot]
+name = "drv-stm32h7-sprot-server"
+priority = 5
+stacksize = 16384
+start = true
+task-slots = ["sys"]
+features = ["sink_test", "use-spi-core", "h753", "spi3"]
+uses = ["spi3"]
+notifications = ["spi-irq", "rot-irq", "timer"]
+interrupts = {"spi3.irq" = "spi-irq"}
+
+[tasks.control_plane_agent]
+name = "task-control-plane-agent"
+priority = 7
+stacksize = 6256
+start = true
+uses = ["usart1"]
+task-slots = [
+    "jefe",
+    "net",
+    "dump_agent",
+    "update_server",
+    "sys",
+    "hf",
+    { cpu_seq = "gimlet_seq" },
+    "validate",
+    "sensor",
+    "sprot",
+    "i2c_driver",
+    "packrat",
+    "user_leds",
+]
+features = ["gimlet", "usart1-gimletlet", "baud_rate_3M"]
+notifications = ["usart-irq", "socket", "timer"]
+interrupts = {"usart1.irq" = "usart-irq"}
+
 [tasks.idle]
 name = "task-idle"
-priority = 7
-max-sizes = {flash = 128, ram = 256}
+priority = 9
 stacksize = 256
 start = true
 
 [tasks.rng_driver]
-features = ["h753"]
+features = ["h753", "packrat"]
 priority = 3
 name = "drv-stm32h7-rng"
 stacksize = 512
 start = true
-task-slots = ["sys", "user_leds"]
+task-slots = ["sys", "user_leds", "packrat"]
 uses = ["rng"]
 
 [tasks.dump_agent]
@@ -204,6 +273,24 @@ start = true
 task-slots = ["jefe", "net"]
 stacksize = 2400
 extern-regions = [ "sram1", "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
+
+# Demo/test task for ereports
+[tasks.ereportulator]
+name = "task-ereportulator"
+priority = 6
+start = true
+task-slots = ["packrat"]
+notifications = []
+
+[tasks.snitch]
+name = "task-snitch"
+# The snitch should have a priority immediately below that of the net task,
+# to minimize the number of components that can starve it from resources.
+priority = 6
+stacksize = 1200
+start = true
+task-slots = ["net", "packrat"]
 notifications = ["socket"]
 
 [config]
@@ -237,6 +324,20 @@ mux = "cn7_arduino"
 cs = [{port = "D", pin = 14}]
 clock_divider = "DIV32"
 
+[config.spi.spi3]
+controller = 3
+
+[config.spi.spi3.mux_options.port_c]
+outputs = [
+    {port = "C", pins = [10, 12], af = 6},
+]
+input = {port = "C", pin = 11, af = 6}
+
+[config.spi.spi3.devices.spi3_header]
+mux = "port_c"
+cs = [{port = "A", pin = 15}]
+clock_divider = "DIV256"
+
 [config.net]
 # UDP ports in sockets below are assigned in oxidecomputer/oana
 
@@ -267,3 +368,19 @@ owner = {name = "dump_agent", notification = "socket"}
 port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.control_plane_agent]
+kind = "udp"
+owner = {name = "control_plane_agent", notification = "socket"}
+port = 11111
+tx = { packets = 3, bytes = 2048 }
+rx = { packets = 3, bytes = 2048 }
+
+[config.net.sockets.ereport]
+kind = "udp"
+owner = {name = "snitch", notification = "socket"}
+port = 57005
+tx = { packets = 3, bytes = 1024 }
+# v0 ereport requests are always 35B, so just make the buffer exactly
+# that size...
+rx = { packets = 3, bytes = 35 }

--- a/build/net/src/lib.rs
+++ b/build/net/src/lib.rs
@@ -166,6 +166,20 @@ pub fn generate_vlan_enum(
             pub enum VLanId {
                 None,
             }
+
+            impl VLanId {
+                pub fn cfg(&self) -> VLanConfig {
+                    // No VLANs are configured on this board (e.g. Nucleo dev
+                    // boards). Return a fixed config so callers that only need
+                    // `.port` compile without per-call-site cfg handling. This
+                    // arm is only generated for non-VLAN builds.
+                    VLanConfig {
+                        vid: 0,
+                        always_trusted: true,
+                        port: SpPort::One,
+                    }
+                }
+            }
         }
     } else {
         let names = config

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -137,7 +137,11 @@ cfg_if::cfg_if! {
         const ROT_SPI_DEVICE: u8 = drv_spi_api::devices::ROT;
         fn debug_config(_sys: &sys_api::Sys) { }
         fn debug_set(_sys: &sys_api::Sys, _asserted: bool) { }
-    } else if #[cfg(target_board = "gimletlet-2")] {
+    } else if #[cfg(any(
+            target_board = "gimletlet-2",
+            target_board = "nucleo-h743zi2",
+            target_board = "nucleo-h753zi",
+            ))] {
         const DEBUG_PIN: sys_api::PinSet = sys_api::PinSet {
             port: sys_api::Port::E,
             pin_mask: 1 << 6,

--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -607,7 +607,10 @@ impl NetHandler {
         assert!(self.packet_to_send.is_none());
         let sender = Sender {
             addr,
+            #[cfg(feature = "vlan")]
             vid: meta.vid,
+            #[cfg(not(feature = "vlan"))]
+            vid: task_net_api::VLanId::None,
         };
         if let Some(n) = sp_impl::handle_message(
             sender,

--- a/task/control-plane-agent/src/mgs_compute_sled.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled.rs
@@ -337,6 +337,7 @@ impl MgsHandler {
             addr: Address::Ipv6(sender.addr.ip.into()),
             port: sender.addr.port,
             size: n as u32,
+            #[cfg(feature = "vlan")]
             vid: sender.vid,
         })
     }

--- a/task/control-plane-agent/src/mgs_compute_sled/host_phase2.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled/host_phase2.rs
@@ -179,15 +179,19 @@ impl HostPhase2Requester {
 
         let n = gateway_messages::serialize(tx_buf, &message).unwrap_lite();
 
+        #[cfg(feature = "vlan")]
         let vid = match port {
             SpPort::One => task_net_api::VLanId::Sidecar1,
             SpPort::Two => task_net_api::VLanId::Sidecar2,
         };
+        #[cfg(not(feature = "vlan"))]
+        let _ = port;
 
         Some(UdpMetadata {
             addr: SP_TO_MGS_MULTICAST_ADDR,
             port: MGS_UDP_PORT,
             size: n as u32,
+            #[cfg(feature = "vlan")]
             vid,
         })
     }


### PR DESCRIPTION
Improve Nucleo support for Hubris and hardware testing

The Nucleo board is a useful off-the-shelf board for prototyping and for
testing "pure Hubris" code paths. Configuring the control plane agent
into the image makes the board more useful.

The Nucleo board can also be a convenient platform for developing I2C
device drivers.

While there is enforcement in xtask to ensure that the vlan feature is
enabled for production boards, the feature results in compilation errors
if those guards are commented out and the vlan feature is removed from
the `app.toml`. That is fixed so that the Nucleo boards can opt out of
the vlan feature.

All of the changes in the machine code output are explained by line
number changes (ringbuf, etc.), the caboose `GITC` value, a different
Hubris ImageId, and one layout change due to a line number constant value
being a different size: in `control_plane_agent` in `handle_mgs_request`
a `cmp.w r0, #728` became `move r1,#729; cmp r0, r1`

While people have prototyped a Nucleo + NXP LPC55S69 xPresso board to
simulate SP + RoT, there is no intention to officially support that
configuration.

Configuration changes to Nucleo boards:
  - add `control_plane_agent` (CPA)
  - add "Caboose" for Hubris image identification
  - omitting VLAN tags on Nucleo boards
  - `update_server` to manage firmware updates
  - `sprot` is assigned the appropriate pins for connection to a non-existent RoT

`control_plane_agent` references `i2c_driver` unconditionally via
`task_slot!(I2C, i2c_driver)`, so add it to CPA's task-slots in
`app-h743.toml` (`app-h753.toml` already had it).