### PR TITLE
Make jefe's server-impl a static, to make it easier to nab in dumps

### DIFF
--- a/app/demo-stm32g0-nucleo/app-g031.toml
+++ b/app/demo-stm32g0-nucleo/app-g031.toml
@@ -13,9 +13,9 @@ stacksize = 640
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
-stacksize = 368
+stacksize = 256
 notifications = ["fault", "timer"]
 
 [tasks.sys]

--- a/app/demo-stm32g0-nucleo/app-g070-mini.toml
+++ b/app/demo-stm32g0-nucleo/app-g070-mini.toml
@@ -19,9 +19,9 @@ size = 256
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
-stacksize = 400
+stacksize = 256
 notifications = ["fault", "timer"]
 
 [tasks.idle]

--- a/app/demo-stm32g0-nucleo/app-g070.toml
+++ b/app/demo-stm32g0-nucleo/app-g070.toml
@@ -14,9 +14,9 @@ stacksize = 640
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
-stacksize = 416
+stacksize = 256
 notifications = ["fault", "timer"]
 
 [tasks.sys]

--- a/app/donglet/app-g031-i2c.toml
+++ b/app/donglet/app-g031-i2c.toml
@@ -13,9 +13,9 @@ stacksize = 936
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
-stacksize = 368
+stacksize = 256
 notifications = ["fault", "timer"]
 
 [tasks.sys]
@@ -78,7 +78,7 @@ address = 0x73
 [[config.i2c.devices]]
 controller = 1
 mux = 1
-segment = 1 
+segment = 1
 address = 0b1010_000
 device = "at24csw080"
 description = "Sharkfin VPD"

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -17,7 +17,7 @@ max-sizes = {flash = 4096, ram = 768}
 start = true
 stacksize = 256
 notifications = ["fault", "timer"]
-features = ["no-panic", "nano"]
+features = ["nano"]
 
 [tasks.sys]
 name = "drv-stm32xx-sys"

--- a/app/donglet/app-g031.toml
+++ b/app/donglet/app-g031.toml
@@ -13,9 +13,9 @@ stacksize = 936
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
-stacksize = 384
+stacksize = 256
 notifications = ["fault", "timer"]
 features = ["no-panic", "nano"]
 

--- a/app/grapefruit/base.toml
+++ b/app/grapefruit/base.toml
@@ -26,7 +26,7 @@ name = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 4096}
 start = true
-stacksize = 3000
+stacksize = 1536
 notifications = ["fault", "timer"]
 features = ["dump"]
 extern-regions = ["sram1", "sram2", "sram3", "sram4"]

--- a/app/oxcon2023g0/app.toml
+++ b/app/oxcon2023g0/app.toml
@@ -12,10 +12,10 @@ stacksize = 640
 [tasks.jefe]
 name = "task-jefe"
 priority = 0
-max-sizes = {flash = 4096, ram = 512}
+max-sizes = {flash = 4096, ram = 768}
 start = true
 features = ["nano"]
-stacksize = 368
+stacksize = 256
 notifications = ["fault", "timer"]
 
 [tasks.sys]

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -33,7 +33,6 @@ build-util = { path = "../../build/util" }
 [features]
 dump = []
 nano = [ "ringbuf/disabled" ]
-no-panic = [ "userlib/no-panic" ]
 fault-notification = []
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -21,7 +21,7 @@ hubris-num-tasks = { path = "../../sys/num-tasks", features = ["task-enum"] }
 ringbuf = { path = "../../lib/ringbuf" }
 task-jefe-api = { path = "../jefe-api" }
 userlib = { path = "../../sys/userlib" }
-static-cell = { path = "../../lib/static-cell", optional = true }
+static-cell = { path = "../../lib/static-cell" }
 
 [build-dependencies]
 anyhow = { workspace = true }
@@ -34,7 +34,7 @@ build-util = { path = "../../build/util" }
 dump = []
 nano = [ "ringbuf/disabled" ]
 no-panic = [ "userlib/no-panic" ]
