### PR TITLE
Move time forward instead of backwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
             done
             return 1
           }
-          set_time "$(date -d '1 day ago 11 hours ago' "+%Y-%m-%d %H:%M:%S")"
+          set_time "$(date -d '1 day 11 hours' "+%Y-%m-%d %H:%M:%S")"
 
           echo "After time change: $(date)"
 


### PR DESCRIPTION
We are seeing the reproducibility check failing due to an SSL error. This appears to be because GitHub renewed their TLS certificate, with a "not before" date of today, which is in conflict with the change we are making to that VM.

To avoid removing the check, this changes it to move time forward by a day and 11 hours instead of backwards, with the **assumption** that GitHub would renew the certificate with more than two days left in its expiry. If this fails again we might have to remove the check altogether.