### PR TITLE
WIP: Slight i2c codegen retouch

### DIFF
--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -502,9 +502,6 @@ pub struct ConfigGenerator {
     /// Settings
     settings: CodegenSettings,
 
-    /// output that we're building
-    output: String,
-
     /// disposition of this configuration: target v. initiator v. devices
     disposition: Disposition,
 
@@ -602,7 +599,6 @@ impl ConfigGenerator {
         }
 
         Self {
-            output: String::new(),
             devices: i2c.devices.unwrap_or_default(),
             disposition,
             controllers,
@@ -629,19 +625,17 @@ impl ConfigGenerator {
         self.controllers.len()
     }
 
-    pub fn generate_header(&mut self) -> Result<()> {
-        writeln!(&mut self.output, "pub(crate) mod i2c_config {{")?;
+    pub fn generate_header(&self, output: &mut String) -> Result<()> {
+        writeln!(output, "pub(crate) mod i2c_config {{")?;
         Ok(())
     }
 
-    pub fn generate_footer(&mut self) -> Result<()> {
-        writeln!(&mut self.output, "}}")?;
+    pub fn generate_footer(&self, output: &mut String) -> Result<()> {
+        writeln!(output, "}}")?;
         Ok(())
     }
 
-    pub fn generate_controllers(&mut self) -> Result<()> {
-        let mut s = &mut self.output;
-
+    pub fn generate_controllers(&self, output: &mut String) -> Result<()> {
         match self.disposition {
             Disposition::Initiator | Disposition::Target => {}
 
@@ -651,7 +645,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut s,
+            output,
             r##"
     #[allow(dead_code)]
     pub const NCONTROLLERS: usize = {ncontrollers};
@@ -664,35 +658,35 @@ impl ConfigGenerator {
 
         if !self.controllers.is_empty() {
             writeln!(
-                &mut s,
+                output,
                 r##"
         use drv_stm32xx_sys_api::Peripheral;
         use drv_i2c_api::Controller;"##
             )?;
 
             if build_util::has_feature("h743") {
-                writeln!(&mut s, "use stm32h7::stm32h743 as device;")?;
+                writeln!(output, "use stm32h7::stm32h743 as device;")?;
             }
             if build_util::has_feature("h753") {
-                writeln!(&mut s, "use stm32h7::stm32h753 as device;")?;
+                writeln!(output, "use stm32h7::stm32h753 as device;")?;
             }
             if build_util::has_feature("g031") {
-                writeln!(&mut s, "use stm32g0::stm32g031 as device;")?;
+                writeln!(output, "use stm32g0::stm32g031 as device;")?;
             }
             if build_util::has_feature("g030") {
-                writeln!(&mut s, "use stm32g0::stm32g030 as device;")?;
+                writeln!(output, "use stm32g0::stm32g030 as device;")?;
             }
         }
 
         write!(
-            &mut s,
+            output,
             r##"
         ["##
         )?;
 
         for c in &self.controllers {
             write!(
-                &mut s,
+                output,
                 r##"
             I2cController {{
                 controller: Controller::I2C{controller},
@@ -705,7 +699,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut s,
+            output,
             r##"
         ]
     }}"##
@@ -714,8 +708,7 @@ impl ConfigGenerator {
         Ok(())
     }
 
-    pub fn generate_pins(&mut self) -> Result<()> {
-        let mut s = &mut self.output;
+    pub fn generate_pins(&self, output: &mut String) -> Result<()> {
         let mut len = 0;
 
         match self.disposition {
@@ -731,7 +724,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut s,
+            output,
             r##"
     #[allow(unused_imports)]
     use drv_stm32xx_i2c::{{I2cPins, I2cGpio}};
@@ -741,7 +734,7 @@ impl ConfigGenerator {
 
         if len > 0 {
             writeln!(
-                &mut s,
+                output,
                 r##"
         use drv_i2c_api::{{Controller, PortIndex}};
         use drv_stm32xx_sys_api::{{self as gpio_api, Alternate}};"##
@@ -749,7 +742,7 @@ impl ConfigGenerator {
         }
 
         write!(
-            &mut s,
+            output,
             r##"
         ["##
         )?;
@@ -757,7 +750,7 @@ impl ConfigGenerator {
         for c in &self.controllers {
             for (index, (p, port)) in c.ports.iter().enumerate() {
                 writeln!(
-                    &mut s,
+                    output,
                     r##"
             I2cPins {{
                 controller: Controller::I2C{controller},
@@ -783,7 +776,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut s,
+            output,
             r##"
         ]
     }}"##
@@ -792,12 +785,11 @@ impl ConfigGenerator {
         Ok(())
     }
 
-    pub fn generate_muxes(&mut self) -> Result<()> {
+    pub fn generate_muxes(&self, output: &mut String) -> Result<()> {
         if self.disposition == Disposition::Target {
             panic!("cannot generate muxes when configured as target");
         }
 
-        let mut s = &mut self.output;
         let mut nmuxedbuses = 0;
         let mut len = 0;
 
@@ -812,7 +804,7 @@ impl ConfigGenerator {
         }
 
         write!(
-            &mut s,
+            output,
             r##"
     #[allow(dead_code)]
     pub const NMUXEDBUSES: usize = {nmuxedbuses};
@@ -824,7 +816,7 @@ impl ConfigGenerator {
 
         if len > 0 {
             writeln!(
-                &mut s,
+                output,
                 r##"
         use drv_i2c_api::{{Controller, PortIndex, Mux}};
 
@@ -834,7 +826,7 @@ impl ConfigGenerator {
         }
 
         write!(
-            &mut s,
+            output,
             r##"
         ["##
         )?;
@@ -863,7 +855,7 @@ impl ConfigGenerator {
                     );
 
                     write!(
-                        &mut s,
+                        output,
                         r##"
             I2cMux {{
                 controller: Controller::I2C{controller},
@@ -885,7 +877,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut s,
+            output,
             r##"
         ]
     }}"##
@@ -1010,7 +1002,7 @@ impl ConfigGenerator {
         )
     }
 
-    pub fn generate_devices(&mut self) -> Result<()> {
+    pub fn generate_devices(&self, output: &mut String) -> Result<()> {
         //
         // Throw all devices into a MultiMap based on device.
         //
@@ -1057,7 +1049,7 @@ impl ConfigGenerator {
         }
 
         write!(
-            &mut self.output,
+            output,
             r##"
     pub mod devices {{
         #[allow(unused_imports)]
@@ -1068,7 +1060,7 @@ impl ConfigGenerator {
         )?;
 
         write!(
-            &mut self.output,
+            output,
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
@@ -1079,12 +1071,10 @@ impl ConfigGenerator {
         let mut all: Vec<_> = by_controller.iter_all().collect();
         all.sort();
 
-        match_arms(&mut self.output, all, |c| {
-            format!("Some(Controller::I2C{c})")
-        })?;
+        match_arms(output, all, |c| format!("Some(Controller::I2C{c})"))?;
 
         write!(
-            &mut self.output,
+            output,
             r##"
                 _ => None
             }}
@@ -1093,7 +1083,7 @@ impl ConfigGenerator {
         )?;
 
         write!(
-            &mut self.output,
+            output,
             r##"
         #[allow(dead_code)]
         #[allow(clippy::match_single_binding)]
@@ -1104,10 +1094,10 @@ impl ConfigGenerator {
         let mut all: Vec<_> = by_port.iter_all().collect();
         all.sort();
 
-        match_arms(&mut self.output, all, |p| format!("Some(PortIndex({p}))"))?;
+        match_arms(output, all, |p| format!("Some(PortIndex({p}))"))?;
 
         write!(
-            &mut self.output,
+            output,
             r##"
                 _ => None
             }}
@@ -1120,7 +1110,7 @@ impl ConfigGenerator {
 
         for (device, devices) in all {
             write!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub fn {}(task: TaskId) -> [I2cDevice; {}] {{
@@ -1131,11 +1121,11 @@ impl ConfigGenerator {
 
             for d in devices {
                 let out = self.generate_device(d, 16);
-                write!(&mut self.output, "{out},")?;
+                write!(output, "{out},")?;
             }
 
             writeln!(
-                &mut self.output,
+                output,
                 r##"
             ]
         }}"##
@@ -1147,7 +1137,7 @@ impl ConfigGenerator {
 
         for ((device, bus), devices) in all {
             write!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub fn {}_{}(task: TaskId) -> [I2cDevice; {}] {{
@@ -1159,10 +1149,10 @@ impl ConfigGenerator {
 
             for d in devices {
                 let out = self.generate_device(d, 16);
-                write!(&mut self.output, "{out},")?;
+                write!(output, "{out},")?;
             }
             writeln!(
-                &mut self.output,
+                output,
                 r##"
             ]
         }}"##
@@ -1173,7 +1163,7 @@ impl ConfigGenerator {
         all.sort();
         for ((device, name), d) in &all {
             write!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub fn {}_{}(task: TaskId) -> I2cDevice {{"##,
@@ -1182,10 +1172,10 @@ impl ConfigGenerator {
             )?;
 
             let out = self.generate_device(d, 16);
-            write!(&mut self.output, "{out}")?;
+            write!(output, "{out}")?;
 
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         }}"##
             )?;
@@ -1199,40 +1189,40 @@ impl ConfigGenerator {
             max_component_id_len = max_component_id_len.max(refdes.len());
             let name = refdes.to_lower_ident();
             write!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub fn {device}_{name}(task: TaskId) -> I2cDevice {{"##,
             )?;
 
             let out = self.generate_device(d, 16);
-            write!(&mut self.output, "{out}")?;
+            write!(output, "{out}")?;
 
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         }}"##
             )?;
         }
 
-        writeln!(&mut self.output, "    }}")?;
+        writeln!(output, "    }}")?;
 
         if self.component_ids {
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub const MAX_COMPONENT_ID_LEN: usize = {max_component_id_len};"##,
             )?;
         }
 
-        self.generate_power(PowerDevices::PMBus)?;
-        self.generate_power(PowerDevices::NonPMBus)?;
+        self.generate_power(PowerDevices::PMBus, output)?;
+        self.generate_power(PowerDevices::NonPMBus, output)?;
 
         Ok(())
     }
 
-    pub fn generate_validation(&mut self) -> Result<()> {
+    pub fn generate_validation(&self, output: &mut String) -> Result<()> {
         //
         // Lord, have mercy: we are going to find the crate containing i2c
         // devices, and go fishing for where we believe the device drivers
@@ -1277,7 +1267,7 @@ impl ConfigGenerator {
         drivers.remove("lib");
 
         write!(
-            &mut self.output,
+            output,
             r##"
     pub mod validation {{
         #[allow(unused_imports)]
@@ -1331,7 +1321,7 @@ impl ConfigGenerator {
                 let out = self.generate_device(device, 24);
 
                 write!(
-                    &mut self.output,
+                    output,
                     r##"
                 {index} => {{
                     if drv_i2c_devices::{device}::{driver}::validate(&{out})? {{
@@ -1364,7 +1354,7 @@ impl ConfigGenerator {
                 }
                 let out = self.generate_device(device, 20);
                 write!(
-                    &mut self.output,
+                    output,
                     r##"
                 {index} => {{{out}.read::<u8>()?;
                     Ok(I2cValidation::RawReadOk)
@@ -1374,7 +1364,7 @@ impl ConfigGenerator {
         }
 
         writeln!(
-            &mut self.output,
+            output,
             r##"
                 _ => Err(drv_i2c_api::ResponseCode::BadArg)
             }}
@@ -1385,7 +1375,11 @@ impl ConfigGenerator {
         Ok(())
     }
 
-    fn generate_power(&mut self, which: PowerDevices) -> Result<()> {
+    fn generate_power(
+        &self,
+        which: PowerDevices,
+        output: &mut String,
+    ) -> Result<()> {
         let mut byrail = HashMap::new();
 
         for d in &self.devices {
@@ -1434,7 +1428,7 @@ impl ConfigGenerator {
 
         if !byrail.is_empty() {
             write!(
-                &mut self.output,
+                output,
                 r##"
     pub mod {} {{
         use drv_i2c_api::{{I2cDevice, Controller, PortIndex}};
@@ -1456,22 +1450,19 @@ impl ConfigGenerator {
                 // Accessor, returns `(I2cDevice, Option<u8>)`
 
                 write!(
-                    &mut self.output,
+                    output,
                     r##"
         #[allow(dead_code)]
         pub fn {}(task: TaskId)"##,
                     rail.to_lowercase(),
                 )?;
-                write!(&mut self.output, " -> (I2cDevice, Option<u8>) {{")?;
+                write!(output, " -> (I2cDevice, Option<u8>) {{")?;
 
                 let out = self.generate_device(device, 16);
                 if let Some(idx) = index {
-                    writeln!(
-                        &mut self.output,
-                        "({out}, Some({idx}))\n        }}"
-                    )?;
+                    writeln!(output, "({out}, Some({idx}))\n        }}")?;
                 } else {
-                    writeln!(&mut self.output, "({out}, None)\n        }}")?;
+                    writeln!(output, "({out}, None)\n        }}")?;
                 }
 
                 if which == PowerDevices::PMBus {
@@ -1492,7 +1483,7 @@ impl ConfigGenerator {
                     };
 
                     writeln!(
-                        &mut self.output,
+                        output,
                         r##"
         #[allow(dead_code)]
         pub const {}_{rail}_PHASES: Option<&'static [u8]> = {phases};"##,
@@ -1501,21 +1492,22 @@ impl ConfigGenerator {
                 }
             }
 
-            writeln!(&mut self.output, "    }}")?;
+            writeln!(output, "    }}")?;
         }
         Ok(())
     }
 
     fn emit_sensor(
-        &mut self,
+        &self,
         device: &str,
         label: &str,
         ids: &[usize],
+        output: &mut String,
     ) -> Result<()> {
         let device = device.to_uppercase();
         let n_sensors = ids.len();
         writeln!(
-            &mut self.output,
+            output,
             r##"
         #[allow(dead_code)]
         pub const NUM_{device}_{label}_SENSORS: usize = {n_sensors};"##,
@@ -1523,7 +1515,7 @@ impl ConfigGenerator {
 
         if ids.len() == 1 {
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub const {device}_{label}_SENSOR: SensorId = SensorId::new({});"##,
@@ -1531,26 +1523,27 @@ impl ConfigGenerator {
             )?;
         } else {
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub const {device}_{label}_SENSORS: [SensorId; {n_sensors}] = [ "##,
             )?;
 
             for id in ids {
-                writeln!(&mut self.output, "            SensorId::new({id}),",)?;
+                writeln!(output, "            SensorId::new({id}),",)?;
             }
 
-            writeln!(&mut self.output, "        ];")?;
+            writeln!(output, "        ];")?;
         }
 
         Ok(())
     }
 
     fn declare_sensor_struct(
-        &mut self,
+        &self,
         d: &I2cDevice,
         struct_name: &str,
+        output: &mut String,
     ) -> Result<()> {
         // Manually unpack the field so that changes to the sensor types
         // will require changes here as well.
@@ -1566,18 +1559,15 @@ impl ConfigGenerator {
         }) = &d.sensors
         {
             writeln!(
-                &mut self.output,
+                output,
                 "\n        #[allow(non_camel_case_types, dead_code)]
         pub struct Sensors_{struct_name} {{",
             )?;
             let mut f = |name, count| match count {
                 0 => Ok(()),
-                1 => writeln!(
-                    &mut self.output,
-                    "            pub {name}: SensorId,"
-                ),
+                1 => writeln!(output, "            pub {name}: SensorId,"),
                 _ => writeln!(
-                    &mut self.output,
+                    output,
                     "            pub {name}: [SensorId; {count}],"
                 ),
             };
@@ -1588,10 +1578,10 @@ impl ConfigGenerator {
             f("input_current", *input_current)?;
             f("input_voltage", *input_voltage)?;
             f("speed", *speed)?;
-            writeln!(&mut self.output, "        }}")?;
+            writeln!(output, "        }}")?;
         } else {
             writeln!(
-                &mut self.output,
+                output,
                 "\n        #[allow(dead_code, non_camel_case_types)]
         type Sensors_{struct_name} = ();",
             )?;
@@ -1600,14 +1590,15 @@ impl ConfigGenerator {
     }
 
     fn emit_sensor_struct(
-        &mut self,
+        &self,
         d: &I2cDevice,
         label: String,
         name: &str,
         sensors: &[DeviceSensor],
+        output: &mut String,
     ) -> Result<()> {
         write!(
-            &mut self.output,
+            output,
             "        #[allow(dead_code)]
         pub const {}_{label}_SENSORS: Sensors_{name} = ",
             d.device.to_uppercase(),
@@ -1618,11 +1609,11 @@ impl ConfigGenerator {
             sensors_by_kind.entry(s.kind).or_default().push(s.id);
         }
         if sensors_by_kind.is_empty() {
-            writeln!(&mut self.output, "();")?;
+            writeln!(output, "();")?;
             return Ok(());
         }
 
-        writeln!(&mut self.output, "Sensors_{name} {{")?;
+        writeln!(output, "Sensors_{name} {{")?;
 
         for (kind, values) in sensors_by_kind {
             let field = match kind {
@@ -1637,23 +1628,23 @@ impl ConfigGenerator {
             };
             if values.len() == 1 {
                 writeln!(
-                    &mut self.output,
+                    output,
                     "            {field}: SensorId::new({}),",
                     values[0]
                 )?;
             } else {
-                write!(&mut self.output, "            {field}: [")?;
+                write!(output, "            {field}: [")?;
                 for (i, v) in values.iter().enumerate() {
                     if i > 0 {
-                        write!(&mut self.output, ", ")?;
+                        write!(output, ", ")?;
                     }
-                    write!(&mut self.output, "SensorId::new({v})")?;
+                    write!(output, "SensorId::new({v})")?;
                 }
-                writeln!(&mut self.output, "],")?;
+                writeln!(output, "],")?;
             }
         }
 
-        writeln!(&mut self.output, "        }};")?;
+        writeln!(output, "        }};")?;
         Ok(())
     }
 
@@ -1661,11 +1652,11 @@ impl ConfigGenerator {
         I2cSensorsDescription::new(&self.devices)
     }
 
-    pub fn generate_sensors(&mut self) -> Result<()> {
+    pub fn generate_sensors(&self, output: &mut String) -> Result<()> {
         let s = self.sensors_description();
 
         write!(
-            &mut self.output,
+            output,
             r##"
     pub mod sensors {{
         #[allow(unused_imports)]
@@ -1706,7 +1697,7 @@ impl ConfigGenerator {
                 }
             } else {
                 emitted_structs.insert(struct_name.clone(), d.sensors.clone());
-                self.declare_sensor_struct(d, &struct_name)?;
+                self.declare_sensor_struct(d, &struct_name, output)?;
             }
             let s = s.device_sensors[i].as_slice();
             if let Some(name) = &d.name {
@@ -1715,6 +1706,7 @@ impl ConfigGenerator {
                     name.to_uppercase(),
                     &struct_name,
                     s,
+                    output,
                 )?;
             }
             if let Some(refdes) = &d.refdes {
@@ -1723,6 +1715,7 @@ impl ConfigGenerator {
                     refdes.to_upper_ident(),
                     &struct_name,
                     s,
+                    output,
                 )?;
             }
         }
@@ -1731,7 +1724,7 @@ impl ConfigGenerator {
         by_device_sorted.sort();
 
         for (k, ids) in &by_device_sorted {
-            self.emit_sensor(&k.device, &format!("{}", k.kind), ids)?;
+            self.emit_sensor(&k.device, &format!("{}", k.kind), ids, output)?;
         }
 
         let mut by_name_sorted: Vec<_> = s.by_name.iter_all().collect();
@@ -1739,7 +1732,7 @@ impl ConfigGenerator {
 
         for (k, ids) in &by_name_sorted {
             let label = format!("{}_{}", k.name.to_uppercase(), k.kind);
-            self.emit_sensor(&k.device, &label, ids)?;
+            self.emit_sensor(&k.device, &label, ids, output)?;
         }
 
         let mut by_refdes_sorted: Vec<_> = s.by_refdes.iter_all().collect();
@@ -1748,23 +1741,23 @@ impl ConfigGenerator {
         for (k, ids) in &by_refdes_sorted {
             let refdes = k.refdes.to_upper_ident();
             let label = format!("{refdes}_{}", k.kind);
-            self.emit_sensor(&k.device, &label, ids)?;
+            self.emit_sensor(&k.device, &label, ids, output)?;
         }
 
-        writeln!(&mut self.output, "\n    }}")?;
+        writeln!(output, "\n    }}")?;
         Ok(())
     }
 
-    pub fn generate_ports(&mut self) -> Result<()> {
+    pub fn generate_ports(&self, output: &mut String) -> Result<()> {
         writeln!(
-            &mut self.output,
+            output,
             r##"
     pub mod ports {{"##
         )?;
 
         for ((controller, port), index) in &self.ports {
             writeln!(
-                &mut self.output,
+                output,
                 r##"
         #[allow(dead_code)]
         pub const fn i2c{controller}_{port}() -> drv_i2c_api::PortIndex {{
@@ -1776,13 +1769,14 @@ impl ConfigGenerator {
             )?;
         }
 
-        writeln!(&mut self.output, "    }}")?;
+        writeln!(output, "    }}")?;
         Ok(())
     }
 
     /// Use the given ConfigGenerator to do code generation.
-    pub fn codegen_to_string(mut self) -> Result<String> {
-        self.generate_header()?;
+    pub fn codegen_to_string(self) -> Result<String> {
+        let mut output = String::new();
+        self.generate_header(&mut output)?;
 
         match self.settings.disposition {
             Disposition::Target => {
@@ -1799,37 +1793,37 @@ impl ConfigGenerator {
                     );
                 }
 
-                self.generate_controllers()?;
-                self.generate_pins()?;
-                self.generate_ports()?;
+                self.generate_controllers(&mut output)?;
+                self.generate_pins(&mut output)?;
+                self.generate_ports(&mut output)?;
             }
 
             Disposition::Initiator => {
-                self.generate_controllers()?;
-                self.generate_pins()?;
-                self.generate_ports()?;
-                self.generate_muxes()?;
+                self.generate_controllers(&mut output)?;
+                self.generate_pins(&mut output)?;
+                self.generate_ports(&mut output)?;
+                self.generate_muxes(&mut output)?;
             }
 
             Disposition::Devices => {
-                self.generate_devices()?;
-                self.generate_ports()?;
+                self.generate_devices(&mut output)?;
+                self.generate_ports(&mut output)?;
             }
 
             Disposition::Sensors => {
-                self.generate_devices()?;
-                self.generate_sensors()?;
+                self.generate_devices(&mut output)?;
+                self.generate_sensors(&mut output)?;
             }
 
             Disposition::Validation => {
-                self.generate_devices()?;
-                self.generate_validation()?;
+                self.generate_devices(&mut output)?;
+                self.generate_validation(&mut output)?;
             }
         }
 
-        self.generate_footer()?;
+        self.generate_footer(&mut output)?;
 
-        Ok(self.output)
+        Ok(output)
     }
 }
 
@@ -1977,7 +1971,7 @@ pub fn device_descriptions() -> impl Iterator<Item = I2cDeviceDescription> {
 }
 
 fn match_arms<'a, C>(
-    mut out: impl Write,
+    out: &mut impl Write,
     source: impl IntoIterator<Item = (&'a C, &'a Vec<usize>)>,
     fmt: impl Fn(&C) -> String,
 ) -> Result<()>
@@ -1998,7 +1992,7 @@ where
         let result = fmt(controller);
 
         write!(
-            &mut out,
+            out,
             r##"
                 {s} => {result},"##,
         )?;

--- a/build/i2c/src/lib.rs
+++ b/build/i2c/src/lib.rs
@@ -502,9 +502,6 @@ pub struct ConfigGenerator {
     /// Settings
     settings: CodegenSettings,
 
-    /// disposition of this configuration: target v. initiator v. devices
-    disposition: Disposition,
-
     /// all controllers
     controllers: Vec<I2cController>,
 
@@ -519,22 +516,56 @@ pub struct ConfigGenerator {
 
     /// hash of controllers to single port indices
     singletons: HashMap<u8, usize>,
+}
 
-    /// if `true`, include component ID string in output.
-    ///
-    /// this requires that the `"drv-i2c-api/component-id"` feature flag is
-    /// enabled. if that feature flag is enabled, then this MUST also be
-    /// enabled.
-    component_ids: bool,
+fn calculate_validate_drivers() -> Result<HashSet<String>> {
+    //
+    // Lord, have mercy: we are going to find the crate containing i2c
+    // devices, and go fishing for where we believe the device drivers
+    // themselves to be.  It does not need to be said that this is
+    // operating by convention; there are (many) ways to envision this
+    // breaking -- with apologies, dear reader, if that's what brings you
+    // here!
+    //
+    // Apology accepted. Perhaps this should be completely redesigned, but
+    // I've at least made it so the build will now fail with a helpful error
+    // message if the device driver isn't found.
+    let mut drivers = std::collections::HashSet::new();
+
+    use cargo_metadata::MetadataCommand;
+
+    let metadata = MetadataCommand::new()
+        .manifest_path("./Cargo.toml")
+        .exec()
+        .unwrap();
+
+    let pkg = metadata
+        .packages
+        .iter()
+        .find(|p| p.name.as_str() == "drv-i2c-devices")
+        .context("failed to find drv-i2c-devices")?;
+
+    let dir = pkg
+        .manifest_path
+        .parent()
+        .context("failed to get i2c device path")?;
+
+    println!("cargo::rerun-if-changed={}", dir.join("src"));
+
+    for entry in std::fs::read_dir(dir.join("src"))? {
+        if let Some(f) = entry?.path().file_name()
+            && let Some(name) = f.to_str().unwrap().strip_suffix(".rs")
+        {
+            drivers.insert(name.to_string());
+        }
+    }
+
+    drivers.remove("lib");
+    Ok(drivers)
 }
 
 impl ConfigGenerator {
     pub fn new_with_config(settings: CodegenSettings, i2c: I2cConfig) -> Self {
-        let CodegenSettings {
-            disposition,
-            component_ids,
-        } = settings;
-
         let mut controllers = vec![];
         let mut buses = HashMap::new();
         let mut ports = IndexMap::new();
@@ -562,7 +593,7 @@ impl ConfigGenerator {
                 ports.insert((c.controller, p.clone()), index);
             }
 
-            if c.target != (disposition == Disposition::Target) {
+            if c.target != (settings.disposition == Disposition::Target) {
                 continue;
             }
 
@@ -600,12 +631,10 @@ impl ConfigGenerator {
 
         Self {
             devices: i2c.devices.unwrap_or_default(),
-            disposition,
             controllers,
             buses,
             ports,
             singletons,
-            component_ids,
             settings,
         }
     }
@@ -636,7 +665,7 @@ impl ConfigGenerator {
     }
 
     pub fn generate_controllers(&self, output: &mut String) -> Result<()> {
-        match self.disposition {
+        match self.settings.disposition {
             Disposition::Initiator | Disposition::Target => {}
 
             _ => {
@@ -664,18 +693,14 @@ impl ConfigGenerator {
         use drv_i2c_api::Controller;"##
             )?;
 
-            if build_util::has_feature("h743") {
-                writeln!(output, "use stm32h7::stm32h743 as device;")?;
-            }
-            if build_util::has_feature("h753") {
-                writeln!(output, "use stm32h7::stm32h753 as device;")?;
-            }
-            if build_util::has_feature("g031") {
-                writeln!(output, "use stm32g0::stm32g031 as device;")?;
-            }
-            if build_util::has_feature("g030") {
-                writeln!(output, "use stm32g0::stm32g030 as device;")?;
-            }
+            let text = match self.settings.codegen_target {
+                CodegenTarget::None => "",
+                CodegenTarget::Stm32H743 => "use stm32h7::stm32h743 as device;",
+                CodegenTarget::Stm32H753 => "use stm32h7::stm32h753 as device;",
+                CodegenTarget::Stm32G031 => "use stm32g0::stm32g031 as device;",
+                CodegenTarget::Stm32G030 => "use stm32g0::stm32g030 as device;",
+            };
+            writeln!(output, "{text}")?;
         }
 
         write!(
@@ -711,7 +736,7 @@ impl ConfigGenerator {
     pub fn generate_pins(&self, output: &mut String) -> Result<()> {
         let mut len = 0;
 
-        match self.disposition {
+        match self.settings.disposition {
             Disposition::Initiator | Disposition::Target => {}
 
             _ => {
@@ -786,7 +811,7 @@ impl ConfigGenerator {
     }
 
     pub fn generate_muxes(&self, output: &mut String) -> Result<()> {
-        if self.disposition == Disposition::Target {
+        if self.settings.disposition == Disposition::Target {
             panic!("cannot generate muxes when configured as target");
         }
 
@@ -969,7 +994,7 @@ impl ConfigGenerator {
 
         let indent = format!("{:indent$}", "", indent = indent);
 
-        let component_id = if self.component_ids {
+        let component_id = if self.settings.component_ids {
             if let Some(ref refdes) = d.refdes {
                 let id = refdes.to_component_id();
                 format!("\n{indent}    {id:?},")
@@ -1207,7 +1232,7 @@ impl ConfigGenerator {
 
         writeln!(output, "    }}")?;
 
-        if self.component_ids {
+        if self.settings.component_ids {
             writeln!(
                 output,
                 r##"
@@ -1223,48 +1248,7 @@ impl ConfigGenerator {
     }
 
     pub fn generate_validation(&self, output: &mut String) -> Result<()> {
-        //
-        // Lord, have mercy: we are going to find the crate containing i2c
-        // devices, and go fishing for where we believe the device drivers
-        // themselves to be.  It does not need to be said that this is
-        // operating by convention; there are (many) ways to envision this
-        // breaking -- with apologies, dear reader, if that's what brings you
-        // here!
-        //
-        // Apology accepted. Perhaps this should be completely redesigned, but
-        // I've at least made it so the build will now fail with a helpful error
-        // message if the device driver isn't found.
-        use cargo_metadata::MetadataCommand;
-
-        let metadata = MetadataCommand::new()
-            .manifest_path("./Cargo.toml")
-            .exec()
-            .unwrap();
-
-        let pkg = metadata
-            .packages
-            .iter()
-            .find(|p| p.name.as_str() == "drv-i2c-devices")
-            .context("failed to find drv-i2c-devices")?;
-
-        let dir = pkg
-            .manifest_path
-            .parent()
-            .context("failed to get i2c device path")?;
-
-        let mut drivers = std::collections::HashSet::new();
-
-        println!("cargo::rerun-if-changed={}", dir.join("src"));
-
-        for entry in std::fs::read_dir(dir.join("src"))? {
-            if let Some(f) = entry?.path().file_name()
-                && let Some(name) = f.to_str().unwrap().strip_suffix(".rs")
-            {
-                drivers.insert(name.to_string());
-            }
-        }
-
-        drivers.remove("lib");
+        let drivers = &self.settings.drivers;
 
         write!(
             output,
@@ -1827,10 +1811,59 @@ impl ConfigGenerator {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(PartialEq, Copy, Clone)]
+pub enum CodegenTarget {
+    None,
+    Stm32H743,
+    Stm32H753,
+    Stm32G031,
+    Stm32G030,
+}
+
+impl CodegenTarget {
+    fn from_env() -> Self {
+        let h743 = build_util::has_feature("h743");
+        let h753 = build_util::has_feature("h753");
+        let g031 = build_util::has_feature("g031");
+        let g030 = build_util::has_feature("g030");
+        let mut count = 0;
+        for sel in [h743, h753, g031, g030] {
+            if sel {
+                count += 1;
+            }
+        }
+
+        if count > 1 {
+            panic!("Too many features selected!");
+        }
+
+        if h743 {
+            Self::Stm32H743
+        } else if h753 {
+            Self::Stm32H753
+        } else if g031 {
+            Self::Stm32G031
+        } else if g030 {
+            Self::Stm32G030
+        } else {
+            Self::None
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct CodegenSettings {
+    /// disposition of this configuration: target v. initiator v. devices
     pub disposition: Disposition,
+    /// if `true`, include component ID string in output.
+    ///
+    /// this requires that the `"drv-i2c-api/component-id"` feature flag is
+    /// enabled. if that feature flag is enabled, then this MUST also be
+    /// enabled.
     pub component_ids: bool,
+    pub codegen_target: CodegenTarget,
+    /// List of drivers relevant to validation
+    pub drivers: HashSet<String>,
 }
 
 impl From<Disposition> for CodegenSettings {
@@ -1838,6 +1871,12 @@ impl From<Disposition> for CodegenSettings {
         CodegenSettings {
             disposition,
             component_ids: cfg!(feature = "component-id"),
+            codegen_target: CodegenTarget::from_env(),
+            drivers: if disposition == Disposition::Validation {
+                calculate_validate_drivers().unwrap()
+            } else {
+                HashSet::new()
+            },
         }
     }
 }


### PR DESCRIPTION
This is currently staged as a follow-on to #2648, and does two main things:

* Splits the `output` out of `ConfigGenerator`, to make it easier to see methods that mutate that from ones that don't (currently none, analysis is done locally in the codegen functions themselves)
* Moves some of the inline "check the environment variables/project structure" stuff into `CodegenSettings` so that you could invoke codegen directly without actually being in the given project structure

This is likely to have merge conflicts, but I'm gunna work on other stuff for a while, so I wanted to push this up just to have it.