### PR TITLE
auxflash-server: validate slot index to prevent out-of-bounds writes

### DIFF
--- a/drv/auxflash-server/src/main.rs
+++ b/drv/auxflash-server/src/main.rs
@@ -371,6 +371,9 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
         offset: u32,
         data: Leased<R, [u8]>,
     ) -> Result<(), RequestError<AuxFlashError>> {
+        if slot >= SLOT_COUNT {
+            return Err(AuxFlashError::InvalidSlot.into());
+        }
         if Some(slot) == self.active_slot {
             return Err(AuxFlashError::SlotActive.into());
         }
@@ -412,6 +415,9 @@ impl idl::InOrderAuxFlashImpl for ServerImpl {
         offset: u32,
         dest: Leased<W, [u8]>,
     ) -> Result<(), RequestError<AuxFlashError>> {
+        if slot >= SLOT_COUNT {
+            return Err(AuxFlashError::InvalidSlot.into());
+        }
         if offset as usize + dest.len() > SLOT_SIZE {
             return Err(AuxFlashError::AddressOverflow.into());
         }


### PR DESCRIPTION
Before, you could try to write (or read) a slot index higher than the number of slots. If there was extra unused space on the flash chip past the slots, this bug would presumably let you write to the unused space. The grapefruit I tested on doesn't have unused space, so it reported a `QspiTransferError`. Now with the bounds check added, it reports `InvalidSlot` instead.

This would also have been fixed by https://github.com/oxidecomputer/hubris/pull/2296