### PR TITLE
Check for overflow in update size calculations

### DIFF
--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -122,10 +122,15 @@ enum MgsMessage {
     },
     SerialConsoleKeepAlive,
     SerialConsoleDetach,
-    UpdatePrepare {
+    SpUpdatePrepare {
+        id: UpdateId,
+        aux_flash_size: u32,
+        sp_image_size: u32,
+    },
+    ComponentUpdatePrepare {
         component: SpComponent,
         id: UpdateId,
-        length: u32,
+        total_size: u32,
         slot: u16,
     },
     UpdateChunk {

--- a/task/control-plane-agent/src/mgs_compute_sled.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled.rs
@@ -565,7 +565,7 @@ impl SpHandler for MgsHandler {
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
         ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.aux_flash_size + update.sp_image_size,
+            length: update.aux_flash_size.saturating_add(update.sp_image_size),
             component: SpComponent::SP_ITSELF,
             id: update.id,
             slot: 0,

--- a/task/control-plane-agent/src/mgs_compute_sled.rs
+++ b/task/control-plane-agent/src/mgs_compute_sled.rs
@@ -564,11 +564,10 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.aux_flash_size.saturating_add(update.sp_image_size),
-            component: SpComponent::SP_ITSELF,
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpUpdatePrepare {
             id: update.id,
-            slot: 0,
+            aux_flash_size: update.aux_flash_size,
+            sp_image_size: update.sp_image_size,
         }));
 
         self.common.sp_update.prepare(&UPDATE_MEMORY, update)
@@ -578,12 +577,14 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.total_size,
-            component: update.component,
-            id: update.id,
-            slot: update.slot,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentUpdatePrepare {
+                total_size: update.total_size,
+                component: update.component,
+                id: update.id,
+                slot: update.slot,
+            }
+        ));
 
         match update.component {
             SpComponent::HOST_CPU_BOOT_FLASH => {

--- a/task/control-plane-agent/src/mgs_minibar.rs
+++ b/task/control-plane-agent/src/mgs_minibar.rs
@@ -241,11 +241,10 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.aux_flash_size + update.sp_image_size,
-            component: SpComponent::SP_ITSELF,
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpUpdatePrepare {
             id: update.id,
-            slot: 0,
+            aux_flash_size: update.aux_flash_size,
+            sp_image_size: update.sp_image_size,
         }));
 
         self.common.sp_update.prepare(&UPDATE_MEMORY, update)
@@ -255,12 +254,14 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.total_size,
-            component: update.component,
-            id: update.id,
-            slot: update.slot,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentUpdatePrepare {
+                total_size: update.total_size,
+                component: update.component,
+                id: update.id,
+                slot: update.slot,
+            }
+        ));
 
         match update.component {
             SpComponent::ROT | SpComponent::STAGE0 => {

--- a/task/control-plane-agent/src/mgs_psc.rs
+++ b/task/control-plane-agent/src/mgs_psc.rs
@@ -243,11 +243,10 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.aux_flash_size + update.sp_image_size,
-            component: SpComponent::SP_ITSELF,
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpUpdatePrepare {
             id: update.id,
-            slot: 0,
+            aux_flash_size: update.aux_flash_size,
+            sp_image_size: update.sp_image_size,
         }));
 
         self.common.sp_update.prepare(&UPDATE_MEMORY, update)
@@ -257,12 +256,14 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.total_size,
-            component: update.component,
-            id: update.id,
-            slot: update.slot,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentUpdatePrepare {
+                total_size: update.total_size,
+                component: update.component,
+                id: update.id,
+                slot: update.slot,
+            }
+        ));
 
         match update.component {
             SpComponent::ROT | SpComponent::STAGE0 => {

--- a/task/control-plane-agent/src/mgs_sidecar.rs
+++ b/task/control-plane-agent/src/mgs_sidecar.rs
@@ -601,11 +601,10 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.aux_flash_size + update.sp_image_size,
-            component: SpComponent::SP_ITSELF,
+        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::SpUpdatePrepare {
             id: update.id,
-            slot: 0,
+            aux_flash_size: update.aux_flash_size,
+            sp_image_size: update.sp_image_size,
         }));
 
         self.common.sp_update.prepare(&UPDATE_MEMORY, update)
@@ -615,12 +614,14 @@ impl SpHandler for MgsHandler {
         &mut self,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError> {
-        ringbuf_entry_root!(Log::MgsMessage(MgsMessage::UpdatePrepare {
-            length: update.total_size,
-            component: update.component,
-            id: update.id,
-            slot: update.slot,
-        }));
+        ringbuf_entry_root!(Log::MgsMessage(
+            MgsMessage::ComponentUpdatePrepare {
+                total_size: update.total_size,
+                component: update.component,
+                id: update.id,
+                slot: update.slot,
+            }
+        ));
 
         match update.component {
             SpComponent::ROT | SpComponent::STAGE0 => {

--- a/task/control-plane-agent/src/update/sp.rs
+++ b/task/control-plane-agent/src/update/sp.rs
@@ -156,11 +156,6 @@ impl ComponentUpdater for SpUpdate {
             return Err(SpError::RequestUnsupportedForSp);
         }
 
-        // Attempt to prepare for an update (erases our flash).
-        self.sp_task
-            .prep_image_update()
-            .map_err(|err| SpError::UpdateFailed(err as u32))?;
-
         let state = if update.aux_flash_size > 0 {
             State::AuxFlash(AuxFlashState::new(
                 &self.auxflash_task,
@@ -174,12 +169,20 @@ impl ComponentUpdater for SpUpdate {
             })
         };
 
-        self.current = Some(CurrentUpdate::new(
+        let current_update = CurrentUpdate::new(
             update.id,
             update.aux_flash_size,
             update.sp_image_size,
             state,
-        ));
+        )?;
+
+        // Now that we've finished all the other error checks that could make us
+        // return early, attempt to prepare for an update (erases our flash).
+        self.sp_task
+            .prep_image_update()
+            .map_err(|err| SpError::UpdateFailed(err as u32))?;
+
+        self.current = Some(current_update);
 
         Ok(())
     }
@@ -439,16 +442,15 @@ impl CurrentUpdate {
         aux_flash_size: u32,
         sp_image_size: u32,
         state: State,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, SpError> {
+        let total_size = aux_flash_size
+            .checked_add(sp_image_size)
+            .ok_or(SpError::UpdateIsTooLarge)?;
+        Ok(Self {
             aux_flash_size,
             sp_image_size,
-            common: super::common::CurrentUpdate::new(
-                id,
-                aux_flash_size + sp_image_size,
-                state,
-            ),
-        }
+            common: super::common::CurrentUpdate::new(id, total_size, state),
+        })
     }
 }
 


### PR DESCRIPTION
Before, MGS could make the control-plane-agent task panic by claiming that the total size of an update was greater than `u32::MAX`. Now the SP replies with an "update is too large" error instead. Tested on a grapefruit.