### PR TITLE
Trim `hiffy` data copy

### DIFF
--- a/task/hiffy/src/main.rs
+++ b/task/hiffy/src/main.rs
@@ -497,12 +497,13 @@ mod net {
             if (meta.size as usize) < HEADER_SIZE {
                 return (RpcReply::TooShort, &[]);
             }
+            // Slice to our valid data region
+            let rx_data = &self.rx_data_buf[..meta.size as usize];
 
             // We can always read the header, since it's raw data
-            let header =
-                RpcHeader::read_from_bytes(&self.rx_data_buf[..HEADER_SIZE])
-                    .unwrap_lite();
-            let rest = &self.rx_data_buf[HEADER_SIZE..];
+            let header = RpcHeader::read_from_bytes(&rx_data[..HEADER_SIZE])
+                .unwrap_lite();
+            let rest = &rx_data[HEADER_SIZE..];
             if self.image_id != header.image_id.get() {
                 return (RpcReply::BadImageId, self.image_id.as_bytes());
             }


### PR DESCRIPTION
Previously, we would try to copy the entire packet buffer into `HIFFY_TEXT` / `HIFFY_DATA`.  This worked at offset 0 by coincidence (our packet buffer was slightly smaller than `HIFFY_TEXT`), but failed with non-zero offsets because it would overrun the buffer.

This is not the root cause of #2551, but I discovered it along the way.