### PR TITLE
Set VLAN FID in configuration

### DIFF
--- a/drv/vsc7448/src/lib.rs
+++ b/drv/vsc7448/src/lib.rs
@@ -741,10 +741,17 @@ impl<'a, R: Vsc7448Rw> Vsc7448<'a, R> {
             if let Some(mask) = f(p) {
                 // Configure the 0x1YY VLAN, using our closure to decide what
                 // mask to apply
-                self.write_port_mask(
-                    ANA_L3().VLAN(0x100 + p as u16).VLAN_MASK_CFG(),
-                    mask,
-                )?;
+                let vid = 0x100 + p as u16;
+                self.write_port_mask(ANA_L3().VLAN(vid).VLAN_MASK_CFG(), mask)?;
+
+                // Configure the VLAN so that the classified VID is also copied
+                // to the FID ("filtering ID") field in packet metadata.  The
+                // FID is used as part of the MAC table entry (along with the
+                // source MAC), so this is necessary to make the MAC tables
+                // VLAN-aware.
+                self.write_with(ANA_L3().VLAN(vid).VLAN_CFG(), |r| {
+                    r.set_vlan_fid(u32::from(vid))
+                })?;
             }
         }
         Ok(())


### PR DESCRIPTION
The MAC tables in the VSC7448 contain a map from `(source mac, filtering id)` tuples to port.  The filtering id field ("FID") allows for VLAN-aware learning.

Unfortunately, you have to explicitly set a flag to copy the classified VID to the FID.

If you're in a situation where you see the same MAC address on multiple ports (which are on different VLANs), properly setting the FID is load-bearing; otherwise, that MAC address will randomly wander between those ports, and packets directed to that MAC address have unpredictable deliverability.

Fixes https://github.com/oxidecomputer/mfg/issues/224