### PR TITLE
Update versioning scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       brussels-run-id:
         description: Download Brussels from a Run ID
         type: string
+      override-version:
+        description: Custom version number
+        type: string
 
 # Prevent multiple releases for the same group from happening concurrently.
 concurrency:
@@ -42,7 +45,7 @@ jobs:
         name: Download Brussels
         run: |
           if [[ "${BRUSSELS_RUN_ID}" == "" ]]; then
-            gh release download -R oxidecomputer/brussels -p brussels v0.4.0
+            gh release download -R oxidecomputer/brussels -p brussels v0.5.0
           else
             gh run download "${BRUSSELS_RUN_ID}" -R oxidecomputer/brussels -n prebuilt-binary
           fi
@@ -54,10 +57,16 @@ jobs:
 
       - id: init
         name: Initialize the release
-        run: brussels init "$group" HEAD >brussels-manifest.json
+        run: |
+          flags=()
+          if [[ "${override_version}" != "" ]]; then
+            flags+=("--override-version=${override_version}")
+          fi
+          brussels init "$group" HEAD "${flags[@]}" >brussels-manifest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           group: ${{ github.event.inputs.group }}
+          override_version: ${{ github.event.inputs.override-version }}
 
       - name: Upload the release manifest
         uses: actions/upload-artifact@v4

--- a/brussels.toml
+++ b/brussels.toml
@@ -12,7 +12,7 @@ workflow-file = ".github/workflows/release.yml"
 runner-environment = "self-hosted"
 
 [groups.all-sp]
-tag-bump = "patch"
+tag-bump = "minor"
 tag-prefix = "all-sp-v"
 hubris-app-dirs = [
     "app/sidecar/",
@@ -58,7 +58,7 @@ cosmo-b-lab = {}
 observer-a = {}
 
 [groups.rot]
-tag-bump = "patch"
+tag-bump = "minor"
 tag-prefix = "oxide-rot-1-v"
 hubris-app-dirs = ["app/oxide-rot-1/"]
 


### PR DESCRIPTION
This PR updates Brussels and the release workflow to support the proposed versioning scheme in [RFD 705](https://rfd.shared.oxide.computer/rfd/0705) (tl;dr moving the version number to the minor number rather than the patch, to support backports). The new "Custom version number" field in the release workflow will allow both to migrate to the new versioning scheme, and to issue patch releases (where we'll want to bump the patch number rather than let Brussels bump the minor number).