### PR TITLE
observer: remove PSU's auxiliary rail

### DIFF
--- a/app/observer/base.toml
+++ b/app/observer/base.toml
@@ -568,6 +568,9 @@ mux = "port_b"
 cs = [{port = "B", pin = 12}]
 
 # TODO SPI3 is the ignition flash reprogramming port
+# We validated that the hardware works but didn't add proper Observer support to
+# the ignition-flash task. For details and example code, see
+# https://github.com/oxidecomputer/hardware-observer/issues/90
 
 [config.spi.spi4]
 controller = 4

--- a/app/observer/base.toml
+++ b/app/observer/base.toml
@@ -440,10 +440,14 @@ name = "psu0mcu"
 address = 0b1011_000
 device = "mwocp67"
 description = "PSU 0 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU0", "V50_AUX_PSU0" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+# The MWOCP67 PSU has two rails: a 50V main rail and a 12V auxiliary rail that
+# powers the Observer PSC even when the main rail is off. However, only the main
+# rail is accessible over PMBus. The PSU does allow you to set the page to 0 or
+# 1, but this has no effect; in either case, commands like READ_VOUT just report
+# readings for the main rail, and Murata has confirmed that this is the intended
+# behavior. Therefore, we only define the main rail here.
+power = { rails = [ "V50_PSU0" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU0"
 
 [[config.i2c.devices]]
@@ -460,10 +464,8 @@ name = "psu1mcu"
 address = 0b1011_001
 device = "mwocp67"
 description = "PSU 1 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU1", "V50_AUX_PSU1" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+power = { rails = [ "V50_PSU1"], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU1"
 
 [[config.i2c.devices]]
@@ -480,10 +482,8 @@ name = "psu2mcu"
 address = 0b1011_010
 device = "mwocp67"
 description = "PSU 2 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU2", "V50_AUX_PSU2" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+power = { rails = [ "V50_PSU2"], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU2"
 
 [[config.i2c.devices]]
@@ -500,10 +500,8 @@ name = "psu3mcu"
 address = 0b1011_011
 device = "mwocp67"
 description = "PSU 3 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU3", "V50_AUX_PSU3" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+power = { rails = [ "V50_PSU3"], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU3"
 
 [[config.i2c.devices]]
@@ -520,10 +518,8 @@ name = "psu4mcu"
 address = 0b1011_100
 device = "mwocp67"
 description = "PSU 4 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU4", "V50_AUX_PSU4" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+power = { rails = [ "V50_PSU4"], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU4"
 
 [[config.i2c.devices]]
@@ -540,10 +536,8 @@ name = "psu5mcu"
 address = 0b1011_101
 device = "mwocp67"
 description = "PSU 5 MCU"
-# TODO it's not clear what rails the mwocp67 has or how they are paged.
-# https://github.com/oxidecomputer/hubris/issues/2410
-power = { rails = [ "V50_MAIN_PSU5", "V50_AUX_PSU5" ], sensors = ["voltage", "current", "input-voltage", "input-current"] }
-sensors = { input-voltage = 2, input-current = 2, voltage = 2, current = 2, temperature = 5, speed = 1 }
+power = { rails = [ "V50_PSU5"], sensors = ["voltage", "current", "input-voltage", "input-current"] }
+sensors = { input-voltage = 1, input-current = 1, voltage = 1, current = 1, temperature = 5, speed = 1 }
 refdes = "PSU5"
 
 [config.spi.spi1]

--- a/build/xtask/tests/snapshots/i2c_codegen__app_observer_rev-a-dev.toml.devices-Sensors.snap
+++ b/build/xtask/tests/snapshots/i2c_codegen__app_observer_rev-a-dev.toml.devices-Sensors.snap
@@ -307,146 +307,74 @@ pub mod pmbus {
     use userlib::TaskId;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu0(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu0(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 0 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x58),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU0_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU0_PHASES: Option<&'static [u8]> = None;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu1(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu1(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 1 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x59),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU1_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU1_PHASES: Option<&'static [u8]> = None;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu2(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu2(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 2 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5a),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU2_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU2_PHASES: Option<&'static [u8]> = None;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu3(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu3(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 3 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5b),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU3_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU3_PHASES: Option<&'static [u8]> = None;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu4(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu4(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 4 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5c),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU4_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU4_PHASES: Option<&'static [u8]> = None;
 
     #[allow(dead_code)]
-    pub fn v50_aux_psu5(task: TaskId) -> (I2cDevice, Option<u8>) {
+    pub fn v50_psu5(task: TaskId) -> (I2cDevice, Option<u8>) {
         (
             // PSU 5 MCU
             I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5d),
-            Some(1),
+            None,
         )
     }
 
     #[allow(dead_code)]
-    pub const MWOCP67_V50_AUX_PSU5_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu0(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 0 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x58),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU0_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu1(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 1 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x59),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU1_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu2(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 2 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5a),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU2_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu3(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 3 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5b),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU3_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu4(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 4 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5c),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU4_PHASES: Option<&'static [u8]> = None;
-
-    #[allow(dead_code)]
-    pub fn v50_main_psu5(task: TaskId) -> (I2cDevice, Option<u8>) {
-        (
-            // PSU 5 MCU
-            I2cDevice::new(task, Controller::I2C3, PortIndex(0), None, 0x5d),
-            Some(0),
-        )
-    }
-
-    #[allow(dead_code)]
-    pub const MWOCP67_V50_MAIN_PSU5_PHASES: Option<&'static [u8]> = None;
+    pub const MWOCP67_V50_PSU5_PHASES: Option<&'static [u8]> = None;
 }

--- a/drv/psc-seq-server/src/bsp/observer_a.rs
+++ b/drv/psc-seq-server/src/bsp/observer_a.rs
@@ -44,12 +44,12 @@ pub type SummonFn = fn(userlib::TaskId) -> (drv_i2c_api::I2cDevice, Option<u8>);
 
 /// In order to get the PMBus devices by PSU index, we need a little lookup table.
 pub const PSU_PMBUS_DEVS: [SummonFn; PSU_COUNT] = [
-    i2c_config::pmbus::v50_main_psu0,
-    i2c_config::pmbus::v50_main_psu1,
-    i2c_config::pmbus::v50_main_psu2,
-    i2c_config::pmbus::v50_main_psu3,
-    i2c_config::pmbus::v50_main_psu4,
-    i2c_config::pmbus::v50_main_psu5,
+    i2c_config::pmbus::v50_psu0,
+    i2c_config::pmbus::v50_psu1,
+    i2c_config::pmbus::v50_psu2,
+    i2c_config::pmbus::v50_psu3,
+    i2c_config::pmbus::v50_psu4,
+    i2c_config::pmbus::v50_psu5,
 ];
 
 /// Checks whether each PSU is enabled, using PMBus. Note that the MWOCP67 PSUs

--- a/drv/psc-seq-server/src/main.rs
+++ b/drv/psc-seq-server/src/main.rs
@@ -1080,7 +1080,7 @@ impl Psu {
             #[cfg(any(target_board = "psc-b", target_board = "psc-c"))]
             let mut rail_name = *b"V54_PSUx";
             #[cfg(target_board = "observer-a")]
-            let mut rail_name = *b"V50_MAIN_PSUx";
+            let mut rail_name = *b"V50_PSUx";
 
             rail_name[rail_name.len() - 1] = match self.slot {
                 Slot::Psu0 => b'0',
@@ -1235,7 +1235,7 @@ struct PowerUngoodEreport {
 #[derive(microcbor::EncodeFields)]
 struct EreportFields {
     refdes: FixedStr<'static, 20>, // Component ID max length
-    rail: FixedString<13>,         // Example: "V54_PSU0"
+    rail: FixedString<8>,          // Example: "V54_PSU0"
     slot: u8,
     fruid: PsuFruid,
 }

--- a/task/power/src/bsp/observer_a.rs
+++ b/task/power/src/bsp/observer_a.rs
@@ -7,21 +7,15 @@ use crate::{
     i2c_config::{self, sensors},
 };
 
-pub(crate) const CONTROLLER_CONFIG_LEN: usize = 12;
+pub(crate) const CONTROLLER_CONFIG_LEN: usize = 6;
 pub(crate) static CONTROLLER_CONFIG: [PowerControllerConfig;
     CONTROLLER_CONFIG_LEN] = [
-    mwocp67_controller!(PowerShelf, v50_main_psu0, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu0, A2),
-    mwocp67_controller!(PowerShelf, v50_main_psu1, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu1, A2),
-    mwocp67_controller!(PowerShelf, v50_main_psu2, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu2, A2),
-    mwocp67_controller!(PowerShelf, v50_main_psu3, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu3, A2),
-    mwocp67_controller!(PowerShelf, v50_main_psu4, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu4, A2),
-    mwocp67_controller!(PowerShelf, v50_main_psu5, A2),
-    mwocp67_controller!(PowerShelf, v50_aux_psu5, A2),
+    mwocp67_controller!(PowerShelf, v50_psu0, A2),
+    mwocp67_controller!(PowerShelf, v50_psu1, A2),
+    mwocp67_controller!(PowerShelf, v50_psu2, A2),
+    mwocp67_controller!(PowerShelf, v50_psu3, A2),
+    mwocp67_controller!(PowerShelf, v50_psu4, A2),
+    mwocp67_controller!(PowerShelf, v50_psu5, A2),
 ];
 
 pub(crate) fn get_state() -> PowerState {


### PR DESCRIPTION
It turns out that the MWOCP67 PSU's auxiliary rail is not accessible over PMBus, so this PR removes it from the manifest. I had to update the i2c codegen snapshot tests, but it was actually quite nice to see what had changed.

 Tested by running `humility power` and confirming that now only the main rail of each PSU is shown.