### PR TITLE
Increase stack limits, check relative branches

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -132,7 +132,7 @@ notifications = ["i2c1-irq", "i2c2-irq", "i2c3-irq", "i2c4-irq"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 1
-stacksize = 1400
+stacksize = 1496
 start = true
 task-slots = ["jefe"]
 features = ["cosmo", "ereport"]
@@ -259,7 +259,7 @@ uses = ["usart6", "dbgmcu"]
 interrupts = {"usart6.irq" = "usart-irq"}
 priority = 9
 max-sizes = {flash = 74000, ram = 65536}
-stacksize = 5400
+stacksize = 7632
 start = true
 task-slots = ["sys", { cpu_seq = "cosmo_seq" }, "hf", "control_plane_agent", "net", "packrat", "i2c_driver", { spi_driver = "spi2_driver" }, "sprot", "auxflash"]
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
@@ -385,6 +385,7 @@ start = true
 notifications = ["jefe-state-change", "timer"]
 task-slots = ["jefe", "spartan7_loader", "packrat", "sensor"]
 uses = ["mmio_dimms"]
+stacksize = 904
 
 [tasks.auxflash]
 name = "drv-auxflash-server"

--- a/app/gimlet/base.toml
+++ b/app/gimlet/base.toml
@@ -125,7 +125,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 1
-stacksize = 1400
+stacksize = 1496
 start = true
 task-slots = ["jefe"]
 features = ["gimlet", "ereport"]
@@ -166,7 +166,7 @@ name = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
-stacksize = 2600
+stacksize = 2792
 start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf", "jefe", "packrat"]
 notifications = ["timer", "vcore"]
@@ -244,7 +244,7 @@ uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
 priority = 8
 max-sizes = {flash = 72000, ram = 65536}
-stacksize = 5376
+stacksize = 7280
 start = true
 task-slots = ["sys", { cpu_seq = "gimlet_seq" }, "hf", "control_plane_agent", "net", "packrat", "i2c_driver", { spi_driver = "spi2_driver" }, "sprot"]
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]

--- a/app/gimletlet/app.toml
+++ b/app/gimletlet/app.toml
@@ -52,7 +52,7 @@ name = "task-packrat"
 priority = 1
 start = true
 task-slots = ["jefe"]
-stacksize = 1400
+stacksize = 1480
 features = ["ereport"]
 notifications = ["task-faulted"]
 

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -111,6 +111,7 @@ start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
 task-slots = []
 features = ["grapefruit", "boot-kmdb"]
+stacksize = 1496
 
 [tasks.hiffy]
 name = "task-hiffy"

--- a/app/grapefruit/standalone.toml
+++ b/app/grapefruit/standalone.toml
@@ -11,7 +11,7 @@ interrupts = {"uart8.irq" = "usart-irq"}
 
 # Ereport stuff
 [tasks.packrat]
-stacksize = 1400
+stacksize = 1496
 task-slots = ["jefe"]
 features = ["ereport"]
 notifications = ["task-faulted"]

--- a/app/observer/base.toml
+++ b/app/observer/base.toml
@@ -120,7 +120,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 1
-stacksize = 1400
+stacksize = 1480
 start = true
 task-slots = ["jefe"]
 features = ["ereport"]

--- a/app/psc/base.toml
+++ b/app/psc/base.toml
@@ -121,7 +121,7 @@ notifications = ["i2c2-irq", "i2c3-irq"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 1
-stacksize = 1400
+stacksize = 1480
 start = true
 task-slots = ["jefe"]
 features = ["ereport"]

--- a/app/sidecar/base.toml
+++ b/app/sidecar/base.toml
@@ -272,7 +272,7 @@ notifications = ["timer"]
 [tasks.packrat]
 name = "task-packrat"
 priority = 1
-stacksize = 1400
+stacksize = 1480
 start = true
 task-slots = ["jefe"]
 features = ["ereport"]

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1599,6 +1599,9 @@ pub fn get_max_stack(
                     g == &InsnGroupId(InsnGroupType::CS_GRP_CALL as u8)
                         || (g == &InsnGroupId(InsnGroupType::CS_GRP_JUMP as u8)
                             && can_tail)
+                        || g == &InsnGroupId(
+                            InsnGroupType::CS_GRP_BRANCH_RELATIVE as u8,
+                        )
                 }) {
                     let arch = detail.arch_detail();
                     let ops = arch.operands();


### PR DESCRIPTION
This is a more targeted, partial fix for #2588, and contains the most immediate relief from the larger refactoring in #2589.

This catches the largest "novel" defect: ignoring of relative branches, and raises all the stack numbers to what the new analysis in #2589 shows.

This is intended as a stop-gap to prevent seeing stack overflows in test benches. Split into two commits, one with manifest updates, and one with the stack analysis change.