### PR TITLE
thermal: enhance fan state tracking

### DIFF
--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -83,6 +83,7 @@ pub enum ThermalAutoState {
     FanParty,
 }
 
+/// Properties for a particular fan in the system
 pub struct FanProperties {
     /// The speed which a fan should never exceed, even at maximum control
     /// input level. May be higher than the expected max RPM of a fan.
@@ -92,10 +93,11 @@ pub struct FanProperties {
     pub underspeed_rpm: Rpm,
 }
 
+/// Generic Sanyo Denki fan limits use in Oxide products
 pub const SANYO_DENKI_FAN_PROPERTIES: FanProperties = FanProperties {
-    // Nominal max speed: 12_000 RPM, +1_500 RPM (total guess)
+    // Nominal max speed: 12_000 RPM, +1_500 RPM variance allowed (total guess)
     overspeed_rpm: Rpm(13_500),
-    // Nominal min speed:  2_000 RPM, -1_500 RPM (total guess)
+    // Nominal min speed:  2_000 RPM, -1_500 RPM variance allowed (total guess)
     underspeed_rpm: Rpm(500),
 };
 

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -84,6 +84,7 @@ pub enum ThermalAutoState {
 }
 
 /// Properties for a particular fan in the system
+#[derive(Copy, Clone, Debug)]
 pub struct FanProperties {
     /// The speed which a fan should never exceed, even at maximum control
     /// input level. May be higher than the expected max RPM of a fan.

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -10,7 +10,10 @@ use derive_idol_err::IdolError;
 use drv_i2c_api::ResponseCode;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
-use userlib::{units::Celsius, *};
+use userlib::{
+    units::{Celsius, Rpm},
+    *,
+};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[derive(
@@ -79,6 +82,22 @@ pub enum ThermalAutoState {
     Uncontrollable,
     FanParty,
 }
+
+pub struct FanProperties {
+    /// The speed which a fan should never exceed, even at maximum control
+    /// input level. May be higher than the expected max RPM of a fan.
+    pub overspeed_rpm: Rpm,
+    /// The speed which a fan should never fall below, even at minimum control
+    /// input level. May be lower than the expected min RPM of a fan.
+    pub underspeed_rpm: Rpm,
+}
+
+pub const SANYO_DENKI_FAN_PROPERTIES: FanProperties = FanProperties {
+    // Nominal max speed: 12_000 RPM, +1_500 RPM (total guess)
+    overspeed_rpm: Rpm(13_500),
+    // Nominal min speed:  2_000 RPM, -1_500 RPM (total guess)
+    underspeed_rpm: Rpm(500),
+};
 
 /// Properties for a particular part in the system
 #[derive(Clone, Copy, IntoBytes, FromBytes, Immutable, KnownLayout, Debug)]

--- a/task/thermal-api/src/lib.rs
+++ b/task/thermal-api/src/lib.rs
@@ -10,10 +10,8 @@ use derive_idol_err::IdolError;
 use drv_i2c_api::ResponseCode;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
-use userlib::{
-    units::{Celsius, Rpm},
-    *,
-};
+use userlib::units::{Celsius, Rpm};
+use userlib::{FromPrimitive, sys_send};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[derive(

--- a/task/thermal/src/bsp/common/emc2305.rs
+++ b/task/thermal/src/bsp/common/emc2305.rs
@@ -8,11 +8,11 @@ use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::emc2305::Emc2305;
 use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
-use task_thermal_api::{SensorReadError, ThermalError};
+use task_thermal_api::{FanProperties, SensorReadError, ThermalError};
 
 use crate::{
     Trace,
-    control::{Fan, FanPollingOutcome},
+    control::{Fan, FanPresentState, FanState},
 };
 
 /// Tracks whether a Emc2305 fan controller has been initialized, and
@@ -31,7 +31,7 @@ impl Emc2305State {
             fan_count,
             initialized: false,
         };
-        retry_init(|| this.initialize().map(|_| ()));
+        retry_init(|| this.initialize().map(drop));
         this
     }
 
@@ -63,39 +63,6 @@ impl Emc2305State {
         ringbuf_entry_root!(Trace::FanControllerInitialized);
         Ok(&mut self.emc2305)
     }
-
-    pub(crate) fn poll_fan_rpms(
-        &mut self,
-        fans: &mut [Fan<drv_i2c_devices::emc2305::Fan>],
-    ) -> impl Iterator<Item = FanPollingOutcome> {
-        // Try to initialize the fan controller once at the start of the loop
-        let mut fctrl = self.try_initialize().map_err(SensorReadError::from);
-
-        // TODO: Maybe there's a way to make this a method on Fan that we can
-        // call, kind of like ActiveInputState?
-        fans.iter_mut().map(move |f| {
-            let sensor_id = f.rpm_sensor_id;
-            if !f.is_present {
-                return FanPollingOutcome::NotPresent { sensor_id };
-            }
-
-            // If initialization failed, then we short circuit to return that
-            // original error, copied for each fan we're going to report.
-            let fctrl = fctrl.as_mut().map_err(|e| *e);
-
-            // If it was a success, attempt to read the RPMs, and either report
-            // that success or that error for each fan rpm.
-            let res = fctrl.and_then(|fc| {
-                fc.fan_rpm(f.bsp_data).map_err(SensorReadError::I2cError)
-            });
-            match res {
-                Ok(rpm) => FanPollingOutcome::PresentSuccess { rpm, sensor_id },
-                Err(error) => {
-                    FanPollingOutcome::PresentError { error, sensor_id }
-                }
-            }
-        })
-    }
 }
 
 /// Helper function to retry initialization several times, logging errors
@@ -109,6 +76,41 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
             break;
         }
         ringbuf_entry_root!(Trace::FanControllerInitRetry { remaining });
+    }
+}
+
+pub(crate) fn update_fan(
+    now: u64,
+    presence_accurate: bool,
+    fctrl: &mut Emc2305,
+    fan: &mut Fan<drv_i2c_devices::emc2305::Fan>,
+    model: &FanProperties,
+) {
+    if presence_accurate && !fan.is_present() {
+        return;
+    }
+
+    let res = fctrl.fan_rpm(fan.bsp_data);
+    match res {
+        Ok(rpm) => {
+            let state = if rpm < model.underspeed_rpm {
+                FanPresentState::TooSlow(rpm)
+            } else if rpm > model.underspeed_rpm {
+                FanPresentState::TooFast(rpm)
+            } else {
+                FanPresentState::Nominal(rpm)
+            };
+            fan.update_state(FanState::Present(state), now);
+        }
+        Err(ResponseCode::NoDevice) if !presence_accurate => {
+            fan.update_presence(false, now);
+        }
+        Err(_e) => {
+            fan.update_state(
+                FanState::Present(FanPresentState::Unresponsive),
+                now,
+            );
+        }
     }
 }
 
@@ -143,7 +145,7 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::emc2305::Fan::new_const(idx as u8),
         );
-        out[idx].is_present = true;
+        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
         idx += 1;
     }
 

--- a/task/thermal/src/bsp/common/emc2305.rs
+++ b/task/thermal/src/bsp/common/emc2305.rs
@@ -81,18 +81,22 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
 
 pub(crate) fn update_fan(
     now: u64,
-    presence_accurate: bool,
     fctrl: &mut Emc2305,
     fan: &mut Fan<drv_i2c_devices::emc2305::Fan>,
     model: &FanProperties,
 ) {
-    if presence_accurate && !fan.is_present() {
+    // If this fan is not present, then do not attempt to poll it. Presence is
+    // only restored via presence polling.
+    if !fan.is_present() {
         return;
     }
 
+    // Try to get the RPM reading for this fan
     let res = fctrl.fan_rpm(fan.bsp_data);
     match res {
         Ok(rpm) => {
+            // The poll went well! Use the model to determine if this reading
+            // is nominal or not, and report that as the state.
             let state = if rpm < model.underspeed_rpm {
                 FanPresentState::TooSlow(rpm)
             } else if rpm > model.underspeed_rpm {
@@ -102,10 +106,8 @@ pub(crate) fn update_fan(
             };
             fan.update_state(FanState::Present(state), now);
         }
-        Err(ResponseCode::NoDevice) if !presence_accurate => {
-            fan.update_presence(false, now);
-        }
         Err(_e) => {
+            // No good, mark as unresponsive
             fan.update_state(
                 FanState::Present(FanPresentState::Unresponsive),
                 now,
@@ -146,6 +148,7 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             drv_i2c_devices::emc2305::Fan::new_const(idx as u8),
         );
         out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
+        out[idx].presence_acked = true;
         idx += 1;
     }
 

--- a/task/thermal/src/bsp/common/emc2305.rs
+++ b/task/thermal/src/bsp/common/emc2305.rs
@@ -110,7 +110,9 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::emc2305::Fan::new_const(idx as u8),
         );
-        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
+        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive(
+            SensorReadError::NoData,
+        ));
         out[idx].presence_acked = true;
         idx += 1;
     }

--- a/task/thermal/src/bsp/common/emc2305.rs
+++ b/task/thermal/src/bsp/common/emc2305.rs
@@ -8,11 +8,11 @@ use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::emc2305::Emc2305;
 use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
-use task_thermal_api::{FanProperties, SensorReadError, ThermalError};
+use task_thermal_api::{SensorReadError, ThermalError};
 
 use crate::{
     Trace,
-    control::{Fan, FanPresentState, FanState},
+    control::{FanPresentState, FanState},
 };
 
 /// Tracks whether a Emc2305 fan controller has been initialized, and
@@ -76,43 +76,6 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
             break;
         }
         ringbuf_entry_root!(Trace::FanControllerInitRetry { remaining });
-    }
-}
-
-pub(crate) fn update_fan(
-    now: u64,
-    fctrl: &mut Emc2305,
-    fan: &mut Fan<drv_i2c_devices::emc2305::Fan>,
-    model: &FanProperties,
-) {
-    // If this fan is not present, then do not attempt to poll it. Presence is
-    // only restored via presence polling.
-    if !fan.is_present() {
-        return;
-    }
-
-    // Try to get the RPM reading for this fan
-    let res = fctrl.fan_rpm(fan.bsp_data);
-    match res {
-        Ok(rpm) => {
-            // The poll went well! Use the model to determine if this reading
-            // is nominal or not, and report that as the state.
-            let state = if rpm < model.underspeed_rpm {
-                FanPresentState::TooSlow(rpm)
-            } else if rpm > model.underspeed_rpm {
-                FanPresentState::TooFast(rpm)
-            } else {
-                FanPresentState::Nominal(rpm)
-            };
-            fan.update_state(FanState::Present(state), now);
-        }
-        Err(_e) => {
-            // No good, mark as unresponsive
-            fan.update_state(
-                FanState::Present(FanPresentState::Unresponsive),
-                now,
-            );
-        }
     }
 }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -88,18 +88,22 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
 
 pub(crate) fn update_fan(
     now: u64,
-    presence_accurate: bool,
     fctrl: &mut Max31790,
     fan: &mut Fan<drv_i2c_devices::max31790::Fan>,
     model: &FanProperties,
 ) {
-    if presence_accurate && !fan.is_present() {
+    // If this fan is not present, then do not attempt to poll it. Presence is
+    // only restored via presence polling.
+    if !fan.is_present() {
         return;
     }
 
+    // Try to get the RPM reading for this fan
     let res = fctrl.fan_rpm(fan.bsp_data);
     match res {
         Ok(rpm) => {
+            // The poll went well! Use the model to determine if this reading
+            // is nominal or not, and report that as the state.
             let state = if rpm < model.underspeed_rpm {
                 FanPresentState::TooSlow(rpm)
             } else if rpm > model.underspeed_rpm {
@@ -109,10 +113,8 @@ pub(crate) fn update_fan(
             };
             fan.update_state(FanState::Present(state), now);
         }
-        Err(ResponseCode::NoDevice) if !presence_accurate => {
-            fan.update_presence(false, now);
-        }
         Err(_e) => {
+            // No good, mark as unresponsive
             fan.update_state(
                 FanState::Present(FanPresentState::Unresponsive),
                 now,
@@ -153,6 +155,7 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             drv_i2c_devices::max31790::Fan::new_const(idx as u8),
         );
         out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
+        out[idx].presence_acked = true;
         idx += 1;
     }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -10,7 +10,10 @@ use ringbuf::ringbuf_entry;
 use task_sensor_api::SensorId;
 use task_thermal_api::{SensorReadError, ThermalError};
 
-use crate::{__RINGBUF, Trace, control::FanState};
+use crate::{
+    __RINGBUF, Trace,
+    control::{FanPresentState, FanState},
+};
 
 /// Tracks whether a MAX31790 fan controller has been initialized, and
 /// initializes it on demand when accessed, if necessary.
@@ -114,8 +117,8 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::max31790::Fan::new_const(idx as u8),
         );
-        out[idx].prev_state = FanState::PresentUnresponsive;
-        out[idx].cur_state = FanState::PresentUnresponsive;
+        out[idx].prev_state = FanState::Present(FanPresentState::Unresponsive);
+        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
         idx += 1;
     }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -6,13 +6,13 @@
 
 use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::max31790::Max31790;
-use ringbuf::ringbuf_entry;
+use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
-use task_thermal_api::{SensorReadError, ThermalError};
+use task_thermal_api::{FanProperties, SensorReadError, ThermalError};
 
 use crate::{
-    __RINGBUF, Trace,
-    control::{FanPresentState, FanState},
+    Trace,
+    control::{Fan, FanPresentState, FanState},
 };
 
 /// Tracks whether a MAX31790 fan controller has been initialized, and
@@ -62,12 +62,12 @@ impl Max31790State {
     #[inline(never)]
     fn initialize(&mut self) -> Result<&mut Max31790, ControllerInitError> {
         self.max31790.initialize().map_err(|e| {
-            ringbuf_entry!(Trace::FanControllerInitError(e));
+            ringbuf_entry_root!(Trace::FanControllerInitError(e));
             ControllerInitError(e)
         })?;
 
         self.initialized = true;
-        ringbuf_entry!(Trace::FanControllerInitialized);
+        ringbuf_entry_root!(Trace::FanControllerInitialized);
         Ok(&mut self.max31790)
     }
 }
@@ -82,7 +82,42 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
         if init().is_ok() {
             break;
         }
-        ringbuf_entry!(Trace::FanControllerInitRetry { remaining });
+        ringbuf_entry_root!(Trace::FanControllerInitRetry { remaining });
+    }
+}
+
+pub(crate) fn update_fan(
+    now: u64,
+    presence_accurate: bool,
+    fctrl: &mut Max31790,
+    fan: &mut Fan<drv_i2c_devices::max31790::Fan>,
+    model: &FanProperties,
+) {
+    if presence_accurate && !fan.is_present() {
+        return;
+    }
+
+    let res = fctrl.fan_rpm(fan.bsp_data);
+    match res {
+        Ok(rpm) => {
+            let state = if rpm < model.underspeed_rpm {
+                FanPresentState::TooSlow(rpm)
+            } else if rpm > model.underspeed_rpm {
+                FanPresentState::TooFast(rpm)
+            } else {
+                FanPresentState::Nominal(rpm)
+            };
+            fan.update_state(FanState::Present(state), now);
+        }
+        Err(ResponseCode::NoDevice) if !presence_accurate => {
+            fan.update_presence(false, now);
+        }
+        Err(_e) => {
+            fan.update_state(
+                FanState::Present(FanPresentState::Unresponsive),
+                now,
+            );
+        }
     }
 }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -10,10 +10,7 @@ use ringbuf::ringbuf_entry;
 use task_sensor_api::SensorId;
 use task_thermal_api::{SensorReadError, ThermalError};
 
-use crate::{
-    __RINGBUF, Trace,
-    control::{Fan, FanPollingOutcome},
-};
+use crate::{__RINGBUF, Trace, control::FanState};
 
 /// Tracks whether a MAX31790 fan controller has been initialized, and
 /// initializes it on demand when accessed, if necessary.
@@ -70,39 +67,6 @@ impl Max31790State {
         ringbuf_entry!(Trace::FanControllerInitialized);
         Ok(&mut self.max31790)
     }
