### PR TITLE
Update to Brussels 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ on:
 concurrency:
   group: release-${{ github.event.inputs.group }}
 
+env:
+  BRUSSELS_VERSION: v0.6.0
+
 jobs:
   init:
     name: Initialize the release
@@ -46,7 +49,7 @@ jobs:
         name: Download Brussels
         run: |
           if [[ "${BRUSSELS_RUN_ID}" == "" ]]; then
-            gh release download -R oxidecomputer/brussels -p brussels v0.5.0
+            gh release download -R oxidecomputer/brussels -p brussels "${BRUSSELS_VERSION}"
           else
             gh run download "${BRUSSELS_RUN_ID}" -R oxidecomputer/brussels -n prebuilt-binary
           fi

--- a/brussels.toml
+++ b/brussels.toml
@@ -40,22 +40,22 @@ gimlet-e = {}
 gimlet-e-lab = {}
 gimlet-f = {}
 gimlet-f-lab = {}
-psc-b = {}
-psc-c = {}
-sidecar-b = {}
-sidecar-b-lab = {}
-sidecar-b-reverso = {}
-sidecar-c = {}
-sidecar-c-lab = {}
-sidecar-c-reverso = {}
-sidecar-d = {}
-sidecar-d-lab = {}
-sidecar-d-reverso = {}
+psc-b = { corim = false }
+psc-c = { corim = false }
+sidecar-b = { corim = false }
+sidecar-b-lab = { corim = false }
+sidecar-b-reverso = { corim = false, omicron = false }
+sidecar-c = { corim = false }
+sidecar-c-lab = { corim = false }
+sidecar-c-reverso = { corim = false, omicron = false }
+sidecar-d = { corim = false }
+sidecar-d-lab = { corim = false }
+sidecar-d-reverso = { corim = false, omicron = false }
 cosmo-a = {}
 cosmo-a-lab = {}
 cosmo-b = {}
 cosmo-b-lab = {}
-observer-a = {}
+observer-a = { corim = false, omicron = false }
 
 [groups.rot]
 tag-bump = "minor"


### PR DESCRIPTION
This PR updates the release flow to pull in oxidecomputer/brussels#21. This should be the last release process change needed before we can integrate Brussels with the omicron releng tooling!

This also changes the configuration to match the current behavior of sprot-release: sidecar and observer images are not included in the CoRIM measurements anymore, and reverso and observer images will not be pulled into omicron.