### PR TITLE
Check untrusted user input for wrapping range

### DIFF
--- a/task/control-plane-agent/src/dump.rs
+++ b/task/control-plane-agent/src/dump.rs
@@ -59,7 +59,7 @@ impl DumpState {
 
     pub(crate) fn get_task_dump_count(&mut self) -> Result<u32, SpError> {
         let mut count = 0;
-        for index in 0.. {
+        for index in 0..=u8::MAX {
             let data = self
                 .agent
                 .read_dump(index, 0)
@@ -90,7 +90,7 @@ impl DumpState {
         let mut found = None;
         let mut data = [0u8; 256];
         let mut header = humpty::DumpAreaHeader::new_zeroed();
-        for index in 0.. {
+        for index in 0..=u8::MAX {
             data = self
                 .agent
                 .read_dump(index, 0)

--- a/task/cosmo-spd/src/main.rs
+++ b/task/cosmo-spd/src/main.rs
@@ -214,16 +214,16 @@ impl ServerImpl {
                     b.set_op(2); // RANDOM_READ
                 });
                 const TIMEOUT_COUNT: usize = 8;
-                let mut timed_out = false;
-                for i in 0.. {
+                let mut attempts = 0;
+                let timed_out = loop {
                     if self.dimms.$count.data() == 2 {
-                        break;
-                    } else if i == TIMEOUT_COUNT {
-                        timed_out = true;
-                        break;
+                        break false;
+                    } else if attempts == TIMEOUT_COUNT {
+                        break true;
                     }
                     sleep_for(1);
-                }
+                    attempts += 1;
+                };
                 if timed_out {
                     None
                 } else {

--- a/task/jefe/src/dump.rs
+++ b/task/jefe/src/dump.rs
@@ -303,11 +303,11 @@ pub fn dump_task_region(
         length
     });
 
-    if start & 0b11 != 0 {
+    // Require alignment of 4-bytes for start + length
+    if !start.is_multiple_of(4) {
         return Err(DumpAgentError::UnalignedSegmentAddress);
     }
-
-    if length & 0b11 != 0 {
+    if !length.is_multiple_of(4) {
         return Err(DumpAgentError::UnalignedSegmentLength);
     }
 

--- a/task/jefe/src/dump.rs
+++ b/task/jefe/src/dump.rs
@@ -247,7 +247,7 @@ pub fn dump_task(base: u32, task: usize) -> Result<u8, DumpAgentError> {
 
     let area = dump_task_setup(base, DumpTaskContents::SingleTask)?;
 
-    for ndx in 0.. {
+    for ndx in 0..=usize::MAX {
         //
         // We need to ask the kernel which regions we should dump for this
         // task, which we do by asking for each dump region by index.  Note
@@ -261,27 +261,27 @@ pub fn dump_task(base: u32, task: usize) -> Result<u8, DumpAgentError> {
         // regions in a task) -- but could become so if these numbers become
         // larger.
         //
-        match kipc::get_task_dump_region(task, ndx) {
-            None => break,
-            Some(region) if !in_dump_area(region.base, region.size) => {
-                ringbuf_entry!(Trace::DumpRegion(region));
+        let Some(region) = kipc::get_task_dump_region(task, ndx) else {
+            break;
+        };
+        if in_dump_area(region.base, region.size) {
+            continue;
+        }
+        ringbuf_entry!(Trace::DumpRegion(region));
 
-                // SAFETY: we have configured memory so that humpty
-                // should only read headers which are properly initialized and
-                // readable by this task, and should only write memory which is
-                // writeable by this task (i.e. the dump areas).
-                if let Err(e) = humpty::add_dump_segment_header(
-                    area.region.address,
-                    region.base,
-                    region.size,
-                    |addr, buf, _| unsafe { humpty::from_mem(addr, buf) },
-                    |addr, buf| unsafe { humpty::to_mem(addr, buf) },
-                ) {
-                    ringbuf_entry!(Trace::DumpRegionsFailed(e));
-                    return Err(DumpAgentError::BadSegmentAdd);
-                }
-            }
-            Some(_) => {}
+        // SAFETY: we have configured memory so that humpty
+        // should only read headers which are properly initialized and
+        // readable by this task, and should only write memory which is
+        // writeable by this task (i.e. the dump areas).
+        if let Err(e) = humpty::add_dump_segment_header(
+            area.region.address,
+            region.base,
+            region.size,
+            |addr, buf, _| unsafe { humpty::from_mem(addr, buf) },
+            |addr, buf| unsafe { humpty::to_mem(addr, buf) },
+        ) {
+            ringbuf_entry!(Trace::DumpRegionsFailed(e));
+            return Err(DumpAgentError::BadSegmentAdd);
         }
     }
 
@@ -307,7 +307,7 @@ pub fn dump_task_region(
         return Err(DumpAgentError::UnalignedSegmentAddress);
     }
 
-    if (length as usize) & 0b11 != 0 {
+    if length & 0b11 != 0 {
         return Err(DumpAgentError::UnalignedSegmentLength);
     }
 
@@ -316,23 +316,31 @@ pub fn dump_task_region(
     // We don't trust the caller; it may request to dump a region that isn't
     // owned by this particular task!  To check this, we iterate over all of the
     // valid dump regions and confirm that our desired region is within one of
-    // them.
-    let mem = start..start + length;
+    // them. We also check that start+length wouldn't wrap around.
+    let Some(end) = start.checked_add(length) else {
+        return Err(DumpAgentError::BadSegmentAdd);
+    };
+    let mem = start..end;
     let mut okay = false;
 
-    for ndx in 0.. {
+    for ndx in 0..=usize::MAX {
         // This is Accidentally Quadratic; see the note in `dump_task`
-        match kipc::get_task_dump_region(task, ndx) {
-            None => break,
-            Some(region) if !in_dump_area(region.base, region.size) => {
-                ringbuf_entry!(Trace::DumpRegion(region));
-                let region = region.base..region.base + region.size;
-                if mem.start >= region.start && mem.end <= region.end {
-                    okay = true;
-                    break;
-                }
-            }
-            Some(_) => {}
+        let Some(region) = kipc::get_task_dump_region(task, ndx) else {
+            break;
+        };
+
+        if in_dump_area(region.base, region.size) {
+            continue;
+        }
+
+        ringbuf_entry!(Trace::DumpRegion(region));
+
+        // Note: we implicitly trust kipc won't give us a region that wraps,
+        // unlike untrusted user data from the request that we checked above.
+        let region = region.base..region.base + region.size;
+        if mem.start >= region.start && mem.end <= region.end {
+            okay = true;
+            break;
         }
     }
 


### PR DESCRIPTION
In `jefe/src/dump.rs`, use `checked_add` to ensure that the given range does not wrap. We do *not* perform the same check for the range obtained from kipc.

This also has some "nice to have" fixes to reduce some rightward drift, as well as explicitly avoid the "open range loop" footgun, even though it is not a reachable bug in these cases.

Let me know if you want me to break up the "bugfix" and "style fixups" into separate commits/PRs.