-
-    pub(crate) fn poll_fan_rpms(
-        &mut self,
-        fans: &mut [Fan<drv_i2c_devices::max31790::Fan>],
-    ) -> impl Iterator<Item = FanPollingOutcome> {
-        // Try to initialize the fan controller once at the start of the loop
-        let mut fctrl = self.try_initialize().map_err(SensorReadError::from);
-
-        // TODO: Maybe there's a way to make this a method on Fan that we can
-        // call, kind of like ActiveInputState?
-        fans.iter_mut().map(move |f| {
-            let sensor_id = f.rpm_sensor_id;
-            if !f.is_present {
-                return FanPollingOutcome::NotPresent { sensor_id };
-            }
-
-            // If initialization failed, then we short circuit to return that
-            // original error, copied for each fan we're going to report.
-            let fctrl = fctrl.as_mut().map_err(|e| *e);
-
-            // If it was a success, attempt to read the RPMs, and either report
-            // that success or that error for each fan rpm.
-            let res = fctrl.and_then(|fc| {
-                fc.fan_rpm(f.bsp_data).map_err(SensorReadError::I2cError)
-            });
-            match res {
-                Ok(rpm) => FanPollingOutcome::PresentSuccess { rpm, sensor_id },
-                Err(error) => {
-                    FanPollingOutcome::PresentError { error, sensor_id }
-                }
-            }
-        })
-    }
 }
 
 /// Helper function to retry initialization several times, logging errors
@@ -150,7 +114,8 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::max31790::Fan::new_const(idx as u8),
         );
-        out[idx].is_present = true;
+        out[idx].prev_state = FanState::PresentUnresponsive;
+        out[idx].cur_state = FanState::PresentUnresponsive;
         idx += 1;
     }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -117,7 +117,6 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::max31790::Fan::new_const(idx as u8),
         );
-        out[idx].prev_state = FanState::Present(FanPresentState::Unresponsive);
         out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
         idx += 1;
     }

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -8,11 +8,11 @@ use drv_i2c_api::{I2cDevice, ResponseCode};
 use drv_i2c_devices::max31790::Max31790;
 use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
-use task_thermal_api::{FanProperties, SensorReadError, ThermalError};
+use task_thermal_api::{SensorReadError, ThermalError};
 
 use crate::{
     Trace,
-    control::{Fan, FanPresentState, FanState},
+    control::{FanPresentState, FanState},
 };
 
 /// Tracks whether a MAX31790 fan controller has been initialized, and
@@ -83,43 +83,6 @@ pub(crate) fn retry_init<F: FnMut() -> Result<(), ControllerInitError>>(
             break;
         }
         ringbuf_entry_root!(Trace::FanControllerInitRetry { remaining });
-    }
-}
-
-pub(crate) fn update_fan(
-    now: u64,
-    fctrl: &mut Max31790,
-    fan: &mut Fan<drv_i2c_devices::max31790::Fan>,
-    model: &FanProperties,
-) {
-    // If this fan is not present, then do not attempt to poll it. Presence is
-    // only restored via presence polling.
-    if !fan.is_present() {
-        return;
-    }
-
-    // Try to get the RPM reading for this fan
-    let res = fctrl.fan_rpm(fan.bsp_data);
-    match res {
-        Ok(rpm) => {
-            // The poll went well! Use the model to determine if this reading
-            // is nominal or not, and report that as the state.
-            let state = if rpm < model.underspeed_rpm {
-                FanPresentState::TooSlow(rpm)
-            } else if rpm > model.underspeed_rpm {
-                FanPresentState::TooFast(rpm)
-            } else {
-                FanPresentState::Nominal(rpm)
-            };
-            fan.update_state(FanState::Present(state), now);
-        }
-        Err(_e) => {
-            // No good, mark as unresponsive
-            fan.update_state(
-                FanState::Present(FanPresentState::Unresponsive),
-                now,
-            );
-        }
     }
 }
 

--- a/task/thermal/src/bsp/common/max31790.rs
+++ b/task/thermal/src/bsp/common/max31790.rs
@@ -117,7 +117,9 @@ pub(crate) const fn make_consecutive_nonremovable_fans<const N: usize>(
             sensors[idx],
             drv_i2c_devices::max31790::Fan::new_const(idx as u8),
         );
-        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive);
+        out[idx].cur_state = FanState::Present(FanPresentState::Unresponsive(
+            SensorReadError::NoData,
+        ));
         out[idx].presence_acked = true;
         idx += 1;
     }

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -6,8 +6,8 @@
 
 use crate::{
     control::{
-        ActiveInputState, ChannelType, FanPollingOutcome, FanPresence,
-        InputPollingOutcome, MiscSensorPollingOutcome, PidConfig,
+        ActiveInputState, ChannelType, InputPollingOutcome,
+        MiscSensorPollingOutcome, PidConfig,
     },
     i2c_config::{devices, sensors},
 };
@@ -15,9 +15,11 @@ pub use drv_cpu_seq_api::SeqError;
 use drv_cpu_seq_api::{PowerState, Sequencer, StateChangeReason};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::{Sensor, SensorId};
-use task_thermal_api::{ThermalError, ThermalProperties};
+use task_thermal_api::{
+    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+};
 use userlib::{
-    TaskId, task_slot,
+    TaskId, sys_get_timer, task_slot,
     units::{Celsius, PWMDuty},
 };
 
