### PR TITLE
lib/ringbuf: fix two macro syntax bugs in no_dedup and all-disabled arms

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -292,7 +292,7 @@ macro_rules! ringbuf {
             });
     };
     ($name:ident, $t:ty, $n:expr, $init:expr, no_dedup $(,)?) => {
-        static $name: $crate::StaticCell<$crate::Ringbuf<$t, () $n>> =
+        static $name: $crate::StaticCell<$crate::Ringbuf<$t, (), $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
                 buffer: [$crate::RingbufEntry {
@@ -431,7 +431,7 @@ macro_rules! counted_ringbuf {
 #[macro_export]
 macro_rules! counted_ringbuf {
     ($name:ident, $t:ident, $n:expr, $init:expr, no_dedup $(,)?) => {
-        $crate::counted_ringbuf!(%name, $t, $n, $init)
+        $crate::counted_ringbuf!($name, $t, $n, $init)
     };
     ($name:ident, $t:ident, $n:expr, $init:expr $(,)?) => {
         #[allow(dead_code)]

--- a/lib/ringbuf/tests/no_dedup_first_entry.rs
+++ b/lib/ringbuf/tests/no_dedup_first_entry.rs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Verifies that the named no_dedup ringbuf arm records its first entry into
+//! slot 0. One static, one test function — no shared state with other files.
+
+use ringbuf::RecordEntry;
+
+ringbuf::ringbuf!(BUF_FIRST, u32, 4, 0u32, no_dedup);
+
+#[test]
+fn records_first_entry() {
+    BUF_FIRST.record_entry(1, 7u32);
+
+    let ring = BUF_FIRST.try_borrow_mut().unwrap();
+    assert_eq!(ring.last, Some(0));
+    assert_eq!(ring.buffer[0].payload, 7u32);
+    assert_eq!(ring.buffer[0].line, 1);
+}

--- a/lib/ringbuf/tests/no_dedup_no_collapse.rs
+++ b/lib/ringbuf/tests/no_dedup_no_collapse.rs
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Verifies that identical consecutive entries each consume a new slot rather
+//! than incrementing a counter — the defining behaviour of no_dedup.
+//! One static, one test function — no shared state with other files.
+
+use ringbuf::RecordEntry;
+
+ringbuf::ringbuf!(BUF_COLLAPSE, u32, 4, 0u32, no_dedup);
+
+#[test]
+fn identical_entries_are_not_collapsed() {
+    BUF_COLLAPSE.record_entry(1, 99u32);
+    BUF_COLLAPSE.record_entry(1, 99u32);
+
+    let ring = BUF_COLLAPSE.try_borrow_mut().unwrap();
+    assert_eq!(ring.last, Some(1));
+    assert_eq!(ring.buffer[0].payload, 99u32);
+    assert_eq!(ring.buffer[1].payload, 99u32);
+}

--- a/lib/ringbuf/tests/no_dedup_unnamed.rs
+++ b/lib/ringbuf/tests/no_dedup_unnamed.rs
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Verifies that the unnamed `ringbuf!(T, N, init, no_dedup)` form delegates
+//! correctly to the named arm. One static (__RINGBUF), one test function.
+
+use ringbuf::RecordEntry;
+
+ringbuf::ringbuf!(u32, 4, 0u32, no_dedup);
+
+#[test]
+fn unnamed_no_dedup_records_entry() {
+    __RINGBUF.record_entry(1, 55u32);
+
+    let ring = __RINGBUF.try_borrow_mut().unwrap();
+    assert_eq!(ring.last, Some(0));
+    assert_eq!(ring.buffer[0].payload, 55u32);
+}


### PR DESCRIPTION
Two syntactically invalid macro arms in lib/ringbuf/src/lib.rs.

The first is in the `#[cfg(not(feature = "disabled"))]` `ringbuf!` macro,
`no_dedup` named arm (line 295). The type expression reads
`Ringbuf<$t, () $n>` — two adjacent generic arguments with no separator.
Rust requires a comma between them; the correct form is `Ringbuf<$t, (), $n>`.
The parallel default arm on line 283 already has this right (`u16, $n`).

The second is in the `#[cfg(all(counters, counters-disabled, disabled))]`
`counted_ringbuf!` macro, `no_dedup` named arm (line 434). The recursive
call uses `%name` instead of `$name` — `%` is not a Rust macro metavariable
sigil. Every other forwarding arm in the file uses `$name`; this one was
a typo.

Neither arm has an active caller in this repo under the currently enabled
feature combinations, so both are latent compile errors. Adds three
integration tests (one function per file, one static per test) covering
the named no_dedup arm, the unnamed delegation form, and the no-collapse
behaviour that distinguishes no_dedup from the default dedup mode.