### PR TITLE
Read POST code ringbuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service#97c0fa04867a908b92c13886a208e439c7eb713a"
+source = "git+https://github.com/oxidecomputer/management-gateway-service#bab49d2a1e5ddfed4dbe87b0d8cc04a6947d68e6"
 dependencies = [
  "bitflags 2.9.4",
  "hubpack",

--- a/build/fpga-regmap/src/lib.rs
+++ b/build/fpga-regmap/src/lib.rs
@@ -763,10 +763,13 @@ pub fn build_peripheral(
                         fn new() -> Self {
                             #struct_name
                         }
-                        pub fn get(&self, i: usize) -> u32 {
-                            assert!(i < #mementries);
-                            unsafe {
-                                Self::ADDR.add(i).read_volatile()
+                        pub fn get(&self, i: usize) -> Option<u32> {
+                            if i < #mementries {
+                                Some(unsafe {
+                                    Self::ADDR.add(i).read_volatile()
+                                })
+                            } else {
+                                None
                             }
                         }
                     }

--- a/drv/cosmo-seq-server/src/main.rs
+++ b/drv/cosmo-seq-server/src/main.rs
@@ -1095,6 +1095,23 @@ impl idl::InOrderSequencerImpl for ServerImpl {
         Ok(self.espi.last_post_code.payload())
     }
 
+    fn post_code_buffer_len(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Ok(self.espi.post_code_count.count())
+    }
+
+    fn get_post_code(
+        &mut self,
+        _: &RecvMessage,
+        index: u32,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        self.espi.post_code_buffer.get(index as usize).ok_or(
+            RequestError::Fail(idol_runtime::ClientError::BadMessageContents),
+        )
+    }
+
     fn gpio_edge_count(
         &mut self,
         _: &RecvMessage,

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -1252,6 +1252,25 @@ impl<S: SpiServer> idl::InOrderSequencerImpl for ServerImpl<S> {
         ))
     }
 
+    fn post_code_buffer_len(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
+    fn get_post_code(
+        &mut self,
+        _: &RecvMessage,
+        _index: u32,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
     fn gpio_edge_count(
         &mut self,
         _: &RecvMessage,

--- a/drv/grapefruit-seq-server/src/main.rs
+++ b/drv/grapefruit-seq-server/src/main.rs
@@ -194,6 +194,28 @@ impl idl::InOrderSequencerImpl for ServerImpl {
         Ok(self.espi.last_post_code.payload())
     }
 
+    fn post_code_buffer_len(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        // espi.post_code_count exists in the JSON file, but the
+        // post_code_buffer memory isn't present.  Fixing this isn't urgent,
+        // since no one is booting with Grapefruit these days.
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
+    fn get_post_code(
+        &mut self,
+        _: &RecvMessage,
+        _index: u32,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
     fn gpio_edge_count(
         &mut self,
         _: &RecvMessage,

--- a/drv/mock-gimlet-seq-server/src/main.rs
+++ b/drv/mock-gimlet-seq-server/src/main.rs
@@ -113,6 +113,25 @@ impl idl::InOrderSequencerImpl for ServerImpl {
         ))
     }
 
+    fn post_code_buffer_len(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
+    fn get_post_code(
+        &mut self,
+        _: &RecvMessage,
+        _index: u32,
+    ) -> Result<u32, RequestError<core::convert::Infallible>> {
+        Err(RequestError::Fail(
+            idol_runtime::ClientError::BadMessageContents,
+        ))
+    }
+
     fn gpio_edge_count(
         &mut self,
         _: &RecvMessage,

--- a/idl/cpu-seq.idol
+++ b/idl/cpu-seq.idol
@@ -68,6 +68,20 @@ Interface(
             reply: Simple("u32"),
             idempotent: true,
         ),
+        "post_code_buffer_len": (
+            doc: "Read the number of POST codes in the FPGA's ringbuffer (Cosmo only)",
+            args: {},
+            reply: Simple("u32"),
+            idempotent: true,
+        ),
+        "get_post_code": (
+            doc: "Reads a POST code from the FPGA's ringbuffer (Cosmo only)",
+            args: {
+                "index": "u32",
+            },
+            reply: Simple("u32"),
+            idempotent: true,
+        ),
         "gpio_edge_count": (
             doc: "Read the GPIO edge count from the sequencer FPGA (Gimlet only)",
             args: {},

--- a/task/control-plane-agent/src/inventory.rs
+++ b/task/control-plane-agent/src/inventory.rs
@@ -37,19 +37,17 @@ impl Inventory {
         OUR_DEVICES.len() + VALIDATE_DEVICES.len()
     }
 
-    pub(crate) fn num_component_details(
+    pub(crate) fn num_component_details<F>(
         &self,
         component: &SpComponent,
-    ) -> Result<u32, SpError> {
+        our_device_lookup: F,
+    ) -> Result<u32, SpError>
+    where
+        F: Fn(&SpComponent) -> u32,
+    {
         match Index::try_from(component)? {
             Index::OurDevice(d) => {
-                match OUR_DEVICES[d].component {
-                    // The SP5 CPU can report a POST code and GPIO cycle count
-                    SpComponent::SP5_HOST_CPU => Ok(2),
-                    // The SP3 CPU can report GPIO toggle counts
-                    SpComponent::SP3_HOST_CPU => Ok(1),
-                    _ => Ok(0),
-                }
+                Ok(our_device_lookup(&OUR_DEVICES[d].component))
             }
             Index::ValidateDevice(i) => {
                 Ok(VALIDATE_DEVICES[i].sensors.len() as u32)
@@ -256,6 +254,14 @@ mod devices_with_static_validation {
             description: "Cosmo SP5 host cpu",
             capabilities: DeviceCapabilities::HAS_SERIAL_CONSOLE,
             presence: DevicePresence::Present, // TODO: ok to assume always present?
+        },
+        #[cfg(feature = "cosmo")]
+        DeviceDescription {
+            component: SpComponent::SP5_POST_CODES,
+            device: SpComponent::SP5_POST_CODES.const_as_str(),
+            description: "Cosmo SP5 POST code buffer",
+            capabilities: DeviceCapabilities::empty(),
+            presence: DevicePresence::Present, // FPGA is soldered to the board
         },
         // If we're building for gimlet, we always claim to have host boot flash.
         //

--- a/task/control-plane-agent/src/mgs_compute_sled.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled.rs
@@ -18,10 +18,10 @@ use gateway_messages::{
     ignition, ComponentAction, ComponentActionResponse, ComponentDetails,
     ComponentUpdatePrepare, DiscoverResponse, DumpSegment, DumpTask,
     GpioToggleCount, Header, IgnitionCommand, IgnitionState, LastPostCode,
-    Message, MessageKind, MgsError, MgsRequest, MgsResponse, PowerState,
-    PowerStateTransition, RotBootInfo, RotRequest, RotResponse, SensorRequest,
-    SensorResponse, SpComponent, SpError, SpPort as GwSpPort, SpRequest,
-    SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
+    Message, MessageKind, MgsError, MgsRequest, MgsResponse, PostCode,
+    PowerState, PowerStateTransition, RotBootInfo, RotRequest, RotResponse,
+    SensorRequest, SensorResponse, SpComponent, SpError, SpPort as GwSpPort,
+    SpRequest, SpStateV2, SpUpdatePrepare, UpdateChunk, UpdateId, UpdateStatus,
     SERIAL_CONSOLE_IDLE_TIMEOUT,
 };
 use heapless::{Deque, Vec};
@@ -907,7 +907,21 @@ impl SpHandler for MgsHandler {
             component
         }));
 
-        self.common.inventory().num_component_details(&component)
+        self.common
+            .inventory()
+            .num_component_details(&component, |component| {
+                match *component {
+                    // The SP5 CPU can report a POST code and GPIO cycle count
+                    SpComponent::SP5_HOST_CPU => 2,
+                    // The SP3 CPU can report GPIO toggle counts
+                    SpComponent::SP3_HOST_CPU => 1,
+                    // The SP5 POST code buffer reports a dynamic length
+                    SpComponent::SP5_POST_CODES => {
+                        self.sequencer.post_code_buffer_len()
+                    }
+                    _ => 0,
+                }
+            })
     }
 
     fn component_details(
@@ -934,6 +948,9 @@ impl SpHandler for MgsHandler {
                         }
                         _ => panic!("invalid index"),
                     },
+                    SpComponent::SP5_POST_CODES => ComponentDetails::PostCode(
+                        PostCode(self.sequencer.get_post_code(index.0)),
+                    ),
                     SpComponent::SP3_HOST_CPU => {
                         // Only one component detail for now
                         assert_eq!(index.0, 0);

--- a/task/control-plane-agent/src/mgs_minibar.rs
+++ b/task/control-plane-agent/src/mgs_minibar.rs
@@ -429,7 +429,13 @@ impl SpHandler for MgsHandler {
             component
         }));
 
-        self.common.inventory().num_component_details(&component)
+        self.common.inventory().num_component_details(
+            &component,
+            |_component| {
+                // Nothing in OUR_DEVICES has component details
+                0
+            },
+        )
     }
 
     fn component_details(

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -444,7 +444,13 @@ impl SpHandler for MgsHandler {
             component
         }));
 
-        self.common.inventory().num_component_details(&component)
+        self.common.inventory().num_component_details(
+            &component,
+            |_component| {
+                // Nothing in OUR_DEVICES has component details
+                0
+            },
+        )
     }
 
     fn component_details(

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -895,13 +895,15 @@ impl SpHandler for MgsHandler {
             component
         }));
 
-        match component {
-            SpComponent::MONORAIL => Ok(drv_monorail_api::PORT_COUNT as u32),
-            SpComponent::TOFINO => {
-                Ok(drv_sidecar_seq_api::TOFINO_DEBUG_REGS.len() as u32)
-            }
-            _ => self.common.inventory().num_component_details(&component),
-        }
+        self.common
+            .inventory()
+            .num_component_details(&component, |component| match *component {
+                SpComponent::MONORAIL => drv_monorail_api::PORT_COUNT as u32,
+                SpComponent::TOFINO => {
+                    drv_sidecar_seq_api::TOFINO_DEBUG_REGS.len() as u32
+                }
+                _ => 0,
+            })
     }
 
     /// When this method is called by `handle_message`, `index` has been bounds


### PR DESCRIPTION
This is the Hubris side of https://github.com/oxidecomputer/management-gateway-service/pull/480

We add a new `sp5-post-codes` component, which returns a dynamic number of `PostCode` component details based on the sequencer FPGA's ringbuf.