### PR TITLE
Remove power sensor from BMR491

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -1150,7 +1150,7 @@ device = "bmr491"
 name = "IBC"
 description = "Intermediate bus converter"
 power = { rails = [ "V12_SYS_A2" ] }
-sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
+sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = "U80"
 
 [[config.i2c.devices]]

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -1069,7 +1069,7 @@ device = "bmr491"
 name = "IBC"
 description = "Intermediate bus converter"
 power = { rails = [ "V12_SYS_A2" ] }
-sensors = { temperature = 1, power = 1, voltage = 1, current = 1 }
+sensors = { temperature = 1, voltage = 1, current = 1 }
 refdes = "U431"
 
 ################################################################################

--- a/lib/host-sp-messages/src/lib.rs
+++ b/lib/host-sp-messages/src/lib.rs
@@ -471,6 +471,9 @@ pub enum InventoryData {
         mfr_firmware_data: [u8; 20],
 
         temp_sensor: SensorIndex,
+
+        /// The BRM491 doesn't actually have a power sensors; this is always set
+        /// to `u32::MAX` (but can't be removed for compatibility reasons)
         power_sensor: SensorIndex,
         voltage_sensor: SensorIndex,
         current_sensor: SensorIndex,

--- a/task/host-sp-comms/src/bsp/cosmo_ab.rs
+++ b/task/host-sp-comms/src/bsp/cosmo_ab.rs
@@ -140,7 +140,7 @@ impl ServerImpl {
                     temp_sensor: sensors.temperature.into(),
                     voltage_sensor: sensors.voltage.into(),
                     current_sensor: sensors.current.into(),
-                    power_sensor: sensors.power.into(),
+                    power_sensor: u32::MAX, // not present
                 };
                 self.tx_buf.try_encode_inventory(sequence, name, || {
                     use pmbus::commands::bmr491::CommandCode;

--- a/task/host-sp-comms/src/bsp/gimlet_bcde.rs
+++ b/task/host-sp-comms/src/bsp/gimlet_bcde.rs
@@ -141,7 +141,7 @@ impl ServerImpl {
                     temp_sensor: sensors.temperature.into(),
                     voltage_sensor: sensors.voltage.into(),
                     current_sensor: sensors.current.into(),
-                    power_sensor: sensors.power.into(),
+                    power_sensor: u32::MAX, // not present
                 };
                 self.tx_buf.try_encode_inventory(sequence, name, || {
                     use pmbus::commands::bmr491::CommandCode;


### PR DESCRIPTION
Fixes #1581, which is tagged with R20 for some reason 🤷🏻‍♂️ 

Two follow-up questions:

- Will removing this sensor make anything in the control plane mad?  cc @hawkw 
- We no longer have a power sensor ID to send in `host-sp-comms` inventory data, but we can't change the `InventoryData::Bmr491` shape for compatibility reasons.  I'm now sending `u32::MAX` as a "no such sensor" marker, which I _think_ should be fine (`bmr_pout` is never used in `stlouis`), but cc @citrus-it to double-check