### PR TITLE
Update Brussels to 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         name: Download Brussels
         run: |
           if [[ "${BRUSSELS_RUN_ID}" == "" ]]; then
-            gh release download -R oxidecomputer/brussels -p brussels v0.3.0
+            gh release download -R oxidecomputer/brussels -p brussels v0.4.0
           else
             gh run download "${BRUSSELS_RUN_ID}" -R oxidecomputer/brussels -n prebuilt-binary
           fi


### PR DESCRIPTION
This adds to the release some metadata needed for the omicron releng integration.