### PR TITLE
use `front-io-server` to proxy front-io sequencing calls to sidecar-seq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,8 @@ dependencies = [
  "build-fpga-regmap",
  "build-util",
  "cfg-if",
+ "counters",
+ "derive-idol-err",
  "drv-auxflash-api",
  "drv-fpga-api",
  "drv-i2c-api",
@@ -1301,6 +1303,7 @@ dependencies = [
  "gnarle",
  "hubpack",
  "idol",
+ "idol-runtime",
  "num-derive 0.4.2",
  "num-traits",
  "ringbuf",
@@ -1309,6 +1312,26 @@ dependencies = [
  "userlib",
  "vsc7448-pac",
  "vsc85xx",
+ "zerocopy 0.8.27",
+ "zerocopy-derive 0.8.27",
+]
+
+[[package]]
+name = "drv-front-io-server"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "drv-fpga-user-api",
+ "drv-front-io-api",
+ "drv-sidecar-seq-api",
+ "enum-map",
+ "hubpack",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "ringbuf",
+ "serde",
+ "userlib",
  "zerocopy 0.8.27",
  "zerocopy-derive 0.8.27",
 ]

--- a/app/medusa/base.toml
+++ b/app/medusa/base.toml
@@ -138,9 +138,19 @@ task-slots = [
     "net",
     "sensor",
     "sys",
-    {front_io = "ecp5_front_io"},
+    "front_io",
+    {front_io_fpga = "ecp5_front_io"},
     {seq = "sequencer"}]
 notifications = ["socket", "timer"]
+
+[tasks.front_io]
+name = "drv-front-io-server"
+priority = 5
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
+start = true
+task-slots = ["sequencer"]
+notifications = ["timer"]
 
 [tasks.packrat]
 name = "task-packrat"

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -90,7 +90,7 @@ task-slots = ["sys"]
 [tasks.net]
 name = "task-net"
 stacksize = 10000
-priority = 5
+priority = 6
 features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
 max-sizes = {flash = 131072, ram = 131072, sram1_mac = 16384}
 sections = {eth_bulk = "sram1_mac"}
@@ -106,7 +106,7 @@ task-slots = ["sys", "packrat", { seq = "sequencer" }, "jefe"]
 
 [tasks.control_plane_agent]
 name = "task-control-plane-agent"
-priority = 7
+priority = 8
 # This is a big number -- do we need to tune this?
 stacksize = 12000
 start = true
@@ -149,7 +149,7 @@ interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.udpecho]
 name = "task-udpecho"
-priority = 6
+priority = 8
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -159,7 +159,7 @@ notifications = ["socket"]
 
 [tasks.udpbroadcast]
 name = "task-udpbroadcast"
-priority = 6
+priority = 8
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
 start = true
@@ -174,7 +174,7 @@ max-sizes = {flash = 262144, ram = 16384}
 features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753", "spi2"]
 stacksize = 4096
 start = true
-task-slots = ["ecp5_front_io", "sys", { seq = "sequencer" }]
+task-slots = ["ecp5_front_io", "front_io", "sys", { seq = "sequencer" }]
 uses = ["spi2"]
 notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
@@ -244,7 +244,7 @@ interrupts = {"spi1.irq" = "spi-irq"}
 [tasks.transceivers]
 name = "drv-transceivers-server"
 features = ["vlan", "thermal-control"]
-priority = 6
+priority = 7
 max-sizes = {flash = 65536, ram = 16384}
 stacksize = 4096
 start = true
@@ -254,9 +254,19 @@ task-slots = [
     "sensor",
     "sys",
     "thermal",
-    {front_io = "ecp5_front_io"},
+    "front_io",
+    {front_io_fpga = "ecp5_front_io"},
     {seq = "sequencer"}]
 notifications = ["socket", "timer"]
+
+[tasks.front_io]
+name = "drv-front-io-server"
+priority = 5
+max-sizes = {flash = 65536, ram = 16384}
+stacksize = 4096
+start = true
+task-slots = ["sequencer"]
+notifications = ["timer"]
 
 [tasks.packrat]
 name = "task-packrat"