-fault-notification = [ "dep:static-cell" ]
+fault-notification = []
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -108,7 +108,7 @@ fn main() -> ! {
 
     external::set_ready();
 
-    let server = SERVER_IMPL.claim();
+    let server = JEFE_SERVER_IMPL.claim();
     let server = server.write(ServerImpl {
         state: 0,
         deadline,

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -81,7 +81,7 @@ const MIN_RESTART_DELAY: u64 = 5;
 
 /// Store the entire server impl so that it is retrievable in system dumps
 #[unsafe(no_mangle)]
-static SERVER_IMPL: ClaimOnceCell<MaybeUninit<ServerImpl>> =
+static JEFE_SERVER_IMPL: ClaimOnceCell<MaybeUninit<ServerImpl>> =
     ClaimOnceCell::new(MaybeUninit::uninit());
 
 /// Generate a list of task states, considering the compile-time specified

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -32,19 +32,31 @@ mod dump;
 
 mod external;
 
-use core::convert::Infallible;
+use core::{convert::Infallible, mem::MaybeUninit};
 
 use hubris_num_tasks::NUM_TASKS;
 use humpty::DumpArea;
 use idol_runtime::RequestError;
+use static_cell::ClaimOnceCell;
 use task_jefe_api::{DumpAgentError, ResetReason};
 use userlib::{Generation, TaskId, kipc};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Disposition {
-    #[default]
     Restart,
     Hold,
+}
+
+impl Disposition {
+    const fn const_default() -> Self {
+        Self::Restart
+    }
+}
+
+impl Default for Disposition {
+    fn default() -> Self {
+        Self::const_default()
+    }
 }
 
 // We install a timeout to periodically check for an external direction
@@ -79,31 +91,37 @@ const MIN_RUN_TIME: u64 = 50;
 /// the fault cannot prevent tasks from being restarted indefinitely.
 const MIN_RESTART_DELAY: u64 = 5;
 
+/// Store the entire server impl so that it is retrievable in system dumps
+#[unsafe(no_mangle)]
+static SERVER_IMPL: ClaimOnceCell<MaybeUninit<ServerImpl>> =
+    ClaimOnceCell::new(MaybeUninit::uninit());
+
+/// Generate a list of task states, considering the compile-time specified
+/// held tasks.
+const fn initial_task_states() -> [TaskStatus; hubris_num_tasks::NUM_TASKS] {
+    let mut task_states =
+        [TaskStatus::const_default(); hubris_num_tasks::NUM_TASKS];
+    let mut i = 0;
+    while i < generated::HELD_TASKS.len() {
+        task_states[generated::HELD_TASKS[i] as usize].disposition =
+            Disposition::Hold;
+        i += 1;
+    }
+    task_states
+}
+
 #[unsafe(export_name = "main")]
 fn main() -> ! {
-    let mut task_states = [TaskStatus::default(); hubris_num_tasks::NUM_TASKS];
-    for held_task in generated::HELD_TASKS {
-        task_states[held_task as usize].disposition = Disposition::Hold;
-    }
-
     let deadline =
         userlib::set_timer_relative(TIMER_INTERVAL, notifications::TIMER_MASK);
 
     external::set_ready();
 
-    #[cfg(feature = "fault-notification")]
-    let fault_counts = {
-        use static_cell::ClaimOnceCell;
-
-        static COUNTS: ClaimOnceCell<[usize; NUM_TASKS]> =
-            ClaimOnceCell::new([0usize; NUM_TASKS]);
-        COUNTS.claim()
-    };
-
-    let mut server = ServerImpl {
+    let server = SERVER_IMPL.claim();
+    let server = server.write(ServerImpl {
         state: 0,
         deadline,
-        task_states: &mut task_states,
+        task_states: const { initial_task_states() },
         any_tasks_in_timeout: false,
         reset_reason: ResetReason::Unknown,
 
@@ -114,24 +132,24 @@ fn main() -> ! {
         last_dump_area: None,
 
         #[cfg(feature = "fault-notification")]
-        fault_counts,
-    };
+        fault_counts: [0usize; NUM_TASKS],
+    });
     let mut buf = [0u8; idl::INCOMING_SIZE];
 
     loop {
-        idol_runtime::dispatch(&mut buf, &mut server);
+        idol_runtime::dispatch(&mut buf, server);
     }
 }
 
-struct ServerImpl<'s> {
+struct ServerImpl {
     state: u32,
-    task_states: &'s mut [TaskStatus; NUM_TASKS],
+    task_states: [TaskStatus; NUM_TASKS],
     deadline: u64,
     any_tasks_in_timeout: bool,
     reset_reason: ResetReason,
 
     #[cfg(feature = "fault-notification")]
-    fault_counts: &'s mut [usize; NUM_TASKS],
+    fault_counts: [usize; NUM_TASKS],
 
     /// Base address for a linked list of dump areas
     #[cfg(feature = "dump")]
@@ -145,7 +163,7 @@ struct ServerImpl<'s> {
     last_dump_area: Option<DumpArea>,
 }
 
-impl idl::InOrderJefeImpl for ServerImpl<'_> {
+impl idl::InOrderJefeImpl for ServerImpl {
     fn request_reset(
         &mut self,
         _msg: &userlib::RecvMessage,
@@ -386,6 +404,15 @@ struct TaskStatus {
     state: TaskState,
 }
 
+impl TaskStatus {
+    const fn const_default() -> Self {
+        Self {
+            disposition: Disposition::const_default(),
+            state: TaskState::const_default(),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 enum TaskState {
     Running {
@@ -398,13 +425,19 @@ enum TaskState {
     },
 }
 
-impl Default for TaskState {
-    fn default() -> Self {
+impl TaskState {
+    const fn const_default() -> Self {
         TaskState::Running { started_at: 0 }
     }
 }
 
-impl idol_runtime::NotificationHandler for ServerImpl<'_> {
+impl Default for TaskState {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
+
+impl idol_runtime::NotificationHandler for ServerImpl {
     fn current_notification_mask(&self) -> u32 {
         notifications::FAULT_MASK | notifications::TIMER_MASK
     }
@@ -413,7 +446,7 @@ impl idol_runtime::NotificationHandler for ServerImpl<'_> {
         let now = userlib::sys_get_timer().now;
 
         // Handle any external (debugger) requests.
-        external::check(self.task_states, now);
+        external::check(&mut self.task_states, now);
 
         if bits.has_timer_fired(notifications::TIMER_MASK) {
             // If our timer went off, we need to reestablish it. Compute a

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -47,18 +47,6 @@ pub enum Disposition {
     Hold,
 }
 
-impl Disposition {
-    const fn const_default() -> Self {
-        Self::Restart
-    }
-}
-
-impl Default for Disposition {
-    fn default() -> Self {
-        Self::const_default()
-    }
-}
-
 // We install a timeout to periodically check for an external direction
 // of our task disposition (e.g., via Humility).  This timeout should
 // generally be fast for a human but slow for a computer; we pick a
@@ -99,8 +87,11 @@ static SERVER_IMPL: ClaimOnceCell<MaybeUninit<ServerImpl>> =
 /// Generate a list of task states, considering the compile-time specified
 /// held tasks.
 const fn initial_task_states() -> [TaskStatus; hubris_num_tasks::NUM_TASKS] {
-    let mut task_states =
-        [TaskStatus::const_default(); hubris_num_tasks::NUM_TASKS];
+    const TASK_DEFAULT: TaskStatus = TaskStatus {
+        disposition: Disposition::Restart,
+        state: TaskState::Running { started_at: 0 },
+    };
+    let mut task_states = [TASK_DEFAULT; hubris_num_tasks::NUM_TASKS];
     let mut i = 0;
     while i < generated::HELD_TASKS.len() {
         task_states[generated::HELD_TASKS[i] as usize].disposition =
@@ -398,19 +389,10 @@ impl idl::InOrderJefeImpl for ServerImpl {
 
 /// Structure we use for tracking the state of the tasks we supervise. There is
 /// one of these per supervised task.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug)]
 struct TaskStatus {
     disposition: Disposition,
     state: TaskState,
-}
-
-impl TaskStatus {
-    const fn const_default() -> Self {
-        Self {
-            disposition: Disposition::const_default(),
-            state: TaskState::const_default(),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -423,18 +405,6 @@ enum TaskState {
     Timeout {
         restart_at: u64,
     },
-}
-
-impl TaskState {
-    const fn const_default() -> Self {
-        TaskState::Running { started_at: 0 }
-    }
-}
-
-impl Default for TaskState {
-    fn default() -> Self {
-        Self::const_default()
-    }
 }
 
 impl idol_runtime::NotificationHandler for ServerImpl {


### PR DESCRIPTION
This PR moves all of jefe's `ServerImpl` to be a static.

I potentially could have just made the reset reason a static, but we already had some parts in statics, so it seemed more reasonable to just chuck the whole thing in, and inline the parts that were previously separately static'd.

const-ify'ing `task_states` isn't strictly necessary, and was something I did to attempt to fully statically initialize the `ServerImpl`, but unfortunately `dump_areas` is not reasonable to statically initialize, as I was able to find some humpty code paths that implicitly trust that value as a Good Pointer Address, and didn't feel comfortable just marking it as `0x0000_0000` to start with. Making it an `Option<u32>` or so would have been more work than I was interested in doing now.

Closes #1980 