### PR TITLE
Make task config only readable from task crate build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-stm32h7-spi-server-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "build-spi",
+ "build-util",
+ "call_rustfmt",
+ "idol",
+ "indexmap 1.9.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "build-stm32xx-sys"
 version = "0.1.0"
 dependencies = [
@@ -1256,6 +1273,7 @@ name = "drv-fpga-server"
 version = "0.1.0"
 dependencies = [
  "build-i2c",
+ "build-stm32h7-spi-server-core",
  "build-util",
  "cfg-if",
  "drv-fpga-api",
@@ -2264,6 +2282,7 @@ dependencies = [
 name = "drv-spartan7-loader"
 version = "0.1.0"
 dependencies = [
+ "build-stm32h7-spi-server-core",
  "build-util",
  "cfg-if",
  "counters",
@@ -2510,6 +2529,7 @@ dependencies = [
 name = "drv-stm32h7-spi-server"
 version = "0.1.0"
 dependencies = [
+ "build-stm32h7-spi-server-core",
  "build-util",
  "drv-spi-api",
  "drv-stm32h7-spi-server-core",
@@ -2526,28 +2546,17 @@ dependencies = [
 name = "drv-stm32h7-spi-server-core"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "build-spi",
- "build-util",
- "call_rustfmt",
  "cfg-if",
  "cortex-m",
  "counters",
  "drv-spi-api",
  "drv-stm32h7-spi",
  "drv-stm32xx-sys-api",
- "idol",
  "idol-runtime",
- "indexmap 1.9.1",
  "mutable-statics",
  "num-traits",
- "proc-macro2",
- "quote",
- "regex",
  "ringbuf",
- "serde",
  "stm32h7",
- "syn 2.0.106",
  "userlib",
  "zerocopy 0.8.27",
 ]
@@ -2557,6 +2566,7 @@ name = "drv-stm32h7-sprot-server"
 version = "0.1.0"
 dependencies = [
  "attest-api",
+ "build-stm32h7-spi-server-core",
  "build-stm32xx-sys",
  "build-util",
  "cfg-if",
@@ -5970,6 +5980,7 @@ dependencies = [
 name = "task-monorail-server"
 version = "0.1.0"
 dependencies = [
+ "build-stm32h7-spi-server-core",
  "build-util",
  "cfg-if",
  "counters",
@@ -6003,6 +6014,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "build-net",
+ "build-stm32h7-spi-server-core",
  "build-util",
  "cfg-if",
  "cortex-m",

--- a/build/spi/src/lib.rs
+++ b/build/spi/src/lib.rs
@@ -156,13 +156,14 @@ impl ToTokens for SpiConfig {
         let fifo_depth = self.fifo_depth.unwrap_or(8);
 
         tokens.append_all(quote::quote! {
-            const FIFO_DEPTH: usize = #fifo_depth;
-            const CONFIG: ServerConfig = ServerConfig {
+            pub const FIFO_DEPTH: usize = #fifo_depth;
+            pub const CONFIG: ServerConfig = ServerConfig {
                 registers: device::#devname::ptr(),
                 peripheral: sys_api::Peripheral::#pname,
                 mux_options: &[ #(#muxes),* ],
                 devices: &[ #(#device_code),* ],
             };
+            #[allow(dead_code)]
             pub mod devices {
                 #(#device_names)*
             }

--- a/build/stm32h7-spi-server-core/Cargo.toml
+++ b/build/stm32h7-spi-server-core/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "build-stm32h7-spi-server-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+idol.workspace = true
+indexmap.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+regex.workspace = true
+serde.workspace = true
+syn.workspace = true
+
+build-util = { path = "../../build/util" }
+build-spi = { path = "../../build/spi" }
+call_rustfmt = { path = "../../build/call_rustfmt" }
+
+[lints]
+workspace = true

--- a/build/stm32h7-spi-server-core/src/lib.rs
+++ b/build/stm32h7-spi-server-core/src/lib.rs
@@ -9,7 +9,7 @@ use quote::ToTokens;
 use std::collections::BTreeMap;
 use std::io::Write;
 
-fn main() -> Result<()> {
+pub fn build_spi_config() -> Result<()> {
     build_util::expose_target_board();
 
     let full_task_config = build_util::task_full_config_toml()?;

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -45,7 +45,7 @@ pub fn target_os() -> String {
 
 /// Reads the `HUBRIS_TASK_NAME` env var.
 pub fn task_name() -> String {
-    crate::env_var("HUBRIS_TASK_NAME").expect("missing HUBRIS_TASK_NAME")
+    env_var("HUBRIS_TASK_NAME").expect("missing HUBRIS_TASK_NAME")
 }
 
 /// Checks to see whether the given feature is enabled
@@ -84,7 +84,7 @@ pub fn expose_m_profile() -> Result<()> {
 
 /// Returns the `HUBRIS_BOARD` envvar, if set.
 pub fn target_board() -> Option<String> {
-    crate::env_var("HUBRIS_BOARD").ok()
+    env_var("HUBRIS_BOARD").ok()
 }
 
 /// Exposes the board type from the `HUBRIS_BOARD` envvar into
@@ -167,10 +167,10 @@ pub fn task_config<T: DeserializeOwned>() -> Result<T> {
 }
 
 /// Pulls the task configuration, or `None` if the configuration is not
-/// provided.
+/// provided.  Returns an error if the task full config is not present.
 pub fn task_maybe_config<T: DeserializeOwned>() -> Result<Option<T>> {
-    let t = toml_from_env::<toml_task::Task<T>>("HUBRIS_TASK_CONFIG")?;
-    Ok(t.and_then(|t| t.config))
+    let t = task_full_config()?;
+    Ok(t.config)
 }
 
 /// Pulls the full task configuration block for the current task
@@ -178,9 +178,21 @@ pub fn task_maybe_config<T: DeserializeOwned>() -> Result<Option<T>> {
 /// (compare with `task_maybe_config`, which returns just the `config`
 /// subsection)
 pub fn task_full_config<T: DeserializeOwned>() -> Result<toml_task::Task<T>> {
-    let t = toml_from_env::<toml_task::Task<T>>("HUBRIS_TASK_CONFIG")?
-        .ok_or_else(|| anyhow!("HUBRIS_TASK_CONFIG is not defined"))?;
-    Ok(t)
+    try_task_full_config()?
+        .ok_or_else(|| anyhow!("HUBRIS_TASK_CONFIG is not defined"))
+}
+
+pub fn try_task_full_config<T: DeserializeOwned>(
+) -> Result<Option<toml_task::Task<T>>> {
+    let out = toml_from_env::<toml_task::Task<T>>("HUBRIS_TASK_CONFIG")?;
+    if let Some(out) = &out {
+        let crate_name = env_var("CARGO_PKG_NAME").unwrap();
+        assert_eq!(
+            out.name, crate_name,
+            "can't read task config from non-task crate {crate_name}"
+        );
+    }
+    Ok(out)
 }
 
 /// Pulls the full task configuration block, with the `config` subsection
@@ -280,7 +292,7 @@ impl TaskIds {
 /// - `Err(e)` if deserialization failed or the environment variable did not
 ///   contain UTF-8.
 fn toml_from_env<T: DeserializeOwned>(var: &str) -> Result<Option<T>> {
-    let config = match crate::env_var(var) {
+    let config = match env_var(var) {
         Err(e) => {
             use std::env::VarError;
 

--- a/drv/fpga-server/Cargo.toml
+++ b/drv/fpga-server/Cargo.toml
@@ -24,21 +24,22 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [build-dependencies]
 build-i2c = { path = "../../build/i2c" }
 build-util = { path = "../../build/util" }
+build-stm32h7-spi-server-core = { path = "../../build/stm32h7-spi-server-core", optional = true }
 idol = { workspace = true }
 
 [features]
 mainboard = []
 front_io = ["drv-i2c-api", "drv-i2c-devices"]
-use-spi-core = ["drv-stm32h7-spi-server-core"]
+use-spi-core = ["drv-stm32h7-spi-server-core", "build-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
 
-spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 no-ipc-counters = ["idol/no-counters"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/drv/fpga-server/build.rs
+++ b/drv/fpga-server/build.rs
@@ -6,6 +6,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
 
+    #[cfg(feature = "use-spi-core")]
+    build_stm32h7_spi_server_core::build_spi_config()?;
+
     if cfg!(feature = "front_io") {
         let disposition = build_i2c::Disposition::Devices;
 

--- a/drv/fpga-server/src/main.rs
+++ b/drv/fpga-server/src/main.rs
@@ -36,7 +36,15 @@ cfg_if::cfg_if! {
             -> drv_stm32h7_spi_server_core::SpiServerCore
         {
             drv_stm32h7_spi_server_core::declare_spi_core!(
-                sys.clone(), notifications::SPI_IRQ_MASK)
+                sys.clone(),
+                notifications::SPI_IRQ_MASK,
+                spi_config,
+            )
+        }
+
+        mod spi_config {
+            use drv_stm32h7_spi_server_core::__reexport::*;
+            include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
         }
     } else {
         pub fn claim_spi(_sys: &sys_api::Sys) -> drv_spi_api::Spi {

--- a/drv/spartan7-loader/Cargo.toml
+++ b/drv/spartan7-loader/Cargo.toml
@@ -22,17 +22,18 @@ zerocopy-derive = { workspace = true }
 
 [build-dependencies]
 build-util = { path = "../../build/util" }
+build-stm32h7-spi-server-core = { path = "../../build/stm32h7-spi-server-core", optional = true }
 idol = { workspace = true }
 
 [features]
 h753 = ["drv-stm32xx-sys-api/h753"]
-use-spi-core = ["drv-stm32h7-spi-server-core"]
-spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+use-spi-core = ["drv-stm32h7-spi-server-core", "build-stm32h7-spi-server-core"]
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 
 [[bin]]
 name = "drv-spartan7-loader"

--- a/drv/spartan7-loader/build.rs
+++ b/drv/spartan7-loader/build.rs
@@ -7,6 +7,9 @@ use std::{fs, io::Write};
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
 
+    #[cfg(feature = "use-spi-core")]
+    build_stm32h7_spi_server_core::build_spi_config()?;
+
     let out_dir = build_util::out_dir();
     let out_file = out_dir.join("spartan7_fpga.rs");
     let mut file = fs::File::create(out_file)?;

--- a/drv/spartan7-loader/src/main.rs
+++ b/drv/spartan7-loader/src/main.rs
@@ -237,3 +237,8 @@ mod idl {
 mod gen {
     include!(concat!(env!("OUT_DIR"), "/spartan7_fpga.rs"));
 }
+
+mod spi_config {
+    use drv_stm32h7_spi_server_core::__reexport::*;
+    include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
+}

--- a/drv/spartan7-loader/src/main.rs
+++ b/drv/spartan7-loader/src/main.rs
@@ -238,6 +238,7 @@ mod gen {
     include!(concat!(env!("OUT_DIR"), "/spartan7_fpga.rs"));
 }
 
+#[cfg(feature = "use-spi-core")]
 mod spi_config {
     use drv_stm32h7_spi_server_core::__reexport::*;
     include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));

--- a/drv/stm32h7-spi-server-core/Cargo.toml
+++ b/drv/stm32h7-spi-server-core/Cargo.toml
@@ -19,32 +19,7 @@ mutable-statics = { path = "../../lib/mutable-statics" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
-[build-dependencies]
-anyhow.workspace = true
-idol.workspace = true
-indexmap.workspace = true
-proc-macro2.workspace = true
-quote.workspace = true
-regex.workspace = true
-serde.workspace = true
-syn.workspace = true
-
-build-util = { path = "../../build/util" }
-build-spi = { path = "../../build/spi" }
-call_rustfmt = { path = "../../build/call_rustfmt" }
-
 [features]
-# These features are used in `build.rs` to select a global SPI peripheral block,
-# which modifies the generated code that's compiled in the crate.  As such, they
-# don't appear in the crate's source code, but are load-bearing!  Making this
-# choice based on features also prevents extra rebuilds when building a complete
-# Hubris app.
-spi1 = []
-spi2 = []
-spi3 = []
-spi4 = []
-spi5 = []
-spi6 = []
 h743 = ["stm32h7/stm32h743", "drv-stm32h7-spi/h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["stm32h7/stm32h753", "drv-stm32h7-spi/h753", "drv-stm32xx-sys-api/h753"]
 

--- a/drv/stm32h7-spi-server-core/src/lib.rs
+++ b/drv/stm32h7-spi-server-core/src/lib.rs
@@ -20,17 +20,17 @@ use drv_spi_api::*;
 use idol_runtime::{BufReader, BufWriter, ClientError, RequestError};
 use ringbuf::*;
 
+use userlib::*;
+
 #[cfg(feature = "h743")]
-use stm32h7::stm32h743 as device;
+pub use stm32h7::stm32h743 as device;
 
 #[cfg(feature = "h753")]
-use stm32h7::stm32h753 as device;
-
-use userlib::*;
+pub use stm32h7::stm32h753 as device;
 
 use drv_stm32h7_spi as spi_core;
 use drv_stm32xx_sys_api as sys_api;
-use sys_api::PinSet;
+pub use sys_api::PinSet;
 
 use core::{cell::Cell, convert::Infallible};
 
@@ -56,6 +56,8 @@ pub struct SpiServerCore {
     spi: spi_core::Spi,
     sys: sys_api::Sys,
     irq_mask: u32,
+    cfg: &'static ServerConfig,
+    fifo_depth: usize,
     lock_holder: &'static Cell<Option<LockState>>, // used by Idol server
     current_mux_index: &'static Cell<usize>,
 }
@@ -124,14 +126,16 @@ impl SpiServerCore {
         irq_mask: u32,
         lock_holder: &'static Cell<Option<LockState>>, // used by Idol server
         current_mux_index: &'static Cell<usize>,
+        cfg: &'static ServerConfig,
+        fifo_depth: usize,
     ) -> Self {
-        check_server_config();
+        check_server_config(cfg);
 
-        let registers = unsafe { &*CONFIG.registers };
+        let registers = unsafe { &*cfg.registers };
 
-        sys.enable_clock(CONFIG.peripheral);
-        sys.enter_reset(CONFIG.peripheral);
-        sys.leave_reset(CONFIG.peripheral);
+        sys.enable_clock(cfg.peripheral);
+        sys.enter_reset(cfg.peripheral);
+        sys.leave_reset(cfg.peripheral);
         let mut spi = spi_core::Spi::from(registers);
 
         // This should correspond to '0' in the standard SPI parlance
@@ -147,7 +151,7 @@ impl SpiServerCore {
 
         // Configure all devices' CS pins to be deasserted (set).
         // We leave them in GPIO output mode from this point forward.
-        for device in CONFIG.devices {
+        for device in cfg.devices {
             for pin in device.cs {
                 sys.gpio_set(*pin);
                 sys.gpio_configure_output(
@@ -168,11 +172,11 @@ impl SpiServerCore {
         // We deactivate before activate to avoid pin clash if we previously crashed
         // with one of these activated.
         current_mux_index.set(0);
-        for opt in &CONFIG.mux_options[1..] {
+        for opt in &cfg.mux_options[1..] {
             deactivate_mux_option(opt, &sys);
         }
         activate_mux_option(
-            &CONFIG.mux_options[current_mux_index.get()],
+            &cfg.mux_options[current_mux_index.get()],
             &sys,
             &spi,
         );
@@ -182,6 +186,8 @@ impl SpiServerCore {
             sys,
             irq_mask,
             lock_holder,
+            cfg,
+            fifo_depth,
             current_mux_index,
         }
     }
@@ -261,7 +267,7 @@ impl SpiServerCore {
         // a legal state change from the same sender.
 
         // Reject out-of-range devices.
-        let device = CONFIG.devices.get(devidx).ok_or(LockError(()))?;
+        let device = self.cfg.devices.get(devidx).ok_or(LockError(()))?;
 
         for pin in device.cs {
             // If we're asserting CS, we want to *reset* the pin. If
@@ -286,7 +292,7 @@ impl SpiServerCore {
             // should be locked by the sender...but double check.
             assert!(lockstate.task == sender);
 
-            let device = &CONFIG.devices[lockstate.device_index];
+            let device = &self.cfg.devices[lockstate.device_index];
 
             for pin in device.cs {
                 // Deassert CS. If it wasn't asserted, this is a no-op.
@@ -319,7 +325,8 @@ impl SpiServerCore {
         }
 
         // Reject out-of-range devices.
-        let device = CONFIG
+        let device = self
+            .cfg
             .devices
             .get(device_index)
             .ok_or(TransferError::BadDevice)?;
@@ -362,11 +369,11 @@ impl SpiServerCore {
         let current_mux_index = self.current_mux_index.get();
         if device.mux_index != current_mux_index {
             deactivate_mux_option(
-                &CONFIG.mux_options[current_mux_index],
+                &self.cfg.mux_options[current_mux_index],
                 &self.sys,
             );
             activate_mux_option(
-                &CONFIG.mux_options[device.mux_index],
+                &self.cfg.mux_options[device.mux_index],
                 &self.sys,
                 &self.spi,
             );
@@ -421,7 +428,7 @@ impl SpiServerCore {
         // not appear to be possible.
         //
         // See reference manual table 409 for details.
-        let mut tx_permits = FIFO_DEPTH;
+        let mut tx_permits = self.fifo_depth;
 
         // Track number of bytes sent and received. Sent bytes will lead
         // received bytes. Received bytes indicate overall progress and
@@ -617,31 +624,31 @@ fn activate_mux_option(
 // Board-peripheral-server configuration matrix
 //
 // The configurable bits for a given board and controller combination are in the
-// ServerConfig struct. We use conditional compilation below to select _one_
-// instance of this struct in a const called `CONFIG`.
+// ServerConfig struct, which is generated by the parent task and passed in to
+// the `SpiMux` constructor.
 
 /// Rolls up all the configuration options for this server on a given board and
 /// controller.
 #[derive(Copy, Clone)]
-struct ServerConfig {
+pub struct ServerConfig {
     /// Pointer to this controller's register block. Don't let the `spi1` fool
     /// you, they all have that type. This needs to match a peripheral in your
     /// task's `uses` list for this to work.
-    registers: *const device::spi1::RegisterBlock,
+    pub registers: *const device::spi1::RegisterBlock,
     /// Name for the peripheral as far as the RCC is concerned.
-    peripheral: sys_api::Peripheral,
+    pub peripheral: sys_api::Peripheral,
     /// We allow for an individual SPI controller to be switched between several
     /// physical sets of pads. The mux options for a given server configuration
     /// are numbered from 0 and correspond to this slice.
-    mux_options: &'static [SpiMuxOption],
+    pub mux_options: &'static [SpiMuxOption],
     /// We keep track of a fixed set of devices per SPI controller, which each
     /// have an associated routing (from `mux_options`) and CS pin.
-    devices: &'static [DeviceDescriptor],
+    pub devices: &'static [DeviceDescriptor],
 }
 
 /// A routing of the SPI controller onto pins.
 #[derive(Copy, Clone, Debug)]
-struct SpiMuxOption {
+pub struct SpiMuxOption {
     /// A list of config changes to apply to activate the output pins of this
     /// mux option. This is a list because some mux options are spread across
     /// multiple ports, or (in at least one case) the pins in the same port
@@ -650,44 +657,44 @@ struct SpiMuxOption {
     /// To disable the mux, we'll force these pins low. This is correct for SPI
     /// mode 0/1 but not mode 2/3; fortunately we currently don't support mode
     /// 2/3, so we can simplify.
-    outputs: &'static [(PinSet, sys_api::Alternate)],
+    pub outputs: &'static [(PinSet, sys_api::Alternate)],
     /// A list of config changes to apply to activate the input pins of this mux
     /// option. This is _not_ a list because there's only one such pin, CIPO.
     ///
     /// To disable the mux, we'll switch this pin to HiZ.
-    input: (PinSet, sys_api::Alternate),
+    pub input: (PinSet, sys_api::Alternate),
     /// Swap data lines?
-    swap_data: bool,
+    pub swap_data: bool,
 }
 
 /// Information about one device attached to the SPI controller.
 #[derive(Copy, Clone, Debug)]
-struct DeviceDescriptor {
+pub struct DeviceDescriptor {
     /// To reach this device, the SPI controller has to be muxed onto the
     /// correct physical circuit. This gives the index of the right choice in
     /// the server's configured `SpiMuxOption` array.
-    mux_index: usize,
+    pub mux_index: usize,
     /// Where the CS pin is. While this is a `PinSet`, it should only have one
     /// pin in it, and we check this at startup.
-    cs: &'static [PinSet],
+    pub cs: &'static [PinSet],
     /// Clock divider to apply while speaking with this device. Yes, this says
     /// spi1 no matter which SPI block we're in charge of.
-    clock_divider: device::spi1::cfg1::MBR_A,
+    pub clock_divider: device::spi1::cfg1::MBR_A,
 }
 
 /// Any impl of ServerConfig for Server has to pass these tests at startup.
-fn check_server_config() {
+fn check_server_config(cfg: &ServerConfig) {
     // TODO some of this could potentially be moved into const fns for building
     // the tree, and thus to compile time ... if we could assert in const fns.
     //
     // That said, because this is analyzing constants, if the checks _pass_ this
     // should disappear at compilation.
 
-    assert!(!CONFIG.registers.is_null()); // let's start off easy.
+    assert!(!cfg.registers.is_null()); // let's start off easy.
 
     // Mux options must be provided.
-    assert!(!CONFIG.mux_options.is_empty());
-    for muxopt in CONFIG.mux_options {
+    assert!(!cfg.mux_options.is_empty());
+    for muxopt in cfg.mux_options {
         // Each mux option must contain at least one output config record.
         assert!(!muxopt.outputs.is_empty());
         let mut total_pins = 0;
@@ -711,10 +718,10 @@ fn check_server_config() {
         assert!(muxopt.input.0.pin_mask.count_ones() == 1);
     }
     // At least one device must be defined.
-    assert!(!CONFIG.devices.is_empty());
-    for dev in CONFIG.devices {
+    assert!(!cfg.devices.is_empty());
+    for dev in cfg.devices {
         // Mux index must be valid.
-        assert!(dev.mux_index < CONFIG.mux_options.len());
+        assert!(dev.mux_index < cfg.mux_options.len());
 
         for pin in dev.cs {
             // A CS pin must designate _exactly one_ pin in its mask.
@@ -785,9 +792,17 @@ impl SpiServer for SpiServerCore {
 
 pub use mutable_statics::mutable_statics as __mutable_statics_reexport;
 
+/// Module containing types that a generated `spi_config.rs` will need
+#[doc(hidden)]
+pub mod __reexport {
+    pub use super::{device, DeviceDescriptor, ServerConfig, SpiMuxOption};
+    pub use drv_stm32xx_sys_api as sys_api;
+    pub use drv_stm32xx_sys_api::PinSet;
+}
+
 #[macro_export]
 macro_rules! declare_spi_core {
-    ($sys:expr, $irq_mask:expr) => {{
+    ($sys:expr, $irq_mask:expr, $mod:ident$(,)*) => {{
         let (lock_holder, current_mux_index) =
             $crate::__mutable_statics_reexport!(
                 static mut LOCK_HOLDER: [core::cell::Cell<
@@ -801,10 +816,8 @@ macro_rules! declare_spi_core {
             $irq_mask,
             &lock_holder[0],
             &current_mux_index[0],
+            &$mod::CONFIG,
+            $mod::FIFO_DEPTH,
         )
     }}
 }
-
-////////////////////////////////////////////////////////////////////////////////
-
-include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));

--- a/drv/stm32h7-spi-server/Cargo.toml
+++ b/drv/stm32h7-spi-server/Cargo.toml
@@ -17,17 +17,18 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [build-dependencies]
 idol.workspace = true
 build-util.path = "../../build/util"
+build-stm32h7-spi-server-core.path = "../../build/stm32h7-spi-server-core"
 
 [features]
 # These features are used to select a global SPI configuration block; in
 # addition, Humility uses them to decide which SPI server task to address for a
 # given peripheral.
-spi1 = ["drv-stm32h7-spi-server-core/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core/spi6"]
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 h743 = ["drv-stm32h7-spi-server-core/h743", "drv-stm32xx-sys-api/h743"]
 h753 = ["drv-stm32h7-spi-server-core/h753", "drv-stm32xx-sys-api/h753"]
 

--- a/drv/stm32h7-spi-server/build.rs
+++ b/drv/stm32h7-spi-server/build.rs
@@ -12,5 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             "../../idl/spi.idol",
             "server_stub.rs",
             idol::server::ServerStyle::InOrder,
-        )
+        )?;
+    build_stm32h7_spi_server_core::build_spi_config()?;
+    Ok(())
 }

--- a/drv/stm32h7-spi-server/src/main.rs
+++ b/drv/stm32h7-spi-server/src/main.rs
@@ -34,7 +34,8 @@ fn main() -> ! {
     let sys = sys_api::Sys::from(SYS.get_task_id());
     let core = drv_stm32h7_spi_server_core::declare_spi_core!(
         sys,
-        notifications::SPI_IRQ_MASK
+        notifications::SPI_IRQ_MASK,
+        spi_config,
     );
     let mut server = ServerImpl { core };
     let mut incoming = [0u8; INCOMING_SIZE];
@@ -135,3 +136,8 @@ impl NotificationHandler for ServerImpl {
 include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
 
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
+
+mod spi_config {
+    use drv_stm32h7_spi_server_core::__reexport::*;
+    include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
+}

--- a/drv/stm32h7-sprot-server/Cargo.toml
+++ b/drv/stm32h7-sprot-server/Cargo.toml
@@ -28,20 +28,21 @@ userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 [build-dependencies]
 build-util = { path = "../../build/util" }
 build-stm32xx-sys = { path = "../../build/stm32xx-sys" }
+build-stm32h7-spi-server-core = { path = "../../build/stm32h7-spi-server-core", optional = true }
 idol = { workspace = true }
 
 [features]
 sink_test = []
-use-spi-core = ["drv-stm32h7-spi-server-core"]
+use-spi-core = ["drv-stm32h7-spi-server-core", "build-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
 
-spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 
 no-ipc-counters = ["idol/no-counters"]
 

--- a/drv/stm32h7-sprot-server/build.rs
+++ b/drv/stm32h7-sprot-server/build.rs
@@ -7,6 +7,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::build_notifications()?;
     build_stm32xx_sys::build_gpio_irq_pins()?;
 
+    #[cfg(feature = "use-spi-core")]
+    build_stm32h7_spi_server_core::build_spi_config()?;
+
     idol::Generator::new()
         .with_counters(
             idol::CounterSettings::default().with_server_counters(false),

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -32,7 +32,10 @@ cfg_if::cfg_if! {
             -> drv_stm32h7_spi_server_core::SpiServerCore
         {
             drv_stm32h7_spi_server_core::declare_spi_core!(
-                sys.clone(), notifications::SPI_IRQ_MASK)
+                sys.clone(),
+                notifications::SPI_IRQ_MASK,
+                spi_config
+            )
         }
     } else {
         pub fn claim_spi(_sys: &sys_api::Sys) -> drv_spi_api::Spi {
@@ -1558,3 +1561,8 @@ mod idl {
 
 include!(concat!(env!("OUT_DIR"), "/notifications.rs"));
 include!(concat!(env!("OUT_DIR"), "/gpio_irq_pins.rs"));
+
+mod spi_config {
+    use drv_stm32h7_spi_server_core::__reexport::*;
+    include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
+}

--- a/task/monorail-server/Cargo.toml
+++ b/task/monorail-server/Cargo.toml
@@ -38,19 +38,20 @@ reverso = []
 minibar = []
 vlan = ["task-net-api?/vlan"]
 no-ipc-counters = ["idol/no-counters"]
-use-spi-core = ["drv-stm32h7-spi-server-core"]
+use-spi-core = ["drv-stm32h7-spi-server-core", "build-stm32h7-spi-server-core"]
 h743 = ["drv-stm32h7-spi-server-core?/h743"]
 h753 = ["drv-stm32h7-spi-server-core?/h753"]
 
-spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 
 [build-dependencies]
 build-util = {path = "../../build/util"}
+build-stm32h7-spi-server-core = { path = "../../build/stm32h7-spi-server-core", optional = true }
 idol = { workspace = true }
 
 [[bin]]

--- a/task/monorail-server/build.rs
+++ b/task/monorail-server/build.rs
@@ -6,6 +6,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
 
+    #[cfg(feature = "use-spi-core")]
+    build_stm32h7_spi_server_core::build_spi_config()?;
+
     idol::Generator::new()
         .with_counters(
             idol::CounterSettings::default().with_server_counters(false),

--- a/task/monorail-server/src/main.rs
+++ b/task/monorail-server/src/main.rs
@@ -31,6 +31,11 @@ use vsc7448::{spi::Vsc7448Spi, Vsc7448, VscError};
 cfg_if::cfg_if! {
     // Select local vs server SPI communication
     if #[cfg(feature = "use-spi-core")] {
+        mod spi_config {
+            use drv_stm32h7_spi_server_core::__reexport::*;
+            include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
+        }
+
         /// Claims the SPI core.
         ///
         /// This function can only be called once, and will panic otherwise!
@@ -38,7 +43,10 @@ cfg_if::cfg_if! {
             -> drv_stm32h7_spi_server_core::SpiServerCore
         {
             drv_stm32h7_spi_server_core::declare_spi_core!(
-                sys.clone(), notifications::SPI_IRQ_MASK)
+                sys.clone(),
+                notifications::SPI_IRQ_MASK,
+                spi_config,
+            )
         }
     } else {
         pub fn claim_spi(_sys: &Sys) -> drv_spi_api::Spi {

--- a/task/net/Cargo.toml
+++ b/task/net/Cargo.toml
@@ -43,7 +43,7 @@ vsc85xx = { path = "../../drv/vsc85xx"}
 
 [features]
 no-ipc-counters = ["idol/no-counters"]
-use-spi-core = ["drv-stm32h7-spi-server-core"]
+use-spi-core = ["drv-stm32h7-spi-server-core", "build-stm32h7-spi-server-core"]
 mgmt = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/mgmt"]
 vpd-mac = ["task-packrat-api"]
 gimlet = ["drv-cpu-seq-api"]
@@ -58,12 +58,17 @@ vlan = ["task-net-api/vlan", "build-net/vlan", "drv-stm32h7-eth/vlan"]
 gimletlet-nic = ["drv-spi-api", "ksz8463", "drv-user-leds-api", "task-net-api/ksz8463"]
 grapefruit = ["drv-spi-api", "ksz8463", "task-net-api/ksz8463"]
 
-spi1 = ["drv-stm32h7-spi-server-core?/spi1"]
-spi2 = ["drv-stm32h7-spi-server-core?/spi2"]
-spi3 = ["drv-stm32h7-spi-server-core?/spi3"]
-spi4 = ["drv-stm32h7-spi-server-core?/spi4"]
-spi5 = ["drv-stm32h7-spi-server-core?/spi5"]
-spi6 = ["drv-stm32h7-spi-server-core?/spi6"]
+# These features are used in `build.rs` to select a global SPI peripheral block,
+# which modifies the generated code that's compiled in the crate.  As such, they
+# don't appear in the crate's source code, but are load-bearing!  Making this
+# choice based on features also prevents extra rebuilds when building a complete
+# Hubris app.
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
 
 [build-dependencies]
 anyhow.workspace = true
@@ -76,6 +81,7 @@ syn.workspace = true
 
 build-net = { path = "../../build/net" }
 build-util = { path = "../../build/util" }
+build-stm32h7-spi-server-core = { path = "../../build/stm32h7-spi-server-core", optional = true }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/net/build.rs
+++ b/task/net/build.rs
@@ -25,6 +25,9 @@ fn main() -> Result<()> {
     build_util::expose_target_board();
     build_util::build_notifications()?;
 
+    #[cfg(feature = "use-spi-core")]
+    build_stm32h7_spi_server_core::build_spi_config()?;
+
     Ok(())
 }
 

--- a/task/net/src/bsp_support.rs
+++ b/task/net/src/bsp_support.rs
@@ -30,12 +30,19 @@ cfg_if::cfg_if! {
         pub type Ksz8463 =
             ksz8463::Ksz8463<drv_stm32h7_spi_server_core::SpiServerCore>;
 
+        mod spi_config {
+            use drv_stm32h7_spi_server_core::__reexport::*;
+            include!(concat!(env!("OUT_DIR"), "/spi_config.rs"));
+        }
         /// Claims the SPI core.
         ///
         /// This function can only be called once, and will panic otherwise!
         pub fn claim_spi(sys: &Sys) -> drv_stm32h7_spi_server_core::SpiServerCore {
             drv_stm32h7_spi_server_core::declare_spi_core!(
-                sys.clone(), notifications::SPI_IRQ_MASK)
+                sys.clone(),
+                notifications::SPI_IRQ_MASK,
+                spi_config,
+            )
         }
     } else if #[cfg(all(feature = "ksz8463", not(feature = "use-spi-core")))] {
         // The SPI peripheral is owned by a separate `stm32h7-spi-server` task


### PR DESCRIPTION
Right now, dispatching `cargo` once per task is a reason why incremental rebuilds are slow.  I would like to live in a world where we dispatch `cargo` once to build multiple (compatible†) tasks.

One issue with this plan: build scripts for library crates are free to read `HUBRIS_TASK_CONFIG` and react accordingly.  In a world where multiple tasks are built in a single `cargo` invocation, there's no single `HUBRIS_TASK_CONFIG` to read.

The PR eliminates that behavior: build scripts that read `HUBRIS_TASK_CONFIG` must have a `CARGO_PKG_NAME` that matches the task crate name.  In other words, only **a task's** build script may read the task config.  Otherwise, the `build_util::*task*config` function will panic.

This is useful because it also works in the opposite direction: when this property is true, we can use `CARGO_PKG_NAME` to unambiguously‡ pick which task config to use.

--------------------------------------------------------------------------------

It turns out that we *almost* had this property already!  The one exception is the `drv-stm32h7-spi-server-core` crate, which had a build script that read the parent task configuration to pick which SPI peripheral to codegen.  In this PR, I make that codegen the parent crate's responsibility; `drv_stm32h7_spi_server_core::SpiServerCore::init` now takes a configuration from the caller, instead of baking it into a global variable.

The build script for `drv-stm32h7-spi-server-core` is moved to a separate `build-stm32h7-spi-server-core`, so that all of the parent crates can invoke it themselves.

--------------------------------------------------------------------------------

† "compatible" means that they enable the exact same set of features in their dependencies, to avoid feature unification surprises
‡ We will still be unable to simultaneously build multiple tasks that use the same crate, e.g. `spi2` and `spi3`, but that's fine