### PR TITLE
sidecar-seq: do the front IO FPGAs in the opposite order

### DIFF
--- a/drv/sidecar-seq-server/src/front_io.rs
+++ b/drv/sidecar-seq-server/src/front_io.rs
@@ -45,6 +45,13 @@ impl FrontIOBoard {
     pub fn init(&mut self) -> Result<bool, FpgaError> {
         let mut controllers_ready = true;
 
+        // We reverse the order of interaction here, interacting with
+        // controller 1 and then 0. This is because controller 1 is connected
+        // to the techport PHY and its oscillator. An errata with that
+        // oscillator states that the oscillator should be enabled as close to
+        // power being applied as possible. For this reason, we want to program
+        // controller 1 prior to 0, allowing that to happen a few seconds
+        // sooner than it would if we'd program controller 0 first.
         for (i, controller) in self.controllers.iter_mut().enumerate().rev() {
             let state = controller.await_fpga_ready(25)?;
             let mut ident;

--- a/drv/sidecar-seq-server/src/front_io.rs
+++ b/drv/sidecar-seq-server/src/front_io.rs
@@ -45,7 +45,7 @@ impl FrontIOBoard {
     pub fn init(&mut self) -> Result<bool, FpgaError> {
         let mut controllers_ready = true;
 
-        for (i, controller) in self.controllers.iter_mut().enumerate() {
+        for (i, controller) in self.controllers.iter_mut().enumerate().rev() {
             let state = controller.await_fpga_ready(25)?;
             let mut ident;
             let mut ident_valid = false;


### PR DESCRIPTION
As discussed in [this comment][1] on #2625, it *might* help with The Sidecar Front IO Board PHY Oscillator Sadness Situation if we were to initialize FPGA 1 *before* FPGA 0 instead of in the current order. This would decrease the amount of time between when the VDD rail is powered and when the oscillator's EN pin is asserted, because it is enabled by FPGA 1. This might help reduce the chance of sadness maybe?

[1]: https://github.com/oxidecomputer/hubris/issues/2625#issuecomment-5193231743

Co-authored-by: Aaron Hartwig <aaron@oxidecomputer.com>