### PR TITLE
Remove mitigation for loop miscompilation in idle task

### DIFF
--- a/task/idle/src/main.rs
+++ b/task/idle/src/main.rs
@@ -12,20 +12,18 @@ extern crate userlib;
 #[unsafe(export_name = "main")]
 fn main() -> ! {
     loop {
-        if cfg!(feature = "insomniac") {
-            // In insomniac-mode, we just spinloop to absorb idle cycles. This
-            // is useful on certain processors where entering a low-power state
-            // interrupts debugging.
-            //
-            // Note that this is an explicit nop rather than an empty block
-            // because an empty `loop {}` is technically UB and will be replaced
-            // by a trap, bringing the system to a halt with no tasks runnable.
-            // So, do not get clever and remove this.
-            cortex_m::asm::nop();
-        } else {
-            // Wait For Interrupt to pause the processor until an ISR arrives,
-            // which could wake some higher-priority task.
-            cortex_m::asm::wfi();
-        }
+        // In insomniac-mode, we just spinloop to absorb idle cycles. This
+        // is useful on certain processors where entering a low-power state
+        // interrupts debugging.
+        //
+        // An empty loop *used* to cause UB, due to a bug in LLVM (see
+        // https://github.com/rust-lang/rust/issues/28728), but was later fixed
+        // by the upgrade to LLVM12, which resolved this in Rust 1.52.0 (see
+        // https://github.com/rust-lang/rust/pull/81451).
+        //
+        // Wait For Interrupt to pause the processor until an ISR arrives,
+        // which could wake some higher-priority task.
+        #[cfg(not(feature = "insomniac"))]
+        cortex_m::asm::wfi();
     }
 }

--- a/task/idle/src/main.rs
+++ b/task/idle/src/main.rs
@@ -11,6 +11,7 @@ extern crate userlib;
 
 #[unsafe(export_name = "main")]
 fn main() -> ! {
+    #[allow(clippy::empty_loop)]
     loop {
         // In insomniac-mode, we just spinloop to absorb idle cycles. This
         // is useful on certain processors where entering a low-power state


### PR DESCRIPTION
We are now far beyond Rust [v1.52](https://github.com/rust-lang/rust/blob/main/RELEASES.md#version-1520-2021-05-06), which updated to LLVM12 and removed this defect. See:

* https://github.com/rust-lang/rust/issues/28728
* https://github.com/rust-lang/rust/pull/81451