### PR TITLE
[xtask] Correct help message to match CLI flag

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -564,7 +564,7 @@ pub fn package(
                         bail!(
                             "task {task_name} contains your home directory; \
                              the build is probably not reproducible!\n\
-                             Use `--dangerously-skip-path-checks` to disable \
+                             Use `--dangerously-skip-path-check` to disable \
                              this check"
                         );
                     }


### PR DESCRIPTION
The help message currently says `--dangerously-skip-path-checks`, while the CLI is looking for `--dangerously-skip-path-check`. Assuming we'd prefer to update the human output rather than break any existing tooling, I took the singular form.