### PR TITLE
Store measurement result for debug

### DIFF
--- a/drv/stm32h7-startup/src/lib.rs
+++ b/drv/stm32h7-startup/src/lib.rs
@@ -114,9 +114,17 @@ pub fn system_init_custom(
     // Before doing anything else, check for a measurement handoff token
     #[cfg(feature = "measurement-handoff")]
     unsafe {
+        // After each delay, we'll wait roughly 200 ms.  We double the naive
+        // cycle count because the STM32H7 may (under some circumstances)
+        // dual-issue instructions in the delay loop, which would make the loop
+        // run twice as fast as expected.  We'd rather the loop sometimes run
+        // twice as *slow*, because that just slows down SP boot in cases where
+        // the RoT is not present; if the loop is twice as fast, the SP can time
+        // out before RoT comes up at all, which is a much worse failure mode.
+        const DELAY_CYCLES: u32 = 12860000 * 2;
         const RETRY_COUNT: u32 = 20;
         measurement_handoff::check(RETRY_COUNT, || {
-            cortex_m::asm::delay(12860000); // about 200 ms
+            cortex_m::asm::delay(DELAY_CYCLES);
             cortex_m::peripheral::SCB::sys_reset()
         });
     }

--- a/lib/measurement-handoff/src/lib.rs
+++ b/lib/measurement-handoff/src/lib.rs
@@ -39,6 +39,35 @@ unsafe extern "C" {
     static mut __REGION_DTCM_END: [u8; 0];
 }
 
+#[derive(Copy, Clone)]
+pub enum MeasurementResult {
+    /// [`measurement_token::SKIP`] was found in the token slot
+    ///
+    /// This indicates that an external source (typically an attached debugger)
+    /// has instructed Hubris to skip the wait-for-measurement reboot dance.
+    Skipped,
+    /// [`measurement_token::VALID`] was found in the token slot
+    ///
+    /// This indicates that the Root of Trust has measured the SP image
+    Valid { count: Option<u32> },
+    /// Hubris exceeded its retry count and booted without being measured
+    RetryCountExceeded,
+}
+
+impl MeasurementResult {
+    /// Checks whether the result represents a valid measurement
+    fn is_valid(&self) -> bool {
+        match self {
+            MeasurementResult::Valid { .. } => true,
+            MeasurementResult::Skipped
+            | MeasurementResult::RetryCountExceeded => false,
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub static mut HUBRIS_MEASUREMENT_RESULT: Option<MeasurementResult> = None;
+
 /// Check the measurement token, calling `reset_fn` to reset if needed
 ///
 /// Calls `delay_and_reset` (which diverges) if no measurement is present and we
@@ -63,26 +92,35 @@ pub unsafe fn check(retry_count: u32, delay_and_reset: fn() -> !) -> bool {
         (token, tag, counter, check)
     };
 
-    let out = if token == measurement_token::VALID {
-        Ok(true) // told that measurement was completed
+    let counter_valid = tag == COUNTER_TAG && tag ^ counter == check;
+    let result = if token == measurement_token::VALID {
+        // told that measurement was completed
+        let count = if counter_valid { Some(counter) } else { None };
+        Ok(MeasurementResult::Valid { count })
     } else if token == measurement_token::SKIP {
-        Ok(false) // told to skip measuring
-    } else if tag != COUNTER_TAG || tag ^ counter != check {
-        Err(0) // no counter, so initialize it
+        // told to skip measuring
+        Ok(MeasurementResult::Skipped)
+    } else if !counter_valid {
+        // no counter, so initialize it
+        Err(0)
     } else if counter >= retry_count {
-        Ok(false) // exceeded retry count, so boot
+        // exceeded retry count, so boot
+        Ok(MeasurementResult::RetryCountExceeded)
     } else {
-        Err(counter) // we should reset the processor
+        // we should reset the processor
+        Err(counter)
     };
 
-    match out {
-        Ok(v) => {
-            // Destroy the existing token
+    match result {
+        Ok(r) => {
+            // Destroy the existing token and write our global variable for
+            // later debugging.
             unsafe {
                 core::ptr::write_volatile(ptr, 0);
                 core::ptr::write_volatile(ptr.wrapping_add(1), 0);
+                HUBRIS_MEASUREMENT_RESULT = Some(r);
             }
-            v
+            r.is_valid()
         }
         Err(counter) => {
             // Increment the counter, then reset


### PR DESCRIPTION
When debugging https://github.com/oxidecomputer/customer-support/issues/1271, knowing whether the SP was measured on boot would bifurcate the problem space.  Unfortunately, the measurement token is in a section of RAM used by `net`, so it's been wiped with our stack fill.

```
$ humility -d rack-0801-cosmo-209MYPCP-hubris.dump.0 readmem 0x20000000 64
humility: attached to dump
             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0x20000000 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x20000010 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x20000020 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
0x20000030 | fe ca dd ba fe ca dd ba fe ca dd ba fe ca dd ba | ................
```

This PR adds `HUBRIS_MEASUREMENT_RESULT`, which caches the result and can be read with a debugger (or from a full-system dump).

I tested all of the variants on my desktop:
```console
# reflash, which sends the SKIP token
$ humility flash -F
humility: attaching with chip set to "STM32H753ZITx"
humility: attached via CMSIS-DAP
humility: verified auxflash in slot 0
humility: archive appears to be already flashed; forcing re-flash
humility: skipping measurement token handoff
humility: auxiliary flash data is already loaded in slot 0; skipping programming
humility: done with auxiliary flash
humility: flashing done
$ humility readvar HUBRIS_MEASUREMENT_RESULT
humility: attached via CMSIS-DAP
HUBRIS_MEASUREMENT_RESULT (0x24000404) = Some(Skipped)

# reset the SP; the RoT measures it immediately
$ humility readvar HUBRIS_MEASUREMENT_RESULT
humility: attached via CMSIS-DAP
HUBRIS_MEASUREMENT_RESULT (0x24000404) = Some(Valid {
        count: None
    })

# reset the SP and RoT; release the RoT slightly after SP so the SP resets a few times
$ humility readvar HUBRIS_MEASUREMENT_RESULT
humility: attached via CMSIS-DAP
HUBRIS_MEASUREMENT_RESULT (0x24000404) = Some(Valid {
        count: Some(0xe)
    })

# hold the RoT in reset while resetting SP, so the SP times out
$ humility readvar HUBRIS_MEASUREMENT_RESULT
humility: attached via CMSIS-DAP
HUBRIS_MEASUREMENT_RESULT (0x24000404) = Some(RetryCountExceeded)
```