### PR TITLE
Read env var in `task_config` proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5879,12 +5879,12 @@ dependencies = [
 name = "task-config"
 version = "0.1.0"
 dependencies = [
- "build-util",
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.106",
  "toml 1.1.2+spec-1.1.0",
+ "toml-task",
 ]
 
 [[package]]

--- a/lib/task-config/Cargo.toml
+++ b/lib/task-config/Cargo.toml
@@ -9,7 +9,7 @@ quote = { workspace = true }
 serde = { workspace = true }
 syn = { workspace = true }
 toml = { workspace = true }
-build-util = { path = "../../build/util" }
+toml-task = { path = "../../lib/toml-task" }
 
 [lib]
 proc-macro = true

--- a/lib/task-config/src/lib.rs
+++ b/lib/task-config/src/lib.rs
@@ -165,7 +165,7 @@ pub fn task_config(tokens: TokenStream) -> TokenStream {
     // rebuilds if it changes (and trust it's optimized out by the compiler)
     quote! {
         mod _hidden {
-            pub const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
+            const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
         }
         struct Config {
             #(#fields),*
@@ -210,7 +210,7 @@ pub fn optional_task_config(tokens: TokenStream) -> TokenStream {
     // rebuilds if it changes (and trust it's optimized out by the compiler)
     quote! {
         mod _hidden {
-            pub const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
+            const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
         }
         struct Config {
             #(#fields),*

--- a/lib/task-config/src/lib.rs
+++ b/lib/task-config/src/lib.rs
@@ -142,7 +142,7 @@ fn config_to_token(
 /// cannot be configured using this macro).
 #[proc_macro]
 pub fn task_config(tokens: TokenStream) -> TokenStream {
-    let config = build_util::task_config::<toml::Value>().unwrap();
+    let config = get_task_config().expect("task config is missing");
 
     let input = parse_macro_input!(tokens as Config);
     let fields = input.items.iter();
@@ -160,14 +160,13 @@ pub fn task_config(tokens: TokenStream) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
-    let app_toml_path = std::env::var("HUBRIS_APP_TOML")
-        .expect("Could not find 'HUBRIS_APP_TOML' environment variable");
-
     // Once `proc_macro::tracked_env::var` is stable, we won't need to use
-    // this hack, but until then, we include the app TOML file to force
+    // this hack, but until then, we include the environment variable to force
     // rebuilds if it changes (and trust it's optimized out by the compiler)
     quote! {
-        const APP_TOML_TO_ENSURE_REBUILD: &[u8] = include_bytes!(#app_toml_path);
+        mod _hidden {
+            pub const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
+        }
         struct Config {
             #(#fields),*
         }
@@ -185,10 +184,7 @@ pub fn task_config(tokens: TokenStream) -> TokenStream {
 pub fn optional_task_config(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input!(tokens as Config);
     let fields = input.items.iter();
-    let app_toml_path = std::env::var("HUBRIS_APP_TOML")
-        .expect("Could not find 'HUBRIS_APP_TOML' environment variable");
-
-    let cfg_val = if let Ok(config) = build_util::task_config::<toml::Value>() {
+    let cfg_val = if let Some(config) = get_task_config() {
         let values = input
             .items
             .iter()
@@ -201,10 +197,6 @@ pub fn optional_task_config(tokens: TokenStream) -> TokenStream {
                 quote! { #ident: #vs }
             })
             .collect::<Vec<_>>();
-
-        // Once `proc_macro::tracked_env::var` is stable, we won't need to use
-        // this hack, but until then, we include the app TOML file to force
-        // rebuilds if it changes (and trust it's optimized out by the compiler)
         quote! {
             Some(Config {
                 #(#values),*
@@ -214,14 +206,34 @@ pub fn optional_task_config(tokens: TokenStream) -> TokenStream {
         quote! { None }
     };
     // Once `proc_macro::tracked_env::var` is stable, we won't need to use
-    // this hack, but until then, we include the app TOML file to force
+    // this hack, but until then, we include the environment variable to force
     // rebuilds if it changes (and trust it's optimized out by the compiler)
     quote! {
-        const APP_TOML_TO_ENSURE_REBUILD: &[u8] = include_bytes!(#app_toml_path);
+        mod _hidden {
+            pub const _REBUILDER: &'static str = core::env!("HUBRIS_TASK_CONFIG");
+        }
         struct Config {
             #(#fields),*
         }
         const TASK_CONFIG: Option<Config> = #cfg_val;
     }
     .into()
+}
+
+/// Gets a task config from `HUBRIS_TASK_CONFIG`
+///
+/// Note that this is used instead of `build_utils::task_config`; the functions
+/// in `build_utils` print a `cargo::rerun-if-env-changed` message, which isn't
+/// valid in a proc_macro context.
+///
+/// # Panics
+/// If the environment variable is missing or the task TOML cannot be parsed
+fn get_task_config() -> Option<toml::Value> {
+    let config = std::env::var("HUBRIS_TASK_CONFIG")
+        .map_err(|e| format!("could not read HUBRIS_TASK_CONFIG: {e:#}"))
+        .unwrap();
+    toml::from_str::<toml_task::Task<toml::Value>>(&config)
+        .map_err(|e| format!("could not deserialize configuration: {e:#}"))
+        .unwrap()
+        .config
 }


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/hubris/issues/2523

I tested this by building `app/grapefruit/rev-a.toml`, then applying this patch and doing `cargo xtask build --dirty ...` (to avoid the "rerun on manifest change "behavior"):

```
diff --git a/app/grapefruit/base.toml b/app/grapefruit/base.toml
index 6eaeea5f78..bcba1bc935 100644
--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -193,7 +193,7 @@

 [tasks.spartan7_loader.config]
 program_l = "sys_api::Port::B.pin(6)"
-init_l = "sys_api::Port::B.pin(5)"
+init_l = "sys_api::Port::B"
 config_done = "sys_api::Port::B.pin(4)"
 user_reset_l = "sys_api::Port::I.pin(15)"
```

```
building crate drv-spartan7-loader
   Compiling drv-spartan7-loader v0.1.0 (/Users/mjk/oxide/hubris/drv/spartan7-loader)
error[E0308]: mismatched types
   --> drv/spartan7-loader/src/main.rs:127:1
    |
127 | / task_config::task_config! {
128 | |     program_l: sys_api::PinSet,
129 | |     init_l: sys_api::PinSet,
130 | |     config_done: sys_api::PinSet,
131 | |     user_reset_l: sys_api::PinSet,
132 | | }
    | | ^
    | | |
    | |_expected `PinSet`, found `Port`
    |   in this macro invocation
    |
   ::: lib/task-config/src/lib.rs:144:1
    |
144 |   pub fn task_config(tokens: TokenStream) -> TokenStream {
    |   ------------------------------------------------------ in this expansion of `task_config::task_config!`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `drv-spartan7-loader` (bin "drv-spartan7-loader") due to 1 previous error
Error: failed to build spartan7_loader

Caused by:
    command failed, see output for details
```

This indicates that the change in task config triggered a rebuild (which then failed).

Note that this PR removes the "include the bytes of the manifest" behavior from the proc macro; that would not be reliable due to TOML inheritance, and the `HUBRIS_TASK_CONFIG` environment variable is ground truth.