### PR TITLE
ringbuf: don't allow length-0 ringbufs

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -655,19 +655,13 @@ impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
     // *also* an out of bounds read. Luckily, nobody has ever wanted to make a
     // zero-length ringbuf, so this hasn't been an issue in practice, but let's
     // stop you from doing it here just in case.
-    //
-    // Sadly, using a `const` block with an `assert!` in it somehow does not
-    // fail to build, but the "assertion"-using-a-bool-as-an-array-index trick
-    // does work. I don't know why.
-    const RINGBUF_LEN_MUST_BE_NONZERO: () = [()][(N > 0) as usize];
+    pub const RINGBUF_LEN_MUST_BE_NONZERO: bool = {
+        let is_nonzero = N > 0;
+        assert!(is_nonzero, "ringbuf length must be greater than 0");
+        is_nonzero
+    };
 
     fn do_record(&mut self, last: usize, line: u16, count: C, payload: &T) {
-        // Force the compile-time assertion that the length is nonzero to be
-        // evaluated. Clippy complains (not unreasonably), that this let-binding
-        // is not actually doing anything, which is true, but that's on purpose
-        // here.
-        #[allow(clippy::let_unit_value)]
-        let _ = Self::RINGBUF_LEN_MUST_BE_NONZERO;
         // Either we were unable to reuse the entry, or the last index was out
         // of range (perhaps because this is the first insertion). We're going
         // to advance last and wrap if required. This uses a wrapping_add
@@ -700,7 +694,9 @@ impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
             // in order to actually be safe, as a zero-length ringbuf is the one
             // exception to the guarantee that having modulo'd the index (or
             // having done our weird modulo-like thing, technically) ensures
-            // that it is in bounds.
+            // that it is in bounds. So, force that to actually be evaluated
+            // here, so it fails at the location of the unsafe block comment. :)
+            let _is_nonzero = Self::RINGBUF_LEN_MUST_BE_NONZERO;
             self.buffer.get_unchecked_mut(ndx)
         };
         *ent = RingbufEntry {

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -280,6 +280,17 @@ macro_rules! ringbuf {
 #[macro_export]
 macro_rules! ringbuf {
     ($name:ident, $t:ty, $n:expr, $init:expr $(,)?) => {
+        // `N` may not be 0, and constructing a zero-length ringbuf results in a
+        // compiler error. This is necessary because ringbuf entries are written
+        // to using unchecked indexing, which is always valid because the index
+        // has already been modulo'd to the ringbuf's length...unless the length
+        // is 0, in which case reading the 0th index is *also* an out of bounds
+        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
+        // so this hasn't been an issue in practice, but let's stop you from
+        // doing it here just in case.
+        const _: () = {
+            assert!($n > 0, "ringbufs may not be zero-length");
+        };
         static $name: $crate::StaticCell<$crate::Ringbuf<$t, u16, $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
@@ -292,6 +303,17 @@ macro_rules! ringbuf {
             });
     };
     ($name:ident, $t:ty, $n:expr, $init:expr, no_dedup $(,)?) => {
+        // `N` may not be 0, and constructing a zero-length ringbuf results in a
+        // compiler error. This is necessary because ringbuf entries are written
+        // to using unchecked indexing, which is always valid because the index
+        // has already been modulo'd to the ringbuf's length...unless the length
+        // is 0, in which case reading the 0th index is *also* an out of bounds
+        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
+        // so this hasn't been an issue in practice, but let's stop you from
+        // doing it here just in case.
+        const _: () = {
+            assert!($n > 0, "ringbufs may not be zero-length");
+        };
         static $name: $crate::StaticCell<$crate::Ringbuf<$t, () $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
@@ -336,6 +358,17 @@ macro_rules! ringbuf {
 #[macro_export]
 macro_rules! counted_ringbuf {
     ($name:ident, $t:ident, $n:expr, $init:expr $(,)?) => {
+        // `N` may not be 0, and constructing a zero-length ringbuf results in a
+        // compiler error. This is necessary because ringbuf entries are written
+        // to using unchecked indexing, which is always valid because the index
+        // has already been modulo'd to the ringbuf's length...unless the length
+        // is 0, in which case reading the 0th index is *also* an out of bounds
+        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
+        // so this hasn't been an issue in practice, but let's stop you from
+        // doing it here just in case.
+        const _: () = {
+            assert!($n > 0, "ringbufs may not be zero-length");
+        };
         static $name: $crate::CountedRingbuf<$t, u16, $n> =
             $crate::CountedRingbuf {
                 ringbuf: $crate::StaticCell::new($crate::Ringbuf {
@@ -351,6 +384,17 @@ macro_rules! counted_ringbuf {
             };
     };
     ($name:ident, $t:ident, $n:expr, $init:expr, no_dedup $(,)?) => {
+        // `N` may not be 0, and constructing a zero-length ringbuf results in a
+        // compiler error. This is necessary because ringbuf entries are written
+        // to using unchecked indexing, which is always valid because the index
+        // has already been modulo'd to the ringbuf's length...unless the length
+        // is 0, in which case reading the 0th index is *also* an out of bounds
+        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
+        // so this hasn't been an issue in practice, but let's stop you from
+        // doing it here just in case.
+        const _: () = {
+            assert!($n > 0, "ringbufs may not be zero-length");
+        };
         static $name: $crate::CountedRingbuf<$t, (), $n> =
             $crate::CountedRingbuf {
                 ringbuf: $crate::StaticCell::new($crate::Ringbuf {
@@ -675,6 +719,12 @@ impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
             // `self.buffer.get_mut(ndx)` and then silently nop'ing if it
             // returns `None`...but it seems nicer to also elide the bounds
             // check, given that we *just* did one of our own!
+            //
+            // Note that this requires the `const` assertion that `N > 0` in the
+            // ringbuf macro in order to actually be safe, as a zero-length
+            // ringbuf is the one exception to the guarantee that having
+            // modulo'd the index (or having done our weird modulo-like thing,
+            // technically) ensures that it is in bounds.
             self.buffer.get_unchecked_mut(ndx)
         };
         *ent = RingbufEntry {

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -280,17 +280,6 @@ macro_rules! ringbuf {
 #[macro_export]
 macro_rules! ringbuf {
     ($name:ident, $t:ty, $n:expr, $init:expr $(,)?) => {
-        // `N` may not be 0, and constructing a zero-length ringbuf results in a
-        // compiler error. This is necessary because ringbuf entries are written
-        // to using unchecked indexing, which is always valid because the index
-        // has already been modulo'd to the ringbuf's length...unless the length
-        // is 0, in which case reading the 0th index is *also* an out of bounds
-        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
-        // so this hasn't been an issue in practice, but let's stop you from
-        // doing it here just in case.
-        const _: () = {
-            assert!($n > 0, "ringbufs may not be zero-length");
-        };
         static $name: $crate::StaticCell<$crate::Ringbuf<$t, u16, $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
@@ -303,17 +292,6 @@ macro_rules! ringbuf {
             });
     };
     ($name:ident, $t:ty, $n:expr, $init:expr, no_dedup $(,)?) => {
-        // `N` may not be 0, and constructing a zero-length ringbuf results in a
-        // compiler error. This is necessary because ringbuf entries are written
-        // to using unchecked indexing, which is always valid because the index
-        // has already been modulo'd to the ringbuf's length...unless the length
-        // is 0, in which case reading the 0th index is *also* an out of bounds
-        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
-        // so this hasn't been an issue in practice, but let's stop you from
-        // doing it here just in case.
-        const _: () = {
-            assert!($n > 0, "ringbufs may not be zero-length");
-        };
         static $name: $crate::StaticCell<$crate::Ringbuf<$t, () $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
@@ -358,17 +336,6 @@ macro_rules! ringbuf {
 #[macro_export]
 macro_rules! counted_ringbuf {
     ($name:ident, $t:ident, $n:expr, $init:expr $(,)?) => {
-        // `N` may not be 0, and constructing a zero-length ringbuf results in a
-        // compiler error. This is necessary because ringbuf entries are written
-        // to using unchecked indexing, which is always valid because the index
-        // has already been modulo'd to the ringbuf's length...unless the length
-        // is 0, in which case reading the 0th index is *also* an out of bounds
-        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
-        // so this hasn't been an issue in practice, but let's stop you from
-        // doing it here just in case.
-        const _: () = {
-            assert!($n > 0, "ringbufs may not be zero-length");
-        };
         static $name: $crate::CountedRingbuf<$t, u16, $n> =
             $crate::CountedRingbuf {
                 ringbuf: $crate::StaticCell::new($crate::Ringbuf {
@@ -384,17 +351,6 @@ macro_rules! counted_ringbuf {
             };
     };
     ($name:ident, $t:ident, $n:expr, $init:expr, no_dedup $(,)?) => {
-        // `N` may not be 0, and constructing a zero-length ringbuf results in a
-        // compiler error. This is necessary because ringbuf entries are written
-        // to using unchecked indexing, which is always valid because the index
-        // has already been modulo'd to the ringbuf's length...unless the length
-        // is 0, in which case reading the 0th index is *also* an out of bounds
-        // read. Luckily, nobody has ever wanted to make a zero-length ringbuf,
-        // so this hasn't been an issue in practice, but let's stop you from
-        // doing it here just in case.
-        const _: () = {
-            assert!($n > 0, "ringbufs may not be zero-length");
-        };
         static $name: $crate::CountedRingbuf<$t, (), $n> =
             $crate::CountedRingbuf {
                 ringbuf: $crate::StaticCell::new($crate::Ringbuf {
@@ -691,7 +647,27 @@ where
 }
 
 impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
+    // Ensure that `N` is not zero by producing a compile-time error if anyone
+    // tries to construct a zero-length ringbuf. This is necessary because
+    // ringbuf entries are written to using unchecked indexing, which is always
+    // valid because the index has already been modulo'd to the ringbuf's
+    // length...unless the length is 0, in which case reading the 0th index is
+    // *also* an out of bounds read. Luckily, nobody has ever wanted to make a
+    // zero-length ringbuf, so this hasn't been an issue in practice, but let's
+    // stop you from doing it here just in case.
+    //
+    // Sadly, using a `const` block with an `assert!` in it somehow does not
+    // fail to build, but the "assertion"-using-a-bool-as-an-array-index trick
+    // does work. I don't know why.
+    const RINGBUF_LEN_MUST_BE_NONZERO: () = [()][(N > 0) as usize];
+
     fn do_record(&mut self, last: usize, line: u16, count: C, payload: &T) {
+        // Force the compile-time assertion that the length is nonzero to be
+        // evaluated. Clippy complains (not unreasonably), that this let-binding
+        // is not actually doing anything, which is true, but that's on purpose
+        // here.
+        #[allow(clippy::let_unit_value)]
+        let _ = Self::RINGBUF_LEN_MUST_BE_NONZERO;
         // Either we were unable to reuse the entry, or the last index was out
         // of range (perhaps because this is the first insertion). We're going
         // to advance last and wrap if required. This uses a wrapping_add
@@ -720,11 +696,11 @@ impl<T: Copy, C, const N: usize> Ringbuf<T, C, N> {
             // returns `None`...but it seems nicer to also elide the bounds
             // check, given that we *just* did one of our own!
             //
-            // Note that this requires the `const` assertion that `N > 0` in the
-            // ringbuf macro in order to actually be safe, as a zero-length
-            // ringbuf is the one exception to the guarantee that having
-            // modulo'd the index (or having done our weird modulo-like thing,
-            // technically) ensures that it is in bounds.
+            // Note that this requires the `const` assertion that `N > 0` above
+            // in order to actually be safe, as a zero-length ringbuf is the one
+            // exception to the guarantee that having modulo'd the index (or
+            // having done our weird modulo-like thing, technically) ensures
+            // that it is in bounds.
             self.buffer.get_unchecked_mut(ndx)
         };
         *ent = RingbufEntry {


### PR DESCRIPTION
It turns out that, if you try to make a ringbuf with length 0, surprisingly bad things will happen. This is because ringbuf entries are written to using `get_unchecked_mut()`, in order to suppress bounds checks. Suppressing bounds checks is okay to do, because we have already modulo'd the index to the ringbuf's length, so it is guaranteed to be in bounds...AS LONG AS THE LENGTH IS GREATER THAN ZERO. If it is zero, well...`0 % 0 == 0`, so we will do `get_unchecked_mut(0)`, and uncheckedly dereference the first index of the ringbuf array...which it doesn't have, so you end up writing out of bounds to whatever happens to be next to the ringbuf.

Luckily, no one has ever actually tried to make a ringbuf with zero entries, because...why would you want that? But, just in case, it's better if we stop you, so this branch adds a const assertion to the ringbuf macro that checks that the length is greater than zero.

Now, if you try to make one, it fails like this: 

```
  Compiling task-ereportulator v0.1.0 (/home/eliza/Code/oxide/hubris/task/ereportulator)
error[E0080]: evaluation panicked: ringbufs may not be zero-length
    --> /rustlib/panic.rs:62:9
     |
  51 | pub macro panic_2021 {
     | -------------------- in this expansion of `$crate::panic::panic_2021!` (#3)
...
  62 |         $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
     |
    ::: lib/ringbuf/src/lib.rs:282:1
     |
 282 | macro_rules! ringbuf {
     | -------------------- in this expansion of `ringbuf::ringbuf!` (#1)
...
 293 |             assert!($n > 0, "ringbufs may not be zero-length");
     |             --------------------------------------------------
     |             |
     |             in this macro invocation (#2)
     |             in this macro invocation (#3)
     |
    ::: task/ereportulator/src/main.rs:72:1
     |
  72 | ringbuf::ringbuf!(__LOL, Trace, 0, Trace::None);
     | ----------------------------------------------- in this macro invocation (#1)
     |
    ::: /rustlib/macros/mod.rs:1691:5
     |
1691 |     macro_rules! assert {
     |     ------------------- in this expansion of `assert!` (#2)

For more information about this error, try `rustc --explain E0080`.
error: could not compile `task-ereportulator` (bin "task-ereportulator") due to 1 previous error
```