### PR TITLE
ringbuf: Take entries by reference rather than ownership

### DIFF
--- a/app/cosmo/base.toml
+++ b/app/cosmo/base.toml
@@ -258,7 +258,7 @@ features = ["stm32h753", "usart6", "baud_rate_3M", "hardware_flow_control", "vla
 uses = ["usart6", "dbgmcu"]
 interrupts = {"usart6.irq" = "usart-irq"}
 priority = 9
-max-sizes = {flash = 76000, ram = 65536}
+max-sizes = {flash = 78000, ram = 65536}
 stacksize = 7664
 start = true
 task-slots = ["sys", { cpu_seq = "cosmo_seq" }, "hf", "control_plane_agent", "net", "packrat", "i2c_driver", { spi_driver = "spi2_driver" }, "sprot", "auxflash"]

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -460,7 +460,7 @@ macro_rules! ringbuf_entry {
         // Evaluate both buf and payload, without letting them access each
         // other, by evaluating them in a tuple where each cannot
         // accidentally use the other's binding.
-        let (p, buf) = ($payload, &$buf);
+        let (p, buf) = (&$payload, &$buf);
         // Invoke these functions using slightly weird syntax to avoid
         // accidentally calling a _different_ routine called record_entry.
         $crate::RecordEntry::record_entry(buf, line!() as u16, p);
@@ -562,13 +562,13 @@ pub trait RecordEntry<T: Copy> {
     /// This method is typically called by the [`ringbuf_entry!`] and
     /// [`ringbuf_entry_root!`] macros. While you could also call this method
     /// directly, [`ringbuf_entry!`] will capture the line number for you.
-    fn record_entry(&self, line: u16, payload: T);
+    fn record_entry(&self, line: u16, payload: &T);
 }
 
 impl<T: Copy + PartialEq, const N: usize> RecordEntry<T>
     for StaticCell<Ringbuf<T, u16, { N }>>
 {
-    fn record_entry(&self, line: u16, payload: T) {
+    fn record_entry(&self, line: u16, payload: &T) {
         // If the ringbuf is already borrowed, just do nothing, to avoid
         // panicking. This *shouldn't* ever happen, since we are
         // single-threaded, and the code for recording ringbuf entries won't
@@ -591,7 +591,7 @@ impl<T: Copy + PartialEq, const N: usize> RecordEntry<T>
         // last _is_ corrupted, the behavior below will just start us over at 0.
         if let Some(ent) = ring.buffer.get_mut(last)
             && ent.line == line
-            && ent.payload == payload
+            && &ent.payload == payload
             // Only reuse this entry if we don't overflow the count
             && let Some(new_count) = ent.count.checked_add(1)
         {
@@ -606,7 +606,7 @@ impl<T: Copy + PartialEq, const N: usize> RecordEntry<T>
 impl<T: Copy, const N: usize> RecordEntry<T>
     for StaticCell<Ringbuf<T, (), { N }>>
 {
-    fn record_entry(&self, line: u16, payload: T) {
+    fn record_entry(&self, line: u16, payload: &T) {
         // If the ringbuf is already borrowed, just do nothing, to avoid
         // panicking. This *shouldn't* ever happen, since we are
         // single-threaded, and the code for recording ringbuf entries won't
@@ -631,7 +631,7 @@ where
     T: Count + Copy,
     StaticCell<Ringbuf<T, C, N>>: RecordEntry<T>,
 {
-    fn record_entry(&self, _line: u16, payload: T) {
+    fn record_entry(&self, _line: u16, payload: &T) {
         payload.count(&self.counters);
 
         #[cfg(not(feature = "disabled"))]
@@ -643,11 +643,11 @@ impl<T> RecordEntry<T> for ()
 where
     T: Copy + PartialEq,
 {
-    fn record_entry(&self, _: u16, _: T) {}
+    fn record_entry(&self, _: u16, _: &T) {}
 }
 
 impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
-    fn do_record(&mut self, last: usize, line: u16, count: C, payload: T) {
+    fn do_record(&mut self, last: usize, line: u16, count: C, payload: &T) {
         // Either we were unable to reuse the entry, or the last index was out
         // of range (perhaps because this is the first insertion). We're going
         // to advance last and wrap if required. This uses a wrapping_add
@@ -679,7 +679,7 @@ impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
         };
         *ent = RingbufEntry {
             line,
-            payload,
+            payload: *payload,
             count,
             generation: ent.generation.wrapping_add(1),
         };


### PR DESCRIPTION
When logging a ringbuf entry, we traverse through many layers of functions. At each of these steps, we pass the entry by ownership.

Many of these ringbuf entries have grown to several hundred bytes, and this means that they may exist across multiple stack frames at once.

By forcing them to pass by reference, we can avoid duplicating them until the very end when we write to the ring.

This does seem to increase the flash usage in at least one place, I think this may be due to generating some derived traits like Debug or PartialEq for large types for both `T` and `&T`. I'll take a look at the diff.

This stands to save substantial max stack usage, as measured through a hacky change to `xtask sizes` on a cosmo:

```diff
--- /tmp/before.txt	2026-07-21 14:10:14
+++ /tmp/after.txt	2026-07-21 14:15:54
@@ -110,7 +112,7 @@
 sram4     = 0x38000000..0x38010000
 bank2     = 0x08100000..0x08200000
 Used:
-  flash:     0xbea00 (74%)
+  flash:     0xc0100 (75%)
   axi_sram*: 0x53000 (64%)
   dtcm:      0x10800 (51%)
   sram1_mac: 0x4000 (25%)

@@ -298,36 +299,36 @@
                      flash      10012   10240   (auto)
 
 
-jefe: 2144 bytes (limit is 2424)
+jefe: 1952 bytes (limit is 2424)
 net: 5416 bytes (limit is 8000)
 sys: 112 bytes (limit is 896)
-spi2_driver: 568 bytes (limit is 872)
+spi2_driver: 536 bytes (limit is 872)
-spi3_driver: 568 bytes (limit is 872)
+spi3_driver: 536 bytes (limit is 872)
-i2c_driver: 976 bytes (limit is 1048)
+i2c_driver: 808 bytes (limit is 1048)
-packrat: 1560 bytes (limit is 1712)
+packrat: 1160 bytes (limit is 1712)
 rng_driver: 336 bytes (limit is 512)
-thermal: 1488 bytes (limit is 3000)
+thermal: 1424 bytes (limit is 3000)
-power: 3264 bytes (limit is 3800)
+power: 3184 bytes (limit is 3800)
 hiffy: 1216 bytes (limit is 1232)
-cosmo_seq: 2748 bytes (limit is 3200)
+cosmo_seq: 2328 bytes (limit is 3200)
 ignition_flash: 528 bytes (limit is 1200)
-spartan7_loader: 2376 bytes (limit is 2600)
+spartan7_loader: 2312 bytes (limit is 2600)
 hash_driver: 1120 bytes (limit is 2048)
-hf: 2328 bytes (limit is 4000)
+hf: 2024 bytes (limit is 4000)
 update_server: 1520 bytes (limit is 2048)
 sensor: 496 bytes (limit is 1024)
-host_sp_comms: 7656 bytes (limit is 7664)
+host_sp_comms: 7000 bytes (limit is 7664)
 udpecho: 576 bytes (limit is 4096)
 udpbroadcast: 576 bytes (limit is 2048)
-control_plane_agent: 5752 bytes (limit is 7000)
+control_plane_agent: 5568 bytes (limit is 7000)
-sprot: 4024 bytes (limit is 16384)
+sprot: 3960 bytes (limit is 16384)
 validate: 456 bytes (limit is 1000)
 vpd: 600 bytes (limit is 800)
 user_leds: 152 bytes (limit is 896)
-dump_agent: 1624 bytes (limit is 2400)
+dump_agent: 1592 bytes (limit is 2400)
 snitch: 240 bytes (limit is 1200)
-spd: 912 bytes (limit is 920)
+spd: 864 bytes (limit is 920)
 auxflash: 3328 bytes (limit is 3504)
 idle: 8 bytes (limit is 256)
 udprpc: 2608 bytes (limit is 4096)
```