### PR TITLE
sprot: fix panic on rx buffer overflow

### DIFF
--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -121,6 +121,14 @@ impl<'a> Handler {
         Response::pack(&body, tx_buf)
     }
 
+    pub fn request_message_too_large_error(
+        &self,
+        tx_buf: &mut [u8; RESPONSE_BUF_SIZE],
+    ) -> usize {
+        let body = Err(SprotProtocolError::BadMessageLength.into());
+        Response::pack(&body, tx_buf)
+    }
+
     pub fn handle(
         &mut self,
         rx_buf: &[u8],

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -76,6 +76,7 @@ pub(crate) enum Trace {
     Err(SprotProtocolError),
     Stats(RotIoStats),
     Desynchronized,
+    RequestMsgTooLarge,
 
     #[cfg(feature = "sp-ctrl")]
     Dump(u32),
@@ -162,6 +163,9 @@ enum IoError {
     /// send a request to the RoT. We also return this error if we started
     /// receiving a request in the middle.
     Desynchronized,
+
+    /// The SP sent a request that was too large to fit in the RoT's rx buffer.
+    RequestMsgTooLarge,
 }
 
 #[unsafe(export_name = "main")]
@@ -204,6 +208,10 @@ fn main() -> ! {
             Err(IoError::Desynchronized) => {
                 ringbuf_entry!(Trace::Desynchronized);
                 handler.desynchronized_error(tx_buf)
+            }
+            Err(IoError::RequestMsgTooLarge) => {
+                ringbuf_entry!(Trace::RequestMsgTooLarge);
+                handler.request_message_too_large_error(tx_buf)
             }
         };
 
@@ -315,9 +323,9 @@ impl Io {
         // The rx fifo contained more bytes than could fit in the buffer, which
         // is more than we ever expect to receive in one request message.
         if bytes_received > rx_buf.len() {
-            self.stats.rx_protocol_error_too_many_bytes =
-                self.stats.rx_protocol_error_too_many_bytes.wrapping_add(1);
-            return Err(IoError::Flow);
+            self.stats.request_msg_too_large =
+                self.stats.request_msg_too_large.wrapping_add(1);
+            return Err(IoError::RequestMsgTooLarge);
         }
 
         // Was this a CSn pulse?

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -312,6 +312,14 @@ impl Io {
 
         self.check_for_rx_error()?;
 
+        // The rx fifo contained more bytes than could fit in the buffer, which is more than we ever
+        // expect to receive in one request message.
+        if bytes_received > rx_buf.len() {
+            self.stats.rx_protocol_error_too_many_bytes =
+                self.stats.rx_protocol_error_too_many_bytes.wrapping_add(1);
+            return Err(IoError::Flow);
+        }
+
         // Was this a CSn pulse?
         if bytes_received == 0 {
             self.stats.csn_pulses = self.stats.csn_pulses.wrapping_add(1);

--- a/drv/lpc55-sprot-server/src/main.rs
+++ b/drv/lpc55-sprot-server/src/main.rs
@@ -312,8 +312,8 @@ impl Io {
 
         self.check_for_rx_error()?;
 
-        // The rx fifo contained more bytes than could fit in the buffer, which is more than we ever
-        // expect to receive in one request message.
+        // The rx fifo contained more bytes than could fit in the buffer, which
+        // is more than we ever expect to receive in one request message.
         if bytes_received > rx_buf.len() {
             self.stats.rx_protocol_error_too_many_bytes =
                 self.stats.rx_protocol_error_too_many_bytes.wrapping_add(1);

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -634,7 +634,7 @@ pub struct RotIoStats {
     /// The number of times an SP sent more bytes than expected for one
     /// message. In otherwords, the number of bytes sent by the SP to the RoT
     /// between CSn assert and CSn de-assert exceeds `REQUEST_BUF_SIZE`.
-    pub rx_protocol_error_too_many_bytes: u32,
+    pub request_msg_too_large: u32,
 
     /// The number of CSn pulses seen by the RoT
     pub csn_pulses: u32,

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -631,6 +631,11 @@ pub struct RotIoStats {
     /// Number of messages where the RoT failed to service the Rx FIFO in time.
     pub rx_overrun: u32,
 
+    /// The number of times an SP sent more bytes than expected for one
+    /// message. In otherwords, the number of bytes sent by the SP to the RoT
+    /// between CSn assert and CSn de-assert exceeds `REQUEST_BUF_SIZE`.
+    pub rx_protocol_error_too_many_bytes: u32,
+
     /// The number of CSn pulses seen by the RoT
     pub csn_pulses: u32,
 

--- a/drv/sprot-api/src/lib.rs
+++ b/drv/sprot-api/src/lib.rs
@@ -288,15 +288,19 @@ where
 
         // The CRC comes after the body, and is not included in header body_len
         let (crc, _) = hubpack::deserialize(tail)?;
-
-        if computed_crc == crc {
-            let blob_len =
-                header.body_size as usize - (rest.len() - blob_buf.len());
-            let blob = &blob_buf[..blob_len];
-            Ok(Msg { header, body, blob })
-        } else {
-            Err(SprotProtocolError::InvalidCrc)
+        if computed_crc != crc {
+            return Err(SprotProtocolError::InvalidCrc);
         }
+
+        let consumed_by_t = rest.len() - blob_buf.len();
+        if consumed_by_t > header.body_size as usize {
+            // The SP and RoT probably disagree about the definition of type T
+            // because of a version mismatch
+            return Err(SprotProtocolError::BadMessageLength);
+        }
+        let blob_len = header.body_size as usize - consumed_by_t;
+        let blob = &blob_buf[..blob_len];
+        Ok(Msg { header, body, blob })
     }
 }
 

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -285,7 +285,7 @@ impl<S: SpiServer> Io<S> {
             hl::sleep_for(PART2_DELAY);
         }
 
-        if total_size > rx_buf.len() {
+        if total_size > RESPONSE_BUF_SIZE {
             return Err(SprotProtocolError::BadMessageLength.into());
         }
 

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -321,13 +321,13 @@ impl<S: SpiServer> Io<S> {
             if !self.wait_rot_irq(false, TIMEOUT_QUICK) {
                 // Nope, it didn't complete. Pulse CSn.
                 ringbuf_entry!(Trace::UnexpectedRotIrq);
-                self.stats.csn_pulses += self.stats.csn_pulses.wrapping_add(1);
+                self.stats.csn_pulses = self.stats.csn_pulses.wrapping_add(1);
                 // One sample of an LPC55S28 reacting to CSn deasserted
                 // in about 54us. So, 10ms is plenty.
                 if self.do_pulse_cs(10_u64, 10_u64)?.rot_irq_end == 1 {
                     // Did not clear ROT_IRQ
                     ringbuf_entry!(Trace::PulseFailed);
-                    self.stats.csn_pulse_failures +=
+                    self.stats.csn_pulse_failures =
                         self.stats.csn_pulse_failures.wrapping_add(1);
                     debug_set(&self.sys, false); // XXX
                     return Err(SprotProtocolError::RotIrqRemainsAsserted)?;

--- a/drv/stm32h7-sprot-server/src/main.rs
+++ b/drv/stm32h7-sprot-server/src/main.rs
@@ -285,7 +285,7 @@ impl<S: SpiServer> Io<S> {
             hl::sleep_for(PART2_DELAY);
         }
 
-        if total_size > RESPONSE_BUF_SIZE {
+        if total_size > rx_buf.len() {
             return Err(SprotProtocolError::BadMessageLength.into());
         }
 


### PR DESCRIPTION
If the SP sent the RoT a request that couldn't fit in its rx buffer array, the RoT's sprot task would panic. Interestingly, the code used to check for this condition and increment an `rx_protocol_error_too_many_bytes` counter, but the check and the counter were removed a few years ago. I revived them both, and made the sprot task report a flow error instead of panicking. I also tested that the following SPI transaction succeeds.

I did a couple cleanups in the SP's sprot server while I was at it.