### PR TITLE
Add PWM sensor to thermal task

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -1352,6 +1352,12 @@ device = "dimm"
 description = "DIMM L, sensor 1"
 sensors.temperature = 1
 
+[[config.sensor.devices]]
+name = "fan_ctrl"
+device = "thermal_loop"
+description = "Thermal loop"
+sensors.pwm = 1
+
 ################################################################################
 [config.spi.spi2]
 controller = 2

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -1235,6 +1235,14 @@ removable = true
 
 ################################################################################
 
+[[config.sensor.devices]]
+name = "fan_ctrl"
+device = "thermal_loop"
+description = "Thermal loop"
+sensors.pwm = 1
+
+################################################################################
+
 [config.spi.spi2]
 controller = 2
 

--- a/app/grapefruit/app-ruby.toml
+++ b/app/grapefruit/app-ruby.toml
@@ -155,3 +155,9 @@ name = "lm75_h"
 sensors = { temperature = 1 }
 description = "LM75 (H)"
 refdes = "U104"
+
+[[config.sensor.devices]]
+name = "fan_ctrl"
+device = "thermal_loop"
+description = "Thermal loop"
+sensors.pwm = 1

--- a/app/minibar/base.toml
+++ b/app/minibar/base.toml
@@ -289,6 +289,12 @@ power = { rails = [ "V1P0_SYS" ] }
 sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = "U7"
 
+[[config.sensor.devices]]
+name = "fan_ctrl"
+device = "thermal_loop"
+description = "Thermal loop"
+sensors.pwm = 1
+
 [config.spi.spi2]
 controller = 2
 

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -1064,6 +1064,12 @@ device = "qsfp"
 description = "QSFP transceiver 31"
 sensors.temperature = 1
 
+[[config.sensor.devices]]
+name = "fan_ctrl"
+device = "thermal_loop"
+description = "Thermal loop"
+sensors.pwm = 1
+
 [config.spi.spi1]
 controller = 1
 

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -452,6 +452,7 @@ pub enum Sensor {
     InputCurrent,
     InputVoltage,
     Speed,
+    Pwm,
 }
 
 impl std::fmt::Display for Sensor {
@@ -467,6 +468,7 @@ impl std::fmt::Display for Sensor {
                 Sensor::InputCurrent => "INPUT_CURRENT",
                 Sensor::InputVoltage => "INPUT_VOLTAGE",
                 Sensor::Speed => "SPEED",
+                Sensor::Pwm => "PWM",
             }
         )
     }
