### PR TITLE
sidecar: enable `rng-driver`'s "ereport" feature

### DIFF
--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -56,13 +56,13 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.rng_driver]
-features = ["h753"]
+features = ["h753", "ereport"]
 name = "drv-stm32h7-rng"
 priority = 6
 uses = ["rng"]
 start = true
 stacksize = 512
-task-slots = ["sys"]
+task-slots = ["sys", "packrat"]
 
 [tasks.update_server]
 name = "stm32h7-update-server"


### PR DESCRIPTION
In order for ereports to be collected via the `snitch` task, `packrat` must have received the system's restart ID, which is generated by the `rng_driver` task. The `drv-stm32h7-rng` task's "ereport" feature flag configures the RNG driver to send packrat a restart ID when it starts up. Unfortunately, I am stupid. On Sidecar, I apparently forgot to enable this feature in the config file. This means that attempts to collect ereports from the sidecar SP have, apparently, never worked.

I discovered this by looking at the `packrat` ringbuf and the `snitch` counters on one of dogfood's sidecars after @wfchandler informed me that he was not able to use `faux-mgs` to collect ereports from a sidecar:

```console
eliza@castle ~ $ /staff/john/humility -a /staff/dock/mupdate-shipped/mupdate-20260421-v19.2rc0/build-sidecar-image-b.zip --ip 'fe80::aa40:25ff:fe05:0%rack2sw0tp0' ringbuf packrat
humility: connecting to fe80::aa40:25ff:fe05:0%13
humility: ring buffer drv_packrat_vpd_loader::__RINGBUF in sequencer:
humility: ring buffer task_packrat::__RINGBUF in packrat:
 NDX LINE      GEN    COUNT PAYLOAD
   0  255        1        1 MacAddressBlockSet(Set(MacAddressBlock { base_mac: [ 0xa8, 0x40, 0x25, 0x5, 0x0, 0x0 ], count: U16<zerocopy::byteorder::LittleEndian>([ 0x0, 0x1 ], PhantomData<zerocopy::byteorder::LittleEndian>), stride: 0x1 }))
   1  255        1        1 VpdIdentitySet(Set(OxideIdentity { part_number: [ 0x39, 0x31, 0x33, 0x2d, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x36 ], revision: 0x4, serial: [ 0x42, 0x52, 0x4d, 0x34, 0x34, 0x32, 0x32, 0x30, 0x30, 0x31, 0x32 ] }))
humility: ring buffer task_packrat::ereport::__RINGBUF in packrat:
   TOTAL VARIANT
  449641 ReadRequest
 NDX LINE      GEN    COUNT PAYLOAD
   0  328        1    65535 ReadRequest { restart_id: 0x0 }
   1  328        1    65535 ReadRequest { restart_id: 0x0 }
   2  328        1    65535 ReadRequest { restart_id: 0x0 }
   3  328        1    65535 ReadRequest { restart_id: 0x0 }
   4  328        1    65535 ReadRequest { restart_id: 0x0 }
   5  328        1    65535 ReadRequest { restart_id: 0x0 }
   6  328        1    56431 ReadRequest { restart_id: 0x0 }
eliza@castle ~ $ /staff/john/humility -a /staff/dock/mupdate-shipped/mupdate-20260421-v19.2rc0/build-sidecar-image-b.zip --ip 'fe80::aa40:25ff:fe05:0%rack2sw0tp0' counters snitch
humility: connecting to fe80::aa40:25ff:fe05:0%13
snitch
 |
 +---> task_net_api::__NET_CLIENT_COUNTERS:
 |  777112301 recv_packet(Err(QueueEmpty))
 |    449641 recv_packet(Ok)
 +---> task_packrat_api::__PACKRAT_CLIENT_COUNTERS:
 |    449641 read_ereports(Err(RestartIdNotSet))
 +---> task_snitch::__COUNTERS:
      449641 RecvPacket
      449641 ReadError(RestartIdNotSet)
eliza@castle ~ $

```
Note that all the attempts to read ereports coming from the control plane have failed with `ReadError(RestartIdNotSet)`. For those of you following along from home, it's, uh, **not supposed to do that**.

This commit fixes it by adding the feature flag. Oops. Sigh.

I believe this is the root cause of the missing Sidecar ereports I mentioned in https://github.com/oxidecomputer/omicron/issues/10223#issuecomment-4193885303. So, this fixes oxidecomputer/omicron#10223.