### PR TITLE
Bump SPD dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5320,11 +5320,7 @@ dependencies = [
 [[package]]
 name = "spd"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/spd#e37e79f6d7d4805b8a6a8c4d37699c4bd60222ea"
-dependencies = [
- "num-derive 0.3.3",
- "num-traits",
-]
+source = "git+https://github.com/oxidecomputer/spd#b4b97e7f9540969dfce129d88c0ed3f68fd5fe9b"
 
 [[package]]
 name = "spin"

--- a/drv/gimlet-seq-server/src/main.rs
+++ b/drv/gimlet-seq-server/src/main.rs
@@ -29,6 +29,7 @@ use drv_spi_api::{SpiDevice, SpiServer};
 use drv_stm32xx_sys_api as sys_api;
 use idol_runtime::{NotificationHandler, RequestError};
 use seq_spi::{Addr, Reg};
+use spd::ee1004 as spd; // DDR4 SPD types
 use static_assertions::const_assert;
 use task_jefe_api::Jefe;
 
@@ -1342,7 +1343,7 @@ fn read_spd_data_and_load_packrat(
     for nbank in 0..BANKS.len() as u8 {
         let (controller, port, mux) = BANKS[nbank as usize];
 
-        let addr = spd::Function::PageAddress(spd::Page(0))
+        let addr = spd::Function::PageAddress(spd::Page::Page0)
             .to_device_code()
             .unwrap_lite();
         let page =
@@ -1397,7 +1398,7 @@ fn read_spd_data_and_load_packrat(
         }
 
         // Now flip over to the top page.
-        let addr = spd::Function::PageAddress(spd::Page(1))
+        let addr = spd::Function::PageAddress(spd::Page::Page1)
             .to_device_code()
             .unwrap_lite();
         let page =

--- a/task/gimlet-spd/src/main.rs
+++ b/task/gimlet-spd/src/main.rs
@@ -27,6 +27,7 @@ use drv_cpu_seq_api::{NUM_SPD_BANKS, PowerState};
 use drv_stm32xx_i2c::{I2cPins, I2cTargetControl};
 use drv_stm32xx_sys_api::{OutputType, Pull, Speed, Sys};
 use ringbuf::{ringbuf, ringbuf_entry};
+use spd::ee1004 as spd; // DDR4 SPD types
 use task_jefe_api::Jefe;
 use task_packrat_api::Packrat;
 use userlib::{
@@ -124,7 +125,7 @@ fn main() -> ! {
     //
     let ltc4306 = Cell::new(ltc4306::State::init());
     let vbank = Cell::new(Some(0u8));
-    let page = Cell::new(spd::Page(0));
+    let page = Cell::new(spd::Page::Page0);
     let voffs = RefCell::new(&mut voffs);
 
     //


### PR DESCRIPTION
We've updated the `spd` crate for the first time in years to add DDR5 definitions; the existing DDR4 definitions are moved into a module.