### PR TITLE
Enable `net` feature of `taskdump` on Nucleo 753

### DIFF
--- a/app/demo-stm32h7-nucleo/app-h753.toml
+++ b/app/demo-stm32h7-nucleo/app-h753.toml
@@ -196,13 +196,14 @@ uses = ["rng"]
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-features = ["no-rot"]
+features = ["no-rot", "net"]
 priority = 4
-max-sizes = {flash = 32768, ram = 2048 }
+max-sizes = {flash = 32768, ram = 16384 }
 start = true
-task-slots = ["jefe"]
-stacksize = 1200
+task-slots = ["jefe", "net"]
+stacksize = 2400
 extern-regions = [ "sram1", "sram2", "sram3", "sram4" ]
+notifications = ["socket"]
 
 [config]
 [[config.i2c.controllers]]
@@ -256,5 +257,12 @@ rx = { packets = 3, bytes = 1024 }
 kind = "udp"
 owner = {name = "udprpc", notification = "socket"}
 port = 998
+tx = { packets = 3, bytes = 1024 }
+rx = { packets = 3, bytes = 1024 }
+
+[config.net.sockets.dump_agent]
+kind = "udp"
+owner = {name = "dump_agent", notification = "socket"}
+port = 11113
 tx = { packets = 3, bytes = 1024 }
 rx = { packets = 3, bytes = 1024 }


### PR DESCRIPTION
We noticed in testing that the task-dump task on the H753 was not net-enabled. This takes the config values from gimlet in order to rectify that, allowing humility-over-network to work properly.

Before:

```
$ humility --archive=target/demo-stm32h753-nucleo/dist/default/build-demo-stm32h753-nucleo-image-default.zip --ip=fe80::0c1d:6cff:fe4e:3abe%en0 tasks
humility: connecting to fe80::c1d:6cff:fe4e:3abe%7
humility tasks failed: 0x24000538 can't be read via the archive or over the network

Caused by:
    no dump agent available
```

After:

```
$ humility --archive=target/demo-stm32h753-nucleo/dist/default/build-demo-stm32h753-nucleo-image-default.zip --ip=fe80::0c1d:6cff:fe4e:3abe%en0 tasks
humility: connecting to fe80::c1d:6cff:fe4e:3abe%7
humility: reading tasks remotely; state may not be consistent
system time = unavailable-via-net
ID TASK                       GEN PRI STATE    
 0 jefe                         ?   0 [cannot read supervisor memory]
 1 sys                          0   1 recv, notif: exti-wildcard-irq(irq6/irq7/irq8/irq9/irq10/irq23/irq40)
 2 i2c_driver                   0   2 recv
 3 packrat                      0   2 recv
 4 spi_driver                   0   2 recv
 5 net                          0   2 recv, notif: eth-irq(irq61) wake-timer
 6 user_leds                    0   2 recv, notif: timer(T=11001)
 7 user_button                  0   3 notif: button
 8 udpecho                      0   3 notif: socket
 9 udpbroadcast                 0   3 notif: bit31(T=11013)
10 udprpc                       0   3 notif: socket
11 hiffy                        0   5 notif: bit31(T=11045)
12 hf                           0   4 recv
13 hash_driver                  0   3 recv
14 idle                         0   7 ready
15 rng_driver                   0   3 recv
16 dump_agent                   0   4 wait: reply from jefe/gen0
```