### PR TITLE
Fix stack scribbling when the stack spans multiple regions

### DIFF
--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -304,18 +304,46 @@ pub fn reinitialize(task: &mut task::Task) {
     // arithmetic and get zero for the top word, which is outside any region and
     // causes this to be skipped. (Not that we expect zero, but we're the kernel
     // and we don't trust tasks.)
-    if let Some(region) = task
-        .region_table()
-        .iter()
-        .find(|region| region.contains(initial_stack.saturating_sub(4)))
+    if let Some((index, mut region)) =
+        task.region_table().iter().enumerate().find(|(_i, region)| {
+            region.contains(initial_stack.saturating_sub(4))
+        })
     {
+        // The stack may span multiple contiguous regions; iterate backwards
+        // through the sorted region list until we either hit the front or find
+        // a region which is discontiguous.
+        let mut okay = true;
+        for i in (0..index).rev() {
+            let prev_region = &task.region_table()[i];
+
+            // If the region table is corrupt such that a region descriptor
+            // overflows a u32, then bail out.
+            let Some(prev_region_end) =
+                prev_region.base.checked_add(prev_region.size)
+            else {
+                okay = false;
+                break;
+            };
+
+            // If these regions are contiguous, then keep going
+            if prev_region_end == region.base {
+                region = prev_region;
+            } else {
+                // We have found a discontiguous region, so we can break out of
+                // the loop (leaving `region` set to its previous value).
+                break;
+            }
+        }
+
         // If the slice doesn't fit in the region, this will fail. Should this
         // occur, don't crash the entire system, since this is a diagnostic tool
         // -- just skip filling the stack.
-        if let Ok(mut uslice) = USlice::<u32>::from_raw(
-            region.base as usize,
-            (initial_stack - frame_size - region.base as usize) >> 2,
-        ) {
+        if okay
+            && let Some(region_size) =
+                (initial_stack - frame_size).checked_sub(region.base as usize)
+            && let Ok(mut uslice) =
+                USlice::<u32>::from_raw(region.base as usize, region_size >> 2)
+        {
             // This one, we're unwrapping rather than tolerating failure. This
             // is because try_write failing would indicate an invalid region
             // descriptor for the task (read-only stack area) which would bite

--- a/website/bugs/index.html
+++ b/website/bugs/index.html
@@ -52,6 +52,7 @@ hr {
 
 <script>
 const bugs = [
+    ["pull/2492", "2026-04-30T14:28Z", "Fix stack scribbling when the stack spans multiple regions"],
     ["pull/2468", "2026-04-09T13:43Z", "Kernel task dump access indexing error"],
     ["commit/3f93005b33a94", "2024-12-25T04:40Z", "MPU attribute misconfiguration on ARMv8M"],
     ["commit/88617a279efdcc", "2024-12-18T18:19Z", "Client-controlled kernel panic in kipc"],


### PR DESCRIPTION
## Background
In #2458, we allowed tasks to put their RAM into multiple contiguous regions for better packing: instead of a single power-of-two allocation, they have a sum-of-powers-of-two allocation.

This has resurfaced #1943 as a live issue!  @cbiffle noticed a test application failing to boot, panicking at the subtraction here:
https://github.com/oxidecomputer/hubris/blob/8f61b13620eff586614766876e43152834f069bd/sys/kern/src/arch/arm_m.rs#L312-L317

```
humility tasks failed: kernel has panicked on boot: "panicked at sys/kern/src/arch/arm_m.rs:317:13:\nattempt to subtract with overflow"
```

While investigating, I found two different problems; this PR fixes both of them.

## Underflow when computing slice size

The subtraction to compute slice size can underflow if the top-of-stack address (`initial_stack - 4`) is in one MPU region, but `initial_stack - frame_size - region.base` is in the next region down.  This is the failure that Cliff reported, back in #1943 and yesterday.

#1947 tried to fix it, but was not sufficient: we're failing before the `USlice` constructor is even called.  I suspect that #1947 was tested with overflow checks disabled, which _would_ work (because we'd pass a nonsense value into the `USlice` constructor).

## Insufficient scribbling

We were only scribbling a single RAM region: the one containing `initial_stack - 4`.  Consider the `sensors` task in the `grapefruit/rev-a` image, which uses three RAM regions:
```
DESC       LOW          HIGH          SIZE ATTR   ID TASK
0x08005bf4 0x2402a360 - 0x2402a37f      32 rw---- 15 sensor
0x08005c08 0x2402a380 - 0x2402a3ff     128 rw---- 15 sensor
0x08005c1c 0x2402a400 - 0x2402a7ff    1KiB rw---- 15 sensor
```

In our existing code, we only scribble the final region (`0x2402a400 - 0x2402a7ff`).  I checked this with `humility readmem`:
```
➜  hubris jj:(lkt (empty)) h readmem 0x2402a380
humility: attached via ST-Link V3
             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0x2402a360 | 65 64 dd 91 3d 53 44 c1 c5 28 af 26 08 d7 3d ef | ed..=SD..(.&..=.
0x2402a370 | 48 29 f8 48 58 d2 1d 02 e0 55 07 43 85 77 39 93 | H).HX....U.C.w9.
0x2402a380 | a4 11 ba f4 d2 5e e8 06 c3 af 34 87 fe 58 9b de | .....^....4..X..
0x2402a390 | 77 ad 1c 75 96 85 17 28 fd a7 fd 16 ef 6e 78 50 | w..u...(.....nxP
0x2402a3a0 | c4 05 53 ce 27 91 da 40 3c c6 6f 7e 6b 97 ed a2 | ..S.'..@<.o~k...
0x2402a3b0 | 64 b1 0d 0e 4b 83 29 17 3f d4 3e e9 23 55 b9 6a | d...K.).?.>.#U.j
0x2402a3c0 | 59 1d 65 4c 83 c6 28 a8 19 18 2e 6c 65 cc c3 1c | Y.eL..(....le...
0x2402a3d0 | 09 b0 87 80 80 c3 34 65 9d fd a6 bd fa 7b dc fd | ......4e.....{..
0x2402a3e0 | b2 72 5e 01 34 54 3a 46 57 95 ab a5 7b c3 49 7e | .r^.4T:FW...{.I~
0x2402a3f0 | e5 e1 df 41 b2 9a 82 2b b3 7d df 77 37 86 bc 91 | ...A...+.}.w7...
0x2402a400 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x2402a410 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x2402a420 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x2402a430 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x2402a440 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x2402a450 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
```

The scribble pattern isn't written into the lower regions (which span `0x2402a360 - 0x2402a3ff`).

This will make `humility stackmargin` inaccurate if the stack spills out of the first region; I'd expect to see a margin of 0 bytes (since we wouldn't see the `fe ca dd ba fe cc` pattern anywhere).

## The fixes

- When computing the `region_size`, use checked subtraction.  Note that we don't need to check `initial_stack - frame_size`, because we check that earlier in the function
- When picking the start of the scribble slice, find the first of the contiguous regions