### PR TITLE
Avoid trying to read DDR temps while we may be ddr training

### DIFF
--- a/task/cosmo-spd/src/main.rs
+++ b/task/cosmo-spd/src/main.rs
@@ -85,12 +85,13 @@ impl ServerImpl {
         // This laborious list is intended to ensure that new power states
         // have to be added explicitly here.
         match PowerState::from_u32(self.jefe.get_state()) {
-            Some(PowerState::A0) | Some(PowerState::A0PlusHP) => {
+            Some(PowerState::A0PlusHP) => {
                 if !self.active {
                     self.activate()
                 }
             }
-            Some(PowerState::A2)
+            Some(PowerState::A0)
+            | Some(PowerState::A2)
             | Some(PowerState::A2PlusFans)
             | Some(PowerState::A0Reset)
             | Some(PowerState::A0Thermtrip)

--- a/task/cosmo-spd/src/main.rs
+++ b/task/cosmo-spd/src/main.rs
@@ -85,6 +85,12 @@ impl ServerImpl {
         // This laborious list is intended to ensure that new power states
         // have to be added explicitly here.
         match PowerState::from_u32(self.jefe.get_state()) {
+            // We wait for boot before activating temperature polling so
+            // that we don't interrupt the SPD fetches that happen during
+            // boot. The FPGA's SPD mux has proven to have some bugs that
+            // are difficult to reproduce, but seen frequently enough in the
+            // wild, so this is a workaround totally avoids any interaction
+            // with the DDR i2c bus until we're fully booted.
             Some(PowerState::A0PlusHP) => {
                 if !self.active {
                     self.activate()


### PR DESCRIPTION
This PR avoids doing hubris temperature polling i2c transactions (via FPGA) to the DDR subsystem until we have booted to avoid possible contention during boot and DDR training.

We continue to fight with getting successful DDR training every boot which we think is related to bugs in the SPD proxy implementation in the FPGA.  It is unfortunately difficult to get a large enough sample size of boots on an instrumented cosmo to statistically prove a fix and we keep running into issues in larger field deployments.  This provides a workaround where we don't do the SPD proxy during the boot phase which is where all of the existing bugs have been seen (and fixed). It is not critical to monitor temp during the boot phase so by avoiding this, we avoid bus contention during the critical boot phase until we can come up with a more extensive reproducer and fix the remaining bugs or better understand the failures we're seeing.