@@ -329,7 +339,7 @@ stacksize = 800
 
 [tasks.dump_agent]
 name = "task-dump-agent"
-priority = 6
+priority = 7
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
 task-slots = ["sprot", "jefe", "net"]
@@ -342,7 +352,7 @@ features = ["net", "vlan"]
 name = "task-snitch"
 # The snitch should have a priority immediately below that of the net task,
 # to minimize the number of components that can starve it from resources.
-priority = 6
+priority = 7
 stacksize = 1200
 start = true
 task-slots = ["net", "packrat"]
@@ -351,7 +361,7 @@ notifications = ["socket"]
 
 [tasks.idle]
 name = "task-idle"
-priority = 8
+priority = 10
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true

--- a/app/sidecar/dev.toml
+++ b/app/sidecar/dev.toml
@@ -4,7 +4,7 @@ request_reset = ["udprpc"]
 
 [tasks.udprpc]
 name = "task-udprpc"
-priority = 6
+priority = 7
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
 start = true

--- a/drv/front-io-api/Cargo.toml
+++ b/drv/front-io-api/Cargo.toml
@@ -4,16 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-cfg-if = { workspace = true }
-hubpack = { workspace = true }
-num-derive = { workspace = true }
-num-traits = { workspace = true }
-serde = { workspace = true }
-transceiver-messages = { workspace = true }
-vsc7448-pac = { workspace = true, optional = true }
-zerocopy = { workspace = true }
-zerocopy-derive = { workspace = true }
+cfg-if.workspace = true
+hubpack.workspace = true
+idol-runtime.workspace = true
+num-derive.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+transceiver-messages.workspace = true
+zerocopy.workspace = true
+zerocopy-derive.workspace = true
 
+counters = { path = "../../lib/counters", features = ["derive"] }
+derive-idol-err = { path = "../../lib/derive-idol-err" }
 drv-auxflash-api = { path = "../../drv/auxflash-api" }
 drv-fpga-api = { path = "../../drv/fpga-api", features = ["auxflash"] }
 drv-i2c-api = { path = "../i2c-api" }
@@ -21,6 +23,7 @@ drv-i2c-devices = { path = "../i2c-devices" }
 drv-transceivers-api = { path = "../../drv/transceivers-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib" }
+vsc7448-pac = { workspace = true, optional = true }
 vsc85xx = { path = "../../drv/vsc85xx", optional = true }
 
 [features]
@@ -31,10 +34,11 @@ leds = []
 no-ipc-counters = ["idol/no-counters"]
 
 [build-dependencies]
+idol.workspace = true
+
 build-fpga-regmap = { path = "../../build/fpga-regmap" }
 build-util = { path = "../../build/util" }
 gnarle = { path = "../../lib/gnarle", features=["std"] }
-idol = { workspace = true }
 
 [lib]
 test = false

--- a/drv/front-io-api/Cargo.toml
+++ b/drv/front-io-api/Cargo.toml
@@ -13,6 +13,7 @@ serde.workspace = true
 transceiver-messages.workspace = true
 zerocopy.workspace = true
 zerocopy-derive.workspace = true
+vsc7448-pac = { workspace = true, optional = true }
 
 counters = { path = "../../lib/counters", features = ["derive"] }
 derive-idol-err = { path = "../../lib/derive-idol-err" }
@@ -23,7 +24,6 @@ drv-i2c-devices = { path = "../i2c-devices" }
 drv-transceivers-api = { path = "../../drv/transceivers-api" }
 ringbuf = { path = "../../lib/ringbuf" }
 userlib = { path = "../../sys/userlib" }
-vsc7448-pac = { workspace = true, optional = true }
 vsc85xx = { path = "../../drv/vsc85xx", optional = true }
 
 [features]

--- a/drv/front-io-api/build.rs
+++ b/drv/front-io-api/build.rs
@@ -17,6 +17,10 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         panic!("unknown target board");
     }
 
+    idol::Generator::new()
+        .with_counters(idol::CounterSettings::default())
+        .build_client_stub("../../idl/front-io.idol", "client_stub.rs")?;
+
     let out_dir = build_util::out_dir();
     let out_file = out_dir.join("sidecar_qsfp_x32_controller_regs.rs");
     let mut file = fs::File::create(out_file)?;

