### PR TITLE
Switch to stable Rust

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,2 @@
 [alias]
 xtask = "run --package xtask --"
-
-[build]
-# The purpose of this flag is to block crates using version_detect from "detecting"
-# features that are no longer supported by the toolchain, because despite its name,
-# version_detect is basically "if nightly { return true; }". This setting gets
-# overridden within xtask for Hubris programs, so this only affects host tools like
-# xtask.
-rustflags = ["-Zallow-features=proc_macro_diagnostic,used_with_arg,proc_macro_span"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,11 +4443,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",

--- a/build/spi/src/lib.rs
+++ b/build/spi/src/lib.rs
@@ -85,24 +85,19 @@ pub struct DeviceDescriptorConfig {
     pub cs: Vec<GpioPinConfig>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Deserialize)]
 pub enum ClockDivider {
     DIV2,
     DIV4,
     DIV8,
     DIV16,
     DIV32,
+    // When this config mechanism was introduced, we had everything set at
+    // DIV64 for a ~1.5625 MHz SCK rate.
+    #[default]
     DIV64,
     DIV128,
     DIV256,
-}
-
-impl Default for ClockDivider {
-    fn default() -> ClockDivider {
-        // When this config mechanism was introduced, we had everything set at
-        // DIV64 for a ~1.5625 MHz SCK rate.
-        Self::DIV64
-    }
 }
 
 impl ToTokens for SpiConfig {

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -703,20 +703,6 @@ impl BuildConfig<'_> {
         let mut cmd =
             std::process::Command::new(self.sysroot.join("bin").join("cargo"));
 
-        let mut nightly_features = vec![];
-        // nightly features that we use:
-        nightly_features.extend(["emit_stack_sizes"]);
-        // nightly features that our dependencies use:
-        nightly_features.extend([
-            "backtrace",
-            "error_generic_member_access",
-            "proc_macro_span",
-            "proc_macro_span_shrink",
-            "provide_any",
-        ]);
-
-        cmd.arg(format!("-Zallow-features={}", nightly_features.join(",")));
-
         cmd.arg(subcommand);
         cmd.arg("-p").arg(&self.crate_name);
         for a in &self.args {

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1370,6 +1370,7 @@ pub fn build_task_bindep(
         "RUSTFLAGS",
         format!("{COMMON_RUSTFLAGS} {}", cfg.remap_path_flags(),),
     );
+    cmd.env("RUSTC_BOOTSTRAP", "1");
     let mut handle = cmd.spawn().context("failed to spawn bindep command")?;
     let out = handle.wait()?;
     if !out.success() {
@@ -2283,6 +2284,7 @@ const COMMON_RUSTFLAGS: &str = "\
     -C link-arg=-z -C link-arg=common-page-size=0x20 \
     -C link-arg=-z -C link-arg=max-page-size=0x20 \
     -C llvm-args=--enable-machine-outliner=never \
+    -Z allow-features= \
     -Z emit-stack-sizes \
     -Z macro-backtrace \
     -C overflow-checks=y";
@@ -2317,6 +2319,7 @@ fn build(
             cfg.remap_path_flags(),
         ),
     );
+    cmd.env("RUSTC_BOOTSTRAP", "1");
     cmd.arg("--");
 
     // We use attributes to conditionally import based on feature flags;

--- a/drv/cosmo-hf/src/hf.rs
+++ b/drv/cosmo-hf/src/hf.rs
@@ -346,10 +346,8 @@ impl ServerImpl {
     fn invalidate_write(&mut self) {
         match self.hash.state {
             // Only stop the hash for our current device
-            HashState::Hashing { dev, .. } => {
-                if dev == self.dev {
-                    self.hash.state = HashState::NotRunning;
-                }
+            HashState::Hashing { dev, .. } if dev == self.dev => {
+                self.hash.state = HashState::NotRunning;
             }
             _ => (),
         }

--- a/drv/cosmo-seq-server/src/main.rs
+++ b/drv/cosmo-seq-server/src/main.rs
@@ -549,24 +549,24 @@ impl ServerImpl {
                         Ok(A0Sm::Faulted) | Err(_) => {
                             break;
                         }
-                        Ok(A0Sm::EnableGrpA) => {
-                            // hardware-cosmo#658 prevents us from checking `CPU_PRESENT`
-                            // at `A0Sm::ENABLE_GRP_A` time on rev-a boards
-                            if !cfg!(target_board = "cosmo-a") {
-                                let present =
-                                    self.sys.gpio_read(SP5_TO_SP_PRESENT_L)
-                                        == 0;
+                        // hardware-cosmo#658 prevents us from checking
+                        // `CPU_PRESENT` at `A0Sm::ENABLE_GRP_A` time on rev-a
+                        // boards
+                        Ok(A0Sm::EnableGrpA)
+                            if !cfg!(target_board = "cosmo-a") =>
+                        {
+                            let present =
+                                self.sys.gpio_read(SP5_TO_SP_PRESENT_L) == 0;
 
-                                if !present {
-                                    ringbuf_entry!(Trace::CPUNotPresent);
-                                    let _ = self.ereporter.deliver_ereport(
-                                        &ereports::cpu::CpuMissing {
-                                            cpu: &HOST_CPU_REFDES,
-                                        },
-                                    );
-                                    err = CpuSeqError::CPUNotPresent;
-                                    break;
-                                }
+                            if !present {
+                                ringbuf_entry!(Trace::CPUNotPresent);
+                                let _ = self.ereporter.deliver_ereport(
+                                    &ereports::cpu::CpuMissing {
+                                        cpu: &HOST_CPU_REFDES,
+                                    },
+                                );
+                                err = CpuSeqError::CPUNotPresent;
+                                break;
                             }
                         }
                         _ => (),

--- a/drv/gimlet-hf-server/src/main.rs
+++ b/drv/gimlet-hf-server/src/main.rs
@@ -515,10 +515,8 @@ impl ServerImpl {
     fn invalidate_write(&mut self) {
         match self.hash.state {
             // Only stop the hash for our current device
-            HashState::Hashing { dev, .. } => {
-                if dev == self.dev_state {
-                    self.hash.state = HashState::NotRunning;
-                }
+            HashState::Hashing { dev, .. } if dev == self.dev_state => {
+                self.hash.state = HashState::NotRunning;
             }
             _ => (),
         }

--- a/drv/ksz8463/src/lib.rs
+++ b/drv/ksz8463/src/lib.rs
@@ -113,17 +113,12 @@ ringbuf!(Trace, 16, Trace::None);
 
 /// Data from a management information base (MIB) counter on the chip,
 /// used to monitor port activity for network management.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum MIBCounterValue {
+    #[default]
     None,
     Count(u32),
     CountOverflow(u32),
-}
-
-impl Default for MIBCounterValue {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// `pack_with_cb` has large error types which trigger this lint
+#![allow(clippy::result_large_err)]
+
 use crate::Trace;
 use attest_api::Attest;
 use crc::{CRC_32_CKSUM, Crc};

--- a/drv/vsc85xx/src/lib.rs
+++ b/drv/vsc85xx/src/lib.rs
@@ -205,15 +205,10 @@ ringbuf!(Trace, 16, Trace::None);
 /// a counter which isn't available on this particular PHY (in particular,
 /// the VSC8552 doesn't have MAC counters); `Inactive` means that the counter
 /// is available but the active bit is cleared.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum Counter {
     Unavailable,
+    #[default]
     Inactive,
     Value(u16),
-}
-
-impl Default for Counter {
-    fn default() -> Self {
-        Self::Inactive
-    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,7 @@
 # not changed (look at `remap_paths` in `xtask/src/dist.rs`).  This remapping
 # strips local paths from panic messages, because they're bad for both
 # reproducibility and binary size.
-channel = "nightly-2025-07-20"
+channel = "1.95.0"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "clippy", "rustfmt", "rust-analyzer" ]

--- a/task/cosmo-spd/src/main.rs
+++ b/task/cosmo-spd/src/main.rs
@@ -236,13 +236,10 @@ impl ServerImpl {
             let bus = index / 6; // FPGA bus (0 or 1)
             let dev = index % 6; // device index (SDI, 0-6)
 
-            for pos in 0..2 {
+            for (pos, sensor) in DIMM_SENSORS[index].iter().enumerate() {
                 // Mark sensors as absent if they're missing
                 if !present {
-                    self.sensor.nodata_now(
-                        DIMM_SENSORS[index][pos],
-                        NoData::DeviceNotPresent,
-                    );
+                    self.sensor.nodata_now(*sensor, NoData::DeviceNotPresent);
                     continue;
                 }
 
@@ -269,10 +266,7 @@ impl ServerImpl {
                         index,
                         pos,
                     });
-                    self.sensor.nodata_now(
-                        DIMM_SENSORS[index][pos],
-                        NoData::DeviceTimeout,
-                    );
+                    self.sensor.nodata_now(*sensor, NoData::DeviceTimeout);
                     continue;
                 };
 
@@ -286,7 +280,7 @@ impl ServerImpl {
                 let temp_c = f32::from(t) * 0.0078125f32;
 
                 // Send the value to the sensors task
-                self.sensor.post_now(DIMM_SENSORS[index][pos], temp_c);
+                self.sensor.post_now(*sensor, temp_c);
             }
         }
     }


### PR DESCRIPTION
(staged on #2537)

Note that we add `-Zallow-features=` (i.e. the empty list) to ban all nightly features at the code level.  We still enable `-Z emit-stack-sizes` and `-Z macro-backtrace` in our `RUSTFLAGS`, along with `RUSTC_BOOTSTRAP=1` to unlock them.

The `num-bigint-dig` version bump is to fix forward-compatibility warnings during the build:
```
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```