### PR TITLE
Add missing cosmo temperature sensors

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -1079,7 +1079,7 @@ device = "isl68224"
 description = "SP5 power controller (V1P1, V1P8, V3P3)"
 power.rails = [ "V1P1_SP5_A0", "V1P8_SP5_A1", "V3P3_SP5_A1" ]
 power.phases = [ [ 0, 1, 2 ], [ 3 ], [ 4 ] ]
-sensors = { voltage = 3, current = 3 } # XXX add temperature sensors?
+sensors = { temperature = 3, voltage = 3, current = 3 }
 refdes = "U116"
 
 ################################################################################

--- a/task/power/src/bsp/cosmo_ab.rs
+++ b/task/power/src/bsp/cosmo_ab.rs
@@ -22,9 +22,9 @@ pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
     rail_controller!(Core, raa229620A, vddcr_soc_a0, A0),
     rail_controller!(Core, raa229620A, vddcr_cpu1_a0, A0),
     rail_controller!(Core, raa229620A, vddio_sp5_a0, A0),
-    rail_controller_notemp!(Core, isl68224, v1p1_sp5_a0, A0),
-    rail_controller_notemp!(Core, isl68224, v1p8_sp5_a1, A0), // XXX A0 or A2?
-    rail_controller_notemp!(Core, isl68224, v3p3_sp5_a1, A0), // XXX A0 or A2?
+    rail_controller!(Core, isl68224, v1p1_sp5_a0, A0),
+    rail_controller!(Core, isl68224, v1p8_sp5_a1, A0), // XXX A0 or A2?
+    rail_controller!(Core, isl68224, v3p3_sp5_a1, A0), // XXX A0 or A2?
     rail_controller!(Sys, tps546B24A, v3p3_sp_a2, A2),
     rail_controller!(Sys, tps546B24A, v5_sys_a2, A2),
     rail_controller!(Sys, tps546B24A, v1p8_sys_a2, A2),


### PR DESCRIPTION
Closes #2577.

This is a similar change to #2108, but for Cosmo instead of gimlet. I took a look, and the only other apps with this ISL sensor are the gimlet-bu target (which has no sensors), and sidecar (which already has these temp sensors mapped).