### PR TITLE
Remove unused ArchState::stack_pointer

### DIFF
--- a/sys/kern/src/arch/arm_m.rs
+++ b/sys/kern/src/arch/arm_m.rs
@@ -162,10 +162,6 @@ pub struct SavedState {
 /// Map the volatile registers to (architecture-independent) syscall argument
 /// and return slots.
 impl task::ArchState for SavedState {
-    fn stack_pointer(&self) -> u32 {
-        self.psp
-    }
-
     /// Reads syscall argument register 0.
     fn arg0(&self) -> u32 {
         self.r4

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -389,9 +389,6 @@ impl Task {
 /// `syscall_descriptor`, and the rest of the trait (such as the argument proxy
 /// types) will just work.
 pub trait ArchState: Default {
-    /// TODO: this is probably not needed here.
-    fn stack_pointer(&self) -> u32;
-
     /// Reads syscall argument register 0.
     fn arg0(&self) -> u32;
     /// Reads syscall argument register 1.


### PR DESCRIPTION
`stack_pointer()` was added to the `ArchState` trait during the initial multi-architecture refactoring in April 2020, but has never had any callers.
The original implementation work also included a simulator backend where `stack_pointer()` was left unimplemented with a comment noting that its absence was an argument for removing the method from `ArchState`, suggesting that it was speculative API surface rather than a requirement of the abstraction.