### PR TITLE
host-sp-comms: Check for bad cert length

### DIFF
--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1470,12 +1470,22 @@ impl ServerImpl {
                             .sprot
                             .tq_cert_len(index)
                             .map_err(AttestDataSprotError::from)?;
-                        for o in (0..cert_len).step_by(512) {
+                        for o in (0..cert_len).step_by(SPROT_TRANSFER_SIZE) {
                             let idx: usize = buf_idx + o as usize;
-                            let len = usize::min(512, (cert_len - o) as usize);
+                            let end = usize::min(
+                                SPROT_TRANSFER_SIZE,
+                                (cert_len - o) as usize,
+                            );
+
+                            if idx + end >= buf.len() {
+                                return Err(
+                                    AttestDataSprotError::CommsBufTooSmall
+                                        .into(),
+                                );
+                            }
 
                             self.sprot
-                                .tq_cert(index, o, &mut buf[idx..idx + len])
+                                .tq_cert(index, o, &mut buf[idx..idx + end])
                                 .map_err(AttestDataSprotError::from)?;
                         }
                         cnt += cert_len;

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1363,7 +1363,7 @@ impl ServerImpl {
                                 SPROT_TRANSFER_SIZE,
                                 (cert_len - o) as usize,
                             );
-                            if idx + end >= buf.len() {
+                            if idx + end > buf.len() {
                                 return Err(
                                     AttestDataSprotError::CommsBufTooSmall
                                         .into(),
@@ -1403,7 +1403,7 @@ impl ServerImpl {
                             SPROT_TRANSFER_SIZE,
                             (measurement_len - o) as usize,
                         );
-                        if idx + end >= buf.len() {
+                        if idx + end > buf.len() {
                             return Err(
                                 AttestDataSprotError::CommsBufTooSmall.into()
                             );
@@ -1434,7 +1434,7 @@ impl ServerImpl {
                         .attest_len()
                         .map_err(AttestDataSprotError::from)?
                         as usize;
-                    if attest_len >= buf.len() {
+                    if attest_len > buf.len() {
                         return Err(
                             AttestDataSprotError::CommsBufTooSmall.into()
                         );
@@ -1477,7 +1477,7 @@ impl ServerImpl {
                                 (cert_len - o) as usize,
                             );
 
-                            if idx + end >= buf.len() {
+                            if idx + end > buf.len() {
                                 return Err(
                                     AttestDataSprotError::CommsBufTooSmall
                                         .into(),

--- a/task/host-sp-comms/src/main.rs
+++ b/task/host-sp-comms/src/main.rs
@@ -1513,6 +1513,12 @@ impl ServerImpl {
                         .tq_sign_len()
                         .map_err(AttestDataSprotError::from)?
                         as usize;
+
+                    if sign_len > buf.len() {
+                        return Err(
+                            AttestDataSprotError::CommsBufTooSmall.into()
+                        );
+                    }
                     self.sprot
                         .tq_sign(data, &mut buf[..sign_len])
                         .map_err(AttestDataSprotError::from)?;


### PR DESCRIPTION
When host-sp-comms handles the `GetTqCertificates` request, it doesn't explicitly check whether the certificate length reported by the RoT fits in its buffer. This was flagged because we thought it could cause a panic, and I added a check that would return a `CommsBufTooSmall` error instead. However, after I got the hardware set up for testing it, I found that the SP already reported an `AttestOutOfRange` error rather than panicking. 

So this PR is kinda pointless, but I did find a few other small things to fix along the way. Changes:
- `GetTqCertificates` can now report a `CommsBufTooSmall` error, but in practice it never will (unless some surrounding code changes someday.) I guess I'll leave the check in place. I tested this with a grapefruit and faux-ipcc.
- `TqSign` can now report a `CommsBufTooSmall` error. I couldn't figure out a good way to test this. 
- I fixed an off-by-one error in all the existing `CommsBufTooSmall` checks. I didn't test that either.