### PR TITLE
[xtask] Add `aggro` subcommand for building aggregate docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,12 +3655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "layout-rs"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8b38bc67665e362eb770c6b6ae88b48d040d94a0a10c4904c37bc79d263b95"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7535,7 +7529,6 @@ dependencies = [
  "hex",
  "hubtools",
  "indexmap 1.9.1",
- "layout-rs",
  "leb128",
  "lpc55-rom-data",
  "lpc55_sign",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.9.4",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,6 +6967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7536,7 @@ dependencies = [
  "multimap",
  "ordered-toml",
  "path-slash",
+ "pulldown-cmark",
  "rangemap",
  "regex",
  "ron",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,6 +3655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "layout-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8b38bc67665e362eb770c6b6ae88b48d040d94a0a10c4904c37bc79d263b95"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7529,6 +7535,7 @@ dependencies = [
  "hex",
  "hubtools",
  "indexmap 1.9.1",
+ "layout-rs",
  "leb128",
  "lpc55-rom-data",
  "lpc55_sign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ hubpack = { version = "0.1.2", default-features = false }
 indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"] }
 indoc = { version = "2.0.3", default-features = false }
 itertools = { version = "0.10.5", default-features = false }
+layout-rs = { version = "0.1.3", default-features = false }
 leb128 = { version = "0.2.5", default-features = false }
 lpc55-pac = { version = "0.4", default-features = false }
 memchr = { version = "2.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ prettyplease = { version = "0.2.29", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 proptest = { version = "1.8.0" }
 proptest-derive = { version = "0.6.0" }
+pulldown-cmark = { version = "0.13.3", default-features = false, features = ["html"] }
 quote = { version = "1", default-features = false }
 rand = { version = "0.10", default-features = false }
 rand_chacha = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ hubpack = { version = "0.1.2", default-features = false }
 indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"] }
 indoc = { version = "2.0.3", default-features = false }
 itertools = { version = "0.10.5", default-features = false }
-layout-rs = { version = "0.1.3", default-features = false }
 leb128 = { version = "0.2.5", default-features = false }
 lpc55-pac = { version = "0.4", default-features = false }
 memchr = { version = "2.4", default-features = false }

--- a/app/cosmo/README.md
+++ b/app/cosmo/README.md
@@ -5,10 +5,4 @@ The Cosmo is the SP5-based compute sled in the Oxide rack.
 This folder contains the firmware that runs on its service processor (SP).
 
 The Root of Trust firmware is common across multiple boards and can be found
-in the [`oxide-rot-1` subfolder](../oxide-rot-1). Also, [beep boop].
-
-[Oxide Computer] is a website. So is [Google](https://google.com), and so is <https://ask.com>.
-
-
-[beep boop]: ../oxide-rot-1/Cargo.toml
-[Oxide Computer]: https://oxide.computer
+in the [`oxide-rot-1` subfolder](../oxide-rot-1).

--- a/app/cosmo/README.md
+++ b/app/cosmo/README.md
@@ -5,4 +5,10 @@ The Cosmo is the SP5-based compute sled in the Oxide rack.
 This folder contains the firmware that runs on its service processor (SP).
 
 The Root of Trust firmware is common across multiple boards and can be found
-in the [`oxide-rot-1` subfolder](../oxide-rot-1).
+in the [`oxide-rot-1` subfolder](../oxide-rot-1). Also, [beep boop].
+
+[Oxide Computer] is a website. So is [Google](https://google.com), and so is <https://ask.com>.
+
+
+[beep boop]: ../oxide-rot-1/Cargo.toml
+[Oxide Computer]: https://oxide.computer

--- a/app/cosmo/rev-b.toml
+++ b/app/cosmo/rev-b.toml
@@ -2,6 +2,7 @@
 name = "cosmo-b"
 board = "cosmo-b"
 inherit = "base.toml"
+docfile = "README.md"
 
 # We have to include the whole I2C1 configuration fragment, because the
 # [[config.i2c.controllers.ports.B.muxes]] fragment differs between revs A and

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -62,7 +62,6 @@ toml-patch.path = "../toml-patch"
 lpc55_sign = { workspace = true }
 
 # For Aggro docs
-layout-rs = { workspace = true }
 pulldown-cmark = { workspace = true }
 
 [lints]

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -62,6 +62,7 @@ toml-patch.path = "../toml-patch"
 lpc55_sign = { workspace = true }
 
 # For Aggro docs
+layout-rs = { workspace = true }
 pulldown-cmark = { workspace = true }
 
 [lints]

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -61,5 +61,8 @@ toml-patch.path = "../toml-patch"
 # For NXP signing
 lpc55_sign = { workspace = true }
 
+# For Aggro docs
+pulldown-cmark = { workspace = true }
+
 [lints]
 workspace = true

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,6 +1,8 @@
 use crate::config::Config;
 use anyhow::Result;
+use indexmap::IndexMap;
 use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
+use ordered_toml::Value;
 use std::{fmt::Write as _, fs, io::Write as _, path::Path};
 use toml_task::Task;
 
@@ -93,7 +95,7 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     write_app_info(&cfg, &mut html_buf)?;
 
     // STAGE 3: Task Header
-    write_task_header(&cfg, &mut html_buf)?;
+    write_task_header(&cfg, &cfg.tasks, &mut html_buf)?;
 
     // STAGE 4: Document each task
     for (_name, docpath, task) in task_docs {
@@ -121,6 +123,54 @@ fn write_app_header(cfg: &Config, buf: &mut String) -> Result<()> {
     writeln!(&mut mkdn, "# \"{}\" Application", cfg.name)?;
 
     // TODO: What else do we want here? Stuff about the app, not yet the docs?
+    struct IoWrite(String);
+    impl std::io::Write for IoWrite {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let Ok(s) = std::str::from_utf8(buf) else {
+                return Err(std::io::Error::other("not utf-8?"));
+            };
+            self.0.push_str(s);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut dotout = IoWrite(String::new());
+    crate::graph::task_graph_inner(&cfg.app_toml_path, &mut dotout)?;
+
+    // TODO: the `layout` crate doesn't handle comments, filter these
+    let mut filtered = String::new();
+    for line in dotout.0.lines() {
+        if line.trim_start().starts_with("#") {
+            continue;
+        }
+        filtered.push_str(line);
+        filtered.push_str("\n");
+    }
+
+    let mut parser = layout::gv::DotParser::new(&filtered);
+    let graph = match parser.process() {
+        Ok(g) => g,
+        Err(e) => anyhow::bail!("Graphing error: '{e}'"),
+    };
+    let mut gb = layout::gv::GraphBuilder::new();
+    gb.visit_graph(&graph);
+    let mut vg = gb.get();
+    let mut svg = layout::backends::svg::SVGWriter::new();
+    vg.do_it(false, false, false, &mut svg);
+    let content = svg.finalize();
+
+    let mut file = std::fs::File::create("/tmp/layout.svg")?;
+    file.write_all(content.as_bytes())?;
+    file.flush()?;
+    drop(file);
+
+    writeln!(buf, "<svg>")?;
+    buf.push_str(&content);
+    writeln!(buf, "</svg>")?;
+
 
     // Write to HTML. We *don't* do touchup, because this is the top level
     let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
@@ -155,10 +205,43 @@ fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
     Ok(())
 }
 
-fn write_task_header(cfg: &Config, buf: &mut String) -> Result<()> {
+fn write_task_header(
+    cfg: &Config,
+    tasks: &IndexMap<String, Task<Value>>,
+    buf: &mut String,
+) -> Result<()> {
     // Write this as markdown for laziness, then HTMLify it
     let mut mkdn = String::new();
     writeln!(&mut mkdn, "# \"{}\" Tasks", cfg.name)?;
+    writeln!(&mut mkdn)?;
+    writeln!(&mut mkdn, "| task | stack (bytes) | interrupts | task slots |")?;
+    writeln!(&mut mkdn, "| :--  | :---          | :---       | :---       |")?;
+    let mut tasks: Vec<&Task> = tasks.values().collect();
+    tasks.sort_unstable_by_key(|t| &t.name);
+
+    for task in tasks.iter() {
+        let stack = if let Some(amt) = task.stacksize {
+            amt.to_string()
+        } else {
+            "???".to_string()
+        };
+
+        let ints: Vec<&str> = task.interrupts.keys().map(String::as_str).collect();
+        let ints = if !ints.is_empty() {
+            ints.join(", ")
+        } else {
+            "-".to_string()
+        };
+
+        let slots: Vec<&str> = task.task_slots.keys().map(String::as_str).collect();
+        let slots = if !slots.is_empty() {
+            slots.join(", ")
+        } else {
+            "-".to_string()
+        };
+
+        writeln!(&mut mkdn, "| {} | {} | {} | {} |", task.name, stack, ints, slots)?;
+    }
 
     // TODO: What else do we want here? Top level task tables?
 

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -7,20 +7,53 @@ use anyhow::Result;
 use indexmap::IndexMap;
 use ordered_toml::Value;
 use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
-use std::{fmt::Write as _, fs, io::Write as _, path::Path};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    fmt::Write as _,
+    fs,
+    io::Write as _,
+    path::Path,
+};
 use toml_task::Task;
 
 // Todo: not *everything*? Probably just something fully GitHub
 // Flavored Markdown compatible?
 const PULLDOWN_OPTS: pulldown_cmark::Options = pulldown_cmark::Options::all();
 
+#[derive(Default, Debug)]
+struct TaskMeta {
+    calls: HashSet<String>,
+    called_by: HashSet<String>,
+}
+
 pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     let cfg = Config::from_file(app_toml)?;
+
+    println!("{}", std::env::current_dir().unwrap().display());
 
     use cargo_metadata::MetadataCommand;
     let metadata = MetadataCommand::new()
         .manifest_path("./Cargo.toml")
         .exec()?;
+
+    // Analysis
+    let mut meta = HashMap::new();
+    for (name, _) in cfg.tasks.iter() {
+        meta.insert(name.clone(), TaskMeta::default());
+    }
+    for (name, task) in cfg.tasks.iter() {
+        let tmeta = meta.get_mut(name).unwrap();
+        for tst in task.task_slots.values() {
+            tmeta.calls.insert(tst.clone());
+        }
+        for tst in task.task_slots.values() {
+            meta.get_mut(tst)
+                .unwrap()
+                .called_by
+                .insert(name.to_string());
+        }
+    }
 
     let mut task_docs = vec![];
     for (name, task) in cfg.tasks.iter() {
@@ -85,18 +118,16 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     // the prelude, so we can figure out what the table of contents is
     let mut html_buf = prelude(&format!("\"{}\" Aggregate Docs", cfg.name))?;
 
-    // STAGE 1: App Header
-    write_app_header(&cfg, &mut html_buf)?;
-
-    // STAGE 2: Document the App
+    // STAGE 1: Document the App
     write_app_info(&cfg, &mut html_buf)?;
 
-    // STAGE 3: Task Header
-    write_task_header(&cfg, &cfg.tasks, &mut html_buf)?;
+    // STAGE 2: Task Header
+    write_all_tasks_header(&cfg, &cfg.tasks, &mut html_buf, &meta)?;
 
-    // STAGE 4: Document each task
-    for (_name, docpath, task) in task_docs {
-        write_task_info(task, docpath.as_deref(), &mut html_buf)?;
+    // STAGE 3: Document each task
+    task_docs.sort_unstable_by(|a, b| task_sort((&a.0, a.2), (&b.0, b.2)));
+    for (name, docpath, task) in task_docs {
+        write_task_info(&name, task, docpath.as_deref(), &mut html_buf)?;
     }
 
     html_buf.push_str(MARKDOWN_FOOTER);
@@ -111,18 +142,17 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-fn write_app_header(cfg: &Config, buf: &mut String) -> Result<()> {
-    // Write this as markdown for laziness, then HTMLify it
+fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
     let mut mkdn = String::new();
-    writeln!(&mut mkdn, "# \"{}\" Application", cfg.name)?;
+    writeln!(&mut mkdn, "# Application: \"{}\"", cfg.name)?;
+    writeln!(&mut mkdn)?;
 
-    // Write to HTML. We *don't* do touchup, because this is the top level
+    // TODO: Application level docs?
+
+    // Write to HTML.
     let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
     html::push_html(buf, parser);
-    Ok(())
-}
 
-fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
     if let Some(readme) = cfg.docfile.as_ref() {
         let app_readme = std::fs::read_to_string(readme)?;
         let parser =
@@ -136,7 +166,7 @@ fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
         //
         // Write this as markdown for laziness, then HTMLify it
         let mut mkdn = String::new();
-        writeln!(&mut mkdn, "# \"{}\" Firmware", cfg.name)?;
+        writeln!(&mut mkdn, "# \"{}\" docs", cfg.name)?;
         writeln!(&mut mkdn)?;
         writeln!(&mut mkdn, "(this page intentionally left blank)")?;
         writeln!(&mut mkdn)?;
@@ -149,10 +179,11 @@ fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
     Ok(())
 }
 
-fn write_task_header(
+fn write_all_tasks_header(
     cfg: &Config,
     tasks: &IndexMap<String, Task<Value>>,
     buf: &mut String,
+    meta: &HashMap<String, TaskMeta>,
 ) -> Result<()> {
     // Write this as markdown for laziness, then HTMLify it
     let mut mkdn = String::new();
@@ -160,16 +191,19 @@ fn write_task_header(
     writeln!(&mut mkdn)?;
     writeln!(
         &mut mkdn,
-        "| task | stack (bytes) | interrupts | task slots |"
+        "| task: crate | priority | stack (bytes) | interrupts | client of | server for |"
     )?;
     writeln!(
         &mut mkdn,
-        "| :--  | :---          | :---       | :---       |"
+        "| :--          | :---     | :---          | :---       | :---  | :---      |"
     )?;
-    let mut tasks: Vec<&Task> = tasks.values().collect();
-    tasks.sort_unstable_by_key(|t| &t.name);
+    let mut tasks: Vec<(String, &Task)> =
+        tasks.iter().map(|(a, b)| (a.clone(), b)).collect();
+    tasks.sort_unstable_by(|a, b| task_sort((&a.0, a.1), (&b.0, b.1)));
 
-    for task in tasks.iter() {
+    for (name, task) in tasks.iter() {
+        let prio = task.priority.to_string();
+
         let stack = if let Some(amt) = task.stacksize {
             amt.to_string()
         } else {
@@ -179,23 +213,34 @@ fn write_task_header(
         let ints: Vec<&str> =
             task.interrupts.keys().map(String::as_str).collect();
         let ints = if !ints.is_empty() {
-            ints.join(", ")
+            ints.join("<br>")
         } else {
             "-".to_string()
         };
 
-        let slots: Vec<&str> =
-            task.task_slots.keys().map(String::as_str).collect();
-        let slots = if !slots.is_empty() {
-            slots.join(", ")
+        let tmeta = meta.get(name).unwrap();
+        let mut calls: Vec<_> = tmeta.calls.iter().cloned().collect();
+        calls.sort_unstable();
+
+        let calls = if !calls.is_empty() {
+            calls.join("<br>")
+        } else {
+            "-".to_string()
+        };
+
+        let mut called_by: Vec<_> = tmeta.called_by.iter().cloned().collect();
+        called_by.sort_unstable();
+
+        let called_by = if !called_by.is_empty() {
+            called_by.join("<br>")
         } else {
             "-".to_string()
         };
 
         writeln!(
             &mut mkdn,
-            "| {} | {} | {} | {} |",
-            task.name, stack, ints, slots
+            "| {}<br>`{}` | {} | {} | {} | {} | {} |",
+            name, task.name, prio, stack, ints, calls, called_by,
         )?;
     }
 
@@ -208,10 +253,21 @@ fn write_task_header(
 }
 
 fn write_task_info(
+    name: &str,
     task: &Task,
     docs: Option<&Path>,
     buf: &mut String,
 ) -> Result<()> {
+    let mut mkdn = String::new();
+    writeln!(&mut mkdn, "# Task: \"{name}\" (`{}`)", task.name)?;
+    writeln!(&mut mkdn)?;
+
+    // TODO: Meta info about the task, before the readme?
+
+    // Write to HTML.
+    let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
+    html::push_html(buf, parser);
+
     if let Some(readme) = docs {
         let task_readme = std::fs::read_to_string(readme)?;
         let parser =
@@ -225,7 +281,7 @@ fn write_task_info(
         //
         // Write this as markdown for laziness, then HTMLify it
         let mut mkdn = String::new();
-        writeln!(&mut mkdn, "# \"{}\" Task", task.name)?;
+        writeln!(&mut mkdn, "# `{}` docs", task.name)?;
         writeln!(&mut mkdn)?;
         writeln!(&mut mkdn, "(this page intentionally left blank)")?;
         writeln!(&mut mkdn)?;
@@ -251,6 +307,10 @@ fn touchup<'a>(evt: Event<'a>, _base: Option<&'a Path>) -> Event<'a> {
                     if !dest_url.starts_with("http") {
                         // TODO: rewrite relative to `https://github.com/oxidecomputer/hubris/blob/master/`?
                         // use _base to figure out relative paths, we might also need to
+                        println!(
+                            "->{}",
+                            _base.unwrap().canonicalize().unwrap().display()
+                        );
                         println!("WARN: We should be rewriting {dest_url}!");
                     }
                     Event::Start(Tag::Link {
@@ -302,77 +362,32 @@ fn touchup<'a>(evt: Event<'a>, _base: Option<&'a Path>) -> Event<'a> {
                 }
 
                 other => Event::Start(other),
-                // pulldown_cmark::Tag::Paragraph => todo!(),
-                // pulldown_cmark::Tag::BlockQuote(block_quote_kind) => todo!(),
-                // pulldown_cmark::Tag::CodeBlock(code_block_kind) => todo!(),
-                // pulldown_cmark::Tag::HtmlBlock => todo!(),
-                // pulldown_cmark::Tag::List(_) => todo!(),
-                // pulldown_cmark::Tag::Item => todo!(),
-                // pulldown_cmark::Tag::FootnoteDefinition(cow_str) => todo!(),
-                // pulldown_cmark::Tag::DefinitionList => todo!(),
-                // pulldown_cmark::Tag::DefinitionListTitle => todo!(),
-                // pulldown_cmark::Tag::DefinitionListDefinition => todo!(),
-                // pulldown_cmark::Tag::Table(alignments) => todo!(),
-                // pulldown_cmark::Tag::TableHead => todo!(),
-                // pulldown_cmark::Tag::TableRow => todo!(),
-                // pulldown_cmark::Tag::TableCell => todo!(),
-                // pulldown_cmark::Tag::Emphasis => todo!(),
-                // pulldown_cmark::Tag::Strong => todo!(),
-                // pulldown_cmark::Tag::Strikethrough => todo!(),
-                // pulldown_cmark::Tag::Superscript => todo!(),
-                // pulldown_cmark::Tag::Subscript => todo!(),
-                // pulldown_cmark::Tag::MetadataBlock(metadata_block_kind) => todo!(),
             }
         }
-        Event::End(tag_end) => {
-            match tag_end {
-                TagEnd::Heading(heading_level) => {
-                    Event::End(TagEnd::Heading(match heading_level {
-                        HeadingLevel::H1 => HeadingLevel::H2,
-                        HeadingLevel::H2 => HeadingLevel::H3,
-                        HeadingLevel::H3 => HeadingLevel::H4,
-                        HeadingLevel::H4 => HeadingLevel::H5,
-                        HeadingLevel::H5 => HeadingLevel::H6,
-                        HeadingLevel::H6 => HeadingLevel::H6,
-                    }))
-                }
-                other => Event::End(other),
-                // pulldown_cmark::TagEnd::Paragraph => todo!(),
-                // pulldown_cmark::TagEnd::BlockQuote(block_quote_kind) => todo!(),
-                // pulldown_cmark::TagEnd::CodeBlock => todo!(),
-                // pulldown_cmark::TagEnd::HtmlBlock => todo!(),
-                // pulldown_cmark::TagEnd::List(_) => todo!(),
-                // pulldown_cmark::TagEnd::Item => todo!(),
-                // pulldown_cmark::TagEnd::FootnoteDefinition => todo!(),
-                // pulldown_cmark::TagEnd::DefinitionList => todo!(),
-                // pulldown_cmark::TagEnd::DefinitionListTitle => todo!(),
-                // pulldown_cmark::TagEnd::DefinitionListDefinition => todo!(),
-                // pulldown_cmark::TagEnd::Table => todo!(),
-                // pulldown_cmark::TagEnd::TableHead => todo!(),
-                // pulldown_cmark::TagEnd::TableRow => todo!(),
-                // pulldown_cmark::TagEnd::TableCell => todo!(),
-                // pulldown_cmark::TagEnd::Emphasis => todo!(),
-                // pulldown_cmark::TagEnd::Strong => todo!(),
-                // pulldown_cmark::TagEnd::Strikethrough => todo!(),
-                // pulldown_cmark::TagEnd::Superscript => todo!(),
-                // pulldown_cmark::TagEnd::Subscript => todo!(),
-                // pulldown_cmark::TagEnd::Link => todo!(),
-                // pulldown_cmark::TagEnd::Image => todo!(),
-                // pulldown_cmark::TagEnd::MetadataBlock(metadata_block_kind) => todo!(),
+        Event::End(tag_end) => match tag_end {
+            TagEnd::Heading(heading_level) => {
+                Event::End(TagEnd::Heading(match heading_level {
+                    HeadingLevel::H1 => HeadingLevel::H2,
+                    HeadingLevel::H2 => HeadingLevel::H3,
+                    HeadingLevel::H3 => HeadingLevel::H4,
+                    HeadingLevel::H4 => HeadingLevel::H5,
+                    HeadingLevel::H5 => HeadingLevel::H6,
+                    HeadingLevel::H6 => HeadingLevel::H6,
+                }))
             }
-        }
+            other => Event::End(other),
+        },
 
-        other => other, // Event::Text(cow_str) => todo!(),
-                        // Event::Code(cow_str) => todo!(),
-                        // Event::InlineMath(cow_str) => todo!(),
-                        // Event::DisplayMath(cow_str) => todo!(),
-                        // Event::Html(cow_str) => todo!(),
-                        // Event::InlineHtml(cow_str) => todo!(),
-                        // Event::FootnoteReference(cow_str) => todo!(),
-                        // Event::SoftBreak => todo!(),
-                        // Event::HardBreak => todo!(),
-                        // Event::Rule => todo!(),
-                        // Event::TaskListMarker(_) => todo!(),
+        other => other,
+    }
+}
+
+/// Sort by priority (lowest first), then by name
+fn task_sort(a: (&str, &Task), b: (&str, &Task)) -> Ordering {
+    match a.1.priority.cmp(&b.1.priority) {
+        Ordering::Less => Ordering::Less,
+        Ordering::Equal => a.0.cmp(&b.0),
+        Ordering::Greater => Ordering::Greater,
     }
 }
 

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -12,9 +12,6 @@ const PULLDOWN_OPTS: pulldown_cmark::Options = pulldown_cmark::Options::all();
 
 pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     let cfg = Config::from_file(app_toml)?;
-    println!("* App Docs:");
-    println!("  * {:?}", cfg.docfile);
-    println!("* Task Docs:");
 
     use cargo_metadata::MetadataCommand;
     let metadata = MetadataCommand::new()
@@ -80,10 +77,6 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
         task_docs.push((name.to_string(), taskdocpath, task));
     }
 
-    for (name, docpath, _task) in task_docs.iter() {
-        println!("  * {name}: {docpath:?}");
-    }
-
     // TODO: We probably actually want to bundle up all the content first before providing
     // the prelude, so we can figure out what the table of contents is
     let mut html_buf = prelude(&format!("\"{}\" Aggregate Docs", cfg.name))?;
@@ -104,14 +97,11 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
 
     html_buf.push_str(MARKDOWN_FOOTER);
 
-    // TODO: Don't print
-    println!("---");
-    println!("{html_buf}");
-    println!("---");
-
     if let Some(out) = output {
         let mut file = std::fs::File::create(out).unwrap();
         file.write_all(html_buf.as_bytes()).unwrap();
+    } else {
+        println!("{html_buf}");
     }
 
     Ok(())
@@ -121,56 +111,6 @@ fn write_app_header(cfg: &Config, buf: &mut String) -> Result<()> {
     // Write this as markdown for laziness, then HTMLify it
     let mut mkdn = String::new();
     writeln!(&mut mkdn, "# \"{}\" Application", cfg.name)?;
-
-    // TODO: What else do we want here? Stuff about the app, not yet the docs?
-    struct IoWrite(String);
-    impl std::io::Write for IoWrite {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            let Ok(s) = std::str::from_utf8(buf) else {
-                return Err(std::io::Error::other("not utf-8?"));
-            };
-            self.0.push_str(s);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-    let mut dotout = IoWrite(String::new());
-    crate::graph::task_graph_inner(&cfg.app_toml_path, &mut dotout)?;
-
-    // TODO: the `layout` crate doesn't handle comments, filter these
-    let mut filtered = String::new();
-    for line in dotout.0.lines() {
-        if line.trim_start().starts_with("#") {
-            continue;
-        }
-        filtered.push_str(line);
-        filtered.push_str("\n");
-    }
-
-    let mut parser = layout::gv::DotParser::new(&filtered);
-    let graph = match parser.process() {
-        Ok(g) => g,
-        Err(e) => anyhow::bail!("Graphing error: '{e}'"),
-    };
-    let mut gb = layout::gv::GraphBuilder::new();
-    gb.visit_graph(&graph);
-    let mut vg = gb.get();
-    let mut svg = layout::backends::svg::SVGWriter::new();
-    vg.do_it(false, false, false, &mut svg);
-    let content = svg.finalize();
-
-    let mut file = std::fs::File::create("/tmp/layout.svg")?;
-    file.write_all(content.as_bytes())?;
-    file.flush()?;
-    drop(file);
-
-    writeln!(buf, "<svg>")?;
-    buf.push_str(&content);
-    writeln!(buf, "</svg>")?;
-
 
     // Write to HTML. We *don't* do touchup, because this is the top level
     let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,8 +1,9 @@
 use crate::config::Config;
 use anyhow::Result;
-use std::{fs, path::Path};
+use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
+use std::{fs, io::Write as _, fmt::Write as _, path::Path};
 
-pub fn run(app_toml: &Path, _output: Option<&Path>) -> Result<()> {
+pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     let cfg = Config::from_file(app_toml)?;
     println!("* App Docs:");
     println!("  * {:?}", cfg.docfile);
@@ -13,6 +14,7 @@ pub fn run(app_toml: &Path, _output: Option<&Path>) -> Result<()> {
         .manifest_path("./Cargo.toml")
         .exec()?;
 
+    let mut task_docs = vec![];
     for (name, task) in cfg.tasks.iter() {
         // Attempt to autodetect task documentation.
         //
@@ -68,8 +70,203 @@ pub fn run(app_toml: &Path, _output: Option<&Path>) -> Result<()> {
                 }
             });
 
-        println!("  * {name}: {taskdocpath:?}");
+        task_docs.push((name.to_string(), taskdocpath));
+    }
+
+    for (task, docpath) in task_docs.iter() {
+        println!("  * {task}: {docpath:?}");
+    }
+
+    let mut html_buf = prelude(&format!("\"{}\" Aggregate Docs", cfg.name));
+
+    // Start with the app readme
+    if let Some(readme) = cfg.docfile.as_ref() {
+        let app_readme = std::fs::read_to_string(readme)?;
+        let parser = pulldown_cmark::Parser::new_ext(
+            &app_readme,
+            // Todo: not *everything*? Probably just something fully GitHub
+            // Flavored Markdown compatible?
+            pulldown_cmark::Options::all(),
+        );
+        let mut base = readme.to_owned();
+        base.pop();
+        let stream = parser.map(|evt| touchup(evt, &base));
+        html::push_html(&mut html_buf, stream);
+    }
+
+    html_buf.push_str(MARKDOWN_FOOTER);
+
+    // TODO: Don't print
+    println!("---");
+    println!("{html_buf}");
+    println!("---");
+
+    if let Some(out) = output {
+        let mut file = std::fs::File::create(out).unwrap();
+        file.write_all(html_buf.as_bytes()).unwrap();
     }
 
     Ok(())
 }
+
+fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
+    match evt {
+        Event::Start(tag) => {
+            match tag {
+                Tag::Link { link_type, dest_url, title, id } => {
+                    if !dest_url.starts_with("http") {
+                        // TODO: rewrite relative to `https://github.com/oxidecomputer/hubris/blob/master/`?
+                        // use _base to figure out relative paths, we might also need to
+                        println!("WARN: We should be rewriting {dest_url}!");
+                    }
+                    Event::Start(Tag::Link { link_type, dest_url, title, id })
+                },
+                Tag::Image { link_type, dest_url, title, id } => {
+                    if !dest_url.starts_with("http") {
+                        // TODO: rewrite relative to `https://github.com/oxidecomputer/hubris/blob/master/`?
+                        // use _base to figure out relative paths, we might also need to
+                        println!("WARN: We should be rewriting {dest_url}!");
+                    }
+                    Event::Start(Tag::Image { link_type, dest_url, title, id })
+                },
+                // Bump down headings one notch, to allow for top level docs
+                Tag::Heading { level, id, classes, attrs } => {
+                    let level = match level {
+                        HeadingLevel::H1 => HeadingLevel::H2,
+                        HeadingLevel::H2 => HeadingLevel::H3,
+                        HeadingLevel::H3 => HeadingLevel::H4,
+                        HeadingLevel::H4 => HeadingLevel::H5,
+                        HeadingLevel::H5 => HeadingLevel::H6,
+                        HeadingLevel::H6 => HeadingLevel::H6,
+                    };
+                    Event::Start(Tag::Heading { level, id, classes, attrs })
+                },
+
+                other => Event::Start(other),
+                // pulldown_cmark::Tag::Paragraph => todo!(),
+                // pulldown_cmark::Tag::BlockQuote(block_quote_kind) => todo!(),
+                // pulldown_cmark::Tag::CodeBlock(code_block_kind) => todo!(),
+                // pulldown_cmark::Tag::HtmlBlock => todo!(),
+                // pulldown_cmark::Tag::List(_) => todo!(),
+                // pulldown_cmark::Tag::Item => todo!(),
+                // pulldown_cmark::Tag::FootnoteDefinition(cow_str) => todo!(),
+                // pulldown_cmark::Tag::DefinitionList => todo!(),
+                // pulldown_cmark::Tag::DefinitionListTitle => todo!(),
+                // pulldown_cmark::Tag::DefinitionListDefinition => todo!(),
+                // pulldown_cmark::Tag::Table(alignments) => todo!(),
+                // pulldown_cmark::Tag::TableHead => todo!(),
+                // pulldown_cmark::Tag::TableRow => todo!(),
+                // pulldown_cmark::Tag::TableCell => todo!(),
+                // pulldown_cmark::Tag::Emphasis => todo!(),
+                // pulldown_cmark::Tag::Strong => todo!(),
+                // pulldown_cmark::Tag::Strikethrough => todo!(),
+                // pulldown_cmark::Tag::Superscript => todo!(),
+                // pulldown_cmark::Tag::Subscript => todo!(),
+                // pulldown_cmark::Tag::MetadataBlock(metadata_block_kind) => todo!(),
+            }
+        },
+        Event::End(tag_end) => {
+            match tag_end {
+                TagEnd::Heading(heading_level) => {
+                    Event::End(TagEnd::Heading(match heading_level {
+                        HeadingLevel::H1 => HeadingLevel::H2,
+                        HeadingLevel::H2 => HeadingLevel::H3,
+                        HeadingLevel::H3 => HeadingLevel::H4,
+                        HeadingLevel::H4 => HeadingLevel::H5,
+                        HeadingLevel::H5 => HeadingLevel::H6,
+                        HeadingLevel::H6 => HeadingLevel::H6,
+                    }))
+                },
+                other => Event::End(other),
+                // pulldown_cmark::TagEnd::Paragraph => todo!(),
+                // pulldown_cmark::TagEnd::BlockQuote(block_quote_kind) => todo!(),
+                // pulldown_cmark::TagEnd::CodeBlock => todo!(),
+                // pulldown_cmark::TagEnd::HtmlBlock => todo!(),
+                // pulldown_cmark::TagEnd::List(_) => todo!(),
+                // pulldown_cmark::TagEnd::Item => todo!(),
+                // pulldown_cmark::TagEnd::FootnoteDefinition => todo!(),
+                // pulldown_cmark::TagEnd::DefinitionList => todo!(),
+                // pulldown_cmark::TagEnd::DefinitionListTitle => todo!(),
+                // pulldown_cmark::TagEnd::DefinitionListDefinition => todo!(),
+                // pulldown_cmark::TagEnd::Table => todo!(),
+                // pulldown_cmark::TagEnd::TableHead => todo!(),
+                // pulldown_cmark::TagEnd::TableRow => todo!(),
+                // pulldown_cmark::TagEnd::TableCell => todo!(),
+                // pulldown_cmark::TagEnd::Emphasis => todo!(),
+                // pulldown_cmark::TagEnd::Strong => todo!(),
+                // pulldown_cmark::TagEnd::Strikethrough => todo!(),
+                // pulldown_cmark::TagEnd::Superscript => todo!(),
+                // pulldown_cmark::TagEnd::Subscript => todo!(),
+                // pulldown_cmark::TagEnd::Link => todo!(),
+                // pulldown_cmark::TagEnd::Image => todo!(),
+                // pulldown_cmark::TagEnd::MetadataBlock(metadata_block_kind) => todo!(),
+            }
+        },
+
+        other => other
+        // Event::Text(cow_str) => todo!(),
+        // Event::Code(cow_str) => todo!(),
+        // Event::InlineMath(cow_str) => todo!(),
+        // Event::DisplayMath(cow_str) => todo!(),
+        // Event::Html(cow_str) => todo!(),
+        // Event::InlineHtml(cow_str) => todo!(),
+        // Event::FootnoteReference(cow_str) => todo!(),
+        // Event::SoftBreak => todo!(),
+        // Event::HardBreak => todo!(),
+        // Event::Rule => todo!(),
+        // Event::TaskListMarker(_) => todo!(),
+    }
+}
+
+// TODO: don't use CDN'd CSS - https://cdnjs.com/libraries/github-markdown-css
+// TODO: we need some templating for the title
+// From: https://github.com/sindresorhus/github-markdown-css
+const PRELUDE_PART_ONE: &str = r#"
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+"#;
+
+const PRELUDE_PART_TWO: &str = r#"
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css">
+  <style>
+      .markdown-body {
+          box-sizing: border-box;
+          min-width: 200px;
+          max-width: 980px;
+          margin: 0 auto;
+          padding: 45px;
+      }
+
+      @media (max-width: 767px) {
+          .markdown-body {
+              padding: 15px;
+          }
+      }
+
+      @media (prefers-color-scheme: dark) {
+          body {
+              background-color: #0d1117;
+          }
+      }
+  </style>
+</head>
+<body>
+  <article class="markdown-body">
+"#;
+
+fn prelude(title: &str) -> String {
+    let mut out = String::new();
+    out.push_str(PRELUDE_PART_ONE);
+    writeln!(&mut out, "  <title>{title}</title>").ok();
+    out.push_str(PRELUDE_PART_TWO);
+    out
+}
+
+const MARKDOWN_FOOTER: &str = r#"
+  </article>
+</body>
+</html>
+"#;

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,0 +1,75 @@
+use crate::config::Config;
+use anyhow::Result;
+use std::{fs, path::Path};
+
+pub fn run(app_toml: &Path, _output: Option<&Path>) -> Result<()> {
+    let cfg = Config::from_file(app_toml)?;
+    println!("* App Docs:");
+    println!("  * {:?}", cfg.docfile);
+    println!("* Task Docs:");
+
+    use cargo_metadata::MetadataCommand;
+    let metadata = MetadataCommand::new()
+        .manifest_path("./Cargo.toml")
+        .exec()?;
+
+    for (name, task) in cfg.tasks.iter() {
+        // Attempt to autodetect task documentation.
+        //
+        // Traverse the cargo metadata (inspired by `dist::build_archive`) to
+        // find the path to the task manifest.
+        let taskdocpath = metadata
+            .packages
+            .iter()
+            .find(|p| p.name == task.name)
+            .and_then(|pakidge| {
+                // Take the manifest path, and pop off the Cargo.toml part
+                let mut buf = pakidge.manifest_path.clone();
+                buf.pop();
+                let mut matches = vec![];
+
+                // For each file in the folder:
+                for path in fs::read_dir(&buf).ok()? {
+                    // Make sure it's a real path, and we can do stringy things
+                    // with the name
+                    let Ok(path) = path else {
+                        continue;
+                    };
+                    let fname = path.file_name();
+                    let Some(s) = fname.to_str() else {
+                        continue;
+                    };
+
+                    // Basically do a case insensitive check that the given file
+                    // starts with "readme", and ends with ".md" or ".mkdn", which
+                    // are the two extensions we currently use.
+                    let lower = s.to_lowercase();
+                    if !lower.starts_with("readme") {
+                        continue;
+                    }
+                    if !(lower.ends_with("md") || lower.ends_with("mkdn")) {
+                        continue;
+                    }
+                    let path = path.path();
+                    if !path.is_file() {
+                        continue;
+                    }
+                    matches.push(path);
+                }
+
+                match matches.as_slice() {
+                    // No matches
+                    [] => None,
+                    // Exactly one match
+                    [found] => Some(found.clone()),
+                    _ => {
+                        panic!("too many readmes");
+                    }
+                }
+            });
+
+        println!("  * {name}: {taskdocpath:?}");
+    }
+
+    Ok(())
+}

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,8 +1,8 @@
 use crate::config::Config;
 use anyhow::Result;
 use indexmap::IndexMap;
-use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
 use ordered_toml::Value;
+use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
 use std::{fmt::Write as _, fs, io::Write as _, path::Path};
 use toml_task::Task;
 
@@ -154,8 +154,14 @@ fn write_task_header(
     let mut mkdn = String::new();
     writeln!(&mut mkdn, "# \"{}\" Tasks", cfg.name)?;
     writeln!(&mut mkdn)?;
-    writeln!(&mut mkdn, "| task | stack (bytes) | interrupts | task slots |")?;
-    writeln!(&mut mkdn, "| :--  | :---          | :---       | :---       |")?;
+    writeln!(
+        &mut mkdn,
+        "| task | stack (bytes) | interrupts | task slots |"
+    )?;
+    writeln!(
+        &mut mkdn,
+        "| :--  | :---          | :---       | :---       |"
+    )?;
     let mut tasks: Vec<&Task> = tasks.values().collect();
     tasks.sort_unstable_by_key(|t| &t.name);
 
@@ -166,21 +172,27 @@ fn write_task_header(
             "???".to_string()
         };
 
-        let ints: Vec<&str> = task.interrupts.keys().map(String::as_str).collect();
+        let ints: Vec<&str> =
+            task.interrupts.keys().map(String::as_str).collect();
         let ints = if !ints.is_empty() {
             ints.join(", ")
         } else {
             "-".to_string()
         };
 
-        let slots: Vec<&str> = task.task_slots.keys().map(String::as_str).collect();
+        let slots: Vec<&str> =
+            task.task_slots.keys().map(String::as_str).collect();
         let slots = if !slots.is_empty() {
             slots.join(", ")
         } else {
             "-".to_string()
         };
 
-        writeln!(&mut mkdn, "| {} | {} | {} | {} |", task.name, stack, ints, slots)?;
+        writeln!(
+            &mut mkdn,
+            "| {} | {} | {} | {} |",
+            task.name, stack, ints, slots
+        )?;
     }
 
     // TODO: What else do we want here? Top level task tables?

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::config::Config;
 use anyhow::Result;
 use indexmap::IndexMap;

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -1,7 +1,12 @@
 use crate::config::Config;
 use anyhow::Result;
 use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd, html};
-use std::{fs, io::Write as _, fmt::Write as _, path::Path};
+use std::{fmt::Write as _, fs, io::Write as _, path::Path};
+use toml_task::Task;
+
+// Todo: not *everything*? Probably just something fully GitHub
+// Flavored Markdown compatible?
+const PULLDOWN_OPTS: pulldown_cmark::Options = pulldown_cmark::Options::all();
 
 pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     let cfg = Config::from_file(app_toml)?;
@@ -70,28 +75,29 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
                 }
             });
 
-        task_docs.push((name.to_string(), taskdocpath));
+        task_docs.push((name.to_string(), taskdocpath, task));
     }
 
-    for (task, docpath) in task_docs.iter() {
-        println!("  * {task}: {docpath:?}");
+    for (name, docpath, _task) in task_docs.iter() {
+        println!("  * {name}: {docpath:?}");
     }
 
-    let mut html_buf = prelude(&format!("\"{}\" Aggregate Docs", cfg.name));
+    // TODO: We probably actually want to bundle up all the content first before providing
+    // the prelude, so we can figure out what the table of contents is
+    let mut html_buf = prelude(&format!("\"{}\" Aggregate Docs", cfg.name))?;
 
-    // Start with the app readme
-    if let Some(readme) = cfg.docfile.as_ref() {
-        let app_readme = std::fs::read_to_string(readme)?;
-        let parser = pulldown_cmark::Parser::new_ext(
-            &app_readme,
-            // Todo: not *everything*? Probably just something fully GitHub
-            // Flavored Markdown compatible?
-            pulldown_cmark::Options::all(),
-        );
-        let mut base = readme.to_owned();
-        base.pop();
-        let stream = parser.map(|evt| touchup(evt, &base));
-        html::push_html(&mut html_buf, stream);
+    // STAGE 1: App Header
+    write_app_header(&cfg, &mut html_buf)?;
+
+    // STAGE 2: Document the App
+    write_app_info(&cfg, &mut html_buf)?;
+
+    // STAGE 3: Task Header
+    write_task_header(&cfg, &mut html_buf)?;
+
+    // STAGE 4: Document each task
+    for (_name, docpath, task) in task_docs {
+        write_task_info(task, docpath.as_deref(), &mut html_buf)?;
     }
 
     html_buf.push_str(MARKDOWN_FOOTER);
@@ -109,28 +115,137 @@ pub fn run(app_toml: &Path, output: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
+fn write_app_header(cfg: &Config, buf: &mut String) -> Result<()> {
+    // Write this as markdown for laziness, then HTMLify it
+    let mut mkdn = String::new();
+    writeln!(&mut mkdn, "# \"{}\" Application", cfg.name)?;
+
+    // TODO: What else do we want here? Stuff about the app, not yet the docs?
+
+    // Write to HTML. We *don't* do touchup, because this is the top level
+    let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
+    html::push_html(buf, parser);
+    Ok(())
+}
+
+fn write_app_info(cfg: &Config, buf: &mut String) -> Result<()> {
+    if let Some(readme) = cfg.docfile.as_ref() {
+        let app_readme = std::fs::read_to_string(readme)?;
+        let parser =
+            pulldown_cmark::Parser::new_ext(&app_readme, PULLDOWN_OPTS);
+        let mut base = readme.to_owned();
+        base.pop();
+        let stream = parser.map(|evt| touchup(evt, Some(&base)));
+        html::push_html(buf, stream);
+    } else {
+        // Placeholder for no docs!
+        //
+        // Write this as markdown for laziness, then HTMLify it
+        let mut mkdn = String::new();
+        writeln!(&mut mkdn, "# \"{}\" Firmware", cfg.name)?;
+        writeln!(&mut mkdn)?;
+        writeln!(&mut mkdn, "(this page intentionally left blank)")?;
+        writeln!(&mut mkdn)?;
+
+        // Write to HTML.
+        let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
+        let stream = parser.map(|evt| touchup(evt, None));
+        html::push_html(buf, stream);
+    }
+    Ok(())
+}
+
+fn write_task_header(cfg: &Config, buf: &mut String) -> Result<()> {
+    // Write this as markdown for laziness, then HTMLify it
+    let mut mkdn = String::new();
+    writeln!(&mut mkdn, "# \"{}\" Tasks", cfg.name)?;
+
+    // TODO: What else do we want here? Top level task tables?
+
+    // Write to HTML. We *don't* do touchup, because this is the top level
+    let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
+    html::push_html(buf, parser);
+    Ok(())
+}
+
+fn write_task_info(
+    task: &Task,
+    docs: Option<&Path>,
+    buf: &mut String,
+) -> Result<()> {
+    if let Some(readme) = docs {
+        let task_readme = std::fs::read_to_string(readme)?;
+        let parser =
+            pulldown_cmark::Parser::new_ext(&task_readme, PULLDOWN_OPTS);
+        let mut base = readme.to_owned();
+        base.pop();
+        let stream = parser.map(|evt| touchup(evt, Some(&base)));
+        html::push_html(buf, stream);
+    } else {
+        // Placeholder for no docs!
+        //
+        // Write this as markdown for laziness, then HTMLify it
+        let mut mkdn = String::new();
+        writeln!(&mut mkdn, "# \"{}\" Task", task.name)?;
+        writeln!(&mut mkdn)?;
+        writeln!(&mut mkdn, "(this page intentionally left blank)")?;
+        writeln!(&mut mkdn)?;
+
+        // Write to HTML.
+        let parser = pulldown_cmark::Parser::new_ext(&mkdn, PULLDOWN_OPTS);
+        let stream = parser.map(|evt| touchup(evt, None));
+        html::push_html(buf, stream);
+    }
+    Ok(())
+}
+
+fn touchup<'a>(evt: Event<'a>, _base: Option<&'a Path>) -> Event<'a> {
     match evt {
         Event::Start(tag) => {
             match tag {
-                Tag::Link { link_type, dest_url, title, id } => {
+                Tag::Link {
+                    link_type,
+                    dest_url,
+                    title,
+                    id,
+                } => {
                     if !dest_url.starts_with("http") {
                         // TODO: rewrite relative to `https://github.com/oxidecomputer/hubris/blob/master/`?
                         // use _base to figure out relative paths, we might also need to
                         println!("WARN: We should be rewriting {dest_url}!");
                     }
-                    Event::Start(Tag::Link { link_type, dest_url, title, id })
-                },
-                Tag::Image { link_type, dest_url, title, id } => {
+                    Event::Start(Tag::Link {
+                        link_type,
+                        dest_url,
+                        title,
+                        id,
+                    })
+                }
+                Tag::Image {
+                    link_type,
+                    dest_url,
+                    title,
+                    id,
+                } => {
                     if !dest_url.starts_with("http") {
                         // TODO: rewrite relative to `https://github.com/oxidecomputer/hubris/blob/master/`?
                         // use _base to figure out relative paths, we might also need to
                         println!("WARN: We should be rewriting {dest_url}!");
                     }
-                    Event::Start(Tag::Image { link_type, dest_url, title, id })
-                },
+                    Event::Start(Tag::Image {
+                        link_type,
+                        dest_url,
+                        title,
+                        id,
+                    })
+                }
                 // Bump down headings one notch, to allow for top level docs
-                Tag::Heading { level, id, classes, attrs } => {
+                Tag::Heading {
+                    level,
+                    id,
+                    classes,
+                    attrs,
+                } => {
                     let level = match level {
                         HeadingLevel::H1 => HeadingLevel::H2,
                         HeadingLevel::H2 => HeadingLevel::H3,
@@ -139,8 +254,13 @@ fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
                         HeadingLevel::H5 => HeadingLevel::H6,
                         HeadingLevel::H6 => HeadingLevel::H6,
                     };
-                    Event::Start(Tag::Heading { level, id, classes, attrs })
-                },
+                    Event::Start(Tag::Heading {
+                        level,
+                        id,
+                        classes,
+                        attrs,
+                    })
+                }
 
                 other => Event::Start(other),
                 // pulldown_cmark::Tag::Paragraph => todo!(),
@@ -164,7 +284,7 @@ fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
                 // pulldown_cmark::Tag::Subscript => todo!(),
                 // pulldown_cmark::Tag::MetadataBlock(metadata_block_kind) => todo!(),
             }
-        },
+        }
         Event::End(tag_end) => {
             match tag_end {
                 TagEnd::Heading(heading_level) => {
@@ -176,7 +296,7 @@ fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
                         HeadingLevel::H5 => HeadingLevel::H6,
                         HeadingLevel::H6 => HeadingLevel::H6,
                     }))
-                },
+                }
                 other => Event::End(other),
                 // pulldown_cmark::TagEnd::Paragraph => todo!(),
                 // pulldown_cmark::TagEnd::BlockQuote(block_quote_kind) => todo!(),
@@ -201,20 +321,19 @@ fn touchup<'a>(evt: Event<'a>, _base: &'a Path) -> Event<'a> {
                 // pulldown_cmark::TagEnd::Image => todo!(),
                 // pulldown_cmark::TagEnd::MetadataBlock(metadata_block_kind) => todo!(),
             }
-        },
+        }
 
-        other => other
-        // Event::Text(cow_str) => todo!(),
-        // Event::Code(cow_str) => todo!(),
-        // Event::InlineMath(cow_str) => todo!(),
-        // Event::DisplayMath(cow_str) => todo!(),
-        // Event::Html(cow_str) => todo!(),
-        // Event::InlineHtml(cow_str) => todo!(),
-        // Event::FootnoteReference(cow_str) => todo!(),
-        // Event::SoftBreak => todo!(),
-        // Event::HardBreak => todo!(),
-        // Event::Rule => todo!(),
-        // Event::TaskListMarker(_) => todo!(),
+        other => other, // Event::Text(cow_str) => todo!(),
+                        // Event::Code(cow_str) => todo!(),
+                        // Event::InlineMath(cow_str) => todo!(),
+                        // Event::DisplayMath(cow_str) => todo!(),
+                        // Event::Html(cow_str) => todo!(),
+                        // Event::InlineHtml(cow_str) => todo!(),
+                        // Event::FootnoteReference(cow_str) => todo!(),
+                        // Event::SoftBreak => todo!(),
+                        // Event::HardBreak => todo!(),
+                        // Event::Rule => todo!(),
+                        // Event::TaskListMarker(_) => todo!(),
     }
 }
 
@@ -257,12 +376,12 @@ const PRELUDE_PART_TWO: &str = r#"
   <article class="markdown-body">
 "#;
 
-fn prelude(title: &str) -> String {
+fn prelude(title: &str) -> Result<String> {
     let mut out = String::new();
     out.push_str(PRELUDE_PART_ONE);
-    writeln!(&mut out, "  <title>{title}</title>").ok();
+    writeln!(&mut out, "  <title>{title}</title>")?;
     out.push_str(PRELUDE_PART_TWO);
-    out
+    Ok(out)
 }
 
 const MARKDOWN_FOOTER: &str = r#"
@@ -270,3 +389,14 @@ const MARKDOWN_FOOTER: &str = r#"
 </body>
 </html>
 "#;
+
+// IDEAS FOR STUFF TO ADD TO THE DOCs:
+//
+// * A 2d table of all deps, unified across all app+tasks, showing which used
+//   * maybe either a checkmark, OR a version number
+// * a `<details>` box for the full unified app toml
+// * a listing of flash and ram sizes foreach task, maybe in a table?
+//   * is there more metadata that would be good to table-ify?
+// * the .dot output
+//   * use https://crates.io/crates/layout-rs to just render the existing
+//     dot syntax we produce? do as an inline svg?

--- a/build/xtask/src/aggro.rs
+++ b/build/xtask/src/aggro.rs
@@ -386,7 +386,7 @@ fn touchup<'a>(evt: Event<'a>, _base: Option<&'a Path>) -> Event<'a> {
 fn task_sort(a: (&str, &Task), b: (&str, &Task)) -> Ordering {
     match a.1.priority.cmp(&b.1.priority) {
         Ordering::Less => Ordering::Less,
-        Ordering::Equal => a.0.cmp(&b.0),
+        Ordering::Equal => a.0.cmp(b.0),
         Ordering::Greater => Ordering::Greater,
     }
 }

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -43,6 +43,7 @@ struct RawConfig {
     config: Option<ordered_toml::Value>,
     auxflash: Option<AuxFlash>,
     caboose: Option<CabooseConfig>,
+    docfile: Option<String>,
 }
 
 pub const DEFAULT_RAM_NAME: &str = "ram";
@@ -88,6 +89,7 @@ pub struct Config {
     pub app_config: String,
     pub auxflash: Option<AuxFlashData>,
     pub caboose: Option<CabooseConfig>,
+    pub docfile: Option<PathBuf>,
 }
 
 impl Config {
@@ -289,6 +291,18 @@ impl Config {
             )?;
         }
 
+        // Doc file (path)
+        let docfile = toml.docfile.and_then(|docfile| {
+            let mut path = cfg.to_owned();
+            path.pop();
+            path.push(Path::new(&docfile));
+            if path.is_file() {
+                Some(path)
+            } else {
+                None
+            }
+        });
+
         Ok(Config {
             name: toml.name,
             target: toml.target,
@@ -312,6 +326,7 @@ impl Config {
             app_toml_path: cfg.to_owned(),
             app_config: cfg_contents,
             caboose: toml.caboose,
+            docfile,
         })
     }
 

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -296,11 +296,7 @@ impl Config {
             let mut path = cfg.to_owned();
             path.pop();
             path.push(Path::new(&docfile));
-            if path.is_file() {
-                Some(path)
-            } else {
-                None
-            }
+            if path.is_file() { Some(path) } else { None }
         });
 
         Ok(Config {

--- a/build/xtask/src/graph.rs
+++ b/build/xtask/src/graph.rs
@@ -15,12 +15,17 @@ use crate::config::Config;
 /// Generate a directed graph of task priorities and task_slot
 /// dependencies.
 pub fn task_graph(app_toml: &Path, path: &Path) -> Result<()> {
+    let dot = File::create(path)?;
+    task_graph_inner(app_toml, dot)
+}
+
+pub(crate) fn task_graph_inner(app_toml: &Path, mut dot: impl Write) -> Result<()> {
     // Generate dot syntax for a graph of process priorities.
     // Collect each task in a priority group
     // Collect each edge
     let mut priorities = BTreeMap::new();
     let mut edges = Vec::new();
-    let mut dot = File::create(path)?;
+
     let mut ranks = HashSet::new();
     let toml = Config::from_file(app_toml)?;
 

--- a/build/xtask/src/graph.rs
+++ b/build/xtask/src/graph.rs
@@ -19,7 +19,10 @@ pub fn task_graph(app_toml: &Path, path: &Path) -> Result<()> {
     task_graph_inner(app_toml, dot)
 }
 
-pub(crate) fn task_graph_inner(app_toml: &Path, mut dot: impl Write) -> Result<()> {
+pub(crate) fn task_graph_inner(
+    app_toml: &Path,
+    mut dot: impl Write,
+) -> Result<()> {
     // Generate dot syntax for a graph of process priorities.
     // Collect each task in a priority group
     // Collect each edge

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 
 use crate::config::Config;
 
+mod aggro;
 mod auxflash;
 mod caboose_pos;
 mod config;
@@ -254,6 +255,16 @@ enum Xtask {
         /// Path to the JSONL file containing all of the attestations to upload, if generated.
         attestation: Option<PathBuf>,
     },
+
+    /// Create aggregate docs for a task
+    Aggro {
+        /// Path to the image configuration file, in TOML.
+        cfg: PathBuf,
+
+        /// Path to output file
+        #[clap(short, long)]
+        output: Option<PathBuf>,
+    }
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -549,6 +560,9 @@ fn run(xtask: Xtask) -> Result<()> {
         Xtask::GhaPrepareArtifacts { cfg, attestation } => {
             gha_prepare_artifacts::run(&cfg, attestation.as_deref())?;
         }
+        Xtask::Aggro { cfg, output } => {
+            aggro::run(&cfg, output.as_deref())?;
+        },
     }
 
     Ok(())

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -261,7 +261,7 @@ enum Xtask {
         /// Path to the image configuration file, in TOML.
         cfg: PathBuf,
 
-        /// Path to output file
+        /// Path to output file (html)
         #[clap(short, long)]
         output: Option<PathBuf>,
     },

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -264,7 +264,7 @@ enum Xtask {
         /// Path to output file
         #[clap(short, long)]
         output: Option<PathBuf>,
-    }
+    },
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -562,7 +562,7 @@ fn run(xtask: Xtask) -> Result<()> {
         }
         Xtask::Aggro { cfg, output } => {
             aggro::run(&cfg, output.as_deref())?;
-        },
+        }
     }
 
     Ok(())


### PR DESCRIPTION
I've currently plumbed a good "base coat" of the `aggro` subcommand (name bikeshedding welcome, it was funny on a Friday morning), which generally:

* Takes a task config
* Figures out all the tasks in that config
* Splats all of the READMEs (that are present) into a single bundle, and renders them into a single HTML "report".

Currently, it looks like this:

<img width="2529" height="26341" alt="Screenshot 2026-04-20 at 15-53-02 cosmo-b Aggregate Docs" src="https://github.com/user-attachments/assets/e3c1268a-06fd-44f1-862e-4b92f10c0396" />

[aggro.html](https://github.com/user-attachments/files/26898729/aggro.html)

From now, there are a couple of questions:

1. I could use some feedback on "matters of taste":
  * What information WOULD be useful to document on a per-app, or a per-task basis?
  * I included some simple tables, but these should be considered a proof of concept.
  * How do we want to shape this? One big MD/HTML/PDF file? Something more multi-page organized like `mdbook`?
2. I think we'll want to make a pass over our task docs:
  * Most tasks don't have any docs! But we can backfill this :)
  * We probably want to set out a bit of a "standard" of how drivers+tasks+apps are documented

I did try figuring out how to insert the task graph, sadly the `launch-rs` crate isn't as good at layouting as the `dot` bin is, and neither are *great* for making legible diagrams. We may want to break this up on a per-task basis just to reduce the number of entities per-graph.

<img width="1994" height="1240" alt="Screenshot 2026-04-17 at 7 33 04 PM" src="https://github.com/user-attachments/assets/c9e43663-790d-4cdc-b2e7-a7e407ef7f38" />