@@ -1547,6 +1549,7 @@ impl ConfigGenerator {
                 Sensor::InputCurrent => "input_current",
                 Sensor::InputVoltage => "input_voltage",
                 Sensor::Speed => "speed",
+                Sensor::Pwm => "pwm",
             };
             if values.len() == 1 {
                 writeln!(

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -41,11 +41,16 @@ pub const DEFAULT_KERNEL_STACK: u32 = 1024;
 /// without breaking CI.
 ///
 /// # Changelog
-/// Version 10 requires Humility to be aware of the `handoff` kernel feature,
-/// which lets the RoT inform the SP when measurements have been taken.  If
-/// Humility is unaware of this feature, the SP will reset itself repeatedly,
-/// which interferes with subsequent programming of auxiliary flash.
-const HUBRIS_ARCHIVE_VERSION: u32 = 10;
+/// ## Version 11
+/// Adds a `pwm` sensor, which requires Humility to either accept that sensor
+/// kind or accept unrecognized sensors without bailing.
+///
+/// ## Version 10
+/// Requires Humility to be aware of the `handoff` kernel feature, which lets
+/// the RoT inform the SP when measurements have been taken.  If Humility is
+/// unaware of this feature, the SP will reset itself repeatedly, which
+/// interferes with subsequent programming of auxiliary flash.
+const HUBRIS_ARCHIVE_VERSION: u32 = 11;
 
 /// `PackageConfig` contains a bundle of data that's commonly used when
 /// building a full app image, grouped together to avoid passing a bunch

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -1495,7 +1495,7 @@ impl<'a> ThermalControl<'a> {
             ControlResult::Pwm(target_pwm) => {
                 // Send the new RPM to all of our fans
                 ringbuf_entry!(Trace::ControlPwm(target_pwm.0));
-                self.set_pwm(target_pwm)?;
+                self.set_pwm(Ok(target_pwm), now_ms)?;
             }
             ControlResult::PowerDown => {
                 ringbuf_entry!(Trace::PowerDownAt(sys_get_timer().now));
@@ -1504,7 +1504,7 @@ impl<'a> ThermalControl<'a> {
                 if let Err(e) = self.bsp.power_down() {
                     ringbuf_entry!(Trace::PowerDownFailed(e));
                 }
-                self.set_pwm(PWMDuty(0))?;
+                self.set_pwm(Err(task_sensor_api::NoData::DeviceOff), now_ms)?;
             }
         }
 
@@ -1674,10 +1674,37 @@ impl<'a> ThermalControl<'a> {
     /// set to zero. Returns the last error if one occurred, but does not short
     /// circuit (i.e. attempts to set *all* present fan duty cycles, even if one
     /// fails)
-    pub fn set_pwm(&mut self, pwm: PWMDuty) -> Result<(), ThermalError> {
-        if pwm.0 > 100 {
-            return Err(ThermalError::InvalidPWM);
-        }
+    ///
+    /// The PWM value (or error code) is sent to the `sensors` task for logging,
+    /// timestamped with the `now_ms` argument.
+    pub fn set_pwm(
+        &mut self,
+        pwm: Result<PWMDuty, task_sensor_api::NoData>,
+        now_ms: u64,
+    ) -> Result<(), ThermalError> {
+        // We'll post the PWM value to the sensors task for logging
+        use task_sensor_api::config::other_sensors;
+        pub const OUTPUT_PWM_SENSOR: SensorId =
+            other_sensors::THERMAL_LOOP_FAN_CTRL_PWM_SENSOR;
+        let pwm = match pwm {
+            Ok(pwm) => {
+                if pwm.0 > 100 {
+                    self.sensor_api.nodata(
+                        OUTPUT_PWM_SENSOR,
+                        task_sensor_api::NoData::DeviceError,
+                        now_ms,
+                    );
+                    return Err(ThermalError::InvalidPWM);
+                }
+                self.sensor_api
+                    .post(OUTPUT_PWM_SENSOR, pwm.0 as f32, now_ms);
+                pwm
+            }
+            Err(e) => {
+                self.sensor_api.nodata(OUTPUT_PWM_SENSOR, e, now_ms);
+                PWMDuty(0)
+            }
+        };
         self.last_pwm = pwm;
         let mut last_err = Ok(());
         for (index, sensor_id) in self.fans.enumerate() {
@@ -1705,7 +1732,7 @@ impl<'a> ThermalControl<'a> {
     /// This is used by ThermalMode::Manual to accomodate the removal and
     /// replacement of fan modules.
     pub fn maintain_pwm(&mut self) -> Result<(), ThermalError> {
-        self.set_pwm(self.last_pwm)
+        self.set_pwm(Ok(self.last_pwm), sys_get_timer().now)
     }
 
     pub fn set_watchdog(

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -179,7 +179,7 @@ impl<'a> ServerImpl<'a> {
         initial_pwm: PWMDuty,
     ) -> Result<(), ThermalError> {
         self.set_mode(ThermalMode::Manual);
-        self.control.set_pwm(initial_pwm)
+        self.control.set_pwm(Ok(initial_pwm), sys_get_timer().now)
     }
 
     /// Configures the control loop to run in automatic mode.


### PR DESCRIPTION
(staged on top of #2428)

This adds a new `fan_ctrl` sensor, which is updated by the thermal loop.  In combination with https://github.com/oxidecomputer/humility/pull/602, we can log both fan speed (which was already possible) and commanded PWM values with `humility dashboard -o out.csv`

Here's an example while running `stress-ng`:

<img width="1336" height="1528" alt="Screenshot 2026-03-09 at 10 54 42 AM" src="https://github.com/user-attachments/assets/a2bfd55d-9063-41f2-b0b0-e51a98061b2a" />

The hysteresis from the fan controller is quite noticeable if we plot PWM vs RPM:

<img width="1330" height="880" alt="Screenshot 2026-03-09 at 10 55 01 AM" src="https://github.com/user-attachments/assets/52a4f1ae-a90e-4f1b-9d18-6d870917be40" />