@@ -57,8 +59,6 @@ pub(crate) struct Bsp {
 
     /// Monitored sensors
     misc_sensors: &'static [TemperatureSensor; NUM_TEMPERATURE_SENSORS],
-
-    fans_added: bool,
 
     /// Fans
     fans: &'static mut [Fan; NUM_FANS],
@@ -101,6 +101,8 @@ impl crate::control::BspInterface for Bsp {
         max_output: 100.0,
     };
 
+    type FanBspId = drv_i2c_devices::max31790::Fan;
+
     fn power_down(&self) -> Result<(), SeqError> {
         self.seq.set_state_with_reason(
             PowerState::A2,
@@ -119,20 +121,21 @@ impl crate::control::BspInterface for Bsp {
         }
     }
 
-    // We assume Cosmo fan presence cannot change
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<impl Iterator<Item = FanPresence>, SeqError> {
-        let report_new = !self.fans_added;
-        self.fans_added = true;
-        Ok(self.fans.iter().map(move |f| FanPresence::Present {
-            fan_id: f.bsp_data.into(),
-            changed: report_new,
-        }))
-    }
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
+        if let Ok(fctl) = self.fctrl.try_initialize() {
+            let now = sys_get_timer().now;
+            for fan in self.fans.iter_mut() {
+                max31790::update_fan(
+                    now,
+                    true,
+                    fctl,
+                    fan,
+                    &SANYO_DENKI_FAN_PROPERTIES,
+                );
+            }
+        }
 
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome> {
-        self.fctrl.poll_fan_rpms(self.fans)
+        self.fans.iter_mut()
     }
 
     fn poll_misc_sensors(
@@ -170,7 +173,6 @@ impl crate::control::BspInterface for Bsp {
         Err(ThermalError::InvalidIndex)
     }
 
-    // sets last_reading to Some(Missing), returns sensor id
     fn remove_dynamic_input(
         &mut self,
         _index: usize,
@@ -245,7 +247,6 @@ impl Bsp {
 
             inputs: INPUTS_ONCE.claim(),
             fans: FANS_ONCE.claim(),
-            fans_added: false,
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -127,7 +127,6 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 max31790::update_fan(
                     now,
-                    true,
                     fctl,
                     fan,
                     &SANYO_DENKI_FAN_PROPERTIES,

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -125,12 +125,10 @@ impl crate::control::BspInterface for Bsp {
         if let Ok(fctl) = self.fctrl.try_initialize() {
             let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
-                max31790::update_fan(
-                    now,
-                    fctl,
-                    fan,
-                    &SANYO_DENKI_FAN_PROPERTIES,
-                );
+                let bsp_data = fan.bsp_data;
+                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                    fctl.fan_rpm(bsp_data)
+                });
             }
         }
 

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -20,7 +20,7 @@ use task_thermal_api::{
     ThermalProperties,
 };
 use userlib::{
-    TaskId, sys_get_timer, task_slot,
+    TaskId, task_slot,
     units::{Celsius, PWMDuty},
 };
 
@@ -124,10 +124,9 @@ impl crate::control::BspInterface for Bsp {
 
     fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
         if let Ok(fctl) = self.fctrl.try_initialize() {
-            let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
-                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                fan.poll_rpm_with(&SANYO_DENKI_FAN_PROPERTIES, || {
                     fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
@@ -238,18 +237,13 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
-        // Fast forward fan time to now
-        let fans = FANS_ONCE.claim();
-        let now = sys_get_timer().now;
-        fans.iter_mut().for_each(|f| f.initialize_time(now));
-
         Self {
             seq,
             i2c_task,
             fctrl,
 
             inputs: INPUTS_ONCE.claim(),
-            fans,
+            fans: FANS_ONCE.claim(),
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -16,7 +16,8 @@ use drv_cpu_seq_api::{PowerState, Sequencer, StateChangeReason};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::{Sensor, SensorId};
 use task_thermal_api::{
-    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+    SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalError,
+    ThermalProperties,
 };
 use userlib::{
     TaskId, sys_get_timer, task_slot,
@@ -127,7 +128,7 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
                 fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
-                    fctl.fan_rpm(bsp_data)
+                    fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
         }

--- a/task/thermal/src/bsp/cosmo_ab.rs
+++ b/task/thermal/src/bsp/cosmo_ab.rs
@@ -238,13 +238,18 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
+        // Fast forward fan time to now
+        let fans = FANS_ONCE.claim();
+        let now = sys_get_timer().now;
+        fans.iter_mut().for_each(|f| f.initialize_time(now));
+
         Self {
             seq,
             i2c_task,
             fctrl,
 
             inputs: INPUTS_ONCE.claim(),
-            fans: FANS_ONCE.claim(),
+            fans,
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -170,12 +170,10 @@ impl crate::control::BspInterface for Bsp {
         if let Ok(fctl) = self.fctrl.try_initialize() {
             let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
-                max31790::update_fan(
-                    now,
-                    fctl,
-                    fan,
-                    &SANYO_DENKI_FAN_PROPERTIES,
-                );
+                let bsp_data = fan.bsp_data;
+                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                    fctl.fan_rpm(bsp_data)
+                });
             }
         }
 

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -6,8 +6,8 @@
 
 use crate::{
     control::{
-        ActiveInputState, ChannelType, FanPollingOutcome, FanPresence,
-        InputPollingOutcome, MiscSensorPollingOutcome, PidConfig,
+        ActiveInputState, ChannelType, InputPollingOutcome,
+        MiscSensorPollingOutcome, PidConfig,
     },
     i2c_config::{devices, sensors},
 };
@@ -15,9 +15,11 @@ pub use drv_cpu_seq_api::SeqError;
 use drv_cpu_seq_api::{PowerState, Sequencer, StateChangeReason};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::{Sensor, SensorId};
-use task_thermal_api::{ThermalError, ThermalProperties};
+use task_thermal_api::{
+    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+};
 use userlib::{
-    TaskId, task_slot,
+    TaskId, sys_get_timer, task_slot,
     units::{Celsius, PWMDuty},
 };
 
@@ -69,8 +71,6 @@ pub(crate) struct Bsp {
     /// Monitored sensors
     misc_sensors: &'static [TemperatureSensor; NUM_TEMPERATURE_SENSORS],
 
-    fans_added: bool,
-
     /// Fans
     fans: &'static mut [Fan; NUM_FANS],
 
@@ -119,6 +119,8 @@ impl crate::control::BspInterface for Bsp {
         max_output: 100.0,
     };
 
+    type FanBspId = drv_i2c_devices::max31790::Fan;
+
     fn power_down(&self) -> Result<(), SeqError> {
         self.seq.set_state_with_reason(
             PowerState::A2,
@@ -164,20 +166,21 @@ impl crate::control::BspInterface for Bsp {
         }
     }
 
-    // We assume Gimlet fan presence cannot change
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<impl Iterator<Item = FanPresence>, SeqError> {
-        let report_new = !self.fans_added;
-        self.fans_added = true;
-        Ok(self.fans.iter().map(move |f| FanPresence::Present {
-            fan_id: f.bsp_data.into(),
-            changed: report_new,
-        }))
-    }
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
+        if let Ok(fctl) = self.fctrl.try_initialize() {
+            let now = sys_get_timer().now;
+            for fan in self.fans.iter_mut() {
+                max31790::update_fan(
+                    now,
+                    true,
+                    fctl,
+                    fan,
+                    &SANYO_DENKI_FAN_PROPERTIES,
+                );
+            }
+        }
 
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome> {
-        self.fctrl.poll_fan_rpms(self.fans)
+        self.fans.iter_mut()
     }
 
     fn poll_misc_sensors(
@@ -289,7 +292,6 @@ impl Bsp {
 
             inputs: INPUTS_ONCE.claim(),
             fans: FANS_ONCE.claim(),
-            fans_added: false,
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -20,7 +20,7 @@ use task_thermal_api::{
     ThermalProperties,
 };
 use userlib::{
-    TaskId, sys_get_timer, task_slot,
+    TaskId, task_slot,
     units::{Celsius, PWMDuty},
 };
 
@@ -169,10 +169,9 @@ impl crate::control::BspInterface for Bsp {
 
     fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
         if let Ok(fctl) = self.fctrl.try_initialize() {
-            let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
-                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                fan.poll_rpm_with(&SANYO_DENKI_FAN_PROPERTIES, || {
                     fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
@@ -283,18 +282,13 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
-        // Fast forward fan time to now
-        let fans = FANS_ONCE.claim();
-        let now = sys_get_timer().now;
-        fans.iter_mut().for_each(|f| f.initialize_time(now));
-
         Self {
             seq,
             i2c_task,
             fctrl,
 
             inputs: INPUTS_ONCE.claim(),
-            fans,
+            fans: FANS_ONCE.claim(),
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -16,7 +16,8 @@ use drv_cpu_seq_api::{PowerState, Sequencer, StateChangeReason};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::{Sensor, SensorId};
 use task_thermal_api::{
-    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+    SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalError,
+    ThermalProperties,
 };
 use userlib::{
     TaskId, sys_get_timer, task_slot,
@@ -172,7 +173,7 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
                 fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
-                    fctl.fan_rpm(bsp_data)
+                    fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
         }

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -283,13 +283,18 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
+        // Fast forward fan time to now
+        let fans = FANS_ONCE.claim();
+        let now = sys_get_timer().now;
+        fans.iter_mut().for_each(|f| f.initialize_time(now));
+
         Self {
             seq,
             i2c_task,
             fctrl,
 
             inputs: INPUTS_ONCE.claim(),
-            fans: FANS_ONCE.claim(),
+            fans,
 
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,

--- a/task/thermal/src/bsp/gimlet_bcdef.rs
+++ b/task/thermal/src/bsp/gimlet_bcdef.rs
@@ -172,7 +172,6 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 max31790::update_fan(
                     now,
-                    true,
                     fctl,
                     fan,
                     &SANYO_DENKI_FAN_PROPERTIES,

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -91,12 +91,10 @@ impl crate::control::BspInterface for Bsp {
         if let Ok(fctl) = self.fctrl.try_initialize() {
             let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
-                emc2305::update_fan(
-                    now,
-                    fctl,
-                    fan,
-                    &SANYO_DENKI_FAN_PROPERTIES,
-                );
+                let bsp_data = fan.bsp_data;
+                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                    fctl.fan_rpm(bsp_data)
+                });
             }
         }
 

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -2,15 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! BSP for Medusa
+//! BSP for Grapefruit Ruby
 
-use crate::control::{ActiveInputState, FanPresence, MiscSensorPollingOutcome};
+use crate::control::{ActiveInputState, MiscSensorPollingOutcome};
 use crate::control::{ChannelType, PidConfig};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::SensorId;
-use task_thermal_api::{ThermalError, ThermalProperties};
-use userlib::TaskId;
+use task_thermal_api::{
+    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+};
 use userlib::units::{Celsius, PWMDuty};
+use userlib::{TaskId, sys_get_timer};
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 use i2c_config::devices;
@@ -75,6 +77,8 @@ impl crate::control::BspInterface for Bsp {
         max_output: 100.0,
     };
 
+    type FanBspId = drv_i2c_devices::emc2305::Fan;
+
     fn power_down(&self) -> Result<(), crate::SeqError> {
         Ok(())
     }
@@ -83,24 +87,21 @@ impl crate::control::BspInterface for Bsp {
         PowerBitmask::ON
     }
 
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<
-        impl Iterator<Item = crate::control::FanPresence>,
-        crate::SeqError,
-    > {
-        let report_new = !self.fans_added;
-        self.fans_added = true;
-        Ok(self.fans.iter().map(move |f| FanPresence::Present {
-            fan_id: f.bsp_data.into(),
-            changed: report_new,
-        }))
-    }
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
+        if let Ok(fctl) = self.fctrl.try_initialize() {
+            let now = sys_get_timer().now;
+            for fan in self.fans.iter_mut() {
+                emc2305::update_fan(
+                    now,
+                    true,
+                    fctl,
+                    fan,
+                    &SANYO_DENKI_FAN_PROPERTIES,
+                );
+            }
+        }
 
-    fn poll_fan_rpms(
-        &mut self,
-    ) -> impl Iterator<Item = crate::control::FanPollingOutcome> {
-        self.fctrl.poll_fan_rpms(self.fans)
+        self.fans.iter_mut()
     }
 
     fn poll_misc_sensors(

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -93,7 +93,6 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 emc2305::update_fan(
                     now,
-                    true,
                     fctl,
                     fan,
                     &SANYO_DENKI_FAN_PROPERTIES,

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -12,8 +12,8 @@ use task_thermal_api::{
     SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalError,
     ThermalProperties,
 };
+use userlib::TaskId;
 use userlib::units::{Celsius, PWMDuty};
-use userlib::{TaskId, sys_get_timer};
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
 use i2c_config::devices;
@@ -89,10 +89,9 @@ impl crate::control::BspInterface for Bsp {
 
     fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
         if let Ok(fctl) = self.fctrl.try_initialize() {
-            let now = sys_get_timer().now;
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
-                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                fan.poll_rpm_with(&SANYO_DENKI_FAN_PROPERTIES, || {
                     fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
@@ -195,13 +194,8 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
-        // Fast forward fan time to now
-        let fans = FANS_ONCE.claim();
-        let now = sys_get_timer().now;
-        fans.iter_mut().for_each(|f| f.initialize_time(now));
-
         Self {
-            fans,
+            fans: FANS_ONCE.claim(),
 
             inputs: INPUTS_ONCE.claim(),
 

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -9,7 +9,8 @@ use crate::control::{ChannelType, PidConfig};
 use drv_i2c_devices::max31790::I2cWatchdog;
 use task_sensor_api::SensorId;
 use task_thermal_api::{
-    SANYO_DENKI_FAN_PROPERTIES, ThermalError, ThermalProperties,
+    SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalError,
+    ThermalProperties,
 };
 use userlib::units::{Celsius, PWMDuty};
 use userlib::{TaskId, sys_get_timer};
@@ -57,7 +58,6 @@ pub(crate) struct Bsp {
     pub inputs: &'static mut [InputChannel; NUM_TEMPERATURE_INPUTS],
 
     fans: &'static mut [Fan; NUM_FANS],
-    fans_added: bool,
     i2c_task: TaskId,
 
     fctrl: Emc2305State,
@@ -93,7 +93,7 @@ impl crate::control::BspInterface for Bsp {
             for fan in self.fans.iter_mut() {
                 let bsp_data = fan.bsp_data;
                 fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
-                    fctl.fan_rpm(bsp_data)
+                    fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
         }
@@ -196,7 +196,6 @@ impl Bsp {
             static_cell::ClaimOnceCell::new(FANS);
 
         Self {
-            fans_added: false,
             fans: FANS_ONCE.claim(),
 
             inputs: INPUTS_ONCE.claim(),

--- a/task/thermal/src/bsp/grapefruit.rs
+++ b/task/thermal/src/bsp/grapefruit.rs
@@ -195,8 +195,13 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
+        // Fast forward fan time to now
+        let fans = FANS_ONCE.claim();
+        let now = sys_get_timer().now;
+        fans.iter_mut().for_each(|f| f.initialize_time(now));
+
         Self {
-            fans: FANS_ONCE.claim(),
+            fans,
 
             inputs: INPUTS_ONCE.claim(),
 

--- a/task/thermal/src/bsp/minibar.rs
+++ b/task/thermal/src/bsp/minibar.rs
@@ -4,7 +4,7 @@
 
 //! BSP for Minibar
 
-use crate::control::{MiscSensorPollingOutcome, PidConfig};
+use crate::control::{Fan, MiscSensorPollingOutcome, PidConfig};
 use task_sensor_api::SensorId;
 use task_thermal_api::{ThermalError, ThermalProperties};
 use userlib::TaskId;
@@ -36,6 +36,8 @@ impl crate::control::BspInterface for Bsp {
         max_output: 100.,
     };
 
+    type FanBspId = u8;
+
     fn power_down(&self) -> Result<(), crate::SeqError> {
         Ok(())
     }
@@ -44,18 +46,7 @@ impl crate::control::BspInterface for Bsp {
         PowerBitmask::empty()
     }
 
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<
-        impl Iterator<Item = crate::control::FanPresence>,
-        crate::SeqError,
-    > {
-        Ok(core::iter::empty())
-    }
-
-    fn poll_fan_rpms(
-        &mut self,
-    ) -> impl Iterator<Item = crate::control::FanPollingOutcome> {
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan<u8>> {
         core::iter::empty()
     }
 

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -6,10 +6,9 @@
 
 use crate::control::{
     ActiveInputState, ChannelType, DynamicInputChannel,
-    DynamicTemperatureState, FanPresentState, FanState,
-    MiscSensorPollingOutcome, PidConfig, TimestampedTemperatureReading,
+    DynamicTemperatureState, FanState, MiscSensorPollingOutcome, PidConfig,
+    TimestampedTemperatureReading,
 };
-use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
 pub use drv_sidecar_seq_api::SeqError;
@@ -17,7 +16,7 @@ use drv_sidecar_seq_api::{Sequencer, TofinoSeqState, TofinoSequencerPolicy};
 use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
 use task_thermal_api::ThermalError;
-use task_thermal_api::ThermalProperties;
+use task_thermal_api::{SANYO_DENKI_FAN_PROPERTIES, ThermalProperties};
 use userlib::sys_get_timer;
 use userlib::{TaskId, task_slot, units::Celsius};
 
@@ -144,46 +143,30 @@ impl crate::control::BspInterface for Bsp {
             }
         }
 
-        let update_fan = |fctrl: &mut Max31790, fan: &mut Fan| {
-            if have_presence && !fan.is_present() {
-                return;
-            }
-
-            let res = fctrl.fan_rpm(fan.bsp_data);
-            match res {
-                Ok(rpm) => {
-                    let state = if rpm.0 < 500 {
-                        FanPresentState::TooSlow(rpm)
-                    } else if rpm.0 > 13500 {
-                        FanPresentState::TooFast(rpm)
-                    } else {
-                        FanPresentState::Nominal(rpm)
-                    };
-                    fan.update_state(FanState::Present(state), now);
-                }
-                Err(ResponseCode::NoDevice) if !have_presence => {
-                    fan.update_presence(false, now);
-                }
-                Err(_e) => {
-                    fan.update_state(
-                        FanState::Present(FanPresentState::Unresponsive),
-                        now,
-                    );
-                }
-            }
-        };
-
         // Load bearing assumption: the first 4 fans are the EAST fans, and the
         // last 4 fans are the WEST fans.
+        let now = sys_get_timer().now;
         let (east, west) = self.fans.split_at_mut(4);
         if let Ok(fctrl) = self.fctrl_east.try_initialize() {
             for fan in east.iter_mut() {
-                update_fan(fctrl, fan);
+                max31790::update_fan(
+                    now,
+                    have_presence,
+                    fctrl,
+                    fan,
+                    &SANYO_DENKI_FAN_PROPERTIES,
+                );
             }
         }
         if let Ok(fctrl) = self.fctrl_west.try_initialize() {
             for fan in west.iter_mut() {
-                update_fan(fctrl, fan);
+                max31790::update_fan(
+                    now,
+                    have_presence,
+                    fctrl,
+                    fan,
+                    &SANYO_DENKI_FAN_PROPERTIES,
+                );
             }
         }
 

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -125,11 +125,18 @@ impl crate::control::BspInterface for Bsp {
     }
 
     fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
+        // Attempt to get presence bits from the sequencer.
+        //
+        // If we *don't* have presence data, something has gone terribly wrong
+        // with the sequencer, and we will keep using the last reported presence
+        // state, which starts as "not present" at power-up.
         let have_presence;
         let now = sys_get_timer().now;
         match self.seq.fan_module_presence() {
             Ok(pres) => {
                 have_presence = true;
+
+                // Each presence bit represents 2 physical fans
                 let fanchs = self.fans.chunks_exact_mut(2);
                 for (p, pair) in pres.0.iter().zip(fanchs) {
                     for fan in pair {
@@ -147,11 +154,12 @@ impl crate::control::BspInterface for Bsp {
         // last 4 fans are the WEST fans.
         let now = sys_get_timer().now;
         let (east, west) = self.fans.split_at_mut(4);
+
+        // Fan controller initialization is
         if let Ok(fctrl) = self.fctrl_east.try_initialize() {
             for fan in east.iter_mut() {
                 max31790::update_fan(
                     now,
-                    have_presence,
                     fctrl,
                     fan,
                     &SANYO_DENKI_FAN_PROPERTIES,
@@ -162,7 +170,6 @@ impl crate::control::BspInterface for Bsp {
             for fan in west.iter_mut() {
                 max31790::update_fan(
                     now,
-                    have_presence,
                     fctrl,
                     fan,
                     &SANYO_DENKI_FAN_PROPERTIES,
@@ -331,7 +338,7 @@ impl crate::control::BspInterface for Bsp {
         let mut any_err = false;
         let mut set_all = |fctrl: &mut Max31790, fans: &mut [Fan]| {
             for fan in fans.iter_mut() {
-                let val = if matches!(fan.cur_state, FanState::NotPresent) {
+                let val = if !fan.is_present() {
                     userlib::units::PWMDuty(0)
                 } else {
                     duty

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -6,7 +6,7 @@
 
 use crate::control::{
     ActiveInputState, ChannelType, DynamicInputChannel,
-    DynamicTemperatureState, FanState, MiscSensorPollingOutcome, PidConfig,
+    DynamicTemperatureState, MiscSensorPollingOutcome, PidConfig,
     TimestampedTemperatureReading,
 };
 use drv_i2c_devices::max31790::Max31790;
@@ -130,12 +130,9 @@ impl crate::control::BspInterface for Bsp {
         // If we *don't* have presence data, something has gone terribly wrong
         // with the sequencer, and we will keep using the last reported presence
         // state, which starts as "not present" at power-up.
-        let have_presence;
         let now = sys_get_timer().now;
         match self.seq.fan_module_presence() {
             Ok(pres) => {
-                have_presence = true;
-
                 // Each presence bit represents 2 physical fans
                 let fanchs = self.fans.chunks_exact_mut(2);
                 for (p, pair) in pres.0.iter().zip(fanchs) {
@@ -145,7 +142,6 @@ impl crate::control::BspInterface for Bsp {
                 }
             }
             Err(e) => {
-                have_presence = false;
                 ringbuf_entry_root!(crate::Trace::FanPresenceUpdateFailed(e))
             }
         }
@@ -155,25 +151,22 @@ impl crate::control::BspInterface for Bsp {
         let now = sys_get_timer().now;
         let (east, west) = self.fans.split_at_mut(4);
 
-        // Fan controller initialization is
-        if let Ok(fctrl) = self.fctrl_east.try_initialize() {
+        // Fan controller initialization is latching, if it never succeeds, fans
+        // will stay in their presence state, but read Unresponsive if present.
+        if let Ok(fctl) = self.fctrl_east.try_initialize() {
             for fan in east.iter_mut() {
-                max31790::update_fan(
-                    now,
-                    fctrl,
-                    fan,
-                    &SANYO_DENKI_FAN_PROPERTIES,
-                );
+                let bsp_data = fan.bsp_data;
+                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                    fctl.fan_rpm(bsp_data)
+                });
             }
         }
-        if let Ok(fctrl) = self.fctrl_west.try_initialize() {
+        if let Ok(fctl) = self.fctrl_west.try_initialize() {
             for fan in west.iter_mut() {
-                max31790::update_fan(
-                    now,
-                    fctrl,
-                    fan,
-                    &SANYO_DENKI_FAN_PROPERTIES,
-                );
+                let bsp_data = fan.bsp_data;
+                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                    fctl.fan_rpm(bsp_data)
+                });
             }
         }
 

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -5,17 +5,20 @@
 //! BSP for Sidecar
 
 use crate::control::{
-    ActiveInputState, ChannelType, DynamicTemperatureState, FanPresence,
+    ActiveInputState, ChannelType, DynamicTemperatureState, FanState,
     MiscSensorPollingOutcome, PidConfig, TimestampedTemperatureReading,
 };
 use crate::control::{DynamicInputChannel, FanPollingOutcome};
+use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
 pub use drv_sidecar_seq_api::SeqError;
 use drv_sidecar_seq_api::{Sequencer, TofinoSeqState, TofinoSequencerPolicy};
+use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
 use task_thermal_api::ThermalError;
 use task_thermal_api::ThermalProperties;
+use userlib::sys_get_timer;
 use userlib::{TaskId, task_slot, units::Celsius};
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
@@ -120,48 +123,72 @@ impl crate::control::BspInterface for Bsp {
         }
     }
 
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<impl Iterator<Item = FanPresence>, crate::SeqError> {
-        // Get presence bits from the sequencer
-        let iter = self
-            .seq
-            .fan_module_presence()?
-            // First, get an iterator over all of the presence bools.
-            .0
-            .into_iter()
-            // Since each bool represets the state of two fans at a time, we
-            // chunk up the fans in pairs, and dupe the presence bit onto each
-            // one, THEN flatten it back into a single linear iterator.
-            .zip(self.fans.chunks_exact_mut(2))
-            .flat_map(|(p, c)| core::iter::repeat(p).zip(c.iter_mut()))
-            // Finally, for each fan, see if it is newly here/gone, and report
-            // that with its "fan" ID, which is just the order that we define
-            // our fans. We don't change the order, so it's okay to enumerate
-            // "late" instead of earlier in the chain.
-            .enumerate()
-            .map(|(fan_id, (present, c))| {
-                let fan_id = fan_id as u8;
-                let was = c.is_present;
-                let changed = was ^ present;
-                c.is_present = present;
-
-                if present {
-                    FanPresence::Present { fan_id, changed }
-                } else {
-                    FanPresence::NotPresent { fan_id, changed }
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome<'_>> {
+        let have_presence;
+        let now = sys_get_timer().now;
+        match self.seq.fan_module_presence() {
+            Ok(pres) => {
+                have_presence = true;
+                let fanchs = self.fans.chunks_exact_mut(2);
+                for (p, pair) in pres.0.iter().zip(fanchs) {
+                    for fan in pair {
+                        fan.update_presence(*p, now);
+                    }
                 }
-            });
-        Ok(iter)
-    }
+            }
+            Err(e) => {
+                have_presence = false;
+                ringbuf_entry_root!(crate::Trace::FanPresenceUpdateFailed(e))
+            }
+        }
 
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome> {
+        let update_fan = |fctrl: &mut Max31790, fan: &mut Fan| {
+            if have_presence && !fan.is_present() {
+                return;
+            }
+
+            let res = fctrl.fan_rpm(fan.bsp_data);
+            match res {
+                Ok(rpm) => {
+                    let state = if rpm.0 < 500 {
+                        FanState::PresentTooSlow(rpm)
+                    } else if rpm.0 > 13500 {
+                        FanState::PresentTooFast(rpm)
+                    } else {
+                        FanState::Present(rpm)
+                    };
+                    fan.update_state(state, now);
+                }
+                Err(ResponseCode::NoDevice) if !have_presence => {
+                    fan.update_presence(false, now);
+                }
+                Err(_e) => {
+                    fan.update_state(FanState::PresentUnresponsive, now);
+                }
+            }
+        };
+
         // Load bearing assumption: the first 4 fans are the EAST fans, and the
         // last 4 fans are the WEST fans.
         let (east, west) = self.fans.split_at_mut(4);
-        self.fctrl_east
-            .poll_fan_rpms(east)
-            .chain(self.fctrl_west.poll_fan_rpms(west))
+        if let Ok(fctrl) = self.fctrl_east.try_initialize() {
+            for fan in east.iter_mut() {
+                update_fan(fctrl, fan);
+            }
+        }
+        if let Ok(fctrl) = self.fctrl_west.try_initialize() {
+            for fan in west.iter_mut() {
+                update_fan(fctrl, fan);
+            }
+        }
+
+        self.fans.iter_mut().map(move |f| FanPollingOutcome {
+            sensor_id: f.rpm_sensor_id,
+            fan_id: f.bsp_data.into(),
+            cur_state: f.current_state(),
+            duration_ms: now.saturating_sub(f.since_ms),
+            reported: &mut f.acked,
+        })
     }
 
     fn poll_misc_sensors(
@@ -322,7 +349,7 @@ impl crate::control::BspInterface for Bsp {
         let mut any_err = false;
         let mut set_all = |fctrl: &mut Max31790, fans: &mut [Fan]| {
             for fan in fans.iter_mut() {
-                let val = if !fan.is_present {
+                let val = if matches!(fan.cur_state, FanState::NotPresent) {
                     userlib::units::PWMDuty(0)
                 } else {
                     duty

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -19,7 +19,6 @@ use task_thermal_api::ThermalError;
 use task_thermal_api::{
     SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalProperties,
 };
-use userlib::sys_get_timer;
 use userlib::{TaskId, task_slot, units::Celsius};
 
 include!(concat!(env!("OUT_DIR"), "/i2c_config.rs"));
@@ -132,14 +131,13 @@ impl crate::control::BspInterface for Bsp {
         // If we *don't* have presence data, something has gone terribly wrong
         // with the sequencer, and we will keep using the last reported presence
         // state, which starts as "not present" at power-up.
-        let now = sys_get_timer().now;
         match self.seq.fan_module_presence() {
             Ok(pres) => {
                 // Each presence bit represents 2 physical fans
                 let fanchs = self.fans.chunks_exact_mut(2);
                 for (p, pair) in pres.0.iter().zip(fanchs) {
                     for fan in pair {
-                        fan.update_presence(*p, now);
+                        fan.update_presence(*p);
                     }
                 }
             }
@@ -157,7 +155,7 @@ impl crate::control::BspInterface for Bsp {
         if let Ok(fctl) = self.fctrl_east.try_initialize() {
             for fan in east.iter_mut() {
                 let bsp_data = fan.bsp_data;
-                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                fan.poll_rpm_with(&SANYO_DENKI_FAN_PROPERTIES, || {
                     fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
@@ -165,7 +163,7 @@ impl crate::control::BspInterface for Bsp {
         if let Ok(fctl) = self.fctrl_west.try_initialize() {
             for fan in west.iter_mut() {
                 let bsp_data = fan.bsp_data;
-                fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
+                fan.poll_rpm_with(&SANYO_DENKI_FAN_PROPERTIES, || {
                     fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
@@ -381,11 +379,6 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
-        // Fast forward fan time to now
-        let fans = FANS_ONCE.claim();
-        let now = sys_get_timer().now;
-        fans.iter_mut().for_each(|f| f.initialize_time(now));
-
         static DYN_INS_ONCE: static_cell::ClaimOnceCell<
             [DynamicInputChannel; NUM_DYNAMIC_TEMPERATURE_INPUTS],
         > = static_cell::ClaimOnceCell::new(DYNAMIC_INPUTS);
@@ -411,7 +404,7 @@ impl Bsp {
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,
             i2c_task,
-            fans,
+            fans: FANS_ONCE.claim(),
         }
     }
 }

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -5,11 +5,10 @@
 //! BSP for Sidecar
 
 use crate::control::{
-    ActiveInputState, ChannelType, DynamicTemperatureState, FanPresentState,
-    FanState, MiscSensorPollingOutcome, PidConfig,
-    TimestampedTemperatureReading,
+    ActiveInputState, ChannelType, DynamicInputChannel,
+    DynamicTemperatureState, FanPresentState, FanState,
+    MiscSensorPollingOutcome, PidConfig, TimestampedTemperatureReading,
 };
-use crate::control::{DynamicInputChannel, FanPollingOutcome};
 use drv_i2c_api::ResponseCode;
 use drv_i2c_devices::max31790::Max31790;
 use drv_i2c_devices::tmp451::*;
@@ -106,6 +105,8 @@ impl crate::control::BspInterface for Bsp {
         max_output: 100.0,
     };
 
+    type FanBspId = drv_i2c_devices::max31790::Fan;
+
     fn power_down(&self) -> Result<(), crate::SeqError> {
         self.seq
             .set_tofino_seq_policy(TofinoSequencerPolicy::Disabled)
@@ -124,7 +125,7 @@ impl crate::control::BspInterface for Bsp {
         }
     }
 
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome<'_>> {
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = &'_ mut Fan> {
         let have_presence;
         let now = sys_get_timer().now;
         match self.seq.fan_module_presence() {
@@ -186,14 +187,7 @@ impl crate::control::BspInterface for Bsp {
             }
         }
 
-        self.fans.iter_mut().map(move |f| FanPollingOutcome {
-            sensor_id: f.rpm_sensor_id,
-            fan_id: f.bsp_data.into(),
-            cur_state: f.current_state(),
-            duration_ms: now.saturating_sub(f.since_ms),
-            state_reported: &mut f.state_acked,
-            presence_reported: &mut f.presence_acked,
-        })
+        self.fans.iter_mut()
     }
 
     fn poll_misc_sensors(

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -381,6 +381,11 @@ impl Bsp {
         static FANS_ONCE: static_cell::ClaimOnceCell<[Fan; NUM_FANS]> =
             static_cell::ClaimOnceCell::new(FANS);
 
+        // Fast forward fan time to now
+        let fans = FANS_ONCE.claim();
+        let now = sys_get_timer().now;
+        fans.iter_mut().for_each(|f| f.initialize_time(now));
+
         static DYN_INS_ONCE: static_cell::ClaimOnceCell<
             [DynamicInputChannel; NUM_DYNAMIC_TEMPERATURE_INPUTS],
         > = static_cell::ClaimOnceCell::new(DYNAMIC_INPUTS);
@@ -406,7 +411,7 @@ impl Bsp {
             // We monitor and log all of the air temperatures
             misc_sensors: &MISC_SENSORS,
             i2c_task,
-            fans: FANS_ONCE.claim(),
+            fans,
         }
     }
 }

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -16,7 +16,9 @@ use drv_sidecar_seq_api::{Sequencer, TofinoSeqState, TofinoSequencerPolicy};
 use ringbuf::ringbuf_entry_root;
 use task_sensor_api::SensorId;
 use task_thermal_api::ThermalError;
-use task_thermal_api::{SANYO_DENKI_FAN_PROPERTIES, ThermalProperties};
+use task_thermal_api::{
+    SANYO_DENKI_FAN_PROPERTIES, SensorReadError, ThermalProperties,
+};
 use userlib::sys_get_timer;
 use userlib::{TaskId, task_slot, units::Celsius};
 
@@ -148,7 +150,6 @@ impl crate::control::BspInterface for Bsp {
 
         // Load bearing assumption: the first 4 fans are the EAST fans, and the
         // last 4 fans are the WEST fans.
-        let now = sys_get_timer().now;
         let (east, west) = self.fans.split_at_mut(4);
 
         // Fan controller initialization is latching, if it never succeeds, fans
@@ -157,7 +158,7 @@ impl crate::control::BspInterface for Bsp {
             for fan in east.iter_mut() {
                 let bsp_data = fan.bsp_data;
                 fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
-                    fctl.fan_rpm(bsp_data)
+                    fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
         }
@@ -165,7 +166,7 @@ impl crate::control::BspInterface for Bsp {
             for fan in west.iter_mut() {
                 let bsp_data = fan.bsp_data;
                 fan.poll_rpm_with(now, &SANYO_DENKI_FAN_PROPERTIES, || {
-                    fctl.fan_rpm(bsp_data)
+                    fctl.fan_rpm(bsp_data).map_err(SensorReadError::I2cError)
                 });
             }
         }

--- a/task/thermal/src/bsp/sidecar_bcd.rs
+++ b/task/thermal/src/bsp/sidecar_bcd.rs
@@ -5,8 +5,9 @@
 //! BSP for Sidecar
 
 use crate::control::{
-    ActiveInputState, ChannelType, DynamicTemperatureState, FanState,
-    MiscSensorPollingOutcome, PidConfig, TimestampedTemperatureReading,
+    ActiveInputState, ChannelType, DynamicTemperatureState, FanPresentState,
+    FanState, MiscSensorPollingOutcome, PidConfig,
+    TimestampedTemperatureReading,
 };
 use crate::control::{DynamicInputChannel, FanPollingOutcome};
 use drv_i2c_api::ResponseCode;
@@ -151,19 +152,22 @@ impl crate::control::BspInterface for Bsp {
             match res {
                 Ok(rpm) => {
                     let state = if rpm.0 < 500 {
-                        FanState::PresentTooSlow(rpm)
+                        FanPresentState::TooSlow(rpm)
                     } else if rpm.0 > 13500 {
-                        FanState::PresentTooFast(rpm)
+                        FanPresentState::TooFast(rpm)
                     } else {
-                        FanState::Present(rpm)
+                        FanPresentState::Nominal(rpm)
                     };
-                    fan.update_state(state, now);
+                    fan.update_state(FanState::Present(state), now);
                 }
                 Err(ResponseCode::NoDevice) if !have_presence => {
                     fan.update_presence(false, now);
                 }
                 Err(_e) => {
-                    fan.update_state(FanState::PresentUnresponsive, now);
+                    fan.update_state(
+                        FanState::Present(FanPresentState::Unresponsive),
+                        now,
+                    );
                 }
             }
         };
@@ -187,7 +191,8 @@ impl crate::control::BspInterface for Bsp {
             fan_id: f.bsp_data.into(),
             cur_state: f.current_state(),
             duration_ms: now.saturating_sub(f.since_ms),
-            reported: &mut f.acked,
+            state_reported: &mut f.state_acked,
+            presence_reported: &mut f.presence_acked,
         })
     }
 

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -250,7 +250,7 @@ pub struct Fan<D> {
 }
 
 #[allow(dead_code)] // Not all bsps have fans!
-impl<D: Copy + Into<u8>> Fan<D> {
+impl<D> Fan<D> {
     /// Create a new fan
     pub const fn new(rpm_sensor_id: SensorId, bsp_data: D) -> Self {
         Self {
@@ -321,17 +321,11 @@ impl<D: Copy + Into<u8>> Fan<D> {
             (Fs::Present(cur), Fs::Present(newp)) => match (cur, newp) {
                 // Unresponsive -> Unresponsive, nothing to update
                 (Fps::Unresponsive, Fps::Unresponsive) => {}
-                // Nominal -> Nominal, just take state
-                (Fps::Nominal(_), Fps::Nominal(_)) => {
+                // Same -> Same, just take state
+                (Fps::Nominal(_), Fps::Nominal(_))
+                | (Fps::TooFast(_), Fps::TooFast(_))
+                | (Fps::TooSlow(_), Fps::TooSlow(_)) => {
                     self.cur_state = new;
-                }
-                (Fps::TooFast(old_rpm), Fps::TooFast(new_rpm)) => {
-                    let rpm = old_rpm.0.max(new_rpm.0);
-                    self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
-                }
-                (Fps::TooSlow(old_rpm), Fps::TooSlow(new_rpm)) => {
-                    let rpm = old_rpm.0.min(new_rpm.0);
-                    self.cur_state = Fs::Present(Fps::TooSlow(Rpm(rpm)));
                 }
                 // Nominal -> Deviant, or Deviant -> Nominal, update:
                 //
@@ -366,7 +360,7 @@ impl<D: Copy + Into<u8>> Fan<D> {
 
     /// Update the RPM of a present fan with the given closure, which should
     /// retrieve the RPM. Used to share logic across different fan controllers
-    pub(crate) fn poll_rpm_with<E>(
+    pub(crate) fn poll_rpm_with<E: Into<SensorReadError>>(
         &mut self,
         now: u64,
         model: &FanProperties,
@@ -386,7 +380,7 @@ impl<D: Copy + Into<u8>> Fan<D> {
                 // reading is nominal or not, and report that as the state.
                 let state = if rpm < model.underspeed_rpm {
                     FanPresentState::TooSlow(rpm)
-                } else if rpm > model.underspeed_rpm {
+                } else if rpm > model.overspeed_rpm {
                     FanPresentState::TooFast(rpm)
                 } else {
                     FanPresentState::Nominal(rpm)
@@ -402,19 +396,6 @@ impl<D: Copy + Into<u8>> Fan<D> {
             }
         }
     }
-}
-
-#[allow(dead_code)] // Not all bsps have fans!
-pub enum FanPresence {
-    Present {
-        fan_id: u8,
-        changed: bool,
-    },
-    #[allow(dead_code)] // Some bsps don't have removable fans
-    NotPresent {
-        fan_id: u8,
-        changed: bool,
-    },
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1065,8 +1046,9 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
         }
 
         // Read fan data and log it to the sensors task
-        for reading in self.bsp.poll_fan_rpms() {
-            report_fan_state(reading, &self.sensor_api);
+        let now = sys_get_timer().now;
+        for fan in self.bsp.poll_fan_rpms() {
+            report_fan_state(fan, &self.sensor_api, now);
         }
 
         // Read miscellaneous temperature data and log it to the sensors task
@@ -1574,13 +1556,13 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
 /// - Sensor API data
 /// - Ringbuf logging on state changes
 /// - ereport logging on state changes
-fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi) {
+fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
     /// This is an arbitrarily chosen debounce time to avoid throwing errors
     /// for momentary hiccups. Right now, this influences our reporting for any
     /// non-nominal state.
     const STABILITY_TIME_MS: u64 = 3_000;
 
-    let duration_ms = sys_get_timer().now.saturating_sub(fan.since_ms);
+    let duration_ms = now_ms.saturating_sub(fan.since_ms);
     let stable = duration_ms > STABILITY_TIME_MS;
     let FanState::Present(pres) = fan.cur_state else {
         if stable {
@@ -1593,6 +1575,10 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi) {
         }
         return;
     };
+    if !fan.presence_acked {
+        ringbuf_entry!(Trace::FanAdded(fan.rpm_sensor_id));
+        fan.presence_acked = true;
+    }
 
     // Report RPM immediately if we have it, OR clear it if it is erroneous and
     // has been for a reasonable amount of time.

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -205,7 +205,7 @@ pub trait BspInterface {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// State of a given fan
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FanState {
     NotPresent,
     Present(FanPresentState),
@@ -213,10 +213,10 @@ pub enum FanState {
 
 /// State specific to fans that are present
 #[allow(dead_code)] // Not all bsps have fans!
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FanPresentState {
     /// The fan is physically present, but is unresponsive to RPM queries
-    Unresponsive,
+    Unresponsive(SensorReadError),
     /// The fan is present and at a reasonable speed
     Nominal(Rpm),
     /// The fan is present, but is overspeed
@@ -283,7 +283,9 @@ impl<D> Fan<D> {
     pub(crate) fn update_presence(&mut self, is_present: bool, now_ms: u64) {
         match (is_present, self.cur_state) {
             (true, FanState::NotPresent) => self.update_state(
-                FanState::Present(FanPresentState::Unresponsive),
+                FanState::Present(FanPresentState::Unresponsive(
+                    SensorReadError::NoData,
+                )),
                 now_ms,
             ),
             (true, _) => {}
@@ -319,12 +321,11 @@ impl<D> Fan<D> {
             }
             // Present -> Present
             (Fs::Present(cur), Fs::Present(newp)) => match (cur, newp) {
-                // Unresponsive -> Unresponsive, nothing to update
-                (Fps::Unresponsive, Fps::Unresponsive) => {}
                 // Same -> Same, just take state
                 (Fps::Nominal(_), Fps::Nominal(_))
                 | (Fps::TooFast(_), Fps::TooFast(_))
-                | (Fps::TooSlow(_), Fps::TooSlow(_)) => {
+                | (Fps::TooSlow(_), Fps::TooSlow(_))
+                | (Fps::Unresponsive(_), Fps::Unresponsive(_)) => {
                     self.cur_state = new;
                 }
                 // Nominal -> Deviant, or Deviant -> Nominal, update:
@@ -341,12 +342,12 @@ impl<D> Fan<D> {
                 // deviant -> deviant, update:
                 //
                 // - New state
-                (Fps::TooFast(_), Fps::Unresponsive)
+                (Fps::TooFast(_), Fps::Unresponsive(_))
                 | (Fps::TooFast(_), Fps::TooSlow(_))
-                | (Fps::TooSlow(_), Fps::Unresponsive)
+                | (Fps::TooSlow(_), Fps::Unresponsive(_))
                 | (Fps::TooSlow(_), Fps::TooFast(_))
-                | (Fps::Unresponsive, Fps::TooFast(_))
-                | (Fps::Unresponsive, Fps::TooSlow(_)) => {
+                | (Fps::Unresponsive(_), Fps::TooFast(_))
+                | (Fps::Unresponsive(_), Fps::TooSlow(_)) => {
                     // TODO: Do we want ringbuf entries and/or ereports for
                     // deviant -> deviant transitions? If so, we should reset
                     // the since_ms and state_acked values here too, basically
@@ -387,10 +388,10 @@ impl<D> Fan<D> {
                 };
                 self.update_state(FanState::Present(state), now);
             }
-            Err(_e) => {
+            Err(e) => {
                 // No good, mark as unresponsive
                 self.update_state(
-                    FanState::Present(FanPresentState::Unresponsive),
+                    FanState::Present(FanPresentState::Unresponsive(e.into())),
                     now,
                 );
             }
@@ -1565,13 +1566,11 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
     let duration_ms = now_ms.saturating_sub(fan.since_ms);
     let stable = duration_ms > STABILITY_TIME_MS;
     let FanState::Present(pres) = fan.cur_state else {
-        if stable {
-            sensor_api.nodata_now(fan.rpm_sensor_id, NoData::DeviceNotPresent);
+        sensor_api.nodata_now(fan.rpm_sensor_id, NoData::DeviceNotPresent);
 
-            if !fan.presence_acked {
-                ringbuf_entry!(Trace::FanRemoved(fan.rpm_sensor_id));
-                fan.presence_acked = true;
-            }
+        if !fan.presence_acked {
+            ringbuf_entry!(Trace::FanRemoved(fan.rpm_sensor_id));
+            fan.presence_acked = true;
         }
         return;
     };
@@ -1583,7 +1582,7 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
     // Report RPM immediately if we have it, OR clear it if it is erroneous and
     // has been for a reasonable amount of time.
     match pres {
-        FanPresentState::Unresponsive => {
+        FanPresentState::Unresponsive(_) => {
             if stable {
                 sensor_api
                     .nodata_now(fan.rpm_sensor_id, NoData::DeviceUnavailable);
@@ -1599,8 +1598,8 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
     // Handle reporting, if stable and unreported
     if stable && !fan.state_acked {
         match pres {
-            FanPresentState::Unresponsive => {
-                ringbuf_entry!(Trace::FanReadFailed(fan.rpm_sensor_id));
+            FanPresentState::Unresponsive(e) => {
+                ringbuf_entry!(Trace::FanReadFailed(fan.rpm_sensor_id, e));
             }
             FanPresentState::Nominal(_) => {
                 ringbuf_entry!(Trace::FanNominal(fan.rpm_sensor_id));

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -256,6 +256,13 @@ impl<D> Fan<D> {
         }
     }
 
+    /// Method that should be called at BSP initialization that sets the
+    /// `since_ms` to `now_ms`, instead of a likely zero-initialized value which
+    /// may be significantly in the past if the thermal task restarts.
+    pub(crate) fn initialize_time(&mut self, now_ms: u64) {
+        self.since_ms = now_ms;
+    }
+
     /// The currently tracked state of the fan
     pub(crate) fn current_state(&self) -> FanState {
         self.cur_state

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -69,7 +69,7 @@
 //!   move the fans to their highest commanded speed when not communicated with
 //!   for a configured time duration.
 
-use crate::{TIMER_INTERVAL, ThermalError, Trace, bsp::PowerBitmask};
+use crate::{ThermalError, Trace, bsp::PowerBitmask};
 use drv_i2c_devices::max31790::I2cWatchdog;
 
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
@@ -236,8 +236,6 @@ pub struct Fan<D> {
     pub state_acked: bool,
     /// The current state of the fan
     pub cur_state: FanState,
-    /// The time (e.g. an Instant) that the fan changed to the current state
-    pub since_ms: u64,
     /// A BSP-specific ID used to identify the fan
     pub bsp_data: D,
 }
@@ -251,16 +249,8 @@ impl<D> Fan<D> {
             presence_acked: false,
             state_acked: false,
             cur_state: FanState::NotPresent,
-            since_ms: 0,
             bsp_data,
         }
-    }
-
-    /// Method that should be called at BSP initialization that sets the
-    /// `since_ms` to `now_ms`, instead of a likely zero-initialized value which
-    /// may be significantly in the past if the thermal task restarts.
-    pub(crate) fn initialize_time(&mut self, now_ms: u64) {
-        self.since_ms = now_ms;
     }
 
     /// The currently tracked state of the fan
@@ -280,17 +270,16 @@ impl<D> Fan<D> {
     /// will be marked as such. If the fan is newly present, it will be moved
     /// to the `Present(Unresponsive)` state. Otherwise, the fan state will
     /// not be updated.
-    pub(crate) fn update_presence(&mut self, is_present: bool, now_ms: u64) {
+    pub(crate) fn update_presence(&mut self, is_present: bool) {
         match (is_present, self.cur_state) {
-            (true, FanState::NotPresent) => self.update_state(
-                FanState::Present(FanPresentState::Unresponsive(
-                    SensorReadError::NoData,
-                )),
-                now_ms,
-            ),
+            (true, FanState::NotPresent) => {
+                self.update_state(FanState::Present(
+                    FanPresentState::Unresponsive(SensorReadError::NoData),
+                ))
+            }
             (true, _) => {}
             (false, _) => {
-                self.update_state(FanState::NotPresent, now_ms);
+                self.update_state(FanState::NotPresent);
             }
         }
     }
@@ -299,8 +288,8 @@ impl<D> Fan<D> {
     ///
     /// This method is the primary logic for state transitions of the fan.
     /// It is responsible for determining whether new notification is
-    /// required, or if the time-in-state should be updated.
-    pub(crate) fn update_state(&mut self, new: FanState, now_ms: u64) {
+    /// required.
+    pub(crate) fn update_state(&mut self, new: FanState) {
         use FanPresentState as Fps;
         use FanState as Fs;
         match (self.cur_state, new) {
@@ -311,13 +300,11 @@ impl<D> Fan<D> {
             // - New state
             // - Presence ack state
             // - Status ack state
-            // - Time of change
             (Fs::NotPresent, Fs::Present(_))
             | (Fs::Present(_), Fs::NotPresent) => {
                 self.cur_state = new;
                 self.presence_acked = false;
                 self.state_acked = false;
-                self.since_ms = now_ms;
             }
             // Present -> Present
             (Fs::Present(cur), Fs::Present(newp)) => match (cur, newp) {
@@ -328,32 +315,26 @@ impl<D> Fan<D> {
                 | (Fps::Unresponsive(_), Fps::Unresponsive(_)) => {
                     self.cur_state = new;
                 }
-                // Nominal -> Deviant, or Deviant -> Nominal, update:
+                // Any of the following:
+                //
+                // - Nominal -> Deviant
+                // - Deviant -> Nominal
+                // - Deviant -> Deviant
+                //
+                // Take:
                 //
                 // - New state
                 // - Status ack state
-                // - Time of change
-                (Fps::Nominal(_), _) | (_, Fps::Nominal(_)) => {
-                    self.cur_state = new;
-                    self.state_acked = false;
-                    self.since_ms = now_ms;
-                }
-
-                // deviant -> deviant, update:
-                //
-                // - New state
-                (Fps::TooFast(_), Fps::Unresponsive(_))
+                (Fps::Nominal(_), _)
+                | (_, Fps::Nominal(_))
+                | (Fps::TooFast(_), Fps::Unresponsive(_))
                 | (Fps::TooFast(_), Fps::TooSlow(_))
                 | (Fps::TooSlow(_), Fps::Unresponsive(_))
                 | (Fps::TooSlow(_), Fps::TooFast(_))
                 | (Fps::Unresponsive(_), Fps::TooFast(_))
                 | (Fps::Unresponsive(_), Fps::TooSlow(_)) => {
-                    // TODO: Do we want ringbuf entries and/or ereports for
-                    // deviant -> deviant transitions? If so, we should reset
-                    // the since_ms and state_acked values here too, basically
-                    // collapsing this with the Nominal -> Deviant +
-                    // Deviant -> Nominal case above.
                     self.cur_state = new;
+                    self.state_acked = false;
                 }
             },
         }
@@ -363,7 +344,6 @@ impl<D> Fan<D> {
     /// retrieve the RPM. Used to share logic across different fan controllers
     pub(crate) fn poll_rpm_with<E: Into<SensorReadError>>(
         &mut self,
-        now: u64,
         model: &FanProperties,
         poll_rpm: impl FnOnce() -> Result<Rpm, E>,
     ) {
@@ -386,14 +366,13 @@ impl<D> Fan<D> {
                 } else {
                     FanPresentState::Nominal(rpm)
                 };
-                self.update_state(FanState::Present(state), now);
+                self.update_state(FanState::Present(state));
             }
             Err(e) => {
                 // No good, mark as unresponsive
-                self.update_state(
-                    FanState::Present(FanPresentState::Unresponsive(e.into())),
-                    now,
-                );
+                self.update_state(FanState::Present(
+                    FanPresentState::Unresponsive(e.into()),
+                ));
             }
         }
     }
@@ -1562,18 +1541,8 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
     use FanPresentState as Fps;
     use FanState as Fs;
 
-    /// This is an arbitrarily chosen debounce time to avoid throwing errors
-    /// for momentary hiccups. Right now, this influences our reporting for any
-    /// non-nominal state. This is intentionally between two control polling
-    /// intervals, so it should fire on the third tick, even if there's a little
-    /// timing jitter.
-    const STABILITY_TIME_MS: u64 = (TIMER_INTERVAL * 3) - (TIMER_INTERVAL / 2);
-
-    let id = fan.rpm_sensor_id;
-    let duration_ms = now_ms.saturating_sub(fan.since_ms);
-    let stable = duration_ms > STABILITY_TIME_MS;
-
     // Step one: report presence, if necessary
+    let id = fan.rpm_sensor_id;
     if !fan.presence_acked {
         let trace = match fan.cur_state {
             Fs::NotPresent => Trace::FanRemoved(id),
@@ -1595,22 +1564,18 @@ fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
         Fs::Present(pres) => pres,
     };
     match pres {
-        // If the fan is unresponsive and has been for enough time,
-        // clear the data from the sensor API
-        Fps::Unresponsive(_) if stable => {
+        // If the fan is unresponsive, clear the data from the sensor API
+        Fps::Unresponsive(_) => {
             sensor_api.nodata(id, NoData::DeviceUnavailable, now_ms);
         }
-        // Wait for unresponsive device to become stable
-        Fps::Unresponsive(_) => {}
-        // Although we want to wait for a deviant state to become stable before
-        // reporting it, if we have valid RPM data, report it immediately.
+        // If we have valid RPM data, report it immediately.
         Fps::Nominal(rpm) | Fps::TooFast(rpm) | Fps::TooSlow(rpm) => {
             sensor_api.post(id, rpm.0.into(), now_ms);
         }
     }
 
-    // Step three: handle state reporting, if stable and unreported
-    if stable && !fan.state_acked {
+    // Step three: handle state reporting, if unreported
+    if !fan.state_acked {
         let trace = match pres {
             Fps::Unresponsive(e) => Trace::FanReadFailed(id, e),
             Fps::Nominal(_) => Trace::FanNominal(id),

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -208,6 +208,7 @@ pub enum FanState {
     Present(FanPresentState),
 }
 
+#[allow(dead_code)] // Not all bsps have fans!
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FanPresentState {
     Unresponsive,
@@ -298,7 +299,7 @@ impl<D: Copy + Into<u8>> Fan<D> {
                 }
                 (Fps::TooSlow(old_rpm), Fps::TooSlow(new_rpm)) => {
                     let rpm = old_rpm.0.min(new_rpm.0);
-                    self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
+                    self.cur_state = Fs::Present(Fps::TooSlow(Rpm(rpm)));
                 }
                 // Nominal -> Deviant, or Deviant -> Nominal, update:
                 //

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -69,7 +69,7 @@
 //!   move the fans to their highest commanded speed when not communicated with
 //!   for a configured time duration.
 
-use crate::{ThermalError, Trace, bsp::PowerBitmask};
+use crate::{TIMER_INTERVAL, ThermalError, Trace, bsp::PowerBitmask};
 use drv_i2c_devices::max31790::I2cWatchdog;
 
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
@@ -104,25 +104,18 @@ pub trait BspInterface {
     /// The current power mode reported by the sequencer
     fn power_mode(&self) -> PowerBitmask;
 
-    /// An iterator representing the presence of each fan of the system
+    /// Poll every fan in the system, then yield each one for reporting.
     ///
-    /// Typically reported by the sequencer, or always present in non-variable
-    /// configurations (or an empty iterator, if the board does not have fans).
-    ///
-    /// Note that BSPs are responsible for tracking the changes in state to
-    /// fans, and must accurately report when a fan has been added or removed.
-    /// Unremovable fans should be reported as newly added the first time their
-    /// presence is polled.
-    ///
-    /// Return an iterator of the current status of each fan. The iterator may
-    /// be lazy, meaning that failure to exhaust the iterator means that not all
-    /// fans will be actively read.
+    /// Implementations must update the presence of every removable fan using
+    /// [`Fan::update_presence()`], and poll the RPM of every fan using
+    /// [`Fan::poll_rpm_with()`]. The returned iterator should then yield all
+    /// fans, including any that are not present or are in a deviant state.
     fn poll_fan_rpms(
         &mut self,
     ) -> impl Iterator<Item = &'_ mut Fan<Self::FanBspId>>;
 
     /// Return an iterator of the current status of each misc sensor. The
-    /// iterator may be lazy, meaning that faulure to exhaust the iterator means
+    /// iterator may be lazy, meaning that failure to exhaust the iterator means
     /// that not all sensors will be actively queried.
     fn poll_misc_sensors(
         &self,
@@ -1558,59 +1551,66 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
 /// - Ringbuf logging on state changes
 /// - ereport logging on state changes
 fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi, now_ms: u64) {
+    // Make state matches a little less verbose
+    use FanPresentState as Fps;
+    use FanState as Fs;
+
     /// This is an arbitrarily chosen debounce time to avoid throwing errors
     /// for momentary hiccups. Right now, this influences our reporting for any
-    /// non-nominal state.
-    const STABILITY_TIME_MS: u64 = 3_000;
+    /// non-nominal state. This is intentionally between two control polling
+    /// intervals, so it should fire on the third tick, even if there's a little
+    /// timing jitter.
+    const STABILITY_TIME_MS: u64 = (TIMER_INTERVAL * 3) - (TIMER_INTERVAL / 2);
 
+    let id = fan.rpm_sensor_id;
     let duration_ms = now_ms.saturating_sub(fan.since_ms);
     let stable = duration_ms > STABILITY_TIME_MS;
-    let FanState::Present(pres) = fan.cur_state else {
-        sensor_api.nodata_now(fan.rpm_sensor_id, NoData::DeviceNotPresent);
 
-        if !fan.presence_acked {
-            ringbuf_entry!(Trace::FanRemoved(fan.rpm_sensor_id));
-            fan.presence_acked = true;
-        }
-        return;
-    };
+    // Step one: report presence, if necessary
     if !fan.presence_acked {
-        ringbuf_entry!(Trace::FanAdded(fan.rpm_sensor_id));
+        let trace = match fan.cur_state {
+            Fs::NotPresent => Trace::FanRemoved(id),
+            Fs::Present(_) => Trace::FanAdded(id),
+        };
+        ringbuf_entry!(trace);
         fan.presence_acked = true;
     }
 
-    // Report RPM immediately if we have it, OR clear it if it is erroneous and
-    // has been for a reasonable amount of time.
-    match pres {
-        FanPresentState::Unresponsive(_) => {
-            if stable {
-                sensor_api
-                    .nodata_now(fan.rpm_sensor_id, NoData::DeviceUnavailable);
-            }
+    // Step two: report fan data to sensor API.
+    let pres = match fan.cur_state {
+        Fs::NotPresent => {
+            // If the fan is physically not present, clear data immediately
+            sensor_api.nodata(id, NoData::DeviceNotPresent, now_ms);
+            // There's no more further state to log, return early
+            fan.state_acked = true;
+            return;
         }
-        FanPresentState::Nominal(rpm)
-        | FanPresentState::TooFast(rpm)
-        | FanPresentState::TooSlow(rpm) => {
-            sensor_api.post_now(fan.rpm_sensor_id, rpm.0.into());
+        Fs::Present(pres) => pres,
+    };
+    match pres {
+        // If the fan is unresponsive and has been for enough time,
+        // clear the data from the sensor API
+        Fps::Unresponsive(_) if stable => {
+            sensor_api.nodata(id, NoData::DeviceUnavailable, now_ms);
+        }
+        // Wait for unresponsive device to become stable
+        Fps::Unresponsive(_) => {}
+        // Although we want to wait for a deviant state to become stable before
+        // reporting it, if we have valid RPM data, report it immediately.
+        Fps::Nominal(rpm) | Fps::TooFast(rpm) | Fps::TooSlow(rpm) => {
+            sensor_api.post(id, rpm.0.into(), now_ms);
         }
     }
 
-    // Handle reporting, if stable and unreported
+    // Step three: handle state reporting, if stable and unreported
     if stable && !fan.state_acked {
-        match pres {
-            FanPresentState::Unresponsive(e) => {
-                ringbuf_entry!(Trace::FanReadFailed(fan.rpm_sensor_id, e));
-            }
-            FanPresentState::Nominal(_) => {
-                ringbuf_entry!(Trace::FanNominal(fan.rpm_sensor_id));
-            }
-            FanPresentState::TooFast(rpm) => {
-                ringbuf_entry!(Trace::FanOverspeed(fan.rpm_sensor_id, rpm));
-            }
-            FanPresentState::TooSlow(rpm) => {
-                ringbuf_entry!(Trace::FanUnderspeed(fan.rpm_sensor_id, rpm));
-            }
-        }
+        let trace = match pres {
+            Fps::Unresponsive(e) => Trace::FanReadFailed(id, e),
+            Fps::Nominal(_) => Trace::FanNominal(id),
+            Fps::TooFast(rpm) => Trace::FanOverspeed(id, rpm),
+            Fps::TooSlow(rpm) => Trace::FanUnderspeed(id, rpm),
+        };
+        ringbuf_entry!(trace);
         fan.state_acked = true;
     }
 }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -94,7 +94,7 @@ pub trait BspInterface {
     const USE_CONTROLLER: bool;
 
     /// BSP-specific fan identifier
-    type FanBspId: Into<u8> + Copy;
+    type FanBspId;
 
     /// Instruct the sequencer to power down the system
     fn power_down(&self) -> Result<(), crate::SeqError>;
@@ -202,18 +202,24 @@ pub trait BspInterface {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/// State of a given fan
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FanState {
     NotPresent,
     Present(FanPresentState),
 }
 
+/// State specific to fans that are present
 #[allow(dead_code)] // Not all bsps have fans!
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FanPresentState {
+    /// The fan is physically present, but is unresponsive to RPM queries
     Unresponsive,
+    /// The fan is present and at a reasonable speed
     Nominal(Rpm),
+    /// The fan is present, but is overspeed
     TooFast(Rpm),
+    /// The fan is present, but is underspeed
     TooSlow(Rpm),
 }
 
@@ -225,16 +231,25 @@ pub enum FanPresentState {
 /// fans which are not present and their PWM should only be driven low.
 #[allow(dead_code)] // Not all bsps have fans!
 pub struct Fan<D> {
+    /// The sensor_api ID used for reporting fan RPMs
     pub rpm_sensor_id: SensorId,
+    /// Have we sent a notice about whether the fan was added or removed yet?
+    /// This includes ringbuf and ereport output.
     pub presence_acked: bool,
+    /// Have we sent a notice about the state of a present fan yet?
+    /// This includes ringbuf and ereport output.
     pub state_acked: bool,
+    /// The current state of the fan
     pub cur_state: FanState,
+    /// The time (e.g. an Instant) that the fan changed to the current state
     pub since_ms: u64,
+    /// A BSP-specific ID used to identify the fan
     pub bsp_data: D,
 }
 
 #[allow(dead_code)] // Not all bsps have fans!
 impl<D: Copy + Into<u8>> Fan<D> {
+    /// Create a new fan
     pub const fn new(rpm_sensor_id: SensorId, bsp_data: D) -> Self {
         Self {
             rpm_sensor_id,
@@ -246,14 +261,23 @@ impl<D: Copy + Into<u8>> Fan<D> {
         }
     }
 
+    /// The currently tracked state of the fan
     pub(crate) fn current_state(&self) -> FanState {
         self.cur_state
     }
 
+    /// Is the current fan physically present?
     pub(crate) fn is_present(&self) -> bool {
         !matches!(self.cur_state, FanState::NotPresent)
     }
 
+    /// Mark the fan as present or not.
+    ///
+    /// This method is used to avoid modifying the current state of the fan
+    /// if the presence has not changed. If the fan is newly not present, it
+    /// will be marked as such. If the fan is newly present, it will be moved
+    /// to the `Present(Unresponsive)` state. Otherwise, the fan state will
+    /// not be updated.
     pub(crate) fn update_presence(&mut self, is_present: bool, now_ms: u64) {
         match (is_present, self.cur_state) {
             (true, FanState::NotPresent) => self.update_state(
@@ -266,6 +290,12 @@ impl<D: Copy + Into<u8>> Fan<D> {
             }
         }
     }
+
+    /// Update the current state of the fan.
+    ///
+    /// This method is the primary logic for state transitions of the fan.
+    /// It is responsible for determining whether new notification is
+    /// required, or if the time-in-state should be updated.
     pub(crate) fn update_state(&mut self, new: FanState, now_ms: u64) {
         use FanPresentState as Fps;
         use FanState as Fs;
@@ -1496,64 +1526,65 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
     }
 }
 
-fn report_fan_state<D: Into<u8> + Copy>(
-    reading: &mut Fan<D>,
-    sensor_api: &SensorApi,
-) {
-    let duration_ms = sys_get_timer().now.saturating_sub(reading.since_ms);
-    let stable = duration_ms > 3_000;
-    let FanState::Present(pres) = reading.cur_state else {
-        if stable {
-            sensor_api
-                .nodata_now(reading.rpm_sensor_id, NoData::DeviceNotPresent);
+/// Decide what information to report about the given fan.
+///
+/// This includes updating:
+///
+/// - Sensor API data
+/// - Ringbuf logging on state changes
+/// - ereport logging on state changes
+fn report_fan_state<D>(fan: &mut Fan<D>, sensor_api: &SensorApi) {
+    /// This is an arbitrarily chosen debounce time to avoid throwing errors
+    /// for momentary hiccups. Right now, this influences our reporting for any
+    /// non-nominal state.
+    const STABILITY_TIME_MS: u64 = 3_000;
 
-            if !reading.presence_acked {
-                ringbuf_entry!(Trace::FanRemoved(reading.bsp_data.into()));
-                reading.presence_acked = true;
+    let duration_ms = sys_get_timer().now.saturating_sub(fan.since_ms);
+    let stable = duration_ms > STABILITY_TIME_MS;
+    let FanState::Present(pres) = fan.cur_state else {
+        if stable {
+            sensor_api.nodata_now(fan.rpm_sensor_id, NoData::DeviceNotPresent);
+
+            if !fan.presence_acked {
+                ringbuf_entry!(Trace::FanRemoved(fan.rpm_sensor_id));
+                fan.presence_acked = true;
             }
         }
         return;
     };
 
-    // Report RPM immediately, if we have it, or clear it, if erroneous
+    // Report RPM immediately if we have it, OR clear it if it is erroneous and
+    // has been for a reasonable amount of time.
     match pres {
         FanPresentState::Unresponsive => {
             if stable {
-                sensor_api.nodata_now(
-                    reading.rpm_sensor_id,
-                    NoData::DeviceUnavailable,
-                );
+                sensor_api
+                    .nodata_now(fan.rpm_sensor_id, NoData::DeviceUnavailable);
             }
         }
         FanPresentState::Nominal(rpm)
         | FanPresentState::TooFast(rpm)
         | FanPresentState::TooSlow(rpm) => {
-            sensor_api.post_now(reading.rpm_sensor_id, rpm.0.into());
+            sensor_api.post_now(fan.rpm_sensor_id, rpm.0.into());
         }
     }
 
     // Handle reporting, if stable and unreported
-    if stable && !reading.state_acked {
+    if stable && !fan.state_acked {
         match pres {
             FanPresentState::Unresponsive => {
-                ringbuf_entry!(Trace::FanReadFailed(reading.rpm_sensor_id));
+                ringbuf_entry!(Trace::FanReadFailed(fan.rpm_sensor_id));
             }
             FanPresentState::Nominal(_) => {
-                ringbuf_entry!(Trace::FanNominal(reading.bsp_data.into()));
+                ringbuf_entry!(Trace::FanNominal(fan.rpm_sensor_id));
             }
             FanPresentState::TooFast(rpm) => {
-                ringbuf_entry!(Trace::FanOverspeed(
-                    reading.bsp_data.into(),
-                    rpm
-                ));
+                ringbuf_entry!(Trace::FanOverspeed(fan.rpm_sensor_id, rpm));
             }
             FanPresentState::TooSlow(rpm) => {
-                ringbuf_entry!(Trace::FanUnderspeed(
-                    reading.bsp_data.into(),
-                    rpm
-                ));
+                ringbuf_entry!(Trace::FanUnderspeed(fan.rpm_sensor_id, rpm));
             }
         }
-        reading.state_acked = true;
+        fan.state_acked = true;
     }
 }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -73,7 +73,7 @@ use crate::{ThermalError, Trace, bsp::PowerBitmask};
 use drv_i2c_devices::max31790::I2cWatchdog;
 
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
-use task_sensor_api::{Sensor as SensorApi, SensorId};
+use task_sensor_api::{NoData, Sensor as SensorApi, SensorId};
 use task_thermal_api::{SensorReadError, ThermalAutoState, ThermalProperties};
 use userlib::{
     sys_get_timer,
@@ -108,14 +108,11 @@ pub trait BspInterface {
     /// fans, and must accurately report when a fan has been added or removed.
     /// Unremovable fans should be reported as newly added the first time their
     /// presence is polled.
-    fn poll_fan_presence(
-        &mut self,
-    ) -> Result<impl Iterator<Item = FanPresence>, crate::SeqError>;
-
+    ///
     /// Return an iterator of the current status of each fan. The iterator may
     /// be lazy, meaning that failure to exhaust the iterator means that not all
     /// fans will be actively read.
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome>;
+    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome<'_>>;
 
     /// Return an iterator of the current status of each misc sensor. The
     /// iterator may be lazy, meaning that faulure to exhaust the iterator means
@@ -200,7 +197,16 @@ pub trait BspInterface {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Represents the indvidual fans in the system
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FanState {
+    NotPresent,
+    PresentUnresponsive,
+    Present(Rpm),
+    PresentTooFast(Rpm),
+    PresentTooSlow(Rpm),
+}
+
+/// Represents the individual fans in the system
 ///
 /// Depending on the system we have diferent numbers of fans structured in
 /// different ways. Not all fans are guaranteed to be there at all times so
@@ -209,17 +215,112 @@ pub trait BspInterface {
 #[allow(dead_code)] // Not all bsps have fans!
 pub struct Fan<D> {
     pub rpm_sensor_id: SensorId,
-    pub is_present: bool,
+    pub acked: bool,
+    pub prev_state: FanState,
+    pub cur_state: FanState,
+    pub since_ms: u64,
     pub bsp_data: D,
 }
 
 #[allow(dead_code)] // Not all bsps have fans!
-impl<D> Fan<D> {
+impl<D: Copy + Into<u8>> Fan<D> {
     pub const fn new(rpm_sensor_id: SensorId, bsp_data: D) -> Self {
         Self {
             rpm_sensor_id,
-            is_present: false,
+            acked: false,
+            prev_state: FanState::NotPresent,
+            cur_state: FanState::NotPresent,
+            since_ms: 0,
             bsp_data,
+        }
+    }
+
+    pub(crate) fn current_state(&self) -> FanState {
+        self.cur_state
+    }
+
+    pub(crate) fn is_present(&self) -> bool {
+        !matches!(self.cur_state, FanState::NotPresent)
+    }
+
+    pub(crate) fn update_presence(&mut self, is_present: bool, now_ms: u64) {
+        match (is_present, self.cur_state) {
+            (true, FanState::NotPresent) => {
+                self.update_state(FanState::PresentUnresponsive, now_ms)
+            }
+            (true, _) => {}
+            (false, _) => {
+                self.update_state(FanState::NotPresent, now_ms);
+            }
+        }
+    }
+    pub(crate) fn update_state(&mut self, new: FanState, now_ms: u64) {
+        use FanState as Fs;
+        match (self.cur_state, new) {
+            // Any data-less state staying the same:
+            //
+            // - Don't take new state
+            // - Don't update "since" timer
+            // - Don't update the "acked" flag
+            (Fs::NotPresent, Fs::NotPresent)
+            | (Fs::PresentUnresponsive, Fs::PresentUnresponsive) => {}
+
+            // present staying the same:
+            //
+            // - Do take the new state data
+            // - Don't update "since" timer
+            // - Don't update the "acked" flag
+            (Fs::Present(_), Fs::Present(_)) => {
+                self.cur_state = new;
+            }
+            (Fs::PresentTooFast(old), Fs::PresentTooFast(new)) => {
+                // Keep the fastest fast
+                self.cur_state = Fs::PresentTooFast(Rpm(old.0.max(new.0)));
+            }
+            (Fs::PresentTooSlow(old), Fs::PresentTooSlow(new)) => {
+                // Keep the slowest slow
+                self.cur_state = Fs::PresentTooSlow(Rpm(old.0.min(new.0)));
+            }
+
+            // For any of the following cases, this is an important state
+            // change:
+            //
+            // - Take the new state
+            // - Update the "since" timer
+            // - Clear the "acked" flag
+            //
+            // Any present -> Not present (we already checked (Not, Not) above)
+            (_, Fs::NotPresent)
+            // Not present to any present (we already checked (Not, Not) above)
+            | (Fs::NotPresent, _)
+            // Any deviant-present to nominal-present
+            | (Fs::PresentUnresponsive, Fs::Present(_))
+            | (Fs::PresentTooFast(_), Fs::Present(_))
+            | (Fs::PresentTooSlow(_), Fs::Present(_))
+            // Present to any deviant-present
+            | (Fs::Present(_), Fs::PresentUnresponsive)
+            | (Fs::Present(_), Fs::PresentTooFast(_))
+            | (Fs::Present(_), Fs::PresentTooSlow(_)) => {
+                self.prev_state = self.cur_state;
+                self.cur_state = new;
+                self.since_ms = now_ms;
+                self.acked = false;
+            }
+
+            // Deviant-to-Deviant:
+            //
+            // - Take the new state
+            // - DON'T update the "since" timer
+            // - DON'T clear the "acked" flag
+            (Fs::PresentUnresponsive, Fs::PresentTooFast(_))
+            | (Fs::PresentUnresponsive, Fs::PresentTooSlow(_))
+            | (Fs::PresentTooFast(_), Fs::PresentUnresponsive)
+            | (Fs::PresentTooFast(_), Fs::PresentTooSlow(_))
+            | (Fs::PresentTooSlow(_), Fs::PresentUnresponsive)
+            | (Fs::PresentTooSlow(_), Fs::PresentTooFast(_)) => {
+                self.prev_state = self.cur_state;
+                self.cur_state = new;
+            }
         }
     }
 }
@@ -238,19 +339,12 @@ pub enum FanPresence {
 }
 
 #[allow(dead_code)] // Not all bsps have fans!
-pub enum FanPollingOutcome {
-    PresentSuccess {
-        rpm: Rpm,
-        sensor_id: SensorId,
-    },
-    PresentError {
-        error: SensorReadError,
-        sensor_id: SensorId,
-    },
-    #[allow(dead_code)] // Some bsps don't have removable fans
-    NotPresent {
-        sensor_id: SensorId,
-    },
+pub struct FanPollingOutcome<'a> {
+    pub sensor_id: SensorId,
+    pub fan_id: u8,
+    pub cur_state: FanState,
+    pub duration_ms: u64,
+    pub reported: &'a mut bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -875,8 +969,13 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
         ringbuf_entry!(Trace::AutoState(self.get_state()));
     }
 
-    /// Get latest fan presence state
-    pub fn update_fan_presence(&mut self) {
+    /// Reads all temperature and fan RPM sensors, posting their results
+    /// to the sensors task API.
+    ///
+    /// Records failed sensor reads and failed posts to the sensors task in
+    /// the local ringbuf.  In addition, records the first few failed sensor
+    /// read in `self.err_blackbox` for later investigation.
+    pub fn read_sensors(&mut self) {
         // Try to configure the fan watchdog, if not yet configured
         //
         // With its longest timeout of 30 seconds, this is longer than it takes
@@ -895,50 +994,73 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
             }
         }
 
-        match self.bsp.poll_fan_presence() {
-            Ok(piter) => {
-                for fan in piter {
-                    match fan {
-                        FanPresence::Present { fan_id, changed } if changed => {
-                            ringbuf_entry!(Trace::FanAdded(fan_id));
-                        }
-                        FanPresence::NotPresent { fan_id, changed }
-                            if changed =>
-                        {
-                            ringbuf_entry!(Trace::FanRemoved(fan_id));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Err(e) => ringbuf_entry!(Trace::FanPresenceUpdateFailed(e)),
-        }
-    }
-
-    /// Reads all temperature and fan RPM sensors, posting their results
-    /// to the sensors task API.
-    ///
-    /// Records failed sensor reads and failed posts to the sensors task in
-    /// the local ringbuf.  In addition, records the first few failed sensor
-    /// read in `self.err_blackbox` for later investigation.
-    pub fn read_sensors(&mut self) {
         // Read fan data and log it to the sensors task
         for reading in self.bsp.poll_fan_rpms() {
-            match reading {
-                FanPollingOutcome::PresentSuccess { rpm, sensor_id } => {
-                    self.sensor_api.post_now(sensor_id, rpm.0.into())
+            // Don't report things that haven't been steady for a little bit.
+            let stable = reading.duration_ms > 3_000;
+            let needs_report = !*reading.reported && stable;
+
+            match reading.cur_state {
+                FanState::Present(rpm) => {
+                    // All good boss, no need to debounce
+                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
+
+                    // But we might for presence
+                    if needs_report {
+                        ringbuf_entry!(Trace::FanNominal(reading.fan_id));
+                        *reading.reported = true;
+                    }
                 }
-                FanPollingOutcome::PresentError { error, sensor_id } => {
-                    ringbuf_entry!(Trace::FanReadFailed(sensor_id, error));
-                    self.err_blackbox.push(sensor_id, error);
-                    self.sensor_api.nodata_now(sensor_id, error.into());
+                FanState::PresentTooFast(rpm) => {
+                    // All good boss, no need to debounce
+                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
+
+                    // But we might for presence
+                    if needs_report {
+                        ringbuf_entry!(Trace::FanOverspeed(
+                            reading.fan_id,
+                            rpm
+                        ));
+                        *reading.reported = true;
+                    }
                 }
-                FanPollingOutcome::NotPresent { sensor_id } => {
-                    // Invalidate fan speed readings in the sensors task
-                    self.sensor_api.nodata_now(
-                        sensor_id,
-                        task_sensor_api::NoData::DeviceNotPresent,
-                    );
+                FanState::PresentTooSlow(rpm) => {
+                    // All good boss, no need to debounce
+                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
+
+                    // But we might for presence
+                    if needs_report {
+                        ringbuf_entry!(Trace::FanUnderspeed(
+                            reading.fan_id,
+                            rpm
+                        ));
+                        *reading.reported = true;
+                    }
+                }
+
+                FanState::NotPresent => {
+                    if stable {
+                        self.sensor_api.nodata_now(
+                            reading.sensor_id,
+                            NoData::DeviceNotPresent,
+                        );
+                    }
+                    if needs_report {
+                        ringbuf_entry!(Trace::FanRemoved(reading.fan_id));
+                        *reading.reported = true;
+                    }
+                }
+                FanState::PresentUnresponsive => {
+                    if stable {
+                        self.sensor_api.nodata_now(
+                            reading.sensor_id,
+                            NoData::DeviceUnavailable,
+                        );
+                    }
+                    if needs_report {
+                        ringbuf_entry!(Trace::FanReadFailed(reading.sensor_id));
+                        *reading.reported = true;
+                    }
                 }
             }
         }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -200,10 +200,15 @@ pub trait BspInterface {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FanState {
     NotPresent,
-    PresentUnresponsive,
-    Present(Rpm),
-    PresentTooFast(Rpm),
-    PresentTooSlow(Rpm),
+    Present(FanPresentState),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FanPresentState {
+    Unresponsive,
+    Nominal(Rpm),
+    TooFast(Rpm),
+    TooSlow(Rpm),
 }
 
 /// Represents the individual fans in the system
@@ -215,7 +220,8 @@ pub enum FanState {
 #[allow(dead_code)] // Not all bsps have fans!
 pub struct Fan<D> {
     pub rpm_sensor_id: SensorId,
-    pub acked: bool,
+    pub presence_acked: bool,
+    pub state_acked: bool,
     pub prev_state: FanState,
     pub cur_state: FanState,
     pub since_ms: u64,
@@ -227,7 +233,8 @@ impl<D: Copy + Into<u8>> Fan<D> {
     pub const fn new(rpm_sensor_id: SensorId, bsp_data: D) -> Self {
         Self {
             rpm_sensor_id,
-            acked: false,
+            presence_acked: false,
+            state_acked: false,
             prev_state: FanState::NotPresent,
             cur_state: FanState::NotPresent,
             since_ms: 0,
@@ -245,9 +252,10 @@ impl<D: Copy + Into<u8>> Fan<D> {
 
     pub(crate) fn update_presence(&mut self, is_present: bool, now_ms: u64) {
         match (is_present, self.cur_state) {
-            (true, FanState::NotPresent) => {
-                self.update_state(FanState::PresentUnresponsive, now_ms)
-            }
+            (true, FanState::NotPresent) => self.update_state(
+                FanState::Present(FanPresentState::Unresponsive),
+                now_ms,
+            ),
             (true, _) => {}
             (false, _) => {
                 self.update_state(FanState::NotPresent, now_ms);
@@ -255,72 +263,65 @@ impl<D: Copy + Into<u8>> Fan<D> {
         }
     }
     pub(crate) fn update_state(&mut self, new: FanState, now_ms: u64) {
+        use FanPresentState as Fps;
         use FanState as Fs;
         match (self.cur_state, new) {
-            // Any data-less state staying the same:
+            // Not present -> Not Present, nothing to update
+            (Fs::NotPresent, Fs::NotPresent) => {}
+            // Presence change, update:
             //
-            // - Don't take new state
-            // - Don't update "since" timer
-            // - Don't update the "acked" flag
-            (Fs::NotPresent, Fs::NotPresent)
-            | (Fs::PresentUnresponsive, Fs::PresentUnresponsive) => {}
-
-            // present staying the same:
-            //
-            // - Do take the new state data
-            // - Don't update "since" timer
-            // - Don't update the "acked" flag
-            (Fs::Present(_), Fs::Present(_)) => {
-                self.cur_state = new;
-            }
-            (Fs::PresentTooFast(old), Fs::PresentTooFast(new)) => {
-                // Keep the fastest fast
-                self.cur_state = Fs::PresentTooFast(Rpm(old.0.max(new.0)));
-            }
-            (Fs::PresentTooSlow(old), Fs::PresentTooSlow(new)) => {
-                // Keep the slowest slow
-                self.cur_state = Fs::PresentTooSlow(Rpm(old.0.min(new.0)));
-            }
-
-            // For any of the following cases, this is an important state
-            // change:
-            //
-            // - Take the new state
-            // - Update the "since" timer
-            // - Clear the "acked" flag
-            //
-            // Any present -> Not present (we already checked (Not, Not) above)
-            (_, Fs::NotPresent)
-            // Not present to any present (we already checked (Not, Not) above)
-            | (Fs::NotPresent, _)
-            // Any deviant-present to nominal-present
-            | (Fs::PresentUnresponsive, Fs::Present(_))
-            | (Fs::PresentTooFast(_), Fs::Present(_))
-            | (Fs::PresentTooSlow(_), Fs::Present(_))
-            // Present to any deviant-present
-            | (Fs::Present(_), Fs::PresentUnresponsive)
-            | (Fs::Present(_), Fs::PresentTooFast(_))
-            | (Fs::Present(_), Fs::PresentTooSlow(_)) => {
+            // - New state
+            // - Presence ack state
+            // - Status ack state
+            // - Time of change
+            (Fs::NotPresent, Fs::Present(_))
+            | (Fs::Present(_), Fs::NotPresent) => {
                 self.prev_state = self.cur_state;
                 self.cur_state = new;
+                self.presence_acked = false;
+                self.state_acked = false;
                 self.since_ms = now_ms;
-                self.acked = false;
             }
-
-            // Deviant-to-Deviant:
-            //
-            // - Take the new state
-            // - DON'T update the "since" timer
-            // - DON'T clear the "acked" flag
-            (Fs::PresentUnresponsive, Fs::PresentTooFast(_))
-            | (Fs::PresentUnresponsive, Fs::PresentTooSlow(_))
-            | (Fs::PresentTooFast(_), Fs::PresentUnresponsive)
-            | (Fs::PresentTooFast(_), Fs::PresentTooSlow(_))
-            | (Fs::PresentTooSlow(_), Fs::PresentUnresponsive)
-            | (Fs::PresentTooSlow(_), Fs::PresentTooFast(_)) => {
-                self.prev_state = self.cur_state;
-                self.cur_state = new;
-            }
+            // Present -> Present
+            (Fs::Present(cur), Fs::Present(newp)) => match (cur, newp) {
+                // Unresponsive -> Unresponsive, nothing to update
+                (Fps::Unresponsive, Fps::Unresponsive) => {}
+                // Nominal -> Nominal, just take state
+                (Fps::Nominal(_), Fps::Nominal(_)) => {
+                    self.cur_state = new;
+                }
+                // Nominal -> Deviant, or Deviant -> Nominal, update:
+                //
+                // - New state
+                // - Status ack state
+                // - Time of change
+                (Fps::Nominal(_), _) | (_, Fps::Nominal(_)) => {
+                    self.prev_state = self.cur_state;
+                    self.cur_state = new;
+                    self.state_acked = false;
+                    self.since_ms = now_ms;
+                }
+                (Fps::TooFast(old_rpm), Fps::TooFast(new_rpm)) => {
+                    let rpm = old_rpm.0.max(new_rpm.0);
+                    self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
+                }
+                (Fps::TooSlow(old_rpm), Fps::TooSlow(new_rpm)) => {
+                    let rpm = old_rpm.0.min(new_rpm.0);
+                    self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
+                }
+                // deviant -> deviant, update:
+                //
+                // - New state
+                (Fps::TooFast(_), Fps::Unresponsive)
+                | (Fps::TooFast(_), Fps::TooSlow(_))
+                | (Fps::TooSlow(_), Fps::Unresponsive)
+                | (Fps::TooSlow(_), Fps::TooFast(_))
+                | (Fps::Unresponsive, Fps::TooFast(_))
+                | (Fps::Unresponsive, Fps::TooSlow(_)) => {
+                    self.prev_state = self.cur_state;
+                    self.cur_state = new;
+                }
+            },
         }
     }
 }
@@ -344,7 +345,8 @@ pub struct FanPollingOutcome<'a> {
     pub fan_id: u8,
     pub cur_state: FanState,
     pub duration_ms: u64,
-    pub reported: &'a mut bool,
+    pub state_reported: &'a mut bool,
+    pub presence_reported: &'a mut bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -995,74 +997,8 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
         }
 
         // Read fan data and log it to the sensors task
-        for reading in self.bsp.poll_fan_rpms() {
-            // Don't report things that haven't been steady for a little bit.
-            let stable = reading.duration_ms > 3_000;
-            let needs_report = !*reading.reported && stable;
-
-            match reading.cur_state {
-                FanState::Present(rpm) => {
-                    // All good boss, no need to debounce
-                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
-
-                    // But we might for presence
-                    if needs_report {
-                        ringbuf_entry!(Trace::FanNominal(reading.fan_id));
-                        *reading.reported = true;
-                    }
-                }
-                FanState::PresentTooFast(rpm) => {
-                    // All good boss, no need to debounce
-                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
-
-                    // But we might for presence
-                    if needs_report {
-                        ringbuf_entry!(Trace::FanOverspeed(
-                            reading.fan_id,
-                            rpm
-                        ));
-                        *reading.reported = true;
-                    }
-                }
-                FanState::PresentTooSlow(rpm) => {
-                    // All good boss, no need to debounce
-                    self.sensor_api.post_now(reading.sensor_id, rpm.0.into());
-
-                    // But we might for presence
-                    if needs_report {
-                        ringbuf_entry!(Trace::FanUnderspeed(
-                            reading.fan_id,
-                            rpm
-                        ));
-                        *reading.reported = true;
-                    }
-                }
-
-                FanState::NotPresent => {
-                    if stable {
-                        self.sensor_api.nodata_now(
-                            reading.sensor_id,
-                            NoData::DeviceNotPresent,
-                        );
-                    }
-                    if needs_report {
-                        ringbuf_entry!(Trace::FanRemoved(reading.fan_id));
-                        *reading.reported = true;
-                    }
-                }
-                FanState::PresentUnresponsive => {
-                    if stable {
-                        self.sensor_api.nodata_now(
-                            reading.sensor_id,
-                            NoData::DeviceUnavailable,
-                        );
-                    }
-                    if needs_report {
-                        ringbuf_entry!(Trace::FanReadFailed(reading.sensor_id));
-                        *reading.reported = true;
-                    }
-                }
-            }
+        for mut reading in self.bsp.poll_fan_rpms() {
+            report_fan_state(&mut reading, &self.sensor_api);
         }
 
         // Read miscellaneous temperature data and log it to the sensors task
@@ -1560,5 +1496,57 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
         self.sensor_api
             .nodata_now(sensor_id, task_sensor_api::NoData::DeviceNotPresent);
         Ok(())
+    }
+}
+
+fn report_fan_state(
+    reading: &mut FanPollingOutcome<'_>,
+    sensor_api: &SensorApi,
+) {
+    let stable = reading.duration_ms > 3_000;
+    let FanState::Present(pres) = reading.cur_state else {
+        if stable {
+            sensor_api.nodata_now(reading.sensor_id, NoData::DeviceNotPresent);
+
+            if !*reading.presence_reported {
+                ringbuf_entry!(Trace::FanRemoved(reading.fan_id));
+                *reading.presence_reported = true;
+            }
+        }
+        return;
+    };
+
+    // Report RPM immediately, if we have it, or clear it, if erroneous
+    match pres {
+        FanPresentState::Unresponsive => {
+            if stable {
+                sensor_api
+                    .nodata_now(reading.sensor_id, NoData::DeviceUnavailable);
+            }
+        }
+        FanPresentState::Nominal(rpm)
+        | FanPresentState::TooFast(rpm)
+        | FanPresentState::TooSlow(rpm) => {
+            sensor_api.post_now(reading.sensor_id, rpm.0.into());
+        }
+    }
+
+    // Handle reporting, if stable and unreported
+    if stable && !*reading.state_reported {
+        match pres {
+            FanPresentState::Unresponsive => {
+                ringbuf_entry!(Trace::FanReadFailed(reading.sensor_id));
+            }
+            FanPresentState::Nominal(_) => {
+                ringbuf_entry!(Trace::FanNominal(reading.fan_id));
+            }
+            FanPresentState::TooFast(rpm) => {
+                ringbuf_entry!(Trace::FanOverspeed(reading.fan_id, rpm));
+            }
+            FanPresentState::TooSlow(rpm) => {
+                ringbuf_entry!(Trace::FanUnderspeed(reading.fan_id, rpm));
+            }
+        }
+        *reading.state_reported = true;
     }
 }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -93,6 +93,9 @@ pub trait BspInterface {
     /// Run the PID loop on startup
     const USE_CONTROLLER: bool;
 
+    /// BSP-specific fan identifier
+    type FanBspId: Into<u8> + Copy;
+
     /// Instruct the sequencer to power down the system
     fn power_down(&self) -> Result<(), crate::SeqError>;
 
@@ -112,7 +115,9 @@ pub trait BspInterface {
     /// Return an iterator of the current status of each fan. The iterator may
     /// be lazy, meaning that failure to exhaust the iterator means that not all
     /// fans will be actively read.
-    fn poll_fan_rpms(&mut self) -> impl Iterator<Item = FanPollingOutcome<'_>>;
+    fn poll_fan_rpms(
+        &mut self,
+    ) -> impl Iterator<Item = &'_ mut Fan<Self::FanBspId>>;
 
     /// Return an iterator of the current status of each misc sensor. The
     /// iterator may be lazy, meaning that faulure to exhaust the iterator means
@@ -222,7 +227,6 @@ pub struct Fan<D> {
     pub rpm_sensor_id: SensorId,
     pub presence_acked: bool,
     pub state_acked: bool,
-    pub prev_state: FanState,
     pub cur_state: FanState,
     pub since_ms: u64,
     pub bsp_data: D,
@@ -235,7 +239,6 @@ impl<D: Copy + Into<u8>> Fan<D> {
             rpm_sensor_id,
             presence_acked: false,
             state_acked: false,
-            prev_state: FanState::NotPresent,
             cur_state: FanState::NotPresent,
             since_ms: 0,
             bsp_data,
@@ -276,7 +279,6 @@ impl<D: Copy + Into<u8>> Fan<D> {
             // - Time of change
             (Fs::NotPresent, Fs::Present(_))
             | (Fs::Present(_), Fs::NotPresent) => {
-                self.prev_state = self.cur_state;
                 self.cur_state = new;
                 self.presence_acked = false;
                 self.state_acked = false;
@@ -290,17 +292,6 @@ impl<D: Copy + Into<u8>> Fan<D> {
                 (Fps::Nominal(_), Fps::Nominal(_)) => {
                     self.cur_state = new;
                 }
-                // Nominal -> Deviant, or Deviant -> Nominal, update:
-                //
-                // - New state
-                // - Status ack state
-                // - Time of change
-                (Fps::Nominal(_), _) | (_, Fps::Nominal(_)) => {
-                    self.prev_state = self.cur_state;
-                    self.cur_state = new;
-                    self.state_acked = false;
-                    self.since_ms = now_ms;
-                }
                 (Fps::TooFast(old_rpm), Fps::TooFast(new_rpm)) => {
                     let rpm = old_rpm.0.max(new_rpm.0);
                     self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
@@ -309,6 +300,17 @@ impl<D: Copy + Into<u8>> Fan<D> {
                     let rpm = old_rpm.0.min(new_rpm.0);
                     self.cur_state = Fs::Present(Fps::TooFast(Rpm(rpm)));
                 }
+                // Nominal -> Deviant, or Deviant -> Nominal, update:
+                //
+                // - New state
+                // - Status ack state
+                // - Time of change
+                (Fps::Nominal(_), _) | (_, Fps::Nominal(_)) => {
+                    self.cur_state = new;
+                    self.state_acked = false;
+                    self.since_ms = now_ms;
+                }
+
                 // deviant -> deviant, update:
                 //
                 // - New state
@@ -318,7 +320,11 @@ impl<D: Copy + Into<u8>> Fan<D> {
                 | (Fps::TooSlow(_), Fps::TooFast(_))
                 | (Fps::Unresponsive, Fps::TooFast(_))
                 | (Fps::Unresponsive, Fps::TooSlow(_)) => {
-                    self.prev_state = self.cur_state;
+                    // TODO: Do we want ringbuf entries and/or ereports for
+                    // deviant -> deviant transitions? If so, we should reset
+                    // the since_ms and state_acked values here too, basically
+                    // collapsing this with the Nominal -> Deviant +
+                    // Deviant -> Nominal case above.
                     self.cur_state = new;
                 }
             },
@@ -337,16 +343,6 @@ pub enum FanPresence {
         fan_id: u8,
         changed: bool,
     },
-}
-
-#[allow(dead_code)] // Not all bsps have fans!
-pub struct FanPollingOutcome<'a> {
-    pub sensor_id: SensorId,
-    pub fan_id: u8,
-    pub cur_state: FanState,
-    pub duration_ms: u64,
-    pub state_reported: &'a mut bool,
-    pub presence_reported: &'a mut bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -997,8 +993,8 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
         }
 
         // Read fan data and log it to the sensors task
-        for mut reading in self.bsp.poll_fan_rpms() {
-            report_fan_state(&mut reading, &self.sensor_api);
+        for reading in self.bsp.poll_fan_rpms() {
+            report_fan_state(reading, &self.sensor_api);
         }
 
         // Read miscellaneous temperature data and log it to the sensors task
@@ -1499,18 +1495,20 @@ impl<'a, B: BspInterface> ThermalControl<'a, B> {
     }
 }
 
-fn report_fan_state(
-    reading: &mut FanPollingOutcome<'_>,
+fn report_fan_state<D: Into<u8> + Copy>(
+    reading: &mut Fan<D>,
     sensor_api: &SensorApi,
 ) {
-    let stable = reading.duration_ms > 3_000;
+    let duration_ms = sys_get_timer().now.saturating_sub(reading.since_ms);
+    let stable = duration_ms > 3_000;
     let FanState::Present(pres) = reading.cur_state else {
         if stable {
-            sensor_api.nodata_now(reading.sensor_id, NoData::DeviceNotPresent);
+            sensor_api
+                .nodata_now(reading.rpm_sensor_id, NoData::DeviceNotPresent);
 
-            if !*reading.presence_reported {
-                ringbuf_entry!(Trace::FanRemoved(reading.fan_id));
-                *reading.presence_reported = true;
+            if !reading.presence_acked {
+                ringbuf_entry!(Trace::FanRemoved(reading.bsp_data.into()));
+                reading.presence_acked = true;
             }
         }
         return;
@@ -1520,33 +1518,41 @@ fn report_fan_state(
     match pres {
         FanPresentState::Unresponsive => {
             if stable {
-                sensor_api
-                    .nodata_now(reading.sensor_id, NoData::DeviceUnavailable);
+                sensor_api.nodata_now(
+                    reading.rpm_sensor_id,
+                    NoData::DeviceUnavailable,
+                );
             }
         }
         FanPresentState::Nominal(rpm)
         | FanPresentState::TooFast(rpm)
         | FanPresentState::TooSlow(rpm) => {
-            sensor_api.post_now(reading.sensor_id, rpm.0.into());
+            sensor_api.post_now(reading.rpm_sensor_id, rpm.0.into());
         }
     }
 
     // Handle reporting, if stable and unreported
-    if stable && !*reading.state_reported {
+    if stable && !reading.state_acked {
         match pres {
             FanPresentState::Unresponsive => {
-                ringbuf_entry!(Trace::FanReadFailed(reading.sensor_id));
+                ringbuf_entry!(Trace::FanReadFailed(reading.rpm_sensor_id));
             }
             FanPresentState::Nominal(_) => {
-                ringbuf_entry!(Trace::FanNominal(reading.fan_id));
+                ringbuf_entry!(Trace::FanNominal(reading.bsp_data.into()));
             }
             FanPresentState::TooFast(rpm) => {
-                ringbuf_entry!(Trace::FanOverspeed(reading.fan_id, rpm));
+                ringbuf_entry!(Trace::FanOverspeed(
+                    reading.bsp_data.into(),
+                    rpm
+                ));
             }
             FanPresentState::TooSlow(rpm) => {
-                ringbuf_entry!(Trace::FanUnderspeed(reading.fan_id, rpm));
+                ringbuf_entry!(Trace::FanUnderspeed(
+                    reading.bsp_data.into(),
+                    rpm
+                ));
             }
         }
-        *reading.state_reported = true;
+        reading.state_acked = true;
     }
 }

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -365,7 +365,7 @@ impl<D: Copy + Into<u8>> Fan<D> {
     }
 
     /// Update the RPM of a present fan with the given closure, which should
-    /// retrieve the RPM. Used to share logic across different fan controllers.
+    /// retrieve the RPM. Used to share logic across different fan controllers
     pub(crate) fn poll_rpm_with<E>(
         &mut self,
         now: u64,

--- a/task/thermal/src/control.rs
+++ b/task/thermal/src/control.rs
@@ -74,7 +74,9 @@ use drv_i2c_devices::max31790::I2cWatchdog;
 
 use ringbuf::ringbuf_entry_root as ringbuf_entry;
 use task_sensor_api::{NoData, Sensor as SensorApi, SensorId};
-use task_thermal_api::{SensorReadError, ThermalAutoState, ThermalProperties};
+use task_thermal_api::{
+    FanProperties, SensorReadError, ThermalAutoState, ThermalProperties,
+};
 use userlib::{
     sys_get_timer,
     units::{Celsius, PWMDuty, Rpm},
@@ -359,6 +361,45 @@ impl<D: Copy + Into<u8>> Fan<D> {
                     self.cur_state = new;
                 }
             },
+        }
+    }
+
+    /// Update the RPM of a present fan with the given closure, which should
+    /// retrieve the RPM. Used to share logic across different fan controllers.
+    pub(crate) fn poll_rpm_with<E>(
+        &mut self,
+        now: u64,
+        model: &FanProperties,
+        poll_rpm: impl FnOnce() -> Result<Rpm, E>,
+    ) {
+        // If this fan is not present, then do not attempt to poll it. Presence
+        // is only restored via presence polling.
+        if !self.is_present() {
+            return;
+        }
+
+        // Try to get the RPM reading for this fan
+        let res = poll_rpm();
+        match res {
+            Ok(rpm) => {
+                // The poll went well! Use the model to determine if this
+                // reading is nominal or not, and report that as the state.
+                let state = if rpm < model.underspeed_rpm {
+                    FanPresentState::TooSlow(rpm)
+                } else if rpm > model.underspeed_rpm {
+                    FanPresentState::TooFast(rpm)
+                } else {
+                    FanPresentState::Nominal(rpm)
+                };
+                self.update_state(FanState::Present(state), now);
+            }
+            Err(_e) => {
+                // No good, mark as unresponsive
+                self.update_state(
+                    FanState::Present(FanPresentState::Unresponsive),
+                    now,
+                );
+            }
         }
     }
 }

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -142,8 +142,8 @@ enum Trace {
     },
     #[allow(dead_code)] // Not all fans are removable
     FanPresenceUpdateFailed(SeqError),
-    /// Fan is present and in a nominal state
-    FanNominal(SensorId),
+    /// Fan is present
+    FanAdded(SensorId),
     /// Fan is not present
     FanRemoved(SensorId),
     PowerDownAt(u64),
@@ -152,6 +152,8 @@ enum Trace {
     SetFanWatchdogOk,
     SetFanWatchdogError(ThermalError),
     UnexpectedInputInactive,
+    /// Fan is present and in a nominal state
+    FanNominal(SensorId),
     /// Fan is present and overspeed
     FanOverspeed(SensorId, Rpm),
     /// Fan is present and underspeed

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -140,6 +140,7 @@ enum Trace {
     FanControllerInitRetry {
         remaining: usize,
     },
+    #[allow(dead_code)] // Not all fans are removable
     FanPresenceUpdateFailed(SeqError),
     FanNominal(u8),
     FanRemoved(u8),

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -142,16 +142,20 @@ enum Trace {
     },
     #[allow(dead_code)] // Not all fans are removable
     FanPresenceUpdateFailed(SeqError),
-    FanNominal(u8),
-    FanRemoved(u8),
+    /// Fan is present and in a nominal state
+    FanNominal(SensorId),
+    /// Fan is not present
+    FanRemoved(SensorId),
     PowerDownAt(u64),
     AddedDynamicInput(usize),
     RemovedDynamicInput(usize),
     SetFanWatchdogOk,
     SetFanWatchdogError(ThermalError),
     UnexpectedInputInactive,
-    FanOverspeed(u8, Rpm),
-    FanUnderspeed(u8, Rpm),
+    /// Fan is present and overspeed
+    FanOverspeed(SensorId, Rpm),
+    /// Fan is present and underspeed
+    FanUnderspeed(SensorId, Rpm),
 }
 counted_ringbuf!(Trace, 32, Trace::None);
 

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -58,7 +58,7 @@ use task_thermal_api::{
 };
 use userlib::{
     RecvMessage, UnwrapLite, sys_get_timer, sys_set_timer, task_slot,
-    units::{Celsius, PWMDuty},
+    units::{Celsius, PWMDuty, Rpm},
 };
 
 task_slot!(I2C, i2c_driver);
@@ -125,7 +125,7 @@ enum Trace {
     /// because an entry with two u64s doubles the size of the ringbuf.
     #[count(skip)]
     CriticalFor(u64),
-    FanReadFailed(SensorId, SensorReadError),
+    FanReadFailed(SensorId),
     MiscReadFailed(SensorId, SensorReadError),
     SensorReadFailed(SensorId, SensorReadError),
     ControlPwm(u8),
@@ -141,7 +141,7 @@ enum Trace {
         remaining: usize,
     },
     FanPresenceUpdateFailed(SeqError),
-    FanAdded(u8),
+    FanNominal(u8),
     FanRemoved(u8),
     PowerDownAt(u64),
     AddedDynamicInput(usize),
@@ -149,6 +149,8 @@ enum Trace {
     SetFanWatchdogOk,
     SetFanWatchdogError(ThermalError),
     UnexpectedInputInactive,
+    FanOverspeed(u8, Rpm),
+    FanUnderspeed(u8, Rpm),
 }
 counted_ringbuf!(Trace, 32, Trace::None);
 
@@ -344,9 +346,6 @@ impl<'a, B: control::BspInterface> NotificationHandler for ServerImpl<'a, B> {
     fn handle_notification(&mut self, bits: userlib::NotificationBits) {
         let now = sys_get_timer().now;
         if bits.has_timer_fired(notifications::TIMER_MASK) {
-            // See if any fans were removed or added since last iteration
-            self.control.update_fan_presence();
-
             // We *always* read sensor data, which does not touch the control
             // loop; this simply posts results to the `sensors` task.
             self.control.read_sensors();

--- a/task/thermal/src/main.rs
+++ b/task/thermal/src/main.rs
@@ -125,7 +125,7 @@ enum Trace {
     /// because an entry with two u64s doubles the size of the ringbuf.
     #[count(skip)]
     CriticalFor(u64),
-    FanReadFailed(SensorId),
+    FanReadFailed(SensorId, SensorReadError),
     MiscReadFailed(SensorId, SensorReadError),
     SensorReadFailed(SensorId, SensorReadError),
     ControlPwm(u8),


### PR DESCRIPTION
This is a step towards #2603, and enhances how we track the state of fans. The main states we now track are:

1. Not Present (according to physical presence detection)
2. Present but unresponsive to I2C queries
3. Present but below a minimum speed threshold
4. Present but above a maximum speed threshold
5. Present and all good

This also introduces a slight "debounce" for reporting state, currently 3s, that prevents us from emitting ringbufs if fans are momentarily deviant/non-nominal, but quickly return to a nominal state. Although this PR doesn't add ereports yet, this is intended to avoid spamming back-to-back ereports for minor hiccups. Right now, the plan is to put ereports where we currently ringbuf. In the future, we might choose to ringbuf immediately, but only send ereports after debouncing.

Marked as draft for now, until I see whether CI passes, and after I make a final docs pass for these changes.