--- a/drv/front-io-api/src/lib.rs
+++ b/drv/front-io-api/src/lib.rs
@@ -4,10 +4,10 @@
 
 #![no_std]
 
-include!(concat!(
-    env!("OUT_DIR"),
-    "/sidecar_qsfp_x32_controller_regs.rs"
-));
+use counters::Count;
+use derive_idol_err::IdolError;
+use drv_fpga_api::FpgaError;
+use userlib::*;
 
 #[cfg(feature = "controller")]
 pub mod controller;
@@ -17,3 +17,30 @@ pub mod leds;
 pub mod phy_smi;
 #[cfg(feature = "transceivers")]
 pub mod transceivers;
+
+#[derive(
+    Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError, Count,
+)]
+pub enum FrontIOError {
+    FpgaError = 1,
+    NotPresent,
+    InvalidPhysicalToLogicalMap,
+    InvalidModuleResult,
+    SeqError,
+
+    #[idol(server_death)]
+    ServerRestarted,
+}
+
+impl From<FpgaError> for FrontIOError {
+    fn from(_: FpgaError) -> Self {
+        Self::FpgaError
+    }
+}
+
+include!(concat!(
+    env!("OUT_DIR"),
+    "/sidecar_qsfp_x32_controller_regs.rs"
+));
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/front-io-api/src/phy_smi.rs
+++ b/drv/front-io-api/src/phy_smi.rs
@@ -12,7 +12,7 @@ use zerocopy::{
     byteorder::little_endian,
 };
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, Debug, PartialEq)]
 pub enum PhyOscState {
     Unknown,
     Bad,

--- a/drv/front-io-api/src/phy_smi.rs
+++ b/drv/front-io-api/src/phy_smi.rs
@@ -12,7 +12,7 @@ use zerocopy::{
     byteorder::little_endian,
 };
 
-#[derive(Copy, Clone, Eq, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PhyOscState {
     Unknown,
     Bad,

--- a/drv/front-io-api/src/transceivers.rs
+++ b/drv/front-io-api/src/transceivers.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{Addr, Reg};
+use crate::{Addr, FrontIOError, Reg};
 use drv_fpga_api::{FpgaError, FpgaUserDesign, ReadOp, WriteOp};
-use drv_transceivers_api::{ModuleStatus, NUM_PORTS, TransceiversError};
+use drv_transceivers_api::{ModuleStatus, NUM_PORTS};
 use transceiver_messages::ModuleId;
 use userlib::UnwrapLite;
 use zerocopy::{
@@ -55,14 +55,14 @@ impl PhysicalPort {
     pub fn to_logical_port(
         &self,
         fpga: FpgaController,
-    ) -> Result<LogicalPort, TransceiversError> {
+    ) -> Result<LogicalPort, FrontIOError> {
         let loc = PortLocation {
             controller: fpga,
             port: *self,
         };
         match PORT_MAP.into_iter().position(|&l| l == loc) {
             Some(p) => Ok(LogicalPort(p as u8)),
-            None => Err(TransceiversError::InvalidPhysicalToLogicalMap),
+            None => Err(FrontIOError::InvalidPhysicalToLogicalMap),
         }
     }
 }
@@ -527,12 +527,12 @@ impl ModuleResult {
         failure: LogicalPortMask,
         error: LogicalPortMask,
         failure_types: LogicalPortFailureTypes,
-    ) -> Result<Self, TransceiversError> {
+    ) -> Result<Self, FrontIOError> {
         if !(success & failure).is_empty()
             || !(success & error).is_empty()
             || !(failure & error).is_empty()
         {
-            return Err(TransceiversError::InvalidModuleResult);
+            return Err(FrontIOError::InvalidModuleResult);
         }
         Ok(Self {
             success,
@@ -638,9 +638,9 @@ impl ModuleResultNoFailure {
     pub fn new(
         success: LogicalPortMask,
         error: LogicalPortMask,
-    ) -> Result<Self, TransceiversError> {
+    ) -> Result<Self, FrontIOError> {
         if !(success & error).is_empty() {
-            return Err(TransceiversError::InvalidModuleResult);
+            return Err(FrontIOError::InvalidModuleResult);
         }
         Ok(Self { success, error })
     }

--- a/drv/front-io-server/Cargo.toml
+++ b/drv/front-io-server/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "drv-front-io-server"
+version = "0.1.0"
+edition = "2024"
+authors = ["Arjen Roodselaar <arjen@oxide.computer>", "Aaron Hartwig <aaron@oxide.computer>"]
+
+[dependencies]
+enum-map.workspace = true
+hubpack.workspace = true
+idol-runtime.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+zerocopy.workspace = true
+zerocopy-derive.workspace = true
+
+drv-fpga-user-api = { path = "../fpga-user-api" }
+drv-front-io-api = { path = "../front-io-api", features = ["phy_smi", "transceivers"] }
+drv-sidecar-seq-api = { path = "../sidecar-seq-api" }
+ringbuf = { path = "../../lib/ringbuf" }
+userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
+
+[build-dependencies]
+build-util = { path = "../../build/util" }
+idol = { workspace = true }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-front-io-server"
+test = false
+doctest = false
+bench = false

--- a/drv/front-io-server/build.rs
+++ b/drv/front-io-server/build.rs
@@ -7,7 +7,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     build_util::build_notifications()?;
 
     let board = build_util::env_var("HUBRIS_BOARD")?;
-    if board != "sidecar-b" && board != "sidecar-c" && board != "sidecar-d" {
+    if board != "sidecar-b"
+        && board != "sidecar-c"
+        && board != "sidecar-d"
+        && board != "medusa-a"
+    {
         panic!("unknown target board");
     }
 

--- a/drv/front-io-server/build.rs
+++ b/drv/front-io-server/build.rs
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    build_util::expose_target_board();
+    build_util::build_notifications()?;
+
+    let board = build_util::env_var("HUBRIS_BOARD")?;
+    if board != "sidecar-b" && board != "sidecar-c" && board != "sidecar-d" {
+        panic!("unknown target board");
+    }
+
+    idol::Generator::new()
+        .with_counters(
+            idol::CounterSettings::default().with_server_counters(false),
+        )
+        .build_server_support(
+            "../../idl/front-io.idol",
+            "server_stub.rs",
+            idol::server::ServerStyle::InOrder,
+        )?;
+
+    Ok(())
+}

--- a/drv/front-io-server/src/main.rs
+++ b/drv/front-io-server/src/main.rs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Server for managing the Front IO board
+
+#![no_std]
+#![no_main]
+
+use core::convert::Infallible;
+use drv_front_io_api::FrontIOError;
+use drv_sidecar_seq_api::Sequencer;
+use idol_runtime::{NotificationHandler, RequestError};
+use ringbuf::*;
+use userlib::*;
+
+task_slot!(SEQUENCER, sequencer);
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, PartialEq)]
+enum Trace {
+    None,
+}
+ringbuf!(Trace, 32, Trace::None);
+
+struct ServerImpl {
+    seq: Sequencer,
+}
+
+impl idl::InOrderFrontIOImpl for ServerImpl {
+    /// Returns true if a front IO board was determined to be present and powered on
+    fn board_present(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<bool, RequestError<Infallible>> {
+        Ok(self.seq.front_io_board_present())
+    }
+
+    /// Returns if the front IO board has completely sequenced and is ready
+    fn board_ready(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<bool, RequestError<FrontIOError>> {
+        self.seq
+            .front_io_board_ready()
+            .map_err(|_| FrontIOError::SeqError)
+            .map_err(RequestError::from)
+    }
+
+    fn phy_reset(
+        &mut self,
+        _: &RecvMessage,
+    ) -> Result<(), RequestError<FrontIOError>> {
+        self.seq
+            .reset_front_io_phy()
+            .map_err(|_| FrontIOError::SeqError)
+            .map_err(RequestError::from)
+    }
+
+    /// Set the internal state of the PHY's oscillator
+    fn phy_set_osc_state(
+        &mut self,
+        _: &RecvMessage,
+        good: bool,
+    ) -> Result<(), RequestError<FrontIOError>> {
+        self.seq
+            .set_front_io_phy_osc_state(good)
+            .map_err(|_| FrontIOError::SeqError)
+            .map_err(RequestError::from)
+    }
+}
+
+// notifications are not supported at this time
+impl NotificationHandler for ServerImpl {
+    fn current_notification_mask(&self) -> u32 {
+        0
+    }
+
+    fn handle_notification(&mut self, _bits: NotificationBits) {
+        unreachable!()
+    }
+}
+
+#[unsafe(export_name = "main")]
+fn main() -> ! {
+    let mut server = ServerImpl {
+        seq: Sequencer::from(SEQUENCER.get_task_id()),
+    };
+
+    let mut buffer = [0; idl::INCOMING_SIZE];
+    loop {
+        idol_runtime::dispatch(&mut buffer, &mut server);
+    }
+}
+
+mod idl {
+    use super::FrontIOError;
+
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}

--- a/drv/transceivers-server/src/main.rs
+++ b/drv/transceivers-server/src/main.rs
@@ -14,7 +14,7 @@ use userlib::{sys_get_timer, task_slot, units::Celsius};
 
 use drv_fpga_api::FpgaError;
 use drv_front_io_api::{
-    Reg,
+    FrontIO, FrontIOError, Reg,
     leds::{FullErrorSummary, Leds},
     transceivers::{
         FpgaI2CFailure, LogicalPort, LogicalPortMask, Transceivers,
@@ -38,10 +38,12 @@ use zerocopy::{FromBytes, FromZeros, IntoBytes};
 mod udp; // UDP API is implemented in a separate file
 
 task_slot!(I2C, i2c_driver);
+// front-io-server, which does not yet own the fpga
 task_slot!(FRONT_IO, front_io);
-task_slot!(SEQ, seq);
+task_slot!(FRONT_IO_FPGA, front_io_fpga);
 task_slot!(NET, net);
 task_slot!(SENSOR, sensor);
+task_slot!(SEQ, seq);
 
 #[cfg(feature = "thermal-control")]
 task_slot!(THERMAL, thermal);
@@ -54,7 +56,7 @@ enum Trace {
     #[count(skip)]
     None,
     FrontIOBoardReady(#[count(children)] bool),
-    FrontIOSeqErr(SeqError),
+    FrontIOErr(FrontIOError),
     LEDInit,
     LEDInitComplete,
     LEDInitError(Error),
@@ -621,8 +623,9 @@ fn main() -> ! {
     // before we start doing things with them. A more sophisticated
     // notification system will be put in place.
     let seq = Sequencer::from(SEQ.get_task_id());
+    let front_io = FrontIO::from(FRONT_IO.get_task_id());
 
-    let transceivers = Transceivers::new(FRONT_IO.get_task_id());
+    let transceivers = Transceivers::new(FRONT_IO_FPGA.get_task_id());
     let leds = Leds::new(
         &i2c_config::devices::pca9956b_front_leds_left(I2C.get_task_id()),
         &i2c_config::devices::pca9956b_front_leds_right(I2C.get_task_id()),
@@ -691,15 +694,13 @@ fn main() -> ! {
     let mut buffer = [0; idl::INCOMING_SIZE];
     loop {
         if server.front_io_board_present == FrontIOStatus::NotReady {
-            server.front_io_board_present = match seq.front_io_board_ready() {
+            server.front_io_board_present = match front_io.board_ready() {
                 Ok(true) => {
                     ringbuf_entry!(Trace::FrontIOBoardReady(true));
                     FrontIOStatus::Ready
                 }
-                Err(SeqError::NoFrontIOBoard) => {
-                    ringbuf_entry!(Trace::FrontIOSeqErr(
-                        SeqError::NoFrontIOBoard
-                    ));
+                Err(FrontIOError::NotPresent) => {
+                    ringbuf_entry!(Trace::FrontIOErr(FrontIOError::NotPresent));
                     FrontIOStatus::NotPresent
                 }
                 _ => {

--- a/idl/front-io.idol
+++ b/idl/front-io.idol
@@ -1,0 +1,38 @@
+// Front IO API
+
+Interface(
+    name: "FrontIO",
+    ops: {
+        "board_present": (
+            args: {},
+            reply: Simple("bool"),
+            idempotent: true,
+        ),
+
+        "board_ready": (
+            args: {},
+            reply: Result(
+                ok: "bool",
+                err: CLike("FrontIOError"),
+            ),
+        ),
+
+        "phy_reset": (
+            args: {},
+            reply: Result(
+                ok: "()",
+                err: CLike("FrontIOError"),
+            ),
+        ),
+
+        "phy_set_osc_state": (
+            args: {
+                "good": "bool",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("FrontIOError"),
+            ),
+        ),
+    },
+)

--- a/task/monorail-server/src/bsp/sidecar_bcd.rs
+++ b/task/monorail-server/src/bsp/sidecar_bcd.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use drv_front_io_api::phy_smi::PhySmi;
+use drv_front_io_api::{FrontIO, phy_smi::PhySmi};
 use drv_monorail_api::MonorailError;
 use drv_sidecar_seq_api::Sequencer;
 use idol_runtime::RequestError;
@@ -14,8 +14,9 @@ use vsc7448::{
 };
 use vsc7448_pac::{DEVCPU_GCB, HSIO, VAUI0, VAUI1, phy};
 
+task_slot!(FRONT_IO, front_io);
+task_slot!(FRONT_IO_FPGA, ecp5_front_io);
 task_slot!(SEQ, seq);
-task_slot!(FRONT_IO, ecp5_front_io);
 
 /// Interval at which `Bsp::wake()` is called by the main loop
 pub const WAKE_INTERVAL: Option<u32> = Some(500);
@@ -66,6 +67,9 @@ pub struct Bsp<'a, R> {
 
     /// Handle for the sequencer task
     seq: Sequencer,
+
+    /// Handle for the front IO task
+    front_io: FrontIO,
 
     /// PHY for the on-board PHY ("PHY4")
     vsc8504: Vsc8504,
@@ -178,20 +182,21 @@ pub fn preinit() {
 impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
     /// Constructs and initializes a new BSP handle
     pub fn new(vsc7448: &'a Vsc7448<'a, R>) -> Result<Self, VscError> {
-        let seq = Sequencer::from(SEQ.get_task_id());
-        let has_front_io = seq.front_io_board_present();
+        let front_io = FrontIO::from(FRONT_IO.get_task_id());
+        let has_front_io = front_io.board_present();
         let mut out = Bsp {
             vsc7448,
             vsc8504: Vsc8504::empty(),
             vsc8562: if has_front_io {
-                Some(PhySmi::new(FRONT_IO.get_task_id()))
+                Some(PhySmi::new(FRONT_IO_FPGA.get_task_id()))
             } else {
                 None
             },
             front_io_speed: [Speed::Speed1G; 2],
             link_down_at: None,
             vlan_mode: VLanMode::Locked,
-            seq,
+            seq: Sequencer::from(SEQ.get_task_id()),
+            front_io,
         };
 
         out.reinit()?;
@@ -276,8 +281,8 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             // Notify the sequencer about the state of the oscillator. If the
             // oscillator is good any future resets of the PHY do not require a
             // full power cycle of the front IO board.
-            self.seq
-                .set_front_io_phy_osc_state(osc_good)
+            self.front_io
+                .phy_set_osc_state(osc_good)
                 .map_err(|e| VscError::ProxyError(e.into()))?;
 
             if !osc_good {
@@ -431,8 +436,8 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             // Request a reset of the PHY. If we had previously marked the PHY
             // oscillator as bad, then this power-cycles the entire front IO
             // board; otherwise, it only power-cycles the PHY.
-            self.seq
-                .reset_front_io_phy()
+            self.front_io
+                .phy_reset()
                 .map_err(|e| VscError::ProxyError(e.into()))?;
 
             for p in 0..2 {


### PR DESCRIPTION
This change adds a `front-io-server` where we can start to migrate front IO specific functionality into. Proxying all sequencing related IPCs is a small step in decoupling the front IO logic from the mainboard logic in sidecar. This does not tackle transceiver logic, the front IO I2C bus, or general front IO specific sequencing yet. I'll begin to move those over in a future change.