### PR TITLE
several small improvements to the `monorail` task's BSP ringbufs (and a teeny ringbuf bugfix)

### DIFF
--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -292,7 +292,7 @@ macro_rules! ringbuf {
             });
     };
     ($name:ident, $t:ty, $n:expr, $init:expr, no_dedup $(,)?) => {
-        static $name: $crate::StaticCell<$crate::Ringbuf<$t, () $n>> =
+        static $name: $crate::StaticCell<$crate::Ringbuf<$t, (), $n>> =
             $crate::StaticCell::new($crate::Ringbuf {
                 last: None,
                 buffer: [$crate::RingbufEntry {

--- a/task/monorail-server/src/bsp/medusa_a.rs
+++ b/task/monorail-server/src/bsp/medusa_a.rs
@@ -20,19 +20,21 @@ task_slot!(FRONT_IO, ecp5_front_io);
 /// Interval in milliseconds at which `Bsp::wake()` is called by the main loop
 pub const WAKE_INTERVAL: Option<u32> = Some(500);
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, counters::Count)]
 enum Trace {
+    #[count(skip)]
     None,
     FrontIoSpeedChange {
         port: u8,
         before: Speed,
+        #[count(children)]
         after: Speed,
     },
     FrontIoPhyOscillatorBad,
-    AnegCheckFailed(VscError),
+    AnegCheckFailed(#[count(children)] VscError),
     Reinit,
 }
-ringbuf!(Trace, 16, Trace::None);
+counted_ringbuf!(Trace, 16, Trace::None);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/task/monorail-server/src/bsp/minibar.rs
+++ b/task/monorail-server/src/bsp/minibar.rs
@@ -28,7 +28,7 @@ enum Trace {
     },
     AnegCheckFailed(#[count(children)] VscError),
 }
-ringbuf!(Trace, 16, Trace::None);
+counted_ringbuf!(Trace, 16, Trace::None);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/task/monorail-server/src/bsp/sidecar_bcd.rs
+++ b/task/monorail-server/src/bsp/sidecar_bcd.rs
@@ -46,7 +46,7 @@ enum Trace {
     },
     Vsc8504ReadError(VscError),
 }
-ringbuf!(Trace, 16, Trace::None);
+counted_ringbuf!(Trace, 16, Trace::None);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum VLanMode {

--- a/task/monorail-server/src/bsp/sidecar_bcd.rs
+++ b/task/monorail-server/src/bsp/sidecar_bcd.rs
@@ -35,7 +35,7 @@ enum Trace {
     AnegCheckFailed(#[count(children)] VscError),
     Restarted10GAneg,
     Reinit,
-    UnlockUntil(u64),
+    UnlockingVLans,
     LockingVLans,
     AutomaticLock,
     LockError(#[count(children)] VscError),
@@ -53,6 +53,32 @@ enum VLanMode {
     Locked,
     UnlockedUntil(u64),
 }
+
+#[derive(Copy, Clone, PartialEq)]
+enum VlanLockEvent {
+    None,
+    Locked { at: u64 },
+    Unlocked { at: u64, until: u64 },
+}
+
+// A separate ringbuffer for more detailed recording of recent VLAN locking
+// activity. This is separate from the main ringbuf so that frequent unlocking,
+// such as what we see in the lab environment, doesn't clobber more important
+// debugging information.
+//
+// Note that we don't generate counters for this, because the events are already
+// counted in the main ringbuf. This one is mainly just to include the
+// timestamps/durations that don't include in the main `Trace` ringbuf due to
+// wanting the events to be de-duplicated.
+ringbuf!(
+    __VLAN_LOCK_EVENTS,
+    VlanLockEvent,
+    8,
+    VlanLockEvent::None,
+    // Disable de-duplication, since events in this ringbuf contain timestamps
+    // and will never be equal
+    no_dedup
+);
 
 const VLAN_UNLOCK_TARGETS: vsc7448::VlanTargets = if cfg!(feature = "reverso") {
     vsc7448::VlanTargets::ScrimletOnly
@@ -642,13 +668,21 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
         &mut self,
         unlock_until: u64,
     ) -> Result<(), RequestError<MonorailError>> {
-        ringbuf_entry!(Trace::UnlockUntil(unlock_until));
+        ringbuf_entry!(Trace::UnlockingVLans);
         self.vsc7448
             .sidecar_vlan_unlock(VLAN_UNLOCK_TARGETS)
             .map_err(|e| {
                 ringbuf_entry!(Trace::UnlockError(e));
                 MonorailError::from(e)
             })?;
+
+        ringbuf_entry!(
+            __VLAN_LOCK_EVENTS,
+            VlanLockEvent::Unlocked {
+                at: userlib::sys_get_timer().now,
+                until: unlock_until,
+            }
+        );
         self.vlan_mode = VLanMode::UnlockedUntil(unlock_until);
         Ok(())
     }
@@ -662,6 +696,12 @@ impl<'a, R: Vsc7448Rw> Bsp<'a, R> {
             MonorailError::from(e)
         })?;
         self.vlan_mode = VLanMode::Locked;
+        ringbuf_entry!(
+            __VLAN_LOCK_EVENTS,
+            VlanLockEvent::Locked {
+                at: userlib::sys_get_timer().now
+            }
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
This branch contains several small, self-contained commits that all improve the ringbufs in `task-monorail-server`'s BSPs in small-but-important ways (save for one which fixes a ringbuf bug necessary for the subsequent commit). I'd like to rebase-and-merge these to separate commits to `master`, since they're self-contained.

In particular:
- https://github.com/oxidecomputer/hubris/pull/2628/commits/effd9e9264c17c4b30db6bb21979ab68cd8591df changes the `sidecar_bcd` BSP's ringbuf to use `counted_ringbuf!` so that it actually generates counters. The `Trace` type derives `counters::Count`, but the ringbuf is not declared with counters enabled, so there are no counters actually generated. This was pretty clearly an oversight.
- https://github.com/oxidecomputer/hubris/pull/2628/commits/6135e834af0a53a83051e931912a8c9290a3a34f adds `counted_ringbuf!` to the other BSPs
- https://github.com/oxidecomputer/hubris/pull/2628/commits/4ffd0e6956a43c76b482214f43b83d8b594b867f fixes a single-character bug in `ringbuf!` that makes non-counted ringbufs with `no_dedup` set not compile. Whoopsie!
- https://github.com/oxidecomputer/hubris/pull/2628/commits/efa507f6c1ad172a52cc3905085c2729fc90e303 fixes #2627 by adding a separate ringbuf in the sidecar BSP that records VLAN unlocking deadlines and timestamps, so that the unlock event in the main BSP ringbuf can be de-duplicated when a bunch of unlocks occur in a row. This way, we can still record the deadlines, but we also don't clobber other events in the main ringbuf.