### PR TITLE
Don't panic on bad nonce_size

### DIFF
--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -571,20 +571,17 @@ impl<'a> Handler {
                 nonce_size,
                 write_size,
             }) => {
-                // Ensure the requester didn't send a bad nonce_size that's
-                // larger than the actual blob.
-                let nonce_size = nonce_size as usize;
-                if nonce_size > req.blob.len() {
+                let Some(nonce) = req.blob.get(..nonce_size as usize) else {
+                    // The requester sent a bad nonce_size that's larger than
+                    // the actual blob.
                     return Err(SprotError::Protocol(
                         SprotProtocolError::BadMessageLength,
                     ));
-                }
+                };
+
                 Ok((
                     RspBody::Attest(Ok(AttestRsp::Attest)),
-                    Some(TrailingData::Attest {
-                        nonce: &req.blob[..nonce_size],
-                        write_size,
-                    }),
+                    Some(TrailingData::Attest { nonce, write_size }),
                 ))
             }
             ReqBody::Attest(AttestReq::AttestLen) => {

--- a/drv/lpc55-sprot-server/src/handler.rs
+++ b/drv/lpc55-sprot-server/src/handler.rs
@@ -570,13 +570,23 @@ impl<'a> Handler {
             ReqBody::Attest(AttestReq::Attest {
                 nonce_size,
                 write_size,
-            }) => Ok((
-                RspBody::Attest(Ok(AttestRsp::Attest)),
-                Some(TrailingData::Attest {
-                    nonce: &req.blob[..nonce_size as usize],
-                    write_size,
-                }),
-            )),
+            }) => {
+                // Ensure the requester didn't send a bad nonce_size that's
+                // larger than the actual blob.
+                let nonce_size = nonce_size as usize;
+                if nonce_size > req.blob.len() {
+                    return Err(SprotError::Protocol(
+                        SprotProtocolError::BadMessageLength,
+                    ));
+                }
+                Ok((
+                    RspBody::Attest(Ok(AttestRsp::Attest)),
+                    Some(TrailingData::Attest {
+                        nonce: &req.blob[..nonce_size],
+                        write_size,
+                    }),
+                ))
+            }
             ReqBody::Attest(AttestReq::AttestLen) => {
                 let rsp = match self.attest.attest_len() {
                     Ok(l) => Ok(AttestRsp::AttestLen(l)),

--- a/drv/sprot-api/src/error.rs
+++ b/drv/sprot-api/src/error.rs
@@ -94,7 +94,8 @@ pub enum SprotProtocolError {
     UnsupportedProtocol,
     /// Unknown message
     BadMessageType,
-    /// Transfer size is outside of maximum and minimum lenghts for message type.
+    /// Transfer size is outside of maximum and minimum lengths for message
+    /// type, or a length field within the message is invalid.
     BadMessageLength,
     // We cannot assert chip select
     CannotAssertCSn,


### PR DESCRIPTION
Before, the SP could cause the RoT to panic by sending it an `attest` request with a `nonce_size` larger than the actual blob of nonce data. Now the RoT replies with a `BadMessageLength` error instead.

This is slightly different than the other uses of `BadMessageLength`, but I don't think it's worth making a new error variant just for this case and plumbing it through MGS. Tell me if you disagree.

Tested on a grapefruit.