### PR TITLE
doc: clarify that the supervisor crashing doesn't reboot yet

### DIFF
--- a/doc/guide/supervision.adoc
+++ b/doc/guide/supervision.adoc
@@ -31,7 +31,9 @@ differently:
 
 - The supervisor task is allowed to send any kernel IPC message.
 
-- If the supervisor task crashes, **the system reboots.**
+- If the supervisor task crashes, **the system is assumed to stop working.**
+  The intent is to make the exact behavior application controlled, but the
+  implementation is not yet done.
 
 == What does the supervisor do?
 


### PR DESCRIPTION
Thanks to @jamesmunns for the feedback on this text still being in the reference manual. There may be other places where we make this assertion that I didn't find.