### PR TITLE
static-cell: Change unsafe Sync impl for ClaimOnceCell

### DIFF
--- a/lib/static-cell/src/lib.rs
+++ b/lib/static-cell/src/lib.rs
@@ -99,7 +99,7 @@ pub struct ClaimOnceCell<T> {
 // Safety: because a `ClaimOnceCell` may only create a single mutable reference to
 // the inner value a single time, it can implement `Sync` freely, as the inner
 // `UnsafeCell`'s value cannot be mutably aliased.
-unsafe impl<T> Sync for ClaimOnceCell<T> where for<'a> &'a T: Send {}
+unsafe impl<T> Sync for ClaimOnceCell<T> where T: Send {}
 
 impl<T> ClaimOnceCell<T> {
     /// Returns a new `ClaimOnceCell` containing the provided `value`.


### PR DESCRIPTION
The previous impl was insufficiently broad, and did not allow for types like `core::cell::Cell` to be placed in the ClaimOnceCell. I believe the impl was copied from StaticCell, which needs to have a more restrictive implementation as the user is not given a full `&mut T`.