### PR TITLE
Set rustfmt edition and style_edition for consistency

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,3 @@
 max_width = 80
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
Before, running `rustfmt` on an individual file (eg. via an editor plugin) would sometimes produce different formatting than running `cargo fmt` on the whole workspace. That seems to be because `cargo fmt` infers the `edition` and `style_edition`  from Cargo.toml, but `rustfmt` needs them to be set explicitly in .rustfmt.toml.

Here's a specific formatting difference in case anyone's curious or wants to test it. 

`rustfmt` (before this PR):
```
use foo::{a::C, B};
```
`cargo fmt` (always), and `rustfmt` (after this PR):
```
use foo::{B, a::C};
```

So to be clear, this PR does not change the output of `cargo fmt`. The only downside I know of is that if we bump the edition of the crates, we'll need to remember to bump it in .rustfmt.toml too.