### PR TITLE
Add rust-analyzer component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,4 @@
 channel = "nightly-2025-07-20"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
-components = [ "rustfmt", "rust-analyzer" ]
+components = [ "clippy", "rustfmt", "rust-analyzer" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,4 @@
 channel = "nightly-2025-07-20"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
-components = [ "rustfmt" ]
+components = [ "rustfmt", "rust-analyzer" ]


### PR DESCRIPTION
Since we support `xtask rust-analyzer`, this means that we should have the rust-analyzer component